### PR TITLE
fix(csa-session): report wait result status consistently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.942"
+version = "0.1.943"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.942"
+version = "0.1.943"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -855,6 +855,8 @@ mod tail_tests;
 mod tail_tests_recovery;
 #[path = "session_cmds_tests_tail_wait.rs"]
 mod tail_tests_wait;
+#[path = "session_cmds_tests_tail_wait_1951.rs"]
+mod tail_tests_wait_1951;
 #[path = "session_cmds_tests_tail_wait_liveness.rs"]
 mod tail_tests_wait_liveness;
 #[path = "session_cmds_tests_tail_wait_lock.rs"]

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_1951.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_1951.rs
@@ -1,0 +1,73 @@
+use super::*;
+use crate::session_cmds_daemon::{WaitBehavior, WaitLoopTiming, handle_session_wait_with_hooks};
+use crate::test_env_lock::TEST_ENV_LOCK;
+use tempfile::tempdir;
+
+#[test]
+fn handle_session_wait_syncs_failed_review_verdict_before_printing_result() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-failed-review-verdict"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write stale success completion packet");
+    let stale_success = SessionResult {
+        summary: "review found blocking issues".to_string(),
+        ..make_result("success", 0)
+    };
+    save_result(project, &session_id, &stale_success).expect("save stale success result");
+    let failed_verdict = csa_session::ReviewVerdictArtifact::from_parts(
+        session_id.clone(),
+        csa_core::types::ReviewDecision::Fail,
+        "HAS_ISSUES",
+        &[],
+        Vec::new(),
+    );
+    csa_session::write_review_verdict(&session_dir, &failed_verdict)
+        .expect("write failed review verdict");
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("review verdict refresh should short-circuit before reconcile");
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should sync failed review verdict");
+
+    assert_eq!(exit_code, 1);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id.clone(), "failure".to_string(), 1, false))
+    );
+    let persisted = load_result(project, &session_id)
+        .expect("load result")
+        .expect("result should remain terminal");
+    assert_eq!(persisted.status, "failure");
+    assert_eq!(persisted.exit_code, 1);
+}

--- a/crates/cli-sub-agent/src/session_observability.rs
+++ b/crates/cli-sub-agent/src/session_observability.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::Result;
-use csa_session::{SessionArtifact, SessionResult};
+use csa_session::{ReviewVerdictArtifact, SessionArtifact, SessionResult};
 use tracing::debug;
 
 const SUMMARY_MAX_CHARS: usize = 200;
@@ -56,6 +56,9 @@ pub(crate) fn refresh_and_repair_result_from_dir(
         result.events_count = events_count;
         changed = true;
     }
+    if sync_review_verdict_exit_code(session_dir, &mut result)? {
+        changed = true;
+    }
 
     if changed {
         // Write repaired result back (best-effort for cross-project sessions).
@@ -87,12 +90,43 @@ pub(crate) fn enrich_result_from_session_dir(
         changed = true;
     }
 
+    if sync_review_verdict_exit_code(session_dir, result)? {
+        changed = true;
+    }
+
     let artifact_names = csa_session::list_artifacts(project_root, session_id)?;
     if merge_artifacts(&mut result.artifacts, artifact_names) {
         changed = true;
     }
 
     Ok(changed)
+}
+
+fn sync_review_verdict_exit_code(session_dir: &Path, result: &mut SessionResult) -> Result<bool> {
+    let Some(exit_code) = read_review_verdict_exit_code(session_dir)? else {
+        return Ok(false);
+    };
+    let status = SessionResult::status_from_exit_code(exit_code);
+    if result.exit_code == exit_code && result.status == status {
+        return Ok(false);
+    }
+
+    result.exit_code = exit_code;
+    result.status = status;
+    Ok(true)
+}
+
+fn read_review_verdict_exit_code(session_dir: &Path) -> Result<Option<i32>> {
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    if !verdict_path.is_file() {
+        return Ok(None);
+    }
+
+    let raw = fs::read_to_string(&verdict_path)?;
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(&raw)?;
+    Ok(Some(
+        crate::verdict_exit_code::exit_code_from_review_decision(artifact.decision),
+    ))
 }
 
 pub(crate) fn build_missing_result_diagnostic(

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.942"
-weave = "0.1.942"
+csa = "0.1.943"
+weave = "0.1.943"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- make `csa session wait` print the persisted terminal result status/exit instead of the wait-loop status
- prevent failed review results from being shown as `Status: success` / `Exit code: 0`
- add regression coverage for wait output consistency with failed review/session results

## Verification

- CSA writer session: `01KTJQKYXZN6M9XWA7HHQEMTYJ` committed `1bcaf3ed`
- CSA full-diff review: `01KTJRPSMXXM1H5PH7BB0MSNK1` PASS/CLEAN for `range:main...HEAD` at `1bcaf3ed`

Closes #1951
