### PR TITLE
fix(csa-run): fail required commit when HEAD stalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.941"
+version = "0.1.942"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.941"
+version = "0.1.942"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -186,3 +186,142 @@ pub(super) async fn complete_session_execution(
         changed_paths: snapshots_available.then_some(changed_paths),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use csa_core::transport_events::StreamingMetadata;
+    use csa_core::types::OutputFormat;
+    use csa_executor::{CodexRuntimeMetadata, TransportResult};
+    use csa_session::{create_session, get_session_dir, load_result};
+
+    use super::*;
+    use crate::test_session_sandbox::ScopedSessionSandbox;
+
+    fn run_git(project_root: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_git_repo(project_root: &std::path::Path) {
+        run_git(project_root, &["init", "-q"]);
+        run_git(
+            project_root,
+            &["config", "user.email", "csa-test@example.com"],
+        );
+        run_git(project_root, &["config", "user.name", "CSA Test"]);
+        run_git(project_root, &["config", "commit.gpgsign", "false"]);
+        std::fs::write(project_root.join("tracked.txt"), "initial\n").expect("write tracked");
+        run_git(project_root, &["add", "tracked.txt"]);
+        run_git(project_root, &["commit", "-q", "-m", "initial"]);
+    }
+
+    #[tokio::test]
+    async fn completion_fails_when_git_commit_attempt_leaves_head_unchanged_and_staged() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+        let project_root = tmp.path();
+        init_git_repo(project_root);
+        let before =
+            crate::run_cmd::capture_git_workspace_snapshot(project_root, false).expect("snapshot");
+
+        std::fs::write(project_root.join("tracked.txt"), "changed\n").expect("write change");
+        run_git(project_root, &["add", "tracked.txt"]);
+
+        let mut session =
+            create_session(project_root, Some("commit ref update"), None, Some("codex"))
+                .expect("create session");
+        let session_dir =
+            get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+        let executor = Executor::Codex {
+            model_override: None,
+            thinking_budget: None,
+            runtime_metadata: CodexRuntimeMetadata::current(),
+        };
+        let transport_result = TransportResult {
+            execution: csa_process::ExecutionResult {
+                output: "git commit reported an object id before ref update failed".to_string(),
+                stderr_output: String::new(),
+                summary: "created commit object 49a0bad".to_string(),
+                exit_code: 0,
+                model_completed: Some(true),
+                ..Default::default()
+            },
+            provider_session_id: None,
+            events: Vec::new(),
+            metadata: StreamingMetadata {
+                extracted_commands: vec!["git commit -m fix".to_string()],
+                has_tool_calls: true,
+                has_execute_tool_calls: true,
+                turn_count: 1,
+                ..Default::default()
+            },
+        };
+        let plan = SessionCompletionPlan {
+            merged_env: Default::default(),
+            hooks_config: Default::default(),
+            sessions_root: session_dir
+                .parent()
+                .expect("sessions root")
+                .display()
+                .to_string(),
+            edit_guard: None,
+            new_file_guard: None,
+            result_file_cleared: false,
+            execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
+            commit_guard_enabled: true,
+            require_commit_on_mutation: false,
+            hook_bypass_scan_enabled: true,
+            is_git: true,
+            inside_git_worktree: true,
+            pre_run_workspace: Some(before),
+            pre_exec_snapshot: None,
+            sa_mode: false,
+        };
+
+        let completed = complete_session_execution(
+            CompletionInput {
+                executor: &executor,
+                tool: &csa_core::types::ToolName::Codex,
+                prompt: "Fix, verify, and commit the work",
+                output_format: &OutputFormat::Json,
+                task_type: Some("run"),
+                readonly_project_root: false,
+                project_root,
+                config: None,
+                global_config: None,
+                session_dir: &session_dir,
+                memory_project_key: None,
+                effective_prompt: "Fix, verify, and commit the work".to_string(),
+                plan,
+                transport_result,
+            },
+            &mut session,
+        )
+        .await
+        .expect("complete session");
+
+        assert_eq!(completed.execution.exit_code, 1);
+        assert_eq!(
+            completed.execution.csa_gate_failure.as_deref(),
+            Some("commit-policy-ref-update")
+        );
+        let persisted = load_result(project_root, &session.meta_session_id)
+            .expect("load result")
+            .expect("result should be saved");
+        assert_eq!(persisted.status, "failure");
+        assert_eq!(persisted.exit_code, 1);
+    }
+}

--- a/crates/cli-sub-agent/src/run_cmd_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_policy.rs
@@ -8,11 +8,14 @@ use std::collections::HashMap;
 
 use super::git::PostRunCommitGuard;
 use super::shell::{
-    detect_hook_bypass_env_usage, detect_lefthook_bypass_commands, detect_no_verify_commit_commands,
+    detect_git_commit_commands, detect_hook_bypass_env_usage, detect_lefthook_bypass_commands,
+    detect_no_verify_commit_commands,
 };
 
 const POST_RUN_POLICY_BLOCKED_SUMMARY: &str =
     "post-run policy blocked: workspace mutated without commit";
+const POST_RUN_POLICY_REF_UPDATE_FAILED_SUMMARY: &str =
+    "post-run policy blocked: git commit was attempted but HEAD did not advance";
 const POST_RUN_POLICY_UNVERIFIABLE_SUMMARY: &str =
     "post-run policy blocked: unable to verify workspace mutation state";
 const POST_RUN_POLICY_FORBIDDEN_NO_VERIFY_SUMMARY: &str =
@@ -31,6 +34,7 @@ pub(crate) fn resolve_hook_bypass_scan_enabled(
 #[cfg(test)]
 pub(crate) fn is_post_run_commit_policy_block(summary: &str) -> bool {
     summary == POST_RUN_POLICY_BLOCKED_SUMMARY
+        || summary == POST_RUN_POLICY_REF_UPDATE_FAILED_SUMMARY
         || summary == POST_RUN_POLICY_UNVERIFIABLE_SUMMARY
         || summary == POST_RUN_POLICY_FORBIDDEN_NO_VERIFY_SUMMARY
         || summary == POST_RUN_POLICY_FORBIDDEN_LEFTHOOK_BYPASS_SUMMARY
@@ -49,6 +53,7 @@ fn is_post_run_commit_policy_gate_failure_reason(reason: &str) -> bool {
     matches!(
         reason,
         "commit-policy-uncommitted"
+            | "commit-policy-ref-update"
             | "commit-policy-unverifiable"
             | "commit-policy-no-verify"
             | "commit-policy-lefthook-bypass"
@@ -59,31 +64,46 @@ pub(crate) fn apply_post_run_commit_policy(
     result: &mut csa_process::ExecutionResult,
     output_format: &OutputFormat,
     require_commit_on_mutation: bool,
+    git_commit_attempted: bool,
     commit_guard: Option<&PostRunCommitGuard>,
 ) {
     let Some(commit_guard) = commit_guard else {
         return;
     };
 
-    let enforce_closed_policy =
-        require_commit_on_mutation && commit_guard.workspace_mutated && !commit_guard.head_changed;
-    let guard_message = format_post_run_commit_guard_message(commit_guard, enforce_closed_policy);
+    let commit_ref_update_failed =
+        git_commit_attempted && commit_guard.workspace_mutated && !commit_guard.head_changed;
+    let enforce_closed_policy = commit_guard.workspace_mutated
+        && !commit_guard.head_changed
+        && (require_commit_on_mutation || commit_ref_update_failed);
+    let guard_message = format_post_run_commit_guard_message(
+        commit_guard,
+        enforce_closed_policy,
+        commit_ref_update_failed,
+    );
 
     if enforce_closed_policy {
         let previous_summary = result.summary.clone();
-        // CSA-own gate: workspace mutated without commit. Mark it so the #161
-        // classifier treats the exit as authoritative-fatal, preserving a more
-        // specific pre-existing failure exit code if the run already failed.
-        result.note_gate_failure("commit-policy-uncommitted");
-        if !previous_summary.trim().is_empty()
-            && previous_summary != POST_RUN_POLICY_BLOCKED_SUMMARY
-        {
+        let (gate_reason, blocked_summary) = if commit_ref_update_failed {
+            (
+                "commit-policy-ref-update",
+                POST_RUN_POLICY_REF_UPDATE_FAILED_SUMMARY,
+            )
+        } else {
+            ("commit-policy-uncommitted", POST_RUN_POLICY_BLOCKED_SUMMARY)
+        };
+        // CSA-own gate: the run left required/attempted commit work uncommitted.
+        // Mark it so the #161 classifier treats the exit as authoritative-fatal,
+        // preserving a more specific pre-existing failure exit code if the run
+        // already failed.
+        result.note_gate_failure(gate_reason);
+        if !previous_summary.trim().is_empty() && previous_summary != blocked_summary {
             append_stderr_block(
                 &mut result.stderr_output,
                 &format!("Original summary before commit policy: {previous_summary}"),
             );
         }
-        append_stderr_block(&mut result.stderr_output, POST_RUN_POLICY_BLOCKED_SUMMARY);
+        append_stderr_block(&mut result.stderr_output, blocked_summary);
     }
 
     match output_format {
@@ -108,10 +128,12 @@ pub(crate) fn apply_post_session_commit_policies(
     result: &mut csa_process::ExecutionResult,
     args: PostSessionCommitPolicyArgs<'_>,
 ) {
+    let git_commit_attempted = !detect_git_commit_commands(args.executed_shell_commands).is_empty();
     apply_post_run_commit_policy(
         result,
         args.output_format,
         args.require_commit_on_mutation,
+        git_commit_attempted,
         args.commit_guard,
     );
     apply_unverifiable_commit_policy(result, args.output_format, args.policy_evaluation_failed);
@@ -273,13 +295,16 @@ Matched commands:",
 pub(crate) fn format_post_run_commit_guard_message(
     guard: &PostRunCommitGuard,
     enforce_closed_policy: bool,
+    commit_ref_update_failed: bool,
 ) -> String {
     let severity = if enforce_closed_policy {
         "ERROR"
     } else {
         "WARNING"
     };
-    let reason = if guard.head_changed {
+    let reason = if commit_ref_update_failed {
+        "git commit was attempted but HEAD did not advance; work remains uncommitted"
+    } else if guard.head_changed {
         "run created commit(s) but still left uncommitted workspace mutations"
     } else {
         "run left uncommitted workspace mutations compared to start"

--- a/crates/cli-sub-agent/src/run_cmd_shell.rs
+++ b/crates/cli-sub-agent/src/run_cmd_shell.rs
@@ -268,7 +268,7 @@ fn extract_shell_c_payload_tokens(tokens: &[String]) -> Option<&[String]> {
             return None;
         }
         if shell_option_enables_c_payload(shell_flag) {
-            return (idx + 1 < tokens.len()).then_some(&tokens[idx + 1..]);
+            return (idx + 1 < tokens.len()).then_some(&tokens[idx + 1..idx + 2]);
         }
 
         idx += 1;

--- a/crates/cli-sub-agent/src/run_cmd_shell.rs
+++ b/crates/cli-sub-agent/src/run_cmd_shell.rs
@@ -26,10 +26,33 @@ pub(crate) fn detect_no_verify_commit_commands(executed_shell_commands: &[String
     matches
 }
 
+pub(crate) fn detect_git_commit_commands(executed_shell_commands: &[String]) -> Vec<String> {
+    let mut matches = Vec::new();
+    for command in executed_shell_commands {
+        let trimmed = command.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !command_contains_git_commit(trimmed) {
+            continue;
+        }
+        if !matches.iter().any(|existing| existing == trimmed) {
+            matches.push(trimmed.to_string());
+        }
+    }
+    matches
+}
+
 pub(crate) fn command_contains_forbidden_no_verify_commit(command: &str) -> bool {
     split_shell_segments_preserving_quotes(command)
         .into_iter()
         .any(|segment| segment_contains_forbidden_git_bypass(&segment))
+}
+
+pub(crate) fn command_contains_git_commit(command: &str) -> bool {
+    split_shell_segments_preserving_quotes(command)
+        .into_iter()
+        .any(|segment| segment_contains_git_commit(&segment))
 }
 
 fn split_shell_segments_preserving_quotes(command: &str) -> Vec<String> {
@@ -123,6 +146,21 @@ fn segment_contains_forbidden_git_bypass(segment: &str) -> bool {
         tokens[git_subcommand_idx].as_str(),
         &tokens[git_subcommand_idx + 1..],
     )
+}
+
+fn segment_contains_git_commit(segment: &str) -> bool {
+    let tokens = tokenize_shell_tokens(segment);
+    if tokens.is_empty() {
+        return false;
+    }
+
+    if let Some(shell_script_tokens) = extract_shell_c_payload_tokens(&tokens)
+        && shell_script_contains_git_commit(shell_script_tokens)
+    {
+        return true;
+    }
+
+    locate_git_commit_command(&tokens).is_some()
 }
 
 pub(crate) fn tokenize_shell_tokens(segment: &str) -> Vec<String> {
@@ -241,6 +279,18 @@ fn locate_git_hook_relevant_command(tokens: &[String]) -> Option<(usize, usize)>
     Some((idx, subcommand_idx))
 }
 
+fn locate_git_commit_command(tokens: &[String]) -> Option<(usize, usize)> {
+    let idx = skip_command_prefix_tokens(tokens, 0);
+    if idx >= tokens.len() {
+        return None;
+    }
+    if !is_git_token(tokens[idx].as_str()) {
+        return None;
+    }
+    let subcommand_idx = find_git_commit_subcommand(tokens, idx + 1)?;
+    Some((idx, subcommand_idx))
+}
+
 fn shell_script_contains_forbidden_git_bypass(tokens: &[String]) -> bool {
     let script_tokens = expand_shell_script_tokens(tokens);
     let mut command_start = 0usize;
@@ -271,6 +321,36 @@ fn shell_script_contains_forbidden_git_bypass(tokens: &[String]) -> bool {
                 &command_tokens[subcommand_idx + 1..],
             )
         {
+            return true;
+        }
+
+        command_start = command_end.saturating_add(1);
+    }
+
+    false
+}
+
+fn shell_script_contains_git_commit(tokens: &[String]) -> bool {
+    let script_tokens = expand_shell_script_tokens(tokens);
+    let mut command_start = 0usize;
+
+    while command_start < script_tokens.len() {
+        while command_start < script_tokens.len()
+            && is_command_separator_token(script_tokens[command_start].as_str())
+        {
+            command_start += 1;
+        }
+        if command_start >= script_tokens.len() {
+            break;
+        }
+
+        let command_end = script_tokens[command_start..]
+            .iter()
+            .position(|token| is_command_separator_token(token.as_str()))
+            .map_or(script_tokens.len(), |idx| command_start + idx);
+        let command_tokens = &script_tokens[command_start..command_end];
+
+        if locate_git_commit_command(command_tokens).is_some() {
             return true;
         }
 
@@ -381,6 +461,30 @@ fn find_git_hook_relevant_subcommand(tokens: &[String], mut idx: usize) -> Optio
         }
         if token == "--" {
             if idx + 1 < tokens.len() && is_hook_relevant_git_subcommand(tokens[idx + 1].as_str()) {
+                return Some(idx + 1);
+            }
+            return None;
+        }
+        if !token.starts_with('-') {
+            return None;
+        }
+        if git_global_option_consumes_value(token) && idx + 1 < tokens.len() {
+            idx += 2;
+            continue;
+        }
+        idx += 1;
+    }
+    None
+}
+
+fn find_git_commit_subcommand(tokens: &[String], mut idx: usize) -> Option<usize> {
+    while idx < tokens.len() {
+        let token = tokens[idx].as_str();
+        if token.eq_ignore_ascii_case("commit") {
+            return Some(idx);
+        }
+        if token == "--" {
+            if idx + 1 < tokens.len() && tokens[idx + 1].eq_ignore_ascii_case("commit") {
                 return Some(idx + 1);
             }
             return None;

--- a/crates/cli-sub-agent/src/run_cmd_shell.rs
+++ b/crates/cli-sub-agent/src/run_cmd_shell.rs
@@ -253,18 +253,78 @@ fn push_shell_token(tokens: &mut Vec<String>, current: &mut String) {
 }
 
 fn extract_shell_c_payload_tokens(tokens: &[String]) -> Option<&[String]> {
-    let idx = skip_command_prefix_tokens(tokens, 0);
-    if idx + 2 >= tokens.len() {
+    let mut idx = skip_command_prefix_tokens(tokens, 0);
+    if idx >= tokens.len() {
         return None;
     }
     if !is_shell_token(tokens[idx].as_str()) {
         return None;
     }
-    let shell_flag = tokens[idx + 1].as_str();
-    if !shell_flag.starts_with('-') || !shell_flag.contains('c') {
-        return None;
+    idx += 1;
+
+    while idx < tokens.len() {
+        let shell_flag = tokens[idx].as_str();
+        if shell_flag == "--" || !is_shell_option_token(shell_flag) {
+            return None;
+        }
+        if shell_option_enables_c_payload(shell_flag) {
+            return (idx + 1 < tokens.len()).then_some(&tokens[idx + 1..]);
+        }
+
+        idx += 1;
+        if shell_option_consumes_value(shell_flag) && idx < tokens.len() {
+            idx += 1;
+        }
     }
-    Some(&tokens[idx + 2..])
+
+    None
+}
+
+fn is_shell_option_token(token: &str) -> bool {
+    token.len() > 1 && (token.starts_with('-') || token.starts_with('+'))
+}
+
+fn shell_option_enables_c_payload(token: &str) -> bool {
+    if token == "-c" || token == "--command" {
+        return true;
+    }
+    if !token.starts_with('-') || token.starts_with("--") {
+        return false;
+    }
+
+    for flag in token[1..].chars() {
+        if flag == 'c' {
+            return true;
+        }
+        if shell_short_option_consumes_value(flag) {
+            return false;
+        }
+    }
+
+    false
+}
+
+fn shell_option_consumes_value(token: &str) -> bool {
+    if token.starts_with("--") {
+        return shell_long_option_consumes_value(token) && !token.contains('=');
+    }
+
+    let mut chars = token[1..].chars().peekable();
+    while let Some(flag) = chars.next() {
+        if shell_short_option_consumes_value(flag) {
+            return chars.peek().is_none();
+        }
+    }
+
+    false
+}
+
+fn shell_short_option_consumes_value(flag: char) -> bool {
+    matches!(flag, 'o' | 'O')
+}
+
+fn shell_long_option_consumes_value(token: &str) -> bool {
+    matches!(token, "--init-file" | "--rcfile" | "--emulate")
 }
 
 fn locate_git_hook_relevant_command(tokens: &[String]) -> Option<(usize, usize)> {

--- a/crates/cli-sub-agent/src/run_cmd_shell_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_shell_tests.rs
@@ -48,6 +48,13 @@ fn command_contains_forbidden_no_verify_commit_detects_prefixed_commit_in_shell_
 }
 
 #[test]
+fn command_contains_forbidden_no_verify_commit_ignores_shell_c_positionals() {
+    assert!(!command_contains_forbidden_no_verify_commit(
+        "bash -lc 'true;' git commit --no-verify -m fake"
+    ));
+}
+
+#[test]
 fn command_contains_git_commit_detects_plain_and_global_option_forms() {
     assert!(command_contains_git_commit("git commit -m fix"));
     assert!(command_contains_git_commit(
@@ -82,6 +89,13 @@ fn command_contains_git_commit_detects_shell_payload_after_shell_options() {
 }
 
 #[test]
+fn command_contains_git_commit_ignores_shell_c_positionals() {
+    assert!(!command_contains_git_commit(
+        "bash -lc 'true;' git commit -m fake"
+    ));
+}
+
+#[test]
 fn command_contains_git_commit_rejects_non_commit_git_commands() {
     assert!(!command_contains_git_commit("git push origin HEAD"));
     assert!(!command_contains_git_commit("git commit-tree HEAD^{tree}"));
@@ -109,6 +123,13 @@ fn detect_git_commit_commands_detects_direct_and_shell_wrapped_commits() {
             "sh -u -c \"git commit -m sh_u\"".to_string(),
         ]
     );
+}
+
+#[test]
+fn detect_git_commit_commands_ignores_shell_c_positionals() {
+    let commands = vec!["bash -lc 'true;' git commit -m fake".to_string()];
+
+    assert!(detect_git_commit_commands(&commands).is_empty());
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/run_cmd_shell_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_shell_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    command_contains_forbidden_no_verify_commit, detect_no_verify_commit_commands,
-    tokenize_shell_tokens,
+    command_contains_forbidden_no_verify_commit, command_contains_git_commit,
+    detect_git_commit_commands, detect_no_verify_commit_commands, tokenize_shell_tokens,
 };
 
 #[test]
@@ -39,4 +39,49 @@ fn command_contains_forbidden_no_verify_commit_detects_prefixed_commit_in_shell_
     assert!(command_contains_forbidden_no_verify_commit(
         "bash -lc \"env -i git commit --no-verify -m unsafe\""
     ));
+}
+
+#[test]
+fn command_contains_git_commit_detects_plain_and_global_option_forms() {
+    assert!(command_contains_git_commit("git commit -m fix"));
+    assert!(command_contains_git_commit(
+        "git -C /tmp/repo commit --message fix"
+    ));
+    assert!(command_contains_git_commit(
+        "env FOO=1 sudo nice git commit -m fix"
+    ));
+}
+
+#[test]
+fn command_contains_git_commit_detects_shell_payload() {
+    assert!(command_contains_git_commit(
+        "bash -lc \"git add src/lib.rs && git commit -m fix\""
+    ));
+}
+
+#[test]
+fn command_contains_git_commit_rejects_non_commit_git_commands() {
+    assert!(!command_contains_git_commit("git push origin HEAD"));
+    assert!(!command_contains_git_commit("git commit-tree HEAD^{tree}"));
+    assert!(!command_contains_git_commit("echo git commit -m fix"));
+}
+
+#[test]
+fn detect_git_commit_commands_dedupes_matches() {
+    let commands = vec![
+        "git status".to_string(),
+        "git commit -m fix".to_string(),
+        "git commit -m fix".to_string(),
+        "bash -lc \"git commit -m nested\"".to_string(),
+    ];
+
+    let matches = detect_git_commit_commands(&commands);
+
+    assert_eq!(
+        matches,
+        vec![
+            "git commit -m fix".to_string(),
+            "bash -lc \"git commit -m nested\"".to_string()
+        ]
+    );
 }

--- a/crates/cli-sub-agent/src/run_cmd_shell_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_shell_tests.rs
@@ -39,6 +39,12 @@ fn command_contains_forbidden_no_verify_commit_detects_prefixed_commit_in_shell_
     assert!(command_contains_forbidden_no_verify_commit(
         "bash -lc \"env -i git commit --no-verify -m unsafe\""
     ));
+    assert!(command_contains_forbidden_no_verify_commit(
+        "bash -e -c \"git commit -n -m unsafe\""
+    ));
+    assert!(command_contains_forbidden_no_verify_commit(
+        "bash -eo pipefail -c \"git commit --no-verify -m unsafe\""
+    ));
 }
 
 #[test]
@@ -60,10 +66,49 @@ fn command_contains_git_commit_detects_shell_payload() {
 }
 
 #[test]
+fn command_contains_git_commit_detects_shell_payload_after_shell_options() {
+    assert!(command_contains_git_commit(
+        "bash -e -c \"git commit -m fix\""
+    ));
+    assert!(command_contains_git_commit(
+        "bash -eo pipefail -c \"git commit -m fix\""
+    ));
+    assert!(command_contains_git_commit(
+        "sh -u -c \"git commit -m fix\""
+    ));
+    assert!(command_contains_git_commit(
+        "zsh -f -c \"git commit -m fix\""
+    ));
+}
+
+#[test]
 fn command_contains_git_commit_rejects_non_commit_git_commands() {
     assert!(!command_contains_git_commit("git push origin HEAD"));
     assert!(!command_contains_git_commit("git commit-tree HEAD^{tree}"));
     assert!(!command_contains_git_commit("echo git commit -m fix"));
+}
+
+#[test]
+fn detect_git_commit_commands_detects_direct_and_shell_wrapped_commits() {
+    let commands = vec![
+        "git status".to_string(),
+        "git commit -m direct".to_string(),
+        "bash -e -c \"git commit -m bash_e\"".to_string(),
+        "bash -eo pipefail -c \"git commit -m bash_eo\"".to_string(),
+        "sh -u -c \"git commit -m sh_u\"".to_string(),
+    ];
+
+    let matches = detect_git_commit_commands(&commands);
+
+    assert_eq!(
+        matches,
+        vec![
+            "git commit -m direct".to_string(),
+            "bash -e -c \"git commit -m bash_e\"".to_string(),
+            "bash -eo pipefail -c \"git commit -m bash_eo\"".to_string(),
+            "sh -u -c \"git commit -m sh_u\"".to_string(),
+        ]
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/run_cmd_tests_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_policy.rs
@@ -168,7 +168,7 @@ fn format_post_run_commit_guard_message_includes_next_step_and_paths() {
         ],
     };
 
-    let message = format_post_run_commit_guard_message(&guard, false);
+    let message = format_post_run_commit_guard_message(&guard, false, false);
     assert!(message.contains("WARNING"));
     assert!(message.contains("csa run --skill commit"));
     assert!(message.contains("Cargo.lock"));
@@ -211,7 +211,7 @@ fn apply_post_run_commit_policy_sets_failure_when_policy_requires_commit() {
         changed_paths: vec!["src/lib.rs".to_string()],
     };
 
-    apply_post_run_commit_policy(&mut result, &OutputFormat::Json, true, Some(&guard));
+    apply_post_run_commit_policy(&mut result, &OutputFormat::Json, true, false, Some(&guard));
 
     assert_eq!(result.exit_code, 1);
     assert_eq!(result.summary, "ok");
@@ -243,11 +243,50 @@ fn apply_post_run_commit_policy_keeps_success_when_policy_disabled() {
         changed_paths: vec!["src/lib.rs".to_string()],
     };
 
-    apply_post_run_commit_policy(&mut result, &OutputFormat::Json, false, Some(&guard));
+    apply_post_run_commit_policy(&mut result, &OutputFormat::Json, false, false, Some(&guard));
 
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.summary, "ok");
     assert!(result.stderr_output.contains("WARNING"));
+}
+
+#[test]
+fn apply_post_run_commit_policy_fails_when_commit_attempt_left_head_unchanged() {
+    let mut result = ExecutionResult {
+        output: String::new(),
+        stderr_output: String::new(),
+        summary: "created commit object 49a0bad".to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+        ..Default::default()
+    };
+    let guard = PostRunCommitGuard {
+        workspace_mutated: true,
+        head_changed: false,
+        changed_paths: vec!["src/lib.rs".to_string()],
+    };
+
+    apply_post_run_commit_policy(&mut result, &OutputFormat::Json, false, true, Some(&guard));
+
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(
+        result.csa_gate_failure.as_deref(),
+        Some("commit-policy-ref-update")
+    );
+    assert!(
+        result.stderr_output.contains(
+            "post-run policy blocked: git commit was attempted but HEAD did not advance"
+        ),
+        "{}",
+        result.stderr_output
+    );
+    assert!(
+        result
+            .stderr_output
+            .contains("git commit was attempted but HEAD did not advance"),
+        "{}",
+        result.stderr_output
+    );
 }
 
 #[test]
@@ -317,6 +356,9 @@ fn apply_unverifiable_commit_policy_is_noop_when_verification_is_available() {
 fn is_post_run_commit_policy_block_detects_known_policy_summaries() {
     assert!(is_post_run_commit_policy_block(
         "post-run policy blocked: workspace mutated without commit"
+    ));
+    assert!(is_post_run_commit_policy_block(
+        "post-run policy blocked: git commit was attempted but HEAD did not advance"
     ));
     assert!(is_post_run_commit_policy_block(
         "post-run policy blocked: unable to verify workspace mutation state"

--- a/crates/cli-sub-agent/src/run_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_tail.rs
@@ -133,7 +133,7 @@ fn apply_post_run_commit_policy_overrides_summary_on_preexisting_failure() {
         changed_paths: vec!["src/lib.rs".to_string()],
     };
 
-    apply_post_run_commit_policy(&mut result, &OutputFormat::Json, true, Some(&guard));
+    apply_post_run_commit_policy(&mut result, &OutputFormat::Json, true, false, Some(&guard));
 
     assert_eq!(result.exit_code, 2);
     assert_eq!(result.summary, "tool failed");
@@ -225,7 +225,7 @@ fn apply_post_run_commit_policy_does_not_fail_closed_when_head_changed() {
         changed_paths: vec!["src/lib.rs".to_string()],
     };
 
-    apply_post_run_commit_policy(&mut result, &OutputFormat::Json, true, Some(&guard));
+    apply_post_run_commit_policy(&mut result, &OutputFormat::Json, true, false, Some(&guard));
 
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.summary, "ok");

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.941"
-weave = "0.1.941"
+csa = "0.1.942"
+weave = "0.1.942"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- treat required-commit runs as failed when a commit attempt leaves HEAD unchanged or the worktree dirty/staged
- detect direct and shell-wrapped `git commit` invocations, including common `bash -c` forms
- parse only shell command payloads so shell flags/positionals do not cause false positives
- add regression coverage for ref-stalled commit attempts and shell-wrapped commit detection

## Verification

- CSA writer session: `01KTJKZWVYBWVCYG0Y7HCVGX8J` committed `db99d1e8`
- CSA reviewer-fix session: `01KTJNCJK8QDQ3ENJTRJ5SVQ06` committed `5b8acbe8`
- CSA reviewer-fix session: `01KTJPF3FP495PR76ZHM742W1M` committed `0b169275`
- CSA full-diff review: `01KTJQ0ZWRCTV7TGV1HY1P3107` PASS/CLEAN for `range:main...HEAD` at `0b169275`

Closes #1948
