### PR TITLE
fix(review): classify gemini fallback failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.944"
+version = "0.1.945"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.944"
+version = "0.1.945"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/failover_trace.rs
+++ b/crates/cli-sub-agent/src/failover_trace.rs
@@ -117,6 +117,12 @@ impl FailoverSkipKind {
             || lower.contains("server shut down")
             || lower.contains("spawn")
             || lower.contains("broken pipe")
+            || lower.contains("gemini_cli_crash")
+            || lower.contains("gemini_runtime_home_unavailable")
+            || lower.contains("tool_crash")
+            || lower.contains("unexpected critical error")
+            || lower.contains("enospc")
+            || lower.contains("no space left on device")
         {
             Self::TransportError
         } else {

--- a/crates/cli-sub-agent/src/failover_trace_tests.rs
+++ b/crates/cli-sub-agent/src/failover_trace_tests.rs
@@ -52,6 +52,14 @@ fn classify_distinguishes_quota_rate_limit_transport_and_error() {
         FailoverSkipKind::TransportError
     );
     assert_eq!(
+        FailoverSkipKind::classify("gemini_cli_crash"),
+        FailoverSkipKind::TransportError
+    );
+    assert_eq!(
+        FailoverSkipKind::classify("gemini_runtime_home_unavailable"),
+        FailoverSkipKind::TransportError
+    );
+    assert_eq!(
         FailoverSkipKind::classify("model returned a malformed verdict"),
         FailoverSkipKind::AttemptedAndErrored
     );

--- a/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
@@ -1,20 +1,29 @@
 use super::super::*;
 
-#[test]
-fn classify_review_failover_reason_uses_summary_http_400_for_review_fallback() {
-    let execution = crate::pipeline::SessionExecutionResult {
+fn execution_with(
+    output: &str,
+    stderr: &str,
+    summary: &str,
+    exit_code: i32,
+) -> crate::pipeline::SessionExecutionResult {
+    crate::pipeline::SessionExecutionResult {
         execution: csa_process::ExecutionResult {
-            output: String::new(),
-            stderr_output: String::new(),
-            summary: "Gemini request failed: status: 400 Bad Request".to_string(),
-            exit_code: 1,
+            output: output.to_string(),
+            stderr_output: stderr.to_string(),
+            summary: summary.to_string(),
+            exit_code,
             peak_memory_mb: None,
             ..Default::default()
         },
-        meta_session_id: "01TESTHTTP400SUMMARY".to_string(),
+        meta_session_id: "01TESTREVIEWFAILOVER".to_string(),
         provider_session_id: None,
         changed_paths: None,
-    };
+    }
+}
+
+#[test]
+fn classify_review_failover_reason_uses_summary_http_400_for_review_fallback() {
+    let execution = execution_with("", "", "Gemini request failed: status: 400 Bad Request", 1);
 
     let failure = classify_review_failover_reason(
         ToolName::GeminiCli,
@@ -27,4 +36,100 @@ fn classify_review_failover_reason_uses_summary_http_400_for_review_fallback() {
 
     assert_eq!(failure.reason, "HTTP 400");
     assert_eq!(failure.quota_exhausted, Some(false));
+}
+
+#[test]
+fn classify_review_failover_reason_detects_gemini_noninteractive_manual_auth() {
+    let stderr = "\
+Error authenticating: FatalAuthenticationError: Manual authorization is required but the current session is non-interactive. \
+Please run the Gemini CLI in an interactive terminal to log in, provide a GEMINI_API_KEY, \
+or ensure Application Default Credentials are configured.
+    at async main (file:///usr/local/share/mise/installs/npm-google-gemini-cli/0.45.2/lib/node_modules/@google/gemini-cli/bundle/gemini-75GSY6S7.js:16052:9)";
+    let execution = execution_with("", stderr, "", 41);
+
+    let failure = classify_review_failover_reason(
+        ToolName::GeminiCli,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        &execution,
+        None,
+        Some(std::time::Duration::from_secs(39)),
+    )
+    .expect("Gemini non-interactive manual auth must fall back to the next reviewer (#1949)");
+
+    assert_eq!(failure.reason, "auth_unavailable");
+    assert_eq!(failure.quota_exhausted, Some(false));
+}
+
+#[test]
+fn classify_review_failover_reason_detects_gemini_stack_frame_crash() {
+    let execution = execution_with(
+        "",
+        "",
+        "at async main (file:///usr/local/share/mise/installs/npm-google-gemini-cli/0.45.2/lib/node_modules/@google/gemini-cli/bundle/gemini-75GSY6S7.js:16120:5)",
+        1,
+    );
+
+    let failure = classify_review_failover_reason(
+        ToolName::GeminiCli,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        &execution,
+        None,
+        Some(std::time::Duration::from_secs(39)),
+    )
+    .expect("Gemini CLI internal JS stack crash must be fallbackable (#1936)");
+
+    assert_eq!(failure.reason, "gemini_cli_crash");
+    assert_eq!(failure.quota_exhausted, None);
+}
+
+#[test]
+fn classify_review_failover_reason_detects_gemini_runtime_home_enospc() {
+    let stderr = "\
+Failed to save project registry to /state/sessions/01TEST/runtime/gemini-home/.gemini/projects.json: \
+Error: ENOSPC: no space left on device, rename '/state/sessions/01TEST/runtime/gemini-home/.gemini/projects.json.tmp' \
+-> '/state/sessions/01TEST/runtime/gemini-home/.gemini/projects.json'
+An unexpected critical error occurred:Error: ENOSPC: no space left on device, rename '/state/sessions/01TEST/runtime/gemini-home/.gemini/projects.json.tmp' \
+-> '/state/sessions/01TEST/runtime/gemini-home/.gemini/projects.json'";
+    let execution = execution_with("", stderr, "", 1);
+
+    let failure = classify_review_failover_reason(
+        ToolName::GeminiCli,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        &execution,
+        None,
+        Some(std::time::Duration::from_secs(39)),
+    )
+    .expect("Gemini runtime-home ENOSPC must fall back to the next reviewer (#1938)");
+
+    assert_eq!(failure.reason, "gemini_runtime_home_unavailable");
+    assert_eq!(failure.quota_exhausted, None);
+}
+
+#[test]
+fn classify_review_failover_reason_preserves_completed_structured_review() {
+    let output = "\
+<!-- CSA:SECTION:summary -->
+HAS_ISSUES
+<!-- CSA:SECTION:summary:END -->
+<!-- CSA:SECTION:details -->
+- Critical: real review finding.
+<!-- CSA:SECTION:details:END -->";
+    let stderr = "\
+An unexpected critical error occurred:Error: ENOSPC: no space left on device, rename \
+'/state/sessions/01TEST/runtime/gemini-home/.gemini/projects.json.tmp' \
+-> '/state/sessions/01TEST/runtime/gemini-home/.gemini/projects.json'";
+    let execution = execution_with(output, stderr, "Review completed with findings", 1);
+
+    let failure = classify_review_failover_reason(
+        ToolName::GeminiCli,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        &execution,
+        None,
+        Some(std::time::Duration::from_secs(39)),
+    );
+
+    assert!(
+        failure.is_none(),
+        "a completed structured review must not be reclassified as reviewer-tool unavailable"
+    );
 }

--- a/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
@@ -47,6 +47,64 @@ pub(super) fn classify_review_failover_reason(
         reason: detected.reason,
         quota_exhausted: Some(detected.quota_exhausted),
     })
+    .or_else(|| classify_gemini_cli_runtime_failure(tool, execution))
+}
+
+fn classify_gemini_cli_runtime_failure(
+    tool: ToolName,
+    execution: &crate::pipeline::SessionExecutionResult,
+) -> Option<ReviewFailoverFailure> {
+    if tool != ToolName::GeminiCli || execution.execution.exit_code == 0 {
+        return None;
+    }
+    if has_structured_review_content(&execution.execution.output) {
+        return None;
+    }
+
+    let combined = format!(
+        "{}\n{}\n{}",
+        execution.execution.summary, execution.execution.output, execution.execution.stderr_output,
+    );
+    let lower = combined.to_ascii_lowercase();
+    let reason = if is_gemini_manual_auth_failure(&lower) {
+        "auth_unavailable"
+    } else if is_gemini_runtime_home_enospc_failure(&lower) {
+        "gemini_runtime_home_unavailable"
+    } else if is_gemini_cli_internal_crash(&lower) {
+        "gemini_cli_crash"
+    } else {
+        return None;
+    };
+
+    Some(ReviewFailoverFailure {
+        reason: reason.to_string(),
+        quota_exhausted: None,
+    })
+}
+
+fn is_gemini_manual_auth_failure(lower: &str) -> bool {
+    lower.contains("manual authorization is required")
+        && (lower.contains("non-interactive")
+            || lower.contains("interactive terminal")
+            || lower.contains("gemini_api_key")
+            || lower.contains("application default credentials"))
+}
+
+fn is_gemini_runtime_home_enospc_failure(lower: &str) -> bool {
+    (lower.contains("enospc") || lower.contains("no space left on device"))
+        && (lower.contains(".gemini/projects.json")
+            || lower.contains("runtime/gemini-home")
+            || lower.contains("failed to save project registry"))
+}
+
+fn is_gemini_cli_internal_crash(lower: &str) -> bool {
+    (lower.contains("an unexpected critical error occurred")
+        || lower.contains("fatalauthenticationerror")
+        || lower.contains("at async main "))
+        && (lower.contains("@google/gemini-cli")
+            || lower.contains("node:internal")
+            || lower.contains("/gemini-cli/bundle/")
+            || lower.contains("npm-google-gemini-cli"))
 }
 
 pub(super) fn build_gemini_api_key_retry_env(

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.944"
-weave = "0.1.944"
+csa = "0.1.945"
+weave = "0.1.945"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- classify Gemini CLI manual-auth, JS stack, and runtime-home ENOSPC reviewer failures as fallbackable when tier fallback can use another reviewer
- preserve completed structured review output so real findings stay fail-closed
- add regression coverage for auth_unavailable, status 400, stack-trace, and ENOSPC fallback paths

Closes #1949
Closes #1936
Closes #1938

## Verification
- CSA review PASS: 01KTJVJ16M1G1Y06CS02CWR8HV (gemini-cli fallback to codex)
- pre-push review-check passed for 139bfe2ce82