### PR TITLE
fix(csa-review): trust explicit empty findings verdict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.943"
+version = "0.1.944"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.943"
+version = "0.1.944"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_exact_1953_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_1953_tests.rs
@@ -1,0 +1,93 @@
+#[test]
+fn issue_1953_structured_pass_empty_findings_updates_meta_wait_and_check_verdict() {
+    let _guard = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
+    let project_dir = exact_test_setup_git_repo();
+    let _state_home = crate::test_env_lock::ScopedEnvVarRestore::set(
+        "XDG_STATE_HOME",
+        project_dir.path().join("state"),
+    );
+    let branch = "fix-1953-pass";
+    let head_sha = csa_session::detect_git_head(project_dir.path()).expect("detect HEAD");
+    let (session_id, session_dir) = exact_test_create_review_session(
+        project_dir.path(),
+        branch,
+        &head_sha,
+        "review: issue-1953 final pass",
+    );
+
+    let final_pass = concat!(
+        "Reviewer progress: prior blocking defect is resolved.\n",
+        "<!-- CSA:SECTION:summary -->\n",
+        "PASS\n",
+        "<!-- CSA:SECTION:summary:END -->\n\n",
+        "<!-- CSA:SECTION:details -->\n",
+        "Scope reviewed: `range:main...HEAD`.\n\n",
+        "No blocking findings found.\n\n",
+        "Prior-round recheck:\n",
+        "- `src/mcp/server.rs:3952` novelty merge/audit ordering is resolved.\n\n",
+        "Open questions: none.\n",
+        "<!-- CSA:SECTION:details:END -->\n\n",
+        "```findings.toml\n",
+        "findings = []\n",
+        "```\n",
+    );
+    std::fs::write(
+        session_dir.join("output").join("full.md"),
+        exact_test_codex_agent_message(final_pass),
+    )
+    .expect("write transcript");
+    csa_session::persist_structured_output(&session_dir, final_pass)
+        .expect("persist final structured output");
+
+    let mut meta = exact_test_make_review_meta(&session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    meta.head_sha = head_sha.clone();
+    meta.scope = "range:main...HEAD".to_string();
+    meta.fix_attempted = false;
+    meta.fix_rounds = 0;
+    meta.exit_code = 1;
+
+    let persisted_exit_code =
+        review_cmd::persist_review_sidecars_if_session_exists(project_dir.path(), &meta, Some(&session_id));
+
+    assert_eq!(persisted_exit_code, Some(0));
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json")).unwrap(),
+    )
+    .unwrap();
+    let persisted_meta: ReviewSessionMeta =
+        serde_json::from_str(&std::fs::read_to_string(session_dir.join("review_meta.json")).unwrap())
+            .unwrap();
+    let findings: FindingsFile = toml::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("findings.toml")).unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(artifact.decision, ReviewDecision::Pass);
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+    assert!(artifact.severity_counts.values().all(|count| *count == 0));
+    assert_eq!(persisted_meta.decision, ReviewDecision::Pass.as_str());
+    assert_eq!(persisted_meta.verdict, "CLEAN");
+    assert_eq!(persisted_meta.exit_code, 0);
+    assert!(findings.findings.is_empty());
+
+    let wait_summary = crate::session_cmds_daemon::render_wait_result_summary(
+        &session_dir,
+        &session_id,
+        &exact_test_wait_result(0, "PASS"),
+    );
+    assert!(wait_summary.contains("Review verdict: PASS"));
+
+    let found = review_cmd::check_review_verdict_for_target(
+        project_dir.path(),
+        branch,
+        &head_sha,
+        "range:main...HEAD",
+        None,
+        None,
+    )
+    .unwrap()
+    .expect("check-verdict should accept structured PASS with empty findings");
+    assert_eq!(found.session_id, session_id);
+}

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -911,3 +911,5 @@ async fn execute_review_unavailable_does_not_persist_session_artifacts() {
         unknown_output.display()
     );
 }
+
+include!("review_cmd_exact_1953_tests.rs");

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
@@ -6,7 +6,9 @@ use csa_session::{FindingsFile, write_findings_toml};
 use tracing::{debug, warn};
 
 use crate::review_cmd::output::extract_review_text;
-use crate::review_cmd::prose_findings::findings_file_from_prose;
+use crate::review_cmd::prose_findings::{
+    findings_file_from_explicit_findings_sections, findings_file_from_prose,
+};
 
 const FINDINGS_TOML_FENCE_LABEL: &str = "findings.toml";
 
@@ -109,7 +111,9 @@ fn derive_findings_toml_artifact(
     let prose_artifact = findings_file_from_prose(&review_text);
     match extract_findings_toml_from_text(&review_text) {
         Some(artifact) if artifact.findings.is_empty() => {
-            if let Some(prose_artifact) = prose_artifact {
+            if let Some(prose_artifact) =
+                findings_file_from_explicit_findings_sections(&review_text)
+            {
                 Ok((prose_artifact, None))
             } else {
                 Ok((artifact, None))
@@ -265,6 +269,9 @@ fn is_findings_toml_fence_label(info: &str) -> bool {
         .any(|token| token.eq_ignore_ascii_case(FINDINGS_TOML_FENCE_LABEL))
 }
 
+#[cfg(test)]
+#[path = "review_cmd_findings_toml_1953_tests.rs"]
+mod issue_1953_tests;
 #[cfg(test)]
 #[path = "review_cmd_findings_toml_source_set_tests.rs"]
 mod source_set_tests;

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml_1953_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml_1953_tests.rs
@@ -1,0 +1,89 @@
+use std::fs;
+
+use csa_core::types::ReviewDecision;
+use csa_session::FindingsFile;
+use csa_session::state::ReviewSessionMeta;
+
+use super::{FINDINGS_TOML_SYNTHETIC_MARKER, persist_review_findings_toml};
+
+fn review_meta(session_id: &str) -> ReviewSessionMeta {
+    ReviewSessionMeta {
+        session_id: session_id.to_string(),
+        head_sha: String::new(),
+        decision: ReviewDecision::Fail.as_str().to_string(),
+        verdict: "HAS_ISSUES".to_string(),
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool: "codex".to_string(),
+        scope: "range:main...HEAD".to_string(),
+        exit_code: 1,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+        review_mode: None,
+        fix_convergence: None,
+    }
+}
+
+#[test]
+fn issue_1953_explicit_empty_findings_toml_beats_prior_round_recheck_prose() {
+    let project_root = tempfile::tempdir().expect("temp project root");
+    let _state_home = crate::test_env_lock::ScopedTestEnvVar::set(
+        "XDG_STATE_HOME",
+        project_root.path().join("state"),
+    );
+    let session_id = "01TEST1953PASSRECHECK000";
+    let session_dir =
+        csa_session::get_session_dir(project_root.path(), session_id).expect("session dir");
+    fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    let review_text = r#"Reviewer progress: prior blocking defect is resolved.
+
+<!-- CSA:SECTION:summary -->
+PASS
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+Scope reviewed: `range:main...HEAD`.
+
+No blocking findings found.
+
+Prior-round recheck:
+- `src/mcp/server.rs:3952` novelty merge/audit ordering is resolved.
+
+Open questions: none.
+<!-- CSA:SECTION:details:END -->
+
+```findings.toml
+findings = []
+```"#;
+    let full_output = serde_json::to_string(&serde_json::json!({
+        "type": "item.completed",
+        "item": {
+            "type": "agent_message",
+            "text": review_text
+        }
+    }))
+    .expect("serialize transcript");
+    fs::write(session_dir.join("output").join("full.md"), full_output).expect("write full output");
+    csa_session::persist_structured_output(&session_dir, review_text)
+        .expect("persist structured output");
+
+    persist_review_findings_toml(project_root.path(), &review_meta(session_id));
+
+    let actual = fs::read_to_string(session_dir.join("output").join("findings.toml"))
+        .expect("read findings.toml");
+    let parsed: FindingsFile = toml::from_str(&actual).expect("parse findings.toml");
+    assert_eq!(parsed, FindingsFile::default());
+    assert_eq!(actual.trim(), "findings = []");
+    assert!(
+        !session_dir
+            .join("output")
+            .join(FINDINGS_TOML_SYNTHETIC_MARKER)
+            .exists(),
+        "explicit empty findings.toml must remain authoritative, not synthetic"
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -11,6 +11,26 @@ pub(in crate::review_cmd) fn findings_file_from_prose(text: &str) -> Option<Find
     }
 }
 
+pub(in crate::review_cmd) fn findings_file_from_explicit_findings_sections(
+    text: &str,
+) -> Option<FindingsFile> {
+    let mut findings = Vec::new();
+    for body in findings_section_bodies(text) {
+        let parser_input = format!("Findings\n{}", body.as_str());
+        for mut finding in extract_review_findings_from_prose_with_default(&parser_input, None) {
+            if findings
+                .iter()
+                .any(|existing| review_finding_payload_eq(existing, &finding))
+            {
+                continue;
+            }
+            finding.id = format!("prose-{:03}", findings.len() + 1);
+            findings.push(finding);
+        }
+    }
+    (!findings.is_empty()).then_some(FindingsFile { findings })
+}
+
 pub(in crate::review_cmd) fn extract_review_findings_from_prose(text: &str) -> Vec<ReviewFinding> {
     let default_unlabeled_severity =
         contains_blocking_review_signal(text).then_some(Severity::Medium);
@@ -425,6 +445,14 @@ fn non_empty_or_fallback(value: &str, fallback: &str) -> String {
     } else {
         value.trim().to_string()
     }
+}
+
+fn review_finding_payload_eq(left: &ReviewFinding, right: &ReviewFinding) -> bool {
+    left.severity == right.severity
+        && left.file_ranges == right.file_ranges
+        && left.is_regression_of_commit == right.is_regression_of_commit
+        && left.suggested_test_scenario == right.suggested_test_scenario
+        && left.description == right.description
 }
 
 pub(in crate::review_cmd) fn is_findings_header(line: &str) -> bool {

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.943"
-weave = "0.1.943"
+csa = "0.1.944"
+weave = "0.1.944"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- keep review metadata consistent with explicit PASS/no-finding structured reviewer output
- preserve fail-closed handling for terminal provider errors and real findings
- add regression coverage for PASS summary/details with empty findings producing passing review meta

## Verification

- CSA writer session: `01KTJS5AMTDR3WR7CDJTTG7H07` committed `658256ab`
- CSA full-diff review: `01KTJT7FG4D86TAKXXJFYACC8W` PASS/CLEAN for `range:main...HEAD` at `658256ab`

Closes #1953
