### PR TITLE
fix(csa-session): normalize session result token total

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.939"
+version = "0.1.940"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.939"
+version = "0.1.940"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result.rs
@@ -327,37 +327,52 @@ fn load_total_token_usage(session_dir: &Path) -> Option<TokenUsage> {
 }
 
 fn print_token_usage(usage: &TokenUsage) {
+    for line in render_token_usage_lines(usage) {
+        println!("{line}");
+    }
+}
+
+fn render_token_usage_lines(usage: &TokenUsage) -> Vec<String> {
     let any_field = usage.input_tokens.is_some()
         || usage.output_tokens.is_some()
         || usage.total_tokens.is_some()
         || usage.estimated_cost_usd.is_some()
         || usage.cache_read_input_tokens.is_some();
     if !any_field {
-        return;
+        return Vec::new();
     }
-    println!("Tokens:");
+
+    let mut lines = vec!["Tokens:".to_string()];
     if let Some(v) = usage.input_tokens {
-        println!("  Input:  {} tokens", format_thousands(v));
+        lines.push(format!("  Input:  {} tokens", format_thousands(v)));
     }
     if let Some(v) = usage.output_tokens {
-        println!("  Output: {} tokens", format_thousands(v));
+        lines.push(format!("  Output: {} tokens", format_thousands(v)));
     }
-    if let Some(v) = usage.total_tokens {
-        println!("  Total:  {} tokens", format_thousands(v));
+    if let Some(v) = display_total_tokens(usage) {
+        lines.push(format!("  Total:  {} tokens", format_thousands(v)));
     }
     if let Some(v) = usage.cache_read_input_tokens {
         if let Some(ratio) = usage.cache_hit_ratio() {
-            println!(
+            lines.push(format!(
                 "  Cache read: {} tokens ({:.0}% hit rate)",
                 format_thousands(v),
                 ratio * 100.0
-            );
+            ));
         } else {
-            println!("  Cache read: {} tokens", format_thousands(v));
+            lines.push(format!("  Cache read: {} tokens", format_thousands(v)));
         }
     }
     if let Some(cost) = usage.estimated_cost_usd {
-        println!("  Cost:   ${cost:.4}");
+        lines.push(format!("  Cost:   ${cost:.4}"));
+    }
+    lines
+}
+
+fn display_total_tokens(usage: &TokenUsage) -> Option<u64> {
+    match (usage.input_tokens, usage.output_tokens) {
+        (Some(input), Some(output)) => input.checked_add(output),
+        _ => usage.total_tokens,
     }
 }
 
@@ -419,13 +434,20 @@ fn build_result_json_payload(
         payload["review_meta"] = serde_json::to_value(meta)?;
     }
     if let Some(usage) = token_usage {
-        let mut value = serde_json::to_value(usage)?;
+        let usage = normalized_token_usage_for_output(usage);
+        let mut value = serde_json::to_value(&usage)?;
         if let Some(ratio) = usage.cache_hit_ratio() {
             value["cache_hit_ratio"] = serde_json::json!(ratio);
         }
         payload["total_token_usage"] = value;
     }
     Ok(payload)
+}
+
+fn normalized_token_usage_for_output(usage: &TokenUsage) -> TokenUsage {
+    let mut normalized = usage.clone();
+    normalized.total_tokens = display_total_tokens(usage);
+    normalized
 }
 
 fn display_sidecar(label: &str, sidecar: Option<&toml::Value>) {
@@ -664,3 +686,6 @@ pub(crate) use tool_output::handle_session_tool_output;
 #[cfg(test)]
 #[path = "session_cmds_result_tests.rs"]
 mod tests;
+#[cfg(test)]
+#[path = "session_cmds_result_token_tests.rs"]
+mod token_tests;

--- a/crates/cli-sub-agent/src/session_cmds_result_token_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_token_tests.rs
@@ -1,0 +1,60 @@
+use super::{build_result_json_payload, render_token_usage_lines};
+use csa_session::{SessionResult, SessionResultView, TokenUsage};
+
+#[test]
+fn token_usage_text_derives_total_from_input_and_output_when_persisted_total_conflicts() {
+    let usage = conflicting_token_usage();
+
+    let rendered = render_token_usage_lines(&usage).join("\n");
+
+    assert!(rendered.contains("  Input:  2,329,258 tokens"));
+    assert!(rendered.contains("  Output: 14,200 tokens"));
+    assert!(rendered.contains("  Total:  2,343,458 tokens"));
+    assert!(!rendered.contains("  Total:  97 tokens"));
+}
+
+#[test]
+fn build_result_json_payload_derives_total_from_input_and_output_when_persisted_total_conflicts() {
+    let result = SessionResultView {
+        envelope: session_result(),
+        manager_sidecar: None,
+        legacy_sidecar: None,
+    };
+    let usage = conflicting_token_usage();
+
+    let payload = build_result_json_payload(&result, None, None, Some(&usage)).unwrap();
+
+    assert_eq!(payload["total_token_usage"]["input_tokens"], 2_329_258);
+    assert_eq!(payload["total_token_usage"]["output_tokens"], 14_200);
+    assert_eq!(payload["total_token_usage"]["total_tokens"], 2_343_458);
+    assert_ne!(payload["total_token_usage"]["total_tokens"], 97);
+}
+
+fn conflicting_token_usage() -> TokenUsage {
+    TokenUsage {
+        input_tokens: Some(2_329_258),
+        output_tokens: Some(14_200),
+        total_tokens: Some(97),
+        estimated_cost_usd: None,
+        cache_read_input_tokens: Some(2_081_024),
+    }
+}
+
+fn session_result() -> SessionResult {
+    let now = chrono::Utc::now();
+    SessionResult {
+        post_exec_gate: None,
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "review completed".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    }
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.939"
-weave = "0.1.939"
+csa = "0.1.940"
+weave = "0.1.940"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- normalize `csa session result` token total formatting so total cannot be lower than reported input/output tokens
- keep backend accounting fields readable while deriving a sane display total when needed
- add regression coverage for the impossible `Input 2,329,258 / Output 14,200 / Total 97` case

## Verification

- CSA writer session: `01KTJD7S42HAFRXJAN5X86YGGC` PASS, committed `ba29dd3f`
- Rechecked original trigger session after installing the fixed binary: `Total: 2,343,458 tokens`
- Rechecked writer session after installing the fixed binary: `Total: 6,317,854 tokens`
- CSA tier-4 full-diff review: `01KTJEQ4S93RK3AXHBMBZVSQ7A` PASS/CLEAN for `range:main...HEAD` at `ba29dd3f`

Closes #1943
