### PR TITLE
fix(review): keep tier fallback waits nonterminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.946"
+version = "0.1.947"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.946"
+version = "0.1.947"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -97,6 +97,7 @@ mod session_observability;
 mod session_outcome;
 mod session_result_publish;
 mod session_summary_text;
+mod session_tier_failover;
 mod setup_cmds;
 mod skill_cmds;
 mod skill_dispatch;

--- a/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
@@ -39,6 +39,25 @@ fn classify_review_failover_reason_uses_summary_http_400_for_review_fallback() {
 }
 
 #[test]
+fn classify_review_failover_reason_uses_late_gemini_http_400_for_review_fallback() {
+    let execution = execution_with("", "", "status: 400", 1);
+
+    let failure = classify_review_failover_reason(
+        ToolName::GeminiCli,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        &execution,
+        None,
+        Some(std::time::Duration::from_secs(39)),
+    )
+    .expect(
+        "review-specific Gemini status:400 failure must fall back even past init window (#1958)",
+    );
+
+    assert_eq!(failure.reason, "HTTP 400");
+    assert_eq!(failure.quota_exhausted, Some(false));
+}
+
+#[test]
 fn classify_review_failover_reason_detects_gemini_noninteractive_manual_auth() {
     let stderr = "\
 Error authenticating: FatalAuthenticationError: Manual authorization is required but the current session is non-interactive. \

--- a/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::session_tier_failover::TIER_FAILOVER_SUPERSEDED_STATUS;
 use csa_session::{PhaseEvent, SessionPhase};
 
 /// A classified review-failover failure: the normalized reason plus, when the
@@ -72,13 +73,15 @@ fn classify_gemini_cli_runtime_failure(
         "gemini_runtime_home_unavailable"
     } else if is_gemini_cli_internal_crash(&lower) {
         "gemini_cli_crash"
+    } else if is_gemini_reviewer_http_400_failure(&lower) {
+        "HTTP 400"
     } else {
         return None;
     };
 
     Some(ReviewFailoverFailure {
         reason: reason.to_string(),
-        quota_exhausted: None,
+        quota_exhausted: (reason == "HTTP 400").then_some(false),
     })
 }
 
@@ -105,6 +108,13 @@ fn is_gemini_cli_internal_crash(lower: &str) -> bool {
             || lower.contains("node:internal")
             || lower.contains("/gemini-cli/bundle/")
             || lower.contains("npm-google-gemini-cli"))
+}
+
+fn is_gemini_reviewer_http_400_failure(lower: &str) -> bool {
+    lower.contains("status: 400")
+        || lower.contains("status 400")
+        || lower.contains("http 400")
+        || lower.contains("400 bad request")
 }
 
 pub(super) fn build_gemini_api_key_retry_env(
@@ -288,8 +298,6 @@ fn truncate_for_summary(text: &str, max_chars: usize) -> String {
 ///
 /// Prevents `csa session list` from showing "Failed" during the window between
 /// a tier-failover attempt and the next model's result (#1475).
-pub(super) const TIER_FAILOVER_SUPERSEDED_STATUS: &str = "tier_failover_superseded";
-
 /// Mark an intermediate tier-failover session so it shows as "Retired" in
 /// `csa session list` rather than "Failed" during the failover transition.
 ///

--- a/crates/cli-sub-agent/src/review_cmd_execute_readonly_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_readonly_tests.rs
@@ -27,3 +27,6 @@ fn with_readonly_session_env_injects_flag() {
 
 #[path = "review_cmd_execute_failover_classification_tests.rs"]
 mod failover_classification_tests;
+
+#[path = "review_cmd_execute_tier_1958_tests.rs"]
+mod tier_1958_tests;

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_1958_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_1958_tests.rs
@@ -1,0 +1,128 @@
+use super::super::*;
+use crate::review_cmd::tests::{
+    ScopedEnvVarRestore, project_config_with_enabled_tools, setup_git_repo,
+};
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_config::{GlobalConfig, ProjectProfile, TierStrategy, config::TierConfig};
+use csa_core::types::ToolName;
+
+fn config_with_review_tier(enabled_tools: &[&str], models: &[&str]) -> csa_config::ProjectConfig {
+    let mut config = project_config_with_enabled_tools(enabled_tools);
+    if enabled_tools.contains(&"codex") {
+        config.tools.get_mut("codex").unwrap().transport = Some(csa_config::TransportKind::Cli);
+    }
+    config.tiers.insert(
+        "quality".to_string(),
+        TierConfig {
+            description: "quality".to_string(),
+            models: models.iter().map(|model| (*model).to_string()).collect(),
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    config
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn execute_review_falls_back_from_gemini_status_400_to_codex() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if which::which("bwrap").is_err() {
+        eprintln!("skipping: bwrap not installed (CI gap, see #987)");
+        return;
+    }
+
+    let project_dir = setup_git_repo();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    let bin_dir = project_dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+
+    std::fs::write(
+        bin_dir.join("gemini"),
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf 'status: 400\\n' >&2\nexit 1\n",
+    )
+    .unwrap();
+    std::fs::write(
+        bin_dir.join("codex"),
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex-cli 1.0.0\\n'\n  exit 0\nfi\nprintf '%s\\n' '<!-- CSA:SECTION:summary -->' 'PASS' '<!-- CSA:SECTION:summary:END -->' '<!-- CSA:SECTION:details -->' 'No blocking issues found.' '<!-- CSA:SECTION:details:END -->'\n",
+    )
+    .unwrap();
+    for binary in ["gemini", "codex"] {
+        let path = bin_dir.join(binary);
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+    let _path_guard = ScopedEnvVarRestore::set("PATH", &patched_path);
+
+    let config = config_with_review_tier(
+        &["gemini-cli", "codex"],
+        &[
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "codex/openai/gpt-5.4/high",
+        ],
+    );
+    let global = GlobalConfig::default();
+
+    let result = execute_review(
+        ToolName::GeminiCli,
+        "scope=uncommitted mode=review-only security=auto".to_string(),
+        None,
+        None,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string()),
+        Some("quality".to_string()),
+        true,
+        None,
+        "review: gemini-400-tier-fallback-success".to_string(),
+        project_dir.path(),
+        Some(&config),
+        &global,
+        None,
+        ReviewRoutingMetadata {
+            project_profile: ProjectProfile::Unknown,
+            detection_method: "auto",
+        },
+        csa_process::StreamMode::BufferOnly,
+        crate::pipeline::DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        false,
+        false,
+        false,
+        false,
+        false,
+        &[],
+        &[],
+        Some(false),
+    )
+    .await
+    .expect("Gemini status:400 tier fallback should reach Codex (#1958)");
+
+    assert_eq!(result.executed_tool, ToolName::Codex);
+    assert_eq!(
+        result.routed_to.as_deref(),
+        Some("codex/openai/gpt-5.4/high")
+    );
+    assert!(result.forced_decision.is_none());
+    assert!(result.status_reason.is_none());
+    assert!(result.primary_failure.is_none());
+    assert!(result.failure_reason.is_none());
+
+    let persisted = csa_session::load_result(project_dir.path(), &result.execution.meta_session_id)
+        .unwrap()
+        .expect("result.toml should exist");
+    assert_eq!(persisted.original_tool.as_deref(), Some("gemini-cli"));
+    assert_eq!(persisted.fallback_tool.as_deref(), Some("codex"));
+    let fallback_chain = persisted
+        .fallback_chain
+        .as_ref()
+        .expect("result fallback_chain");
+    assert_eq!(fallback_chain.len(), 1);
+    assert_eq!(fallback_chain[0].tool, "gemini-cli");
+    assert_eq!(fallback_chain[0].skip_reason, "attempted-and-errored");
+    assert!(!fallback_chain[0].quota_exhausted);
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_result.rs
@@ -5,6 +5,23 @@ use anyhow::Result;
 
 use super::super::session_has_terminal_process;
 
+fn suppress_pending_tier_failover_result(
+    session_id: &str,
+    session_dir: &Path,
+    result: csa_session::SessionResult,
+) -> Option<csa_session::SessionResult> {
+    if crate::session_tier_failover::is_pending_tier_failover_handoff(session_dir, &result) {
+        tracing::debug!(
+            session_id,
+            status = %result.status,
+            "Ignoring intermediate tier-failover result while fallback handoff is still live"
+        );
+        None
+    } else {
+        Some(result)
+    }
+}
+
 fn load_completed_daemon_result(
     project_root: &Path,
     session_id: &str,
@@ -26,7 +43,11 @@ fn load_completed_daemon_result(
             Err(err) => return Err(err),
         };
 
-    Ok(Some(result))
+    Ok(suppress_pending_tier_failover_result(
+        session_id,
+        session_dir,
+        result,
+    ))
 }
 
 /// Refresh result via session_dir for cross-project sessions or via project_root otherwise.
@@ -36,11 +57,13 @@ pub(super) fn refresh_result_for_wait(
     session_dir: &Path,
     is_cross_project: bool,
 ) -> Result<Option<csa_session::SessionResult>> {
-    if is_cross_project {
+    let result = if is_cross_project {
         crate::session_observability::refresh_and_repair_result_from_dir(session_dir)
     } else {
         crate::session_observability::refresh_and_repair_result(project_root, session_id)
-    }
+    }?;
+    Ok(result
+        .and_then(|result| suppress_pending_tier_failover_result(session_id, session_dir, result)))
 }
 
 fn load_completed_daemon_result_adaptive(
@@ -66,7 +89,11 @@ fn load_completed_daemon_result_adaptive(
             }
             Err(err) => return Err(err),
         };
-        Ok(Some(result))
+        Ok(suppress_pending_tier_failover_result(
+            session_id,
+            session_dir,
+            result,
+        ))
     } else {
         load_completed_daemon_result(project_root, session_id, session_dir)
     }

--- a/crates/cli-sub-agent/src/session_cmds_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result.rs
@@ -156,6 +156,16 @@ pub(crate) fn handle_session_result(
     if structured.is_active() {
         return display_structured_output(&session_dir, &resolved_id, &structured, json);
     }
+    if let Some(result) = repaired_result.as_ref().filter(|result| {
+        crate::session_tier_failover::is_pending_tier_failover_handoff(&session_dir, result)
+    }) {
+        crate::session_tier_failover::emit_pending_tier_failover_handoff(
+            &resolved_id,
+            result,
+            json,
+        );
+        return Ok(());
+    }
 
     let transcript_summary = match load_transcript_summary(&session_dir) {
         Ok(summary) => summary,

--- a/crates/cli-sub-agent/src/session_cmds_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result.rs
@@ -152,10 +152,6 @@ pub(crate) fn handle_session_result(
     };
     let repaired_result = repaired_result.or(daemon_completion_result);
 
-    // If structured output flags are active, handle them and return early
-    if structured.is_active() {
-        return display_structured_output(&session_dir, &resolved_id, &structured, json);
-    }
     if let Some(result) = repaired_result.as_ref().filter(|result| {
         crate::session_tier_failover::is_pending_tier_failover_handoff(&session_dir, result)
     }) {
@@ -165,6 +161,9 @@ pub(crate) fn handle_session_result(
             json,
         );
         return Ok(());
+    }
+    if structured.is_active() {
+        return display_structured_output(&session_dir, &resolved_id, &structured, json);
     }
 
     let transcript_summary = match load_transcript_summary(&session_dir) {
@@ -696,6 +695,9 @@ pub(crate) use tool_output::handle_session_tool_output;
 #[cfg(test)]
 #[path = "session_cmds_result_tests.rs"]
 mod tests;
+#[cfg(test)]
+#[path = "session_cmds_result_tier_failover_tests.rs"]
+mod tier_failover_tests;
 #[cfg(test)]
 #[path = "session_cmds_result_token_tests.rs"]
 mod token_tests;

--- a/crates/cli-sub-agent/src/session_cmds_result_tier_failover_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tier_failover_tests.rs
@@ -1,0 +1,106 @@
+use super::{StructuredOutputOpts, handle_session_result};
+use crate::test_env_lock::TEST_ENV_LOCK;
+use csa_session::{SessionResult, create_session, get_session_dir, save_result};
+use tempfile::tempdir;
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let original = std::env::var(key).ok();
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+        unsafe {
+            match self.original.as_deref() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn create_pending_tier_failover_session(
+    project: &std::path::Path,
+    label: &str,
+) -> anyhow::Result<String> {
+    let session = create_session(project, Some(label), None, Some("gemini-cli"))?;
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id)?;
+    save_result(
+        project,
+        &session_id,
+        &SessionResult {
+            status: "tier_failover_superseded".to_string(),
+            exit_code: 1,
+            summary: "status: 400".to_string(),
+            tool: "gemini-cli".to_string(),
+            ..Default::default()
+        },
+    )?;
+    std::fs::write(
+        session_dir.join("stderr.log"),
+        "fallback codex review is being scheduled\n",
+    )?;
+
+    let output_dir = session_dir.join("output");
+    std::fs::create_dir_all(&output_dir)?;
+    std::fs::write(output_dir.join("index.toml"), "not = [valid")?;
+    Ok(session_id)
+}
+
+#[test]
+fn structured_flags_report_pending_tier_failover_before_reading_sections() {
+    let tmp = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = tmp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", tmp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = tmp.path();
+
+    for (label, structured) in [
+        (
+            "summary",
+            StructuredOutputOpts {
+                summary: true,
+                ..Default::default()
+            },
+        ),
+        (
+            "section",
+            StructuredOutputOpts {
+                section: Some("details".to_string()),
+                ..Default::default()
+            },
+        ),
+        (
+            "full",
+            StructuredOutputOpts {
+                full: true,
+                ..Default::default()
+            },
+        ),
+    ] {
+        let session_id =
+            create_pending_tier_failover_session(project, &format!("result-pending-{label}"))
+                .unwrap();
+
+        handle_session_result(
+            session_id,
+            false,
+            Some(project.to_string_lossy().into_owned()),
+            structured,
+        )
+        .unwrap_or_else(|err| panic!("{label} structured result should stay pending: {err}"));
+    }
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
@@ -170,3 +170,74 @@ fn handle_session_wait_does_not_complete_daemon_packet_without_terminal_result()
         "test setup must remain without a terminal result"
     );
 }
+
+#[test]
+fn handle_session_wait_ignores_tier_failover_superseded_result_while_liveness_present() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-tier-failover-superseded-live"),
+        None,
+        Some("gemini-cli"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    save_result(
+        project,
+        &session_id,
+        &SessionResult {
+            status: "tier_failover_superseded".to_string(),
+            exit_code: 1,
+            summary: "status: 400".to_string(),
+            tool: "gemini-cli".to_string(),
+            ..make_result("failure", 1)
+        },
+    )
+    .unwrap();
+    std::fs::write(
+        session_dir.join("stderr.log"),
+        "fallback codex review is being scheduled\n",
+    )
+    .unwrap();
+
+    let mut emitted_completion = false;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |_sid: &str, _status: &str, _exit_code, _synthetic, _mirror_to_stdout| {
+            emitted_completion = true;
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        exit_code, 0,
+        "pending tier fallback should use the nonterminal KV-warm path"
+    );
+    assert!(
+        !emitted_completion,
+        "superseded intermediate attempts must not emit terminal wait completion while fallback is live"
+    );
+}

--- a/crates/cli-sub-agent/src/session_tier_failover.rs
+++ b/crates/cli-sub-agent/src/session_tier_failover.rs
@@ -1,0 +1,73 @@
+use std::path::Path;
+
+pub(crate) const TIER_FAILOVER_SUPERSEDED_STATUS: &str = "tier_failover_superseded";
+
+pub(crate) fn is_tier_failover_superseded_status(status: &str) -> bool {
+    status
+        .trim()
+        .eq_ignore_ascii_case(TIER_FAILOVER_SUPERSEDED_STATUS)
+}
+
+pub(crate) fn is_tier_failover_superseded_result(result: &csa_session::SessionResult) -> bool {
+    is_tier_failover_superseded_status(&result.status)
+}
+
+pub(crate) fn is_pending_tier_failover_handoff(
+    session_dir: &Path,
+    result: &csa_session::SessionResult,
+) -> bool {
+    is_tier_failover_superseded_result(result)
+        && (csa_process::ToolLiveness::has_live_process(session_dir)
+            || csa_process::ToolLiveness::daemon_pid_is_alive(session_dir)
+            || csa_process::ToolLiveness::is_alive(session_dir))
+}
+
+pub(crate) fn emit_pending_tier_failover_handoff(
+    session_id: &str,
+    result: &csa_session::SessionResult,
+    json: bool,
+) {
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "session_id": session_id,
+                "status": "tier_failover_handoff_pending",
+                "superseded_status": result.status,
+                "exit_code": result.exit_code,
+                "tool": result.tool,
+            })
+        );
+    } else {
+        eprintln!(
+            "Session {session_id} is awaiting tier fallback; retry `csa session wait --session {session_id}` for the fallback result."
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_result_hides_tier_failover_superseded_result_while_liveness_present() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let result = csa_session::SessionResult {
+            status: TIER_FAILOVER_SUPERSEDED_STATUS.to_string(),
+            exit_code: 1,
+            summary: "status: 400".to_string(),
+            tool: "gemini-cli".to_string(),
+            ..Default::default()
+        };
+        std::fs::write(
+            tmp.path().join("stderr.log"),
+            "fallback codex review is still running\n",
+        )
+        .expect("write liveness");
+
+        assert!(
+            is_pending_tier_failover_handoff(tmp.path(), &result),
+            "live superseded tier attempts are handoff-pending, not terminal result failures"
+        );
+    }
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.946"
-weave = "0.1.946"
+csa = "0.1.947"
+weave = "0.1.947"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- keep pending tier-failover reviewer handoffs nonterminal for wait consumers
- extend structured `session result` output paths so they do not report a stale superseded parent while fallback is pending
- add focused regression coverage for Gemini status:400 fallback and pending failover result handling

Closes #1958

## Verification
- CSA writer: 01KTJYY7AA9WGQ7576AY9HSBKV
- CSA review finding fix: 01KTK137D1JYSB3QRVE5YTETPA -> 01KTK1DG7CEFSVDBR6B1B3XVEH
- Gemini-first CSA review PASS with Codex fallback: 01KTK2H7WQ0G12RX5FVDQZQD51
- pre-push review-check passed for db7de9a4093