### PR TITLE
fix(csa-session): complete wait only from terminal result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.940"
+version = "0.1.941"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.940"
+version = "0.1.941"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_session.rs
+++ b/crates/cli-sub-agent/src/cli_session.rs
@@ -250,7 +250,7 @@ pub enum SessionCommands {
         cd: Option<String>,
     },
 
-    /// Wait for a daemon session to complete (poll until result exists and the daemon exits).
+    /// Wait for a daemon session to report a terminal result.
     /// Timeout comes from `~/.config/cli-sub-agent/config.toml` `[kv_cache].long_poll_seconds`
     /// with a legacy 250s fallback when `[kv_cache]` is absent.
     ///

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -33,7 +33,7 @@ use types::WaitExecutionOptions;
 pub(crate) use types::WaitLoopTiming;
 pub(crate) use types::{SessionWaitOutputMode, WaitBehavior, WaitReconciliationOutcome};
 
-/// Wait for a daemon session to reach a terminal result and daemon exit.
+/// Wait for a daemon session to reach a terminal result.
 /// Exits 0 on session success, 1 on terminal session failure, 124 when the
 /// wait times out while the session is still active, and 33 for memory warnings.
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -145,24 +145,45 @@ where
                     }
                 }
             }
-            let streamed_output = emit_wait_terminal_output(
-                &session_dir,
-                &resolved.session_id,
-                loaded_result.as_ref(),
-                wait_options.output_mode,
-            )?;
-            super::emit_wait_next_step_if_needed(&session_dir)?;
-            #[rustfmt::skip]
-            let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(completion.status.as_str(), completion.exit_code, synthetic, loaded_result.as_ref());
-            emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
-            emit_completion_signal(
-                &resolved.session_id,
-                completion_status.as_ref(),
-                exit_code,
-                synthetic,
-                !streamed_output,
-            );
-            return Ok(exit_code);
+            if let Some(result) = loaded_result {
+                let streamed_output = emit_wait_terminal_output(
+                    &session_dir,
+                    &resolved.session_id,
+                    Some(&result),
+                    wait_options.output_mode,
+                )?;
+                super::emit_wait_next_step_if_needed(&session_dir)?;
+                #[rustfmt::skip]
+                let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(completion.status.as_str(), completion.exit_code, synthetic, Some(&result));
+                emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
+                emit_completion_signal(
+                    &resolved.session_id,
+                    completion_status.as_ref(),
+                    exit_code,
+                    synthetic,
+                    !streamed_output,
+                );
+                return Ok(exit_code);
+            }
+
+            if csa_process::ToolLiveness::is_alive(&session_dir) {
+                tracing::debug!(
+                    session_id = %resolved.session_id,
+                    completion_status = %completion.status,
+                    completion_exit_code = completion.exit_code,
+                    "Daemon completion packet exists but no authoritative result is available yet; continuing wait"
+                );
+            } else {
+                eprintln!(
+                    "Session {} has a daemon completion packet but no terminal result.toml.",
+                    resolved.session_id,
+                );
+                eprintln!(
+                    "Run `csa session result --session {}` for diagnostics.",
+                    resolved.session_id
+                );
+                return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
+            }
         }
 
         if let Some(result) = load_completed_daemon_result_with_fallback(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_result.rs
@@ -26,9 +26,6 @@ fn load_completed_daemon_result(
             Err(err) => return Err(err),
         };
 
-    if session_has_terminal_process(session_dir) {
-        return Ok(None);
-    }
     Ok(Some(result))
 }
 
@@ -69,9 +66,6 @@ fn load_completed_daemon_result_adaptive(
             }
             Err(err) => return Err(err),
         };
-        if session_has_terminal_process(session_dir) {
-            return Ok(None);
-        }
         Ok(Some(result))
     } else {
         load_completed_daemon_result(project_root, session_id, session_dir)

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -859,3 +859,5 @@ mod tail_tests_wait;
 mod tail_tests_wait_liveness;
 #[path = "session_cmds_tests_tail_wait_lock.rs"]
 mod tail_tests_wait_lock;
+#[path = "session_cmds_tests_tail_wait_regression.rs"]
+mod tail_tests_wait_regression;

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
@@ -449,10 +449,9 @@ fn ensure_terminal_result_for_dead_active_session_preserves_session_with_recent_
 
 #[cfg(unix)]
 #[test]
-fn handle_session_wait_waits_for_daemon_exit_before_returning_success() {
+fn handle_session_wait_returns_on_terminal_result_before_daemon_exit() {
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
-    use std::time::{Duration, Instant};
 
     let td = tempdir().unwrap();
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
@@ -471,7 +470,7 @@ fn handle_session_wait_waits_for_daemon_exit_before_returning_success() {
     let result_toml = toml::to_string_pretty(&make_result("success", 0)).unwrap();
     let directive = "<!-- CSA:NEXT_STEP cmd=\"echo done\" required=true -->";
     let script = format!(
-        "#!/bin/sh\nset -eu\nsession_id=\"$1\"\nresult_path=\"$2\"\nstdout_path=\"$3\"\ncat > \"$result_path\" <<'EOF'\n{result_toml}\nEOF\nsleep 2\nprintf '%s\\n' '{directive}' > \"$stdout_path\"\n# Keep the session id in the argv/cmdline for liveness context matching.\nprintf '%s' \"$session_id\" >/dev/null\n"
+        "#!/bin/sh\nset -eu\nsession_id=\"$1\"\nresult_path=\"$2\"\nstdout_path=\"$3\"\ncat > \"$result_path\" <<'EOF'\n{result_toml}\nEOF\nsleep 5\nprintf '%s\\n' '{directive}' > \"$stdout_path\"\n# Keep the session id in the argv/cmdline for liveness context matching.\nprintf '%s' \"$session_id\" >/dev/null\n"
     );
     std::fs::write(&script_path, script).unwrap();
     let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
@@ -487,25 +486,23 @@ fn handle_session_wait_waits_for_daemon_exit_before_returning_success() {
     std::fs::write(session_dir.join("daemon.pid"), child.id().to_string()).unwrap();
     wait_for_spawned_daemon_visibility(&session_dir, &mut child);
 
-    let started = Instant::now();
     let exit_code = handle_session_wait(
         session_id.clone(),
         Some(project.to_string_lossy().into_owned()),
         10,
     )
     .unwrap();
-    let elapsed = started.elapsed();
 
     assert_eq!(exit_code, 0);
     assert!(
-        elapsed >= Duration::from_secs(1),
-        "wait should not return immediately after result.toml appears while daemon is still alive; elapsed={elapsed:?}"
+        child.try_wait().unwrap().is_none(),
+        "terminal result.toml should complete wait before delayed daemon stdout is written"
     );
     assert!(
-        std::fs::read_to_string(&stdout_path)
+        !std::fs::read_to_string(&stdout_path)
             .unwrap_or_default()
             .contains("CSA:NEXT_STEP"),
-        "wait should return only after delayed stdout payload is present"
+        "wait should not wait for post-result stdout once terminal result.toml exists"
     );
 
     let status = child.wait().unwrap();

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_liveness.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_liveness.rs
@@ -31,6 +31,31 @@ impl Drop for EnvVarGuard {
     }
 }
 
+#[cfg(target_os = "linux")]
+fn read_process_start_time_ticks(pid: u32) -> u64 {
+    let stat_path = format!("/proc/{pid}/stat");
+    let content = std::fs::read_to_string(stat_path).expect("read /proc stat");
+    let close_paren = content.rfind(')').expect("stat comm terminator");
+    let after_comm = &content[close_paren + 1..];
+    let mut parts = after_comm.split_whitespace();
+    parts.next().expect("state");
+    parts.next().expect("ppid");
+    parts.next().expect("pgrp");
+    for _ in 0..16 {
+        parts.next().expect("intermediate stat field");
+    }
+    parts
+        .next()
+        .expect("starttime")
+        .parse::<u64>()
+        .expect("starttime parse")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_pid_record(pid: u32) -> String {
+    format!("{pid} {}\n", read_process_start_time_ticks(pid))
+}
+
 /// When PID-level detection misses (session_has_terminal_process=false) but broader
 /// filesystem liveness signals remain (is_alive=true due to recent session writes),
 /// the wait must continue polling and eventually return the KV-warm exit (0) — not
@@ -97,5 +122,78 @@ fn handle_session_wait_continues_polling_when_pid_missing_but_liveness_signals_p
     assert_eq!(
         exit_code, 0,
         "wait must emit the KV-warm exit (0), not report failure (1), when liveness signals exist"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn handle_session_wait_exits_on_terminal_result_even_when_daemon_pid_still_alive() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-terminal-result-live-daemon-pid"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+
+    let terminal_result = SessionResult {
+        summary: "already completed successfully".to_string(),
+        ..make_result("success", 0)
+    };
+    save_result(project, &session_id, &terminal_result).expect("save terminal result");
+
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .expect("spawn live daemon stand-in");
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id()),
+    )
+    .expect("write live daemon pid");
+    assert!(
+        csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir),
+        "test setup requires a live daemon pid signal"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let wait_result = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    );
+
+    child.kill().ok();
+    child.wait().ok();
+
+    let exit_code = wait_result.expect("wait should succeed");
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id, "success".to_string(), 0, false)),
+        "terminal result.toml should complete wait despite stale/live daemon liveness signals"
     );
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
@@ -1,0 +1,172 @@
+use super::*;
+use crate::session_cmds_daemon::{
+    WaitBehavior, WaitLoopTiming, WaitReconciliationOutcome, handle_session_wait_with_hooks,
+};
+use crate::test_env_lock::TEST_ENV_LOCK;
+use tempfile::tempdir;
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn handle_session_wait_completes_terminal_result_with_stale_daemon_pid() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-terminal-result-stale-daemon-pid"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    let terminal_result = SessionResult {
+        summary: "already completed successfully".to_string(),
+        ..make_result("success", 0)
+    };
+    save_result(project, &session_id, &terminal_result).unwrap();
+
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .unwrap();
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        format!("{} 0\n", child.id()),
+    )
+    .unwrap();
+    assert!(
+        !csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir),
+        "start-time mismatch must make daemon.pid stale"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let wait_result = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("terminal result should short-circuit stale liveness reconciliation");
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    );
+
+    child.kill().ok();
+    child.wait().ok();
+
+    let exit_code = wait_result.unwrap();
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id, "success".to_string(), 0, false))
+    );
+}
+
+#[test]
+fn handle_session_wait_does_not_complete_daemon_packet_without_terminal_result() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-completion-packet-no-result"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 1\nstatus = \"failure\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        session_dir.join("stderr.log"),
+        "session still writing diagnostics\n",
+    )
+    .unwrap();
+    assert!(
+        csa_process::ToolLiveness::is_alive(&session_dir),
+        "recent diagnostics should keep this Active session nonterminal"
+    );
+
+    let mut emitted_completion = false;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |_sid: &str, _status: &str, _exit_code, _synthetic, _mirror_to_stdout| {
+            emitted_completion = true;
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        exit_code, 0,
+        "Active no-result sessions should use the nonterminal KV-warm path"
+    );
+    assert!(
+        !emitted_completion,
+        "daemon completion packet alone must not emit SESSION_WAIT_COMPLETED"
+    );
+    assert!(
+        load_result(project, &session_id).unwrap().is_none(),
+        "test setup must remain without a terminal result"
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.940"
-weave = "0.1.940"
+csa = "0.1.941"
+weave = "0.1.941"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- make `result.toml` the authoritative signal for `csa session wait` completion
- release wait locks when a terminal success result already exists even if stale daemon liveness remains
- avoid emitting completed markers for active/no-result sessions with stale daemon state
- add focused regression coverage for terminal result, stale PID, and packet-without-result cases

## Verification

- CSA writer session: `01KTJF79NK6XBBRF2T2HSV67ZD` committed `2120196a`
- CSA follow-up session: `01KTJGA4BJD6K0RE98PCHTMV2E` fixed gate failure and committed `b3d0bc43`
- CSA regression follow-up: `01KTJHX9EYA09PM7BNTTEEJF1E` committed `cbd2c6fb`
- CSA full-diff review: `01KTJKBFYGCH6GQMSF1N0Y4776` PASS/CLEAN for `range:main...HEAD` at `cbd2c6fb`

Closes #1945
