### PR TITLE
fix(cli): improve session command ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.945"
+version = "0.1.946"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.945"
+version = "0.1.946"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -100,6 +100,41 @@ fn daemon_wait_command_places_cd_after_single_session_id() {
 }
 
 #[test]
+fn daemon_wait_command_shell_escapes_project_root_single_quotes() {
+    let command = crate::daemon_caller_hints::format_session_wait_command(
+        "01KAS6M5XG7V4M4M6YDRS7P8R9",
+        Path::new("/tmp/csa'; touch /tmp/csa-review-proof; echo '"),
+    );
+
+    assert!(
+        command.contains("'\\''; touch /tmp/csa-review-proof; echo '\\'''"),
+        "project root single quotes must remain inside the --cd shell argument: {command}"
+    );
+    assert!(
+        !command.contains("--cd '/tmp/csa'; touch"),
+        "project root must not terminate the --cd shell argument: {command}"
+    );
+}
+
+#[test]
+fn daemon_caller_hint_attrs_escape_shell_command_values() {
+    let command = crate::daemon_caller_hints::format_session_wait_command(
+        "01KAS6M5XG7V4M4M6YDRS7P8R9",
+        Path::new("/tmp/a\"b&<c>d"),
+    );
+    let attr = crate::daemon_caller_hints::escape_structured_comment_attr(&command);
+
+    assert_eq!(
+        attr,
+        "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --cd '/tmp/a&quot;b&amp;&lt;c&gt;d'"
+    );
+    assert!(
+        !attr.contains('"') && !attr.contains('<') && !attr.contains('>'),
+        "escaped attribute must not contain raw XML attribute delimiters: {attr}"
+    );
+}
+
+#[test]
 fn caller_hint_blocks_ignores_unrelated_mentions_in_comments() {
     // A doc/line comment that mentions the marker name MUST NOT be parsed
     // as a hint block; only the exact emitted marker prefix counts.

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -6,6 +6,8 @@
 //! removal during future edits to the four daemon entry points.
 #![cfg(test)]
 
+use std::path::Path;
+
 const NO_STACK_WAKEUP_WARNING: &str = "do NOT stack ScheduleWakeup, /loop, or sleep loops on top";
 const BACKGROUND_WAIT_RECOMMENDATION: &str = "with run_in_background: true";
 const TASK_NOTIFICATION_WAKE_SIGNAL: &str = "The task-notification IS your wake signal";
@@ -47,6 +49,14 @@ fn assert_wait_hint_contract(block: &str, site: &str) {
         "{site} CALLER_HINT must recommend backgrounding session wait with run_in_background: true"
     );
     assert!(
+        block.contains("Call {wait_cmd} with run_in_background: true"),
+        "{site} CALLER_HINT must reuse the SESSION_STARTED wait_cmd variable"
+    );
+    assert!(
+        !block.contains("{id}{cd}"),
+        "{site} CALLER_HINT must not rebuild the wait command by concatenating id and cd"
+    );
+    assert!(
         block.contains(TASK_NOTIFICATION_WAKE_SIGNAL),
         "{site} CALLER_HINT must state that task-notification is the wake signal"
     );
@@ -65,6 +75,27 @@ fn assert_wait_hint_contract(block: &str, site: &str) {
     assert!(
         block.contains(NO_STDERR_SUPPRESS_DIRECTIVE),
         "{site} CALLER_HINT must forbid stderr suppression (2>/dev/null)"
+    );
+}
+
+#[test]
+fn daemon_wait_command_places_cd_after_single_session_id() {
+    let session_id = "01KAS6M5XG7V4M4M6YDRS7P8R9";
+    let command =
+        crate::daemon_caller_hints::format_session_wait_command(session_id, Path::new("/tmp/repo"));
+
+    assert_eq!(
+        command,
+        "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --cd '/tmp/repo'"
+    );
+    assert_eq!(
+        command.matches(session_id).count(),
+        1,
+        "session id must appear only in --session"
+    );
+    assert!(
+        !command.contains(&format!("--cd '{session_id}")),
+        "session id must not be duplicated into the --cd argument"
     );
 }
 

--- a/crates/cli-sub-agent/src/cli.rs
+++ b/crates/cli-sub-agent/src/cli.rs
@@ -99,7 +99,7 @@ pub enum Commands {
         #[arg(long, value_name = "PATH", conflicts_with = "prompt")]
         prompt_file: Option<PathBuf>,
         /// Add prior review context to the prompt
-        #[arg(long, value_name = "SESSION_ID", value_parser = validate_ulid)]
+        #[arg(long, value_name = "SESSION")]
         inline_context_from_review_session: Option<String>,
         /// Resume existing session (ULID or prefix match) [DEPRECATED: use --fork-from]
         #[arg(short, long, conflicts_with_all = ["last", "fork_from", "fork_last", "fork_from_caller"])]

--- a/crates/cli-sub-agent/src/cli_common.rs
+++ b/crates/cli-sub-agent/src/cli_common.rs
@@ -88,12 +88,6 @@ pub(crate) fn parse_spec_path_arg(spec: &str) -> std::result::Result<String, Str
         .map_err(|err| err.to_string())
 }
 
-pub(crate) fn validate_ulid(value: &str) -> std::result::Result<String, String> {
-    csa_session::validate_session_id(value)
-        .map(|_| value.to_string())
-        .map_err(|e| e.to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::parse_model_spec_arg_with_warning;

--- a/crates/cli-sub-agent/src/daemon_caller_hints.rs
+++ b/crates/cli-sub-agent/src/daemon_caller_hints.rs
@@ -16,6 +16,19 @@ pub(crate) fn format_session_attach_command(session_id: &str, project_root: &Pat
     )
 }
 
-fn format_cd_arg(project_root: &Path) -> String {
-    format!(" --cd '{}'", project_root.display())
+pub(crate) fn format_cd_arg(project_root: &Path) -> String {
+    let project_root = project_root.to_string_lossy();
+    format!(" --cd {}", shell_escape_for_command(&project_root))
+}
+
+pub(crate) fn escape_structured_comment_attr(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn shell_escape_for_command(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }

--- a/crates/cli-sub-agent/src/daemon_caller_hints.rs
+++ b/crates/cli-sub-agent/src/daemon_caller_hints.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+pub(crate) fn format_session_wait_command(session_id: &str, project_root: &Path) -> String {
+    format!(
+        "csa session wait --session {}{}",
+        session_id,
+        format_cd_arg(project_root)
+    )
+}
+
+pub(crate) fn format_session_attach_command(session_id: &str, project_root: &Path) -> String {
+    format!(
+        "csa session attach --session {}{}",
+        session_id,
+        format_cd_arg(project_root)
+    )
+}
+
+fn format_cd_arg(project_root: &Path) -> String {
+    format!(" --cd '{}'", project_root.display())
+}

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -12,6 +12,7 @@ mod claude_sub_agent_cmd;
 mod cli;
 mod codex_transcript_filter;
 mod config_cmds;
+mod daemon_caller_hints;
 mod debate_cmd;
 mod debate_cmd_output;
 mod debate_cmd_resolve;

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -277,27 +277,32 @@ pub(crate) fn spawn_and_exit(
 
     let result = csa_process::daemon::spawn_daemon(config)?;
     println!("{}", result.session_id);
-    let cd_hint = format!(" --cd '{}'", project_root.display());
+    let wait_cmd =
+        crate::daemon_caller_hints::format_session_wait_command(&result.session_id, &project_root);
+    let attach_cmd = crate::daemon_caller_hints::format_session_attach_command(
+        &result.session_id,
+        &project_root,
+    );
     eprintln!(
         "<!-- CSA:SESSION_STARTED id={id} pid={pid} dir=\"{dir}\" \
-         wait_cmd=\"csa session wait --session {id}{cd}\" \
-         attach_cmd=\"csa session attach --session {id}{cd}\" -->",
+         wait_cmd=\"{wait_cmd}\" \
+         attach_cmd=\"{attach_cmd}\" -->",
         id = result.session_id,
         pid = result.pid,
         dir = result.session_dir.display(),
-        cd = cd_hint,
+        wait_cmd = wait_cmd,
+        attach_cmd = attach_cmd,
     );
     eprintln!(
         "<!-- CSA:CALLER_HINT action=\"wait\" \
-         rule=\"Call 'csa session wait --session {id}{cd}' with run_in_background: true. \
+         rule=\"Call {wait_cmd} with run_in_background: true. \
          The task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top. \
          NEVER batch multiple waits in a for/while loop; use one backgrounded Bash tool call per session. \
          FORBIDDEN after backgrounding: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID — \
          any manual polling wastes caller tokens with zero benefit. \
          FORBIDDEN: piping csa commands through 2>/dev/null. CSA errors on stderr are diagnostic — \
          suppressing them hides invalid-argument errors and causes silent retry loops that waste thousands of tokens.\" -->",
-        id = result.session_id,
-        cd = cd_hint,
+        wait_cmd = wait_cmd,
     );
     let codex_hint = crate::process_tree::codex_yield_hint();
     if !codex_hint.is_empty() {

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -283,15 +283,20 @@ pub(crate) fn spawn_and_exit(
         &result.session_id,
         &project_root,
     );
+    let session_dir_attr = crate::daemon_caller_hints::escape_structured_comment_attr(
+        &result.session_dir.display().to_string(),
+    );
+    let wait_cmd_attr = crate::daemon_caller_hints::escape_structured_comment_attr(&wait_cmd);
+    let attach_cmd_attr = crate::daemon_caller_hints::escape_structured_comment_attr(&attach_cmd);
     eprintln!(
         "<!-- CSA:SESSION_STARTED id={id} pid={pid} dir=\"{dir}\" \
          wait_cmd=\"{wait_cmd}\" \
          attach_cmd=\"{attach_cmd}\" -->",
         id = result.session_id,
         pid = result.pid,
-        dir = result.session_dir.display(),
-        wait_cmd = wait_cmd,
-        attach_cmd = attach_cmd,
+        dir = session_dir_attr,
+        wait_cmd = wait_cmd_attr,
+        attach_cmd = attach_cmd_attr,
     );
     eprintln!(
         "<!-- CSA:CALLER_HINT action=\"wait\" \
@@ -302,7 +307,7 @@ pub(crate) fn spawn_and_exit(
          any manual polling wastes caller tokens with zero benefit. \
          FORBIDDEN: piping csa commands through 2>/dev/null. CSA errors on stderr are diagnostic — \
          suppressing them hides invalid-argument errors and causes silent retry loops that waste thousands of tokens.\" -->",
-        wait_cmd = wait_cmd,
+        wait_cmd = wait_cmd_attr,
     );
     let codex_hint = crate::process_tree::codex_yield_hint();
     if !codex_hint.is_empty() {

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -366,28 +366,32 @@ pub(crate) fn spawn_and_exit(
     // stdout: machine-readable session ID (for script capture).
     println!("{}", result.session_id);
     // stderr: structured RPJ directive for orchestrators.
-    // Include --cd <project_root> so cross-project callers can find the session.
-    let cd_hint = format!(" --cd '{}'", project_root.display());
+    let wait_cmd =
+        crate::daemon_caller_hints::format_session_wait_command(&result.session_id, &project_root);
+    let attach_cmd = crate::daemon_caller_hints::format_session_attach_command(
+        &result.session_id,
+        &project_root,
+    );
     eprintln!(
         "<!-- CSA:SESSION_STARTED id={id} pid={pid} dir=\"{dir}\" \
-         wait_cmd=\"csa session wait --session {id}{cd}\" \
-         attach_cmd=\"csa session attach --session {id}{cd}\" -->",
+         wait_cmd=\"{wait_cmd}\" \
+         attach_cmd=\"{attach_cmd}\" -->",
         id = result.session_id,
         pid = result.pid,
         dir = result.session_dir.display(),
-        cd = cd_hint,
+        wait_cmd = wait_cmd,
+        attach_cmd = attach_cmd,
     );
     eprintln!(
         "<!-- CSA:CALLER_HINT action=\"wait\" \
-         rule=\"Call 'csa session wait --session {id}{cd}' with run_in_background: true. \
+         rule=\"Call {wait_cmd} with run_in_background: true. \
          The task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top. \
          NEVER batch multiple waits in a for/while loop; use one backgrounded Bash tool call per session. \
          FORBIDDEN after backgrounding: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID — \
          any manual polling wastes caller tokens with zero benefit. \
          FORBIDDEN: piping csa commands through 2>/dev/null. CSA errors on stderr are diagnostic — \
          suppressing them hides invalid-argument errors and causes silent retry loops that waste thousands of tokens.\" -->",
-        id = result.session_id,
-        cd = cd_hint,
+        wait_cmd = wait_cmd,
     );
     let codex_hint = crate::process_tree::codex_yield_hint();
     if !codex_hint.is_empty() {

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -372,15 +372,20 @@ pub(crate) fn spawn_and_exit(
         &result.session_id,
         &project_root,
     );
+    let session_dir_attr = crate::daemon_caller_hints::escape_structured_comment_attr(
+        &result.session_dir.display().to_string(),
+    );
+    let wait_cmd_attr = crate::daemon_caller_hints::escape_structured_comment_attr(&wait_cmd);
+    let attach_cmd_attr = crate::daemon_caller_hints::escape_structured_comment_attr(&attach_cmd);
     eprintln!(
         "<!-- CSA:SESSION_STARTED id={id} pid={pid} dir=\"{dir}\" \
          wait_cmd=\"{wait_cmd}\" \
          attach_cmd=\"{attach_cmd}\" -->",
         id = result.session_id,
         pid = result.pid,
-        dir = result.session_dir.display(),
-        wait_cmd = wait_cmd,
-        attach_cmd = attach_cmd,
+        dir = session_dir_attr,
+        wait_cmd = wait_cmd_attr,
+        attach_cmd = attach_cmd_attr,
     );
     eprintln!(
         "<!-- CSA:CALLER_HINT action=\"wait\" \
@@ -391,7 +396,7 @@ pub(crate) fn spawn_and_exit(
          any manual polling wastes caller tokens with zero benefit. \
          FORBIDDEN: piping csa commands through 2>/dev/null. CSA errors on stderr are diagnostic — \
          suppressing them hides invalid-argument errors and causes silent retry loops that waste thousands of tokens.\" -->",
-        wait_cmd = wait_cmd,
+        wait_cmd = wait_cmd_attr,
     );
     let codex_hint = crate::process_tree::codex_yield_hint();
     if !codex_hint.is_empty() {

--- a/crates/cli-sub-agent/src/run_helpers_inline_review_context.rs
+++ b/crates/cli-sub-agent/src/run_helpers_inline_review_context.rs
@@ -12,15 +12,12 @@ pub(crate) fn prepend_review_context_to_prompt(
         return Ok(prompt);
     };
 
-    csa_session::validate_session_id(session_id).with_context(|| {
-        format!("--inline-context-from-review-session: invalid session ID '{session_id}'")
-    })?;
-
-    let session_dir = csa_session::get_session_dir(project_root, session_id)?;
+    let resolved_session_id = resolve_review_session_id(project_root, session_id)?;
+    let session_dir = csa_session::get_session_dir(project_root, &resolved_session_id)?;
     if !session_dir.exists() {
         anyhow::bail!(
             "--inline-context-from-review-session: session {} not found",
-            session_id
+            resolved_session_id
         );
     }
 
@@ -38,8 +35,30 @@ pub(crate) fn prepend_review_context_to_prompt(
     }
 
     Ok(format_review_context_prompt(
-        session_id, &prompt, summary, details, findings,
+        &resolved_session_id,
+        &prompt,
+        summary,
+        details,
+        findings,
     ))
+}
+
+fn resolve_review_session_id(project_root: &Path, session_ref: &str) -> Result<String> {
+    if session_ref.is_empty() {
+        anyhow::bail!("--inline-context-from-review-session: session reference cannot be empty");
+    }
+
+    match csa_session::validate_session_id(session_ref) {
+        Ok(()) => Ok(session_ref.to_string()),
+        Err(err) if session_ref.len() == 26 => Err(err).with_context(|| {
+            format!("--inline-context-from-review-session: invalid session ID '{session_ref}'")
+        }),
+        Err(_) => {
+            crate::session_cmds::resolve_session_prefix_with_fallback(project_root, session_ref)
+                .map(|resolution| resolution.session_id)
+                .map_err(|err| anyhow::anyhow!("--inline-context-from-review-session: {err}"))
+        }
+    }
 }
 
 fn read_optional_review_context_file(path: &Path) -> Result<Option<String>> {

--- a/crates/cli-sub-agent/src/run_helpers_inline_review_context_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_inline_review_context_tests.rs
@@ -126,6 +126,31 @@ fn prepend_review_context_to_prompt_skips_missing_artifacts() {
 }
 
 #[test]
+fn prepend_review_context_to_prompt_accepts_unique_session_prefix() {
+    let project_dir = tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let session_id = "01KAS6M5XG7V4M4M6YDRS7P8R4";
+    let other_session_id = "01KBT6M5XG7V4M4M6YDRS7P8R5";
+    let session_dir = create_review_session(project_dir.path(), session_id);
+    create_review_session(project_dir.path(), other_session_id);
+    fs::write(
+        session_dir.join("output").join("summary.md"),
+        "Prefix summary\n",
+    )
+    .unwrap();
+
+    let prompt = prepend_review_context_to_prompt(
+        project_dir.path(),
+        "Fix the bug".to_string(),
+        Some("01KAS6M5XG7V4"),
+    )
+    .expect("unique review session prefix should resolve");
+
+    assert!(prompt.starts_with("<csa-review-context session=\"01KAS6M5XG7V4M4M6YDRS7P8R4\">\n"));
+    assert!(prompt.contains("<!-- summary.md -->\nPrefix summary\n"));
+}
+
+#[test]
 fn prepend_review_context_to_prompt_warns_and_leaves_prompt_unchanged_when_outputs_missing() {
     let project_dir = tempdir().expect("tempdir");
     let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
@@ -151,6 +176,22 @@ fn prepend_review_context_to_prompt_warns_and_leaves_prompt_unchanged_when_outpu
     assert_eq!(prompt, "Fix the bug");
     assert!(buffer.contents().contains(
         "Inline review context requested but summary/details/findings artifacts were missing"
+    ));
+}
+
+#[test]
+fn prepend_review_context_to_prompt_rejects_malformed_full_session_id() {
+    let project_dir = tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let err = prepend_review_context_to_prompt(
+        project_dir.path(),
+        "Fix the bug".to_string(),
+        Some("!!!!!!!!!!!!!!!!!!!!!!!!!!"),
+    )
+    .expect_err("malformed full session id should fail");
+
+    assert!(err.to_string().contains(
+        "--inline-context-from-review-session: invalid session ID '!!!!!!!!!!!!!!!!!!!!!!!!!!'"
     ));
 }
 
@@ -197,19 +238,26 @@ fn cli_run_inline_context_from_review_session_accepts_ulid() {
 }
 
 #[test]
-fn cli_run_inline_context_from_review_session_rejects_non_ulid() {
-    let err = match Cli::try_parse_from([
+fn cli_run_inline_context_from_review_session_accepts_prefix() {
+    let cli = Cli::try_parse_from([
         "csa",
         "run",
         "--inline-context-from-review-session",
-        "not-a-ulid",
+        "01KAS6",
         "fix it",
-    ]) {
-        Ok(_) => panic!("non-ulid should be rejected"),
-        Err(err) => err,
-    };
+    ])
+    .expect("cli should parse a session prefix");
 
-    let rendered = err.to_string();
-    assert!(rendered.contains("--inline-context-from-review-session"));
-    assert!(rendered.contains("Invalid session ID"));
+    match cli.command {
+        Commands::Run {
+            inline_context_from_review_session,
+            ..
+        } => {
+            assert_eq!(
+                inline_context_from_review_session.as_deref(),
+                Some("01KAS6")
+            );
+        }
+        _ => panic!("expected run command"),
+    }
 }

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -325,35 +325,37 @@ where
         if elapsed >= wait_options.behavior.wait_timeout_secs {
             let cd_arg = cd
                 .as_ref()
-                .map(|path| format!(" --cd '{}'", path))
+                .map(|path| crate::daemon_caller_hints::format_cd_arg(Path::new(path)))
                 .unwrap_or_default();
             let session_alive = session_has_terminal_process(&session_dir)
                 || csa_process::ToolLiveness::is_alive(&session_dir);
             if session_alive {
+                let wait_cmd = format!(
+                    "csa session wait --session {}{}",
+                    resolved.session_id, cd_arg
+                );
+                let wait_cmd_attr =
+                    crate::daemon_caller_hints::escape_structured_comment_attr(&wait_cmd);
                 // KV-warm exit: session still alive at the wait cap. See #1439.
                 eprintln!(
                     "Session {} still running after {}s wait cap; returning so caller can warm its KV cache before re-waiting.",
                     resolved.session_id, wait_options.behavior.wait_timeout_secs,
                 );
                 eprintln!(
-                    "<!-- CSA:SESSION_WAIT_KV_WARM session={} status=alive elapsed={}s action=re-wait cmd=\"csa session wait --session {}{}\" -->",
-                    resolved.session_id, elapsed, resolved.session_id, cd_arg,
+                    "<!-- CSA:SESSION_WAIT_KV_WARM session={} status=alive elapsed={}s action=re-wait cmd=\"{}\" -->",
+                    resolved.session_id, elapsed, wait_cmd_attr,
                 );
                 eprintln!(
                     "<!-- CSA:CALLER_HINT action=\"retry_wait\" \
                      rule=\"Session is alive; this exit is healthy. Process this output NOW and generate tokens to warm your KV cache, \
-                     then call 'csa session wait --session {sid}{cd}' again in a NEW Bash call. \
+                     then call {wait_cmd} again in a NEW Bash call. \
                      NEVER batch multiple session waits in one Bash call. \
                      If you background the wait (run_in_background: true), the completion task-notification IS your wake signal — do NOT stack ScheduleWakeup, /loop, or sleep loops on top; that's pure redundancy and wastes tokens. \
                      FORBIDDEN: ls/cat/wc/grep on session-dir, state.toml reads, ps checks on daemon PID — \
                      any manual polling wastes caller tokens with zero benefit. \
                      FORBIDDEN: piping csa commands through 2>/dev/null. CSA errors on stderr are diagnostic — \
                      suppressing them hides invalid-argument errors and causes silent retry loops that waste thousands of tokens.\" -->",
-                    sid = resolved.session_id,
-                    cd = cd
-                        .as_ref()
-                        .map(|p| format!(" --cd '{p}'"))
-                        .unwrap_or_default(),
+                    wait_cmd = wait_cmd_attr,
                 );
                 let codex_hint = crate::process_tree::codex_yield_hint();
                 if !codex_hint.is_empty() {
@@ -366,9 +368,15 @@ where
                 "Timeout: session {} did not complete within {}s and no live daemon process remains.",
                 resolved.session_id, wait_options.behavior.wait_timeout_secs,
             );
+            let result_cmd = format!(
+                "csa session result --session {}{}",
+                resolved.session_id, cd_arg
+            );
+            let result_cmd_attr =
+                crate::daemon_caller_hints::escape_structured_comment_attr(&result_cmd);
             eprintln!(
-                "<!-- CSA:SESSION_WAIT_TIMEOUT session={} elapsed={}s status=dead cmd=\"csa session result --session {}{}\" -->",
-                resolved.session_id, elapsed, resolved.session_id, cd_arg,
+                "<!-- CSA:SESSION_WAIT_TIMEOUT session={} elapsed={}s status=dead cmd=\"{}\" -->",
+                resolved.session_id, elapsed, result_cmd_attr,
             );
             return Ok(SESSION_WAIT_TIMEOUT_EXIT_CODE);
         }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.945"
-weave = "0.1.945"
+csa = "0.1.946"
+weave = "0.1.946"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- fix caller wait hints so daemon/review commands print shell-safe wait commands without session-id concatenation
- allow unique review-session prefixes for `--inline-context-from-review-session`
- add regression coverage for caller hint formatting and inline review-session prefix resolution
- fix review finding around daemon caller hint command escaping

Closes #1946
Closes #1942

## Verification
- CSA writer: 01KTJW1WFSTVBMNFGCJESV9S8Z
- CSA review FAIL then fix: 01KTJX7ATWW00HT6TFAKJAF655 -> 01KTJXHCW6GRRDTTVSYJ4JPN8W
- CSA Codex tier-4 review PASS: 01KTJYHQQDFY4CXNYE3SGK5Y04
- pre-push review-check passed for 1ae96c7857e

## Follow-up
- Filed #1958 for the observed `tier_failover_superseded` wait/fallback behavior while testing Gemini-first review.