### PR TITLE
fix(plan): report failed pr-bot recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.947"
+version = "0.1.948"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.947"
+version = "0.1.948"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -38,6 +38,9 @@ use plan_cmd_exec::{extract_bash_code_block, truncate};
 #[path = "plan_cmd_flow.rs"]
 mod plan_cmd_flow;
 
+#[path = "plan_cmd_failure.rs"]
+pub(crate) mod plan_cmd_failure;
+
 #[path = "plan_cmd_assignment.rs"]
 mod plan_cmd_assignment;
 
@@ -333,6 +336,8 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
         plan.name,
         plan.steps.len()
     );
+    let recovery_snapshot =
+        plan_cmd_failure::capture_failure_recovery_snapshot(&plan.name, &project_root);
     let total_start = Instant::now();
     if let Some(ref tool) = tool_override {
         eprintln!("  Tool override: --tool {} (all CSA steps)", tool.as_str());
@@ -429,14 +434,25 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
         .count();
     let total_failures = execution_failures + unsupported_skips;
     if total_failures > 0 {
-        journal.status = "failed".to_string();
-        journal.last_error = Some(format!(
+        let failure_summary = format!(
             "{total_failures} step(s) failed ({execution_failures} execution, {unsupported_skips} unsupported-skip)"
-        ));
+        );
+        let recovery = recovery_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.recover_after_failure(&project_root));
+        let failure_report = plan_cmd_failure::PlanFailureReport::from_results(
+            &plan.name,
+            &workflow_path,
+            failure_summary.clone(),
+            &results,
+            recovery,
+        );
+        journal.status = "failed".to_string();
+        journal.last_error = Some(failure_summary.clone());
         apply_repo_fingerprint(&mut journal, &detect_repo_fingerprint(&project_root));
         persist_plan_journal(&journal_path, &journal)?;
-        bail!(
-            "{total_failures} step(s) failed ({execution_failures} execution, {unsupported_skips} unsupported-skip)"
+        return Err(
+            plan_cmd_failure::PlanFailureError::new(failure_summary, failure_report).into(),
         );
     }
 

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -11,9 +11,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use chrono::Utc;
-use csa_session::{
-    MetaSessionState, PhaseEvent, SessionArtifact, SessionResult, save_result, save_session,
-};
+use csa_session::{SessionResult, save_result};
 use tracing::warn;
 
 use crate::cli::PlanCommands;
@@ -27,6 +25,12 @@ use crate::{error_hints, error_report, exit_current_process};
 
 const PLAN_TASK_TYPE: &str = "plan";
 const PLAN_PIPELINE_SOURCE_ENV: &str = "CSA_PLAN_PIPELINE_SOURCE";
+
+#[path = "plan_cmd_daemon_session.rs"]
+mod daemon_session;
+use daemon_session::{
+    describe_plan_run, mark_session_as_plan, persist_placeholder_plan_session, retire_plan_session,
+};
 
 pub(crate) struct PlanRunDispatchInput {
     pub foreground: bool,
@@ -353,10 +357,27 @@ pub(crate) async fn handle_plan_run_daemon_child(
     let completed_at = Utc::now();
     let exit_code = if result.is_ok() { 0 } else { 1 };
     let status = SessionResult::status_from_exit_code(exit_code);
+    let failure_report = plan_cmd::plan_cmd_failure::report_from_error(result.as_ref().err());
+    if let Some(report) = &failure_report
+        && let Err(err) = plan_cmd::plan_cmd_failure::persist_report_for_session(
+            &project_root,
+            session_id,
+            report,
+        )
+    {
+        warn!(
+            session_id = %session_id,
+            error = %err,
+            "Failed to write plan failure structured output",
+        );
+    }
     let summary = match &result {
         Ok(()) => format!("plan complete: {workflow_label}"),
         Err(err) => {
-            let mut text = format!("plan failed: {workflow_label}: {err}");
+            let mut text = failure_report
+                .as_ref()
+                .map(|report| report.summary_line(&workflow_label))
+                .unwrap_or_else(|| format!("plan failed: {workflow_label}: {err}"));
             text.truncate(
                 text.char_indices()
                     .nth(200)
@@ -379,7 +400,10 @@ pub(crate) async fn handle_plan_run_daemon_child(
         started_at,
         completed_at,
         events_count: 0,
-        artifacts: vec![SessionArtifact::new(workflow_label.clone())],
+        artifacts: plan_cmd::plan_cmd_failure::session_artifacts(
+            &workflow_label,
+            failure_report.as_ref(),
+        ),
         ..Default::default()
     };
     if let Err(save_err) = save_result(&project_root, session_id, &session_result) {
@@ -477,88 +501,6 @@ fn establish_foreground_plan_session(
         startup_env,
         minted_session_id: Some(session_id),
     })
-}
-
-fn describe_plan_run(args: &PlanRunArgs) -> String {
-    if let Some(name) = &args.pattern {
-        format!("plan: {name}")
-    } else if let Some(file) = &args.file {
-        format!("plan: {file}")
-    } else if let Some(resume) = &args.resume {
-        format!("plan: --resume {resume}")
-    } else {
-        "plan: (unknown workflow)".to_string()
-    }
-}
-
-fn persist_placeholder_plan_session(
-    project_root: &Path,
-    session_dir: &Path,
-    session_id: &str,
-    description: &str,
-) -> Result<()> {
-    let mut state = csa_session::create_session_with_daemon_env(
-        project_root,
-        Some(description),
-        None,
-        None,
-        Some(session_id),
-        Some(session_dir),
-        Some(project_root),
-    )?;
-    anyhow::ensure!(
-        state.meta_session_id == session_id,
-        "daemon placeholder session id mismatch: requested {session_id}, persisted {}",
-        state.meta_session_id
-    );
-    state.task_context.task_type = Some(PLAN_TASK_TYPE.to_string());
-    if let Err(err) = save_session(&state) {
-        warn!(
-            session_id = %session_id,
-            error = %err,
-            "Failed to persist task_type=plan on placeholder session",
-        );
-    }
-    Ok(())
-}
-
-fn mark_session_as_plan(project_root: &Path, session_id: &str, description: &str) -> Result<()> {
-    let mut session = csa_session::load_session(project_root, session_id)?;
-    let mut changed = false;
-    if session.task_context.task_type.as_deref() != Some(PLAN_TASK_TYPE) {
-        session.task_context.task_type = Some(PLAN_TASK_TYPE.to_string());
-        changed = true;
-    }
-    if session
-        .description
-        .as_deref()
-        .map(str::is_empty)
-        .unwrap_or(true)
-    {
-        session.description = Some(description.to_string());
-        changed = true;
-    }
-    if changed {
-        save_session(&session)?;
-    }
-    Ok(())
-}
-
-fn retire_plan_session(project_root: &Path, session_id: &str) -> Result<()> {
-    let mut session: MetaSessionState = csa_session::load_session(project_root, session_id)?;
-    session.last_accessed = Utc::now();
-    if session.phase != csa_session::SessionPhase::Retired
-        && session.apply_phase_event(PhaseEvent::Retired).is_err()
-    {
-        // From Available the transition is also valid; log and continue if unexpected.
-        warn!(
-            session_id = %session_id,
-            current_phase = ?session.phase,
-            "Could not transition plan session to Retired",
-        );
-    }
-    save_session(&session)?;
-    Ok(())
 }
 
 /// Input snapshot for [`decide_needs_foreground`]. Bundling these into a

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_session.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_session.rs
@@ -1,0 +1,94 @@
+use std::path::Path;
+
+use anyhow::Result;
+use chrono::Utc;
+use csa_session::{MetaSessionState, PhaseEvent, save_session};
+use tracing::warn;
+
+use super::{PLAN_TASK_TYPE, PlanRunArgs};
+
+pub(super) fn describe_plan_run(args: &PlanRunArgs) -> String {
+    if let Some(name) = &args.pattern {
+        format!("plan: {name}")
+    } else if let Some(file) = &args.file {
+        format!("plan: {file}")
+    } else if let Some(resume) = &args.resume {
+        format!("plan: --resume {resume}")
+    } else {
+        "plan: (unknown workflow)".to_string()
+    }
+}
+
+pub(super) fn persist_placeholder_plan_session(
+    project_root: &Path,
+    session_dir: &Path,
+    session_id: &str,
+    description: &str,
+) -> Result<()> {
+    let mut state = csa_session::create_session_with_daemon_env(
+        project_root,
+        Some(description),
+        None,
+        None,
+        Some(session_id),
+        Some(session_dir),
+        Some(project_root),
+    )?;
+    anyhow::ensure!(
+        state.meta_session_id == session_id,
+        "daemon placeholder session id mismatch: requested {session_id}, persisted {}",
+        state.meta_session_id
+    );
+    state.task_context.task_type = Some(PLAN_TASK_TYPE.to_string());
+    if let Err(err) = save_session(&state) {
+        warn!(
+            session_id = %session_id,
+            error = %err,
+            "Failed to persist task_type=plan on placeholder session",
+        );
+    }
+    Ok(())
+}
+
+pub(super) fn mark_session_as_plan(
+    project_root: &Path,
+    session_id: &str,
+    description: &str,
+) -> Result<()> {
+    let mut session = csa_session::load_session(project_root, session_id)?;
+    let mut changed = false;
+    if session.task_context.task_type.as_deref() != Some(PLAN_TASK_TYPE) {
+        session.task_context.task_type = Some(PLAN_TASK_TYPE.to_string());
+        changed = true;
+    }
+    if session
+        .description
+        .as_deref()
+        .map(str::is_empty)
+        .unwrap_or(true)
+    {
+        session.description = Some(description.to_string());
+        changed = true;
+    }
+    if changed {
+        save_session(&session)?;
+    }
+    Ok(())
+}
+
+pub(super) fn retire_plan_session(project_root: &Path, session_id: &str) -> Result<()> {
+    let mut session: MetaSessionState = csa_session::load_session(project_root, session_id)?;
+    session.last_accessed = Utc::now();
+    if session.phase != csa_session::SessionPhase::Retired
+        && session.apply_phase_event(PhaseEvent::Retired).is_err()
+    {
+        // From Available the transition is also valid; log and continue if unexpected.
+        warn!(
+            session_id = %session_id,
+            current_phase = ?session.phase,
+            "Could not transition plan session to Retired",
+        );
+    }
+    save_session(&session)?;
+    Ok(())
+}

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use crate::plan_cmd::PlanRunArgs;
+use std::process::Command;
 
 fn make_args() -> PlanRunArgs {
     PlanRunArgs {
@@ -19,6 +20,65 @@ fn make_args() -> PlanRunArgs {
         pipeline_source: crate::plan_cmd::PlanRunPipelineSource::DirectPlanRun,
         startup_env: crate::startup_env::StartupSubtreeEnv::default(),
     }
+}
+
+fn run_git(project_root: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(args)
+        .output()
+        .expect("git command should start");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_plan_test_repo(project_root: &std::path::Path) {
+    run_git(project_root, &["init", "-b", "main"]);
+    run_git(
+        project_root,
+        &["config", "user.email", "csa-test@example.com"],
+    );
+    run_git(project_root, &["config", "user.name", "CSA Test"]);
+    run_git(project_root, &["config", "core.excludesFile", "/dev/null"]);
+    std::fs::write(
+        project_root.join(".git").join("info").join("exclude"),
+        ".csa/\n",
+    )
+    .expect("write repo-local exclude");
+    std::fs::write(project_root.join("README.md"), "test repo\n").expect("write readme");
+    std::fs::write(project_root.join("weave.lock"), "lock = 1\n").expect("write weave.lock");
+}
+
+fn commit_all(project_root: &std::path::Path, message: &str) {
+    run_git(
+        project_root,
+        &["add", "README.md", "weave.lock", "workflow.toml"],
+    );
+    run_git(project_root, &["commit", "-m", message]);
+}
+
+fn plan_daemon_args(project_root: &std::path::Path) -> PlanRunArgs {
+    let mut args = make_args();
+    args.file = Some("workflow.toml".to_string());
+    args.cd = Some(project_root.display().to_string());
+    args
+}
+
+fn prepare_plan_session(
+    project_root: &std::path::Path,
+    description: &str,
+) -> (String, std::path::PathBuf) {
+    let session_id = csa_session::new_session_id();
+    let session_dir = csa_session::get_session_dir(project_root, &session_id)
+        .expect("session dir should resolve");
+    persist_placeholder_plan_session(project_root, &session_dir, &session_id, description)
+        .expect("placeholder plan session should persist");
+    (session_id, session_dir)
 }
 
 #[test]
@@ -50,8 +110,141 @@ fn describe_unknown_when_no_source_provided() {
     assert_eq!(describe_plan_run(&args), "plan: (unknown workflow)");
 }
 
+#[tokio::test]
+async fn daemon_child_failed_plan_writes_structured_failure_output() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("repo");
+    std::fs::create_dir_all(&project_root).expect("repo dir should be created");
+    init_plan_test_repo(&project_root);
+    std::fs::write(
+        project_root.join("workflow.toml"),
+        r#"[workflow]
+name = "failing-plan"
+
+[[workflow.steps]]
+id = 1
+title = "Failing Bash"
+tool = "bash"
+prompt = '''
+```bash
+printf 'structured boom\n' >&2
+exit 7
+```
+'''
+on_fail = "abort"
+"#,
+    )
+    .expect("write workflow");
+    commit_all(&project_root, "initial");
+    let (session_id, session_dir) = prepare_plan_session(&project_root, "plan: failing-plan");
+
+    let result = handle_plan_run_daemon_child(plan_daemon_args(&project_root), &session_id).await;
+
+    assert!(result.is_err(), "failing plan should return an error");
+    let summary = csa_session::read_section(&session_dir, "summary")
+        .expect("summary should load")
+        .expect("summary section should exist");
+    assert!(
+        summary.contains("Failed step: 1 (Failing Bash) exited 7"),
+        "summary must identify failed step and exit code: {summary}"
+    );
+    let details = csa_session::read_section(&session_dir, "details")
+        .expect("details should load")
+        .expect("details section should exist");
+    assert!(
+        details.contains("Step 1: Failing Bash")
+            && details.contains("exit 7")
+            && details.contains("structured boom"),
+        "details must include failed step id, command, exit code, and stderr excerpt: {details}"
+    );
+    let persisted = csa_session::load_result(&project_root, &session_id)
+        .expect("result should load")
+        .expect("result.toml should exist");
+    assert_eq!(persisted.exit_code, 1);
+    assert!(
+        persisted
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == "output/details.md"),
+        "result artifacts must point callers at structured details"
+    );
+}
+
+#[tokio::test]
+async fn daemon_child_failed_pr_bot_restores_checkout_and_weave_lock_when_initially_clean() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("repo");
+    std::fs::create_dir_all(&project_root).expect("repo dir should be created");
+    init_plan_test_repo(&project_root);
+    std::fs::write(
+        project_root.join("workflow.toml"),
+        r#"[workflow]
+name = "pr-bot"
+
+[[workflow.steps]]
+id = 1
+title = "Dirty Main Failure"
+tool = "bash"
+prompt = '''
+```bash
+git switch main
+printf 'plan drift\n' >> weave.lock
+printf 'failed on main\n' >&2
+exit 9
+```
+'''
+on_fail = "abort"
+"#,
+    )
+    .expect("write workflow");
+    commit_all(&project_root, "initial");
+    run_git(&project_root, &["switch", "-c", "fix/pr-bot-recovery"]);
+    let (session_id, session_dir) = prepare_plan_session(&project_root, "plan: pr-bot");
+
+    let result = handle_plan_run_daemon_child(plan_daemon_args(&project_root), &session_id).await;
+
+    assert!(
+        result.is_err(),
+        "failing pr-bot plan should return an error"
+    );
+    let branch = Command::new("git")
+        .arg("-C")
+        .arg(&project_root)
+        .args(["branch", "--show-current"])
+        .output()
+        .expect("git branch should run");
+    assert_eq!(
+        String::from_utf8_lossy(&branch.stdout).trim(),
+        "fix/pr-bot-recovery",
+        "failed pr-bot plan should restore the caller checkout"
+    );
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(&project_root)
+        .args(["status", "--short"])
+        .output()
+        .expect("git status should run");
+    assert!(
+        status.stdout.is_empty(),
+        "failed pr-bot plan should clean plan-created weave.lock drift: {}",
+        String::from_utf8_lossy(&status.stdout)
+    );
+    let details = csa_session::read_section(&session_dir, "details")
+        .expect("details should load")
+        .expect("details section should exist");
+    assert!(
+        details.contains("Recovery status: `restored`")
+            && details.contains("Restored plan-created weave.lock drift")
+            && details.contains("Restored checkout to fix/pr-bot-recovery"),
+        "details must include structured recovery result: {details}"
+    );
+}
+
 #[test]
 fn daemon_child_injects_preassigned_session_into_startup_env() {
+    let _env_lock = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let session_id = "01PARENTSESSION000000000000";
     let mut args = make_args();

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
@@ -171,7 +171,7 @@ on_fail = "abort"
 }
 
 #[tokio::test]
-async fn daemon_child_failed_pr_bot_restores_checkout_and_weave_lock_when_initially_clean() {
+async fn daemon_child_failed_pr_bot_preserves_weave_lock_after_snapshot() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let project_root = temp.path().join("repo");
     std::fs::create_dir_all(&project_root).expect("repo dir should be created");
@@ -224,17 +224,23 @@ on_fail = "abort"
         .args(["status", "--short"])
         .output()
         .expect("git status should run");
+    let status = String::from_utf8_lossy(&status.stdout);
     assert!(
-        status.stdout.is_empty(),
-        "failed pr-bot plan should clean plan-created weave.lock drift: {}",
-        String::from_utf8_lossy(&status.stdout)
+        status.contains("weave.lock"),
+        "failed pr-bot plan should preserve post-snapshot weave.lock changes: {status}"
+    );
+    let weave_lock = std::fs::read_to_string(project_root.join("weave.lock"))
+        .expect("weave.lock should remain readable");
+    assert!(
+        weave_lock.contains("plan drift"),
+        "failed pr-bot plan must not discard weave.lock content: {weave_lock}"
     );
     let details = csa_session::read_section(&session_dir, "details")
         .expect("details should load")
         .expect("details section should exist");
     assert!(
-        details.contains("Recovery status: `restored`")
-            && details.contains("Restored plan-created weave.lock drift")
+        details.contains("Recovery status: `manual-required`")
+            && details.contains("Preserved dirty weave.lock")
             && details.contains("Restored checkout to fix/pr-bot-recovery"),
         "details must include structured recovery result: {details}"
     );

--- a/crates/cli-sub-agent/src/plan_cmd_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure.rs
@@ -1,0 +1,632 @@
+use std::fmt;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use csa_session::SessionArtifact;
+
+use super::StepResult;
+
+const PR_BOT_WORKFLOW_NAME: &str = "pr-bot";
+const WEAVE_LOCK: &str = "weave.lock";
+
+#[derive(Debug, Clone)]
+pub(crate) struct FailedPlanStep {
+    pub(crate) step_id: usize,
+    pub(crate) title: String,
+    pub(crate) exit_code: i32,
+    pub(crate) skipped: bool,
+    pub(crate) command: Option<String>,
+    pub(crate) stderr_excerpt: Option<String>,
+    pub(crate) error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PlanFailureReport {
+    workflow_name: String,
+    workflow_path: String,
+    summary: String,
+    failed_steps: Vec<FailedPlanStep>,
+    recovery: Option<PlanFailureRecoveryReport>,
+}
+
+impl PlanFailureReport {
+    pub(crate) fn from_results(
+        workflow_name: &str,
+        workflow_path: &Path,
+        summary: String,
+        results: &[StepResult],
+        recovery: Option<PlanFailureRecoveryReport>,
+    ) -> Self {
+        let failed_steps = results
+            .iter()
+            .filter(|result| result.exit_code != 0)
+            .map(|result| FailedPlanStep {
+                step_id: result.step_id,
+                title: result.title.clone(),
+                exit_code: result.exit_code,
+                skipped: result.skipped,
+                command: result.command.clone(),
+                stderr_excerpt: result.stderr.clone(),
+                error: result.error.clone(),
+            })
+            .collect();
+
+        Self {
+            workflow_name: workflow_name.to_string(),
+            workflow_path: workflow_path.display().to_string(),
+            summary,
+            failed_steps,
+            recovery,
+        }
+    }
+
+    pub(crate) fn summary_line(&self, workflow_label: &str) -> String {
+        let failed_step = self.failed_steps.iter().find(|step| !step.skipped);
+        let mut line = format!("plan failed: {workflow_label}: {}", self.summary);
+        if let Some(step) = failed_step {
+            line.push_str(&format!(
+                "; failed_step={} exit_code={}",
+                step.step_id, step.exit_code
+            ));
+        }
+        line
+    }
+
+    pub(crate) fn render_summary_section(&self) -> String {
+        let mut lines = vec![
+            format!("Plan failed: {}", self.workflow_name),
+            format!("Summary: {}", self.summary),
+        ];
+        if let Some(step) = self.failed_steps.iter().find(|step| !step.skipped) {
+            lines.push(format!(
+                "Failed step: {} ({}) exited {}",
+                step.step_id, step.title, step.exit_code
+            ));
+        }
+        if let Some(recovery) = &self.recovery {
+            lines.push(format!("Recovery status: {}", recovery.status.as_str()));
+        }
+        lines.join("\n")
+    }
+
+    pub(crate) fn render_details_section(&self) -> String {
+        let mut details = String::new();
+        details.push_str("# Plan Failure Report\n\n");
+        details.push_str(&format!("- Workflow: `{}`\n", self.workflow_name));
+        details.push_str(&format!("- Workflow path: `{}`\n", self.workflow_path));
+        details.push_str(&format!("- Summary: {}\n", self.summary));
+
+        details.push_str("\n## Failed Steps\n");
+        if self.failed_steps.is_empty() {
+            details.push_str("\nNo failed step records were captured.\n");
+        }
+        for step in &self.failed_steps {
+            details.push_str(&format!("\n### Step {}: {}\n\n", step.step_id, step.title));
+            details.push_str(&format!("- Exit code: `{}`\n", step.exit_code));
+            details.push_str(&format!("- Skipped: `{}`\n", step.skipped));
+            if let Some(command) = step.command.as_deref().filter(|value| !value.is_empty()) {
+                details.push_str("\nCommand:\n\n```bash\n");
+                details.push_str(command.trim_end());
+                details.push_str("\n```\n");
+            }
+            if let Some(stderr) = step
+                .stderr_excerpt
+                .as_deref()
+                .filter(|value| !value.is_empty())
+            {
+                details.push_str("\nStderr excerpt:\n\n```text\n");
+                details.push_str(stderr.trim_end());
+                details.push_str("\n```\n");
+            }
+            if let Some(error) = step.error.as_deref().filter(|value| !value.is_empty()) {
+                details.push_str("\nError:\n\n```text\n");
+                details.push_str(error.trim_end());
+                details.push_str("\n```\n");
+            }
+        }
+
+        if let Some(recovery) = &self.recovery {
+            details.push_str("\n## Recovery\n\n");
+            recovery.render_markdown_into(&mut details);
+        }
+
+        details
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PlanFailureError {
+    summary: String,
+    report: PlanFailureReport,
+}
+
+impl PlanFailureError {
+    pub(crate) fn new(summary: String, report: PlanFailureReport) -> Self {
+        Self { summary, report }
+    }
+
+    pub(crate) fn report(&self) -> &PlanFailureReport {
+        &self.report
+    }
+}
+
+impl fmt::Display for PlanFailureError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.summary)
+    }
+}
+
+impl std::error::Error for PlanFailureError {}
+
+pub(crate) fn persist_plan_failure_output(
+    session_dir: &Path,
+    report: &PlanFailureReport,
+) -> Result<()> {
+    let summary = report.render_summary_section();
+    let details = report.render_details_section();
+    let marked = format!(
+        "<!-- CSA:SECTION:summary -->\n{summary}\n<!-- CSA:SECTION:summary:END -->\n\n\
+         <!-- CSA:SECTION:details -->\n{details}\n<!-- CSA:SECTION:details:END -->\n"
+    );
+
+    std::fs::create_dir_all(session_dir)
+        .with_context(|| format!("Failed to create session dir: {}", session_dir.display()))?;
+    std::fs::write(session_dir.join("output.log"), &marked).with_context(|| {
+        format!(
+            "Failed to write {}",
+            session_dir.join("output.log").display()
+        )
+    })?;
+    csa_session::persist_structured_output(session_dir, &marked).with_context(|| {
+        format!(
+            "Failed to persist plan failure output for {}",
+            session_dir.display()
+        )
+    })?;
+    Ok(())
+}
+
+pub(crate) fn report_from_error(error: Option<&anyhow::Error>) -> Option<PlanFailureReport> {
+    error
+        .and_then(|err| err.downcast_ref::<PlanFailureError>())
+        .map(|err| err.report().clone())
+}
+
+pub(crate) fn persist_report_for_session(
+    project_root: &Path,
+    session_id: &str,
+    report: &PlanFailureReport,
+) -> Result<()> {
+    let session_dir = csa_session::get_session_dir(project_root, session_id)?;
+    persist_plan_failure_output(&session_dir, report)
+}
+
+pub(crate) fn session_artifacts(
+    workflow_label: &str,
+    failure_report: Option<&PlanFailureReport>,
+) -> Vec<SessionArtifact> {
+    let mut artifacts = vec![SessionArtifact::new(workflow_label.to_string())];
+    if failure_report.is_some() {
+        artifacts.push(SessionArtifact::new("output/summary.md"));
+        artifacts.push(SessionArtifact::new("output/details.md"));
+    }
+    artifacts
+}
+
+pub(crate) fn capture_failure_recovery_snapshot(
+    workflow_name: &str,
+    project_root: &Path,
+) -> Option<PlanFailureRecoverySnapshot> {
+    (workflow_name == PR_BOT_WORKFLOW_NAME)
+        .then(|| PlanFailureRecoverySnapshot::capture(project_root))
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PlanFailureRecoverySnapshot {
+    initial_ref: Option<CheckoutRef>,
+    initial_status: Option<Vec<String>>,
+    capture_error: Option<String>,
+}
+
+impl PlanFailureRecoverySnapshot {
+    fn capture(project_root: &Path) -> Self {
+        if let Err(error) = run_git(project_root, &["rev-parse", "--is-inside-work-tree"]) {
+            return Self {
+                initial_ref: None,
+                initial_status: None,
+                capture_error: Some(format!("not a git worktree: {error}")),
+            };
+        }
+
+        let initial_ref = match current_checkout_ref(project_root) {
+            Ok(value) => Some(value),
+            Err(error) => {
+                return Self {
+                    initial_ref: None,
+                    initial_status: None,
+                    capture_error: Some(format!("failed to capture initial checkout: {error}")),
+                };
+            }
+        };
+        let initial_status = match git_status_lines(project_root) {
+            Ok(value) => Some(value),
+            Err(error) => {
+                return Self {
+                    initial_ref,
+                    initial_status: None,
+                    capture_error: Some(format!("failed to capture initial git status: {error}")),
+                };
+            }
+        };
+
+        Self {
+            initial_ref,
+            initial_status,
+            capture_error: None,
+        }
+    }
+
+    pub(crate) fn recover_after_failure(&self, project_root: &Path) -> PlanFailureRecoveryReport {
+        let initial_ref_label = self.initial_ref.as_ref().map(CheckoutRef::label);
+        let current_ref_before = current_checkout_ref(project_root)
+            .ok()
+            .map(|value| value.label());
+
+        if let Some(error) = &self.capture_error {
+            return PlanFailureRecoveryReport::manual(
+                initial_ref_label,
+                current_ref_before,
+                vec![format!(
+                    "Automatic recovery skipped because the initial checkout snapshot failed: {error}."
+                )],
+                vec!["git status --short --branch".to_string()],
+            );
+        }
+
+        let Some(initial_status) = &self.initial_status else {
+            return PlanFailureRecoveryReport::manual(
+                initial_ref_label,
+                current_ref_before,
+                vec![
+                    "Automatic recovery skipped because the initial git status is unavailable."
+                        .to_string(),
+                ],
+                vec!["git status --short --branch".to_string()],
+            );
+        };
+        if !initial_status.is_empty() {
+            return PlanFailureRecoveryReport::manual(
+                initial_ref_label.clone(),
+                current_ref_before,
+                vec![
+                    "Automatic recovery skipped because the worktree was already dirty before pr-bot started.".to_string(),
+                    "Resolve the pre-existing changes before retrying pr-bot.".to_string(),
+                ],
+                recovery_commands(initial_ref_label.as_deref(), true),
+            );
+        }
+
+        let mut actions = Vec::new();
+        let status_before_cleanup = match git_status_lines(project_root) {
+            Ok(lines) => lines,
+            Err(error) => {
+                return PlanFailureRecoveryReport::manual(
+                    initial_ref_label.clone(),
+                    current_ref_before,
+                    vec![format!(
+                        "Could not inspect failed worktree status: {error}."
+                    )],
+                    recovery_commands(initial_ref_label.as_deref(), true),
+                );
+            }
+        };
+
+        if only_weave_lock_dirty(&status_before_cleanup) {
+            match restore_weave_lock(project_root, &status_before_cleanup) {
+                Ok(()) => actions.push("Restored plan-created weave.lock drift.".to_string()),
+                Err(error) => {
+                    return PlanFailureRecoveryReport::manual(
+                        initial_ref_label.clone(),
+                        current_ref_before,
+                        vec![format!(
+                            "Could not restore weave.lock automatically: {error}."
+                        )],
+                        recovery_commands(initial_ref_label.as_deref(), true),
+                    );
+                }
+            }
+        } else if !status_before_cleanup.is_empty() {
+            return PlanFailureRecoveryReport::manual(
+                initial_ref_label.clone(),
+                current_ref_before,
+                vec![
+                    "Automatic cleanup only handles plan-created weave.lock drift.".to_string(),
+                    format!(
+                        "Current dirty paths require manual review: {}",
+                        status_before_cleanup.join("; ")
+                    ),
+                ],
+                recovery_commands(initial_ref_label.as_deref(), false),
+            );
+        }
+
+        if let Some(initial_ref) = &self.initial_ref {
+            match current_checkout_ref(project_root) {
+                Ok(current_ref) if &current_ref == initial_ref => {}
+                Ok(_) | Err(_) => match restore_checkout(project_root, initial_ref) {
+                    Ok(()) => {
+                        actions.push(format!("Restored checkout to {}.", initial_ref.label()))
+                    }
+                    Err(error) => {
+                        return PlanFailureRecoveryReport::manual(
+                            initial_ref_label.clone(),
+                            current_ref_before,
+                            vec![format!(
+                                "Could not restore checkout to {} automatically: {error}.",
+                                initial_ref.label()
+                            )],
+                            recovery_commands(initial_ref_label.as_deref(), false),
+                        );
+                    }
+                },
+            }
+        }
+
+        let final_status = git_status_lines(project_root).unwrap_or_else(|error| {
+            vec![format!(
+                "failed to inspect final status after recovery: {error}"
+            )]
+        });
+        let current_ref_after = current_checkout_ref(project_root)
+            .ok()
+            .map(|value| value.label());
+        let checkout_restored = match &self.initial_ref {
+            Some(initial_ref) => {
+                current_checkout_ref(project_root).is_ok_and(|current| &current == initial_ref)
+            }
+            None => true,
+        };
+        if final_status.is_empty() && checkout_restored {
+            let status = if actions.is_empty() {
+                PlanRecoveryStatus::NotNeeded
+            } else {
+                PlanRecoveryStatus::Restored
+            };
+            return PlanFailureRecoveryReport {
+                status,
+                initial_ref: initial_ref_label,
+                current_ref_before,
+                current_ref_after,
+                messages: if actions.is_empty() {
+                    vec!["No checkout or weave.lock cleanup was needed.".to_string()]
+                } else {
+                    actions
+                },
+                recovery_commands: Vec::new(),
+                final_status,
+            };
+        }
+
+        PlanFailureRecoveryReport::manual(
+            initial_ref_label,
+            current_ref_after,
+            vec![
+                "Automatic recovery ran but the checkout or worktree is still not restored."
+                    .to_string(),
+                format!("Remaining status: {}", final_status.join("; ")),
+            ],
+            vec!["git status --short --branch".to_string()],
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CheckoutRef {
+    Branch(String),
+    Detached(String),
+}
+
+impl CheckoutRef {
+    fn label(&self) -> String {
+        match self {
+            Self::Branch(branch) => branch.clone(),
+            Self::Detached(head) => head.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PlanFailureRecoveryReport {
+    status: PlanRecoveryStatus,
+    initial_ref: Option<String>,
+    current_ref_before: Option<String>,
+    current_ref_after: Option<String>,
+    messages: Vec<String>,
+    recovery_commands: Vec<String>,
+    final_status: Vec<String>,
+}
+
+impl PlanFailureRecoveryReport {
+    fn manual(
+        initial_ref: Option<String>,
+        current_ref: Option<String>,
+        messages: Vec<String>,
+        recovery_commands: Vec<String>,
+    ) -> Self {
+        Self {
+            status: PlanRecoveryStatus::ManualRequired,
+            initial_ref,
+            current_ref_before: current_ref.clone(),
+            current_ref_after: current_ref,
+            messages,
+            recovery_commands,
+            final_status: Vec::new(),
+        }
+    }
+
+    fn render_markdown_into(&self, output: &mut String) {
+        output.push_str(&format!("- Recovery status: `{}`\n", self.status.as_str()));
+        if let Some(initial_ref) = &self.initial_ref {
+            output.push_str(&format!("- Initial checkout: `{initial_ref}`\n"));
+        }
+        if let Some(current_ref) = &self.current_ref_before {
+            output.push_str(&format!("- Checkout at failure: `{current_ref}`\n"));
+        }
+        if let Some(current_ref) = &self.current_ref_after {
+            output.push_str(&format!("- Checkout after recovery: `{current_ref}`\n"));
+        }
+        if !self.messages.is_empty() {
+            output.push_str("\nMessages:\n");
+            for message in &self.messages {
+                output.push_str(&format!("- {message}\n"));
+            }
+        }
+        if !self.final_status.is_empty() {
+            output.push_str("\nRemaining git status:\n\n```text\n");
+            output.push_str(&self.final_status.join("\n"));
+            output.push_str("\n```\n");
+        }
+        if !self.recovery_commands.is_empty() {
+            output.push_str("\nManual recovery commands:\n\n```bash\n");
+            for command in &self.recovery_commands {
+                output.push_str(command);
+                output.push('\n');
+            }
+            output.push_str("```\n");
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PlanRecoveryStatus {
+    Restored,
+    NotNeeded,
+    ManualRequired,
+}
+
+impl PlanRecoveryStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Restored => "restored",
+            Self::NotNeeded => "not-needed",
+            Self::ManualRequired => "manual-required",
+        }
+    }
+}
+
+fn current_checkout_ref(project_root: &Path) -> Result<CheckoutRef> {
+    match run_git(
+        project_root,
+        &["symbolic-ref", "--quiet", "--short", "HEAD"],
+    ) {
+        Ok(branch) if !branch.trim().is_empty() => {
+            Ok(CheckoutRef::Branch(branch.trim().to_string()))
+        }
+        Ok(_) | Err(_) => {
+            let head = run_git(project_root, &["rev-parse", "--verify", "HEAD"])?;
+            Ok(CheckoutRef::Detached(head.trim().to_string()))
+        }
+    }
+}
+
+fn git_status_lines(project_root: &Path) -> Result<Vec<String>> {
+    let status = run_git(
+        project_root,
+        &["status", "--porcelain=v1", "--untracked-files=normal"],
+    )?;
+    Ok(status
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+fn only_weave_lock_dirty(status_lines: &[String]) -> bool {
+    !status_lines.is_empty()
+        && status_lines
+            .iter()
+            .all(|line| porcelain_path(line).is_some_and(|path| path == WEAVE_LOCK))
+}
+
+fn porcelain_path(line: &str) -> Option<&str> {
+    line.get(3..).map(str::trim).map(|path| {
+        path.strip_prefix('"')
+            .and_then(|path| path.strip_suffix('"'))
+            .unwrap_or(path)
+    })
+}
+
+fn restore_weave_lock(project_root: &Path, status_lines: &[String]) -> Result<()> {
+    let tracked = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["ls-files", "--error-unmatch", WEAVE_LOCK])
+        .output()
+        .context("failed to check whether weave.lock is tracked")?
+        .status
+        .success();
+    if tracked {
+        run_git_status(
+            project_root,
+            &["restore", "--staged", "--worktree", "--", WEAVE_LOCK],
+        )
+    } else if status_lines.iter().any(|line| line.starts_with("?? ")) {
+        let path = project_root.join(WEAVE_LOCK);
+        if path.exists() {
+            std::fs::remove_file(&path)
+                .with_context(|| format!("failed to remove {}", path.display()))?;
+        }
+        Ok(())
+    } else {
+        anyhow::bail!("weave.lock is dirty but not tracked or safely removable")
+    }
+}
+
+fn restore_checkout(project_root: &Path, initial_ref: &CheckoutRef) -> Result<()> {
+    match initial_ref {
+        CheckoutRef::Branch(branch) => run_git_status(project_root, &["switch", branch]),
+        CheckoutRef::Detached(head) => {
+            run_git_status(project_root, &["checkout", "--detach", head])
+        }
+    }
+}
+
+fn recovery_commands(initial_ref: Option<&str>, include_weave_lock_restore: bool) -> Vec<String> {
+    let mut commands = Vec::new();
+    if include_weave_lock_restore {
+        commands.push(format!("git restore --staged --worktree -- {WEAVE_LOCK}"));
+    }
+    if let Some(initial_ref) = initial_ref {
+        commands.push(format!(
+            "git switch {}",
+            super::shell_escape_for_command(initial_ref)
+        ));
+    }
+    commands.push("git status --short --branch".to_string());
+    commands
+}
+
+fn run_git(project_root: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to run git {}", args.join(" ")))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git {} failed with status {}: {}",
+            args.join(" "),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .trim_end()
+        .to_string())
+}
+
+fn run_git_status(project_root: &Path, args: &[&str]) -> Result<()> {
+    run_git(project_root, args).map(|_| ())
+}

--- a/crates/cli-sub-agent/src/plan_cmd_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure.rs
@@ -46,16 +46,16 @@ impl PlanFailureReport {
                 title: result.title.clone(),
                 exit_code: result.exit_code,
                 skipped: result.skipped,
-                command: result.command.clone(),
-                stderr_excerpt: result.stderr.clone(),
-                error: result.error.clone(),
+                command: redact_optional_text(&result.command),
+                stderr_excerpt: redact_optional_text(&result.stderr),
+                error: redact_optional_text(&result.error),
             })
             .collect();
 
         Self {
             workflow_name: workflow_name.to_string(),
             workflow_path: workflow_path.display().to_string(),
-            summary,
+            summary: csa_session::redact_text_content(&summary),
             failed_steps,
             recovery,
         }
@@ -169,6 +169,7 @@ pub(crate) fn persist_plan_failure_output(
         "<!-- CSA:SECTION:summary -->\n{summary}\n<!-- CSA:SECTION:summary:END -->\n\n\
          <!-- CSA:SECTION:details -->\n{details}\n<!-- CSA:SECTION:details:END -->\n"
     );
+    let marked = csa_session::redact_text_content(&marked);
 
     std::fs::create_dir_all(session_dir)
         .with_context(|| format!("Failed to create session dir: {}", session_dir.display()))?;
@@ -303,7 +304,7 @@ impl PlanFailureRecoverySnapshot {
                     "Automatic recovery skipped because the worktree was already dirty before pr-bot started.".to_string(),
                     "Resolve the pre-existing changes before retrying pr-bot.".to_string(),
                 ],
-                recovery_commands(initial_ref_label.as_deref(), true),
+                recovery_commands(initial_ref_label.as_deref()),
             );
         }
 
@@ -317,7 +318,7 @@ impl PlanFailureRecoverySnapshot {
                     vec![format!(
                         "Could not inspect failed worktree status: {error}."
                     )],
-                    recovery_commands(initial_ref_label.as_deref(), true),
+                    recovery_commands(initial_ref_label.as_deref()),
                 );
             }
         };
@@ -340,7 +341,7 @@ impl PlanFailureRecoverySnapshot {
                         status_before_cleanup.join("; ")
                     ),
                 ],
-                recovery_commands(initial_ref_label.as_deref(), false),
+                recovery_commands(initial_ref_label.as_deref()),
             );
         }
 
@@ -361,7 +362,7 @@ impl PlanFailureRecoverySnapshot {
                             initial_ref_label.clone(),
                             current_ref_before,
                             messages,
-                            recovery_commands(initial_ref_label.as_deref(), false),
+                            recovery_commands(initial_ref_label.as_deref()),
                         );
                     }
                 },
@@ -595,11 +596,12 @@ fn restore_checkout(project_root: &Path, initial_ref: &CheckoutRef) -> Result<()
     }
 }
 
-fn recovery_commands(initial_ref: Option<&str>, include_weave_lock_restore: bool) -> Vec<String> {
+fn redact_optional_text(value: &Option<String>) -> Option<String> {
+    value.as_deref().map(csa_session::redact_text_content)
+}
+
+fn recovery_commands(initial_ref: Option<&str>) -> Vec<String> {
     let mut commands = Vec::new();
-    if include_weave_lock_restore {
-        commands.push(format!("git restore --staged --worktree -- {WEAVE_LOCK}"));
-    }
     if let Some(initial_ref) = initial_ref {
         commands.push(format!(
             "git switch {}",

--- a/crates/cli-sub-agent/src/plan_cmd_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure.rs
@@ -322,26 +322,19 @@ impl PlanFailureRecoverySnapshot {
             }
         };
 
-        if only_weave_lock_dirty(&status_before_cleanup) {
-            match restore_weave_lock(project_root, &status_before_cleanup) {
-                Ok(()) => actions.push("Restored plan-created weave.lock drift.".to_string()),
-                Err(error) => {
-                    return PlanFailureRecoveryReport::manual(
-                        initial_ref_label.clone(),
-                        current_ref_before,
-                        vec![format!(
-                            "Could not restore weave.lock automatically: {error}."
-                        )],
-                        recovery_commands(initial_ref_label.as_deref(), true),
-                    );
-                }
-            }
+        let weave_lock_changed_after_snapshot = only_weave_lock_dirty(&status_before_cleanup);
+        if weave_lock_changed_after_snapshot {
+            actions.push(
+                "Preserved dirty weave.lock because automatic recovery cannot prove it was \
+                 created by this pr-bot run."
+                    .to_string(),
+            );
         } else if !status_before_cleanup.is_empty() {
             return PlanFailureRecoveryReport::manual(
                 initial_ref_label.clone(),
                 current_ref_before,
                 vec![
-                    "Automatic cleanup only handles plan-created weave.lock drift.".to_string(),
+                    "Automatic recovery will not modify dirty paths that it cannot prove were created by pr-bot.".to_string(),
                     format!(
                         "Current dirty paths require manual review: {}",
                         status_before_cleanup.join("; ")
@@ -359,13 +352,15 @@ impl PlanFailureRecoverySnapshot {
                         actions.push(format!("Restored checkout to {}.", initial_ref.label()))
                     }
                     Err(error) => {
+                        let mut messages = actions;
+                        messages.push(format!(
+                            "Could not restore checkout to {} automatically: {error}.",
+                            initial_ref.label()
+                        ));
                         return PlanFailureRecoveryReport::manual(
                             initial_ref_label.clone(),
                             current_ref_before,
-                            vec![format!(
-                                "Could not restore checkout to {} automatically: {error}.",
-                                initial_ref.label()
-                            )],
+                            messages,
                             recovery_commands(initial_ref_label.as_deref(), false),
                         );
                     }
@@ -407,16 +402,32 @@ impl PlanFailureRecoverySnapshot {
                 final_status,
             };
         }
+        if weave_lock_changed_after_snapshot
+            && checkout_restored
+            && only_weave_lock_dirty(&final_status)
+        {
+            let mut messages = actions;
+            messages.push("Review weave.lock before retrying pr-bot.".to_string());
+            return PlanFailureRecoveryReport::manual_with_refs(
+                initial_ref_label,
+                current_ref_before,
+                current_ref_after,
+                messages,
+                vec!["git status --short --branch".to_string()],
+                final_status,
+            );
+        }
 
-        PlanFailureRecoveryReport::manual(
+        PlanFailureRecoveryReport::manual_with_refs(
             initial_ref_label,
+            current_ref_before,
             current_ref_after,
             vec![
                 "Automatic recovery ran but the checkout or worktree is still not restored."
                     .to_string(),
-                format!("Remaining status: {}", final_status.join("; ")),
             ],
             vec!["git status --short --branch".to_string()],
+            final_status,
         )
     }
 }
@@ -454,14 +465,32 @@ impl PlanFailureRecoveryReport {
         messages: Vec<String>,
         recovery_commands: Vec<String>,
     ) -> Self {
+        Self::manual_with_refs(
+            initial_ref,
+            current_ref.clone(),
+            current_ref,
+            messages,
+            recovery_commands,
+            Vec::new(),
+        )
+    }
+
+    fn manual_with_refs(
+        initial_ref: Option<String>,
+        current_ref_before: Option<String>,
+        current_ref_after: Option<String>,
+        messages: Vec<String>,
+        recovery_commands: Vec<String>,
+        final_status: Vec<String>,
+    ) -> Self {
         Self {
             status: PlanRecoveryStatus::ManualRequired,
             initial_ref,
-            current_ref_before: current_ref.clone(),
-            current_ref_after: current_ref,
+            current_ref_before,
+            current_ref_after,
             messages,
             recovery_commands,
-            final_status: Vec::new(),
+            final_status,
         }
     }
 
@@ -557,32 +586,6 @@ fn porcelain_path(line: &str) -> Option<&str> {
     })
 }
 
-fn restore_weave_lock(project_root: &Path, status_lines: &[String]) -> Result<()> {
-    let tracked = Command::new("git")
-        .arg("-C")
-        .arg(project_root)
-        .args(["ls-files", "--error-unmatch", WEAVE_LOCK])
-        .output()
-        .context("failed to check whether weave.lock is tracked")?
-        .status
-        .success();
-    if tracked {
-        run_git_status(
-            project_root,
-            &["restore", "--staged", "--worktree", "--", WEAVE_LOCK],
-        )
-    } else if status_lines.iter().any(|line| line.starts_with("?? ")) {
-        let path = project_root.join(WEAVE_LOCK);
-        if path.exists() {
-            std::fs::remove_file(&path)
-                .with_context(|| format!("failed to remove {}", path.display()))?;
-        }
-        Ok(())
-    } else {
-        anyhow::bail!("weave.lock is dirty but not tracked or safely removable")
-    }
-}
-
 fn restore_checkout(project_root: &Path, initial_ref: &CheckoutRef) -> Result<()> {
     match initial_ref {
         CheckoutRef::Branch(branch) => run_git_status(project_root, &["switch", branch]),
@@ -630,3 +633,7 @@ fn run_git(project_root: &Path, args: &[&str]) -> Result<String> {
 fn run_git_status(project_root: &Path, args: &[&str]) -> Result<()> {
     run_git(project_root, args).map(|_| ())
 }
+
+#[cfg(test)]
+#[path = "plan_cmd_failure_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/plan_cmd_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure.rs
@@ -9,6 +9,7 @@ use super::StepResult;
 
 const PR_BOT_WORKFLOW_NAME: &str = "pr-bot";
 const WEAVE_LOCK: &str = "weave.lock";
+const CSA_PLAN_STATE_PREFIX: &str = ".csa/state/plan/";
 
 #[derive(Debug, Clone)]
 pub(crate) struct FailedPlanStep {
@@ -250,7 +251,7 @@ impl PlanFailureRecoverySnapshot {
                 };
             }
         };
-        let initial_status = match git_status_lines(project_root) {
+        let initial_status = match git_recovery_status_lines(project_root) {
             Ok(value) => Some(value),
             Err(error) => {
                 return Self {
@@ -309,7 +310,7 @@ impl PlanFailureRecoverySnapshot {
         }
 
         let mut actions = Vec::new();
-        let status_before_cleanup = match git_status_lines(project_root) {
+        let status_before_cleanup = match git_recovery_status_lines(project_root) {
             Ok(lines) => lines,
             Err(error) => {
                 return PlanFailureRecoveryReport::manual(
@@ -369,7 +370,7 @@ impl PlanFailureRecoverySnapshot {
             }
         }
 
-        let final_status = git_status_lines(project_root).unwrap_or_else(|error| {
+        let final_status = git_recovery_status_lines(project_root).unwrap_or_else(|error| {
             vec![format!(
                 "failed to inspect final status after recovery: {error}"
             )]
@@ -563,13 +564,24 @@ fn current_checkout_ref(project_root: &Path) -> Result<CheckoutRef> {
 fn git_status_lines(project_root: &Path) -> Result<Vec<String>> {
     let status = run_git(
         project_root,
-        &["status", "--porcelain=v1", "--untracked-files=normal"],
+        &["status", "--porcelain=v1", "--untracked-files=all"],
     )?;
     Ok(status
         .lines()
         .filter(|line| !line.trim().is_empty())
         .map(ToOwned::to_owned)
         .collect())
+}
+
+fn git_recovery_status_lines(project_root: &Path) -> Result<Vec<String>> {
+    Ok(git_status_lines(project_root)?
+        .into_iter()
+        .filter(|line| !is_csa_plan_state_status(line))
+        .collect())
+}
+
+fn is_csa_plan_state_status(line: &str) -> bool {
+    porcelain_path(line).is_some_and(|path| path.starts_with(CSA_PLAN_STATE_PREFIX))
 }
 
 fn only_weave_lock_dirty(status_lines: &[String]) -> bool {

--- a/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
@@ -39,6 +39,17 @@ fn current_branch(project_root: &Path) -> String {
     run_git(project_root, &["branch", "--show-current"]).expect("branch should resolve")
 }
 
+fn write_plan_journal(project_root: &Path, content: &str) {
+    let journal_path = project_root.join(".csa/state/plan/pr-bot.journal.json");
+    std::fs::create_dir_all(
+        journal_path
+            .parent()
+            .expect("journal path should have parent"),
+    )
+    .expect("plan state dir should be created");
+    std::fs::write(journal_path, content).expect("plan journal should be written");
+}
+
 #[test]
 fn persisted_failure_output_redacts_step_secrets() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
@@ -93,6 +104,96 @@ fn persisted_failure_output_redacts_step_secrets() {
             "client secret leaked: {rendered}"
         );
     }
+}
+
+#[test]
+fn recovery_ignores_untracked_plan_journal_after_snapshot() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("repo");
+    init_recovery_test_repo(&project_root, false);
+    run_test_git(&project_root, &["switch", "-c", "fix/recovery"]);
+    let snapshot = PlanFailureRecoverySnapshot::capture(&project_root);
+
+    run_test_git(&project_root, &["switch", "main"]);
+    write_plan_journal(&project_root, r#"{"status":"running"}"#);
+
+    let report = snapshot.recover_after_failure(&project_root);
+
+    assert_eq!(report.status.as_str(), "restored");
+    assert_eq!(current_branch(&project_root), "fix/recovery");
+    assert!(
+        report
+            .final_status
+            .iter()
+            .all(|line| !line.contains(".csa/")),
+        "CSA plan state should not appear as remaining recovery dirt: {report:?}"
+    );
+}
+
+#[test]
+fn recovery_ignores_tracked_plan_journal_change_after_snapshot() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("repo");
+    init_recovery_test_repo(&project_root, false);
+    write_plan_journal(&project_root, r#"{"status":"running"}"#);
+    run_test_git(
+        &project_root,
+        &["add", ".csa/state/plan/pr-bot.journal.json"],
+    );
+    run_test_git(&project_root, &["commit", "-m", "track plan journal"]);
+    run_test_git(&project_root, &["switch", "-c", "fix/recovery"]);
+    let snapshot = PlanFailureRecoverySnapshot::capture(&project_root);
+
+    run_test_git(&project_root, &["switch", "main"]);
+    write_plan_journal(&project_root, r#"{"status":"failed"}"#);
+
+    let report = snapshot.recover_after_failure(&project_root);
+
+    assert_eq!(report.status.as_str(), "restored");
+    assert_eq!(current_branch(&project_root), "fix/recovery");
+    assert!(
+        std::fs::read_to_string(project_root.join(".csa/state/plan/pr-bot.journal.json"))
+            .expect("plan journal should remain readable")
+            .contains("failed"),
+        "recovery must not discard tracked CSA plan journal content"
+    );
+    assert!(
+        report
+            .final_status
+            .iter()
+            .all(|line| !line.contains(".csa/")),
+        "tracked CSA plan journal changes should not appear as remaining recovery dirt: {report:?}"
+    );
+}
+
+#[test]
+fn recovery_preserves_unknown_csa_file_after_snapshot() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("repo");
+    init_recovery_test_repo(&project_root, false);
+    run_test_git(&project_root, &["switch", "-c", "fix/recovery"]);
+    let snapshot = PlanFailureRecoverySnapshot::capture(&project_root);
+
+    run_test_git(&project_root, &["switch", "main"]);
+    std::fs::create_dir_all(project_root.join(".csa")).expect("CSA dir should be created");
+    std::fs::write(project_root.join(".csa/config.toml"), "tool = 'codex'\n")
+        .expect("CSA config should be written");
+
+    let report = snapshot.recover_after_failure(&project_root);
+
+    assert_eq!(report.status.as_str(), "manual-required");
+    assert_eq!(
+        current_branch(&project_root),
+        "main",
+        "unknown .csa files must still block automatic checkout recovery"
+    );
+    assert!(
+        report
+            .messages
+            .iter()
+            .any(|message| message.contains(".csa/config.toml")),
+        "manual report should surface unknown .csa dirt: {report:?}"
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
@@ -40,6 +40,62 @@ fn current_branch(project_root: &Path) -> String {
 }
 
 #[test]
+fn persisted_failure_output_redacts_step_secrets() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let session_dir = temp.path().join("session");
+    let workflow_path = temp.path().join("workflow.toml");
+    let results = vec![StepResult {
+        step_id: 1,
+        title: "Secret Failure".to_string(),
+        exit_code: 7,
+        duration_secs: 0.0,
+        skipped: false,
+        error: Some("Exit code 7\nstderr:\npassword=hunter2".to_string()),
+        output: None,
+        session_id: None,
+        command: Some(
+            "curl -H 'Authorization: Bearer abcDEF123._-token' api_key=key-prod_987654321"
+                .to_string(),
+        ),
+        stderr: Some("client_secret=top-secret-value".to_string()),
+    }];
+    let report = PlanFailureReport::from_results(
+        "failing-plan",
+        &workflow_path,
+        "1 step(s) failed".to_string(),
+        &results,
+        None,
+    );
+
+    persist_plan_failure_output(&session_dir, &report).expect("failure output should persist");
+
+    let output_log =
+        std::fs::read_to_string(session_dir.join("output.log")).expect("output.log should exist");
+    let details = csa_session::read_section(&session_dir, "details")
+        .expect("details should load")
+        .expect("details section should exist");
+    for rendered in [&output_log, &details] {
+        assert!(
+            rendered.contains("[REDACTED]"),
+            "persisted failure output must mark redacted secrets: {rendered}"
+        );
+        assert!(
+            !rendered.contains("abcDEF123._-token"),
+            "bearer token leaked: {rendered}"
+        );
+        assert!(
+            !rendered.contains("key-prod_987654321"),
+            "api key leaked: {rendered}"
+        );
+        assert!(!rendered.contains("hunter2"), "password leaked: {rendered}");
+        assert!(
+            !rendered.contains("top-secret-value"),
+            "client secret leaked: {rendered}"
+        );
+    }
+}
+
+#[test]
 fn recovery_preserves_tracked_weave_lock_change_after_snapshot() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let project_root = temp.path().join("repo");
@@ -104,5 +160,42 @@ fn recovery_preserves_untracked_weave_lock_change_after_snapshot() {
             .iter()
             .any(|line| line.starts_with("?? ") && line.contains(WEAVE_LOCK)),
         "manual report should surface untracked weave.lock status: {report:?}"
+    );
+}
+
+#[test]
+fn recovery_commands_do_not_restore_initially_dirty_weave_lock() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("repo");
+    init_recovery_test_repo(&project_root, true);
+    std::fs::write(
+        project_root.join(WEAVE_LOCK),
+        "lock = 1\npre-existing user edit\n",
+    )
+    .expect("write pre-existing weave.lock change");
+    let snapshot = PlanFailureRecoverySnapshot::capture(&project_root);
+
+    let report = snapshot.recover_after_failure(&project_root);
+
+    assert_eq!(report.status.as_str(), "manual-required");
+    assert!(
+        report
+            .messages
+            .iter()
+            .any(|message| message.contains("already dirty before pr-bot started")),
+        "manual report should explain pre-existing dirty state: {report:?}"
+    );
+    assert!(
+        report
+            .recovery_commands
+            .iter()
+            .all(|command| !command.contains("git restore --staged --worktree -- weave.lock")),
+        "manual recovery commands must not discard pre-existing weave.lock edits: {report:?}"
+    );
+    assert!(
+        std::fs::read_to_string(project_root.join(WEAVE_LOCK))
+            .expect("weave.lock should remain")
+            .contains("pre-existing user edit"),
+        "recovery report generation must not alter pre-existing weave.lock content"
     );
 }

--- a/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
@@ -1,0 +1,108 @@
+use super::*;
+use std::path::Path;
+
+fn run_test_git(project_root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(args)
+        .output()
+        .expect("git command should start");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_recovery_test_repo(project_root: &Path, track_weave_lock: bool) {
+    std::fs::create_dir_all(project_root).expect("repo dir should be created");
+    run_test_git(project_root, &["init", "-b", "main"]);
+    run_test_git(
+        project_root,
+        &["config", "user.email", "csa-test@example.com"],
+    );
+    run_test_git(project_root, &["config", "user.name", "CSA Test"]);
+    run_test_git(project_root, &["config", "core.excludesFile", "/dev/null"]);
+    std::fs::write(project_root.join("README.md"), "test repo\n").expect("write readme");
+    if track_weave_lock {
+        std::fs::write(project_root.join(WEAVE_LOCK), "lock = 1\n").expect("write weave.lock");
+        run_test_git(project_root, &["add", "README.md", WEAVE_LOCK]);
+    } else {
+        run_test_git(project_root, &["add", "README.md"]);
+    }
+    run_test_git(project_root, &["commit", "-m", "initial"]);
+}
+
+fn current_branch(project_root: &Path) -> String {
+    run_git(project_root, &["branch", "--show-current"]).expect("branch should resolve")
+}
+
+#[test]
+fn recovery_preserves_tracked_weave_lock_change_after_snapshot() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("repo");
+    init_recovery_test_repo(&project_root, true);
+    run_test_git(&project_root, &["switch", "-c", "fix/recovery"]);
+    let snapshot = PlanFailureRecoverySnapshot::capture(&project_root);
+
+    run_test_git(&project_root, &["switch", "main"]);
+    std::fs::write(
+        project_root.join(WEAVE_LOCK),
+        "lock = 1\nuser concurrent edit\n",
+    )
+    .expect("write post-snapshot weave.lock change");
+
+    let report = snapshot.recover_after_failure(&project_root);
+
+    assert_eq!(report.status.as_str(), "manual-required");
+    assert_eq!(current_branch(&project_root), "fix/recovery");
+    assert!(
+        std::fs::read_to_string(project_root.join(WEAVE_LOCK))
+            .expect("weave.lock should remain")
+            .contains("user concurrent edit"),
+        "recovery must preserve tracked weave.lock content"
+    );
+    assert!(
+        report
+            .messages
+            .iter()
+            .any(|message| message.contains("Preserved dirty weave.lock")),
+        "manual recovery message should explain why weave.lock was preserved: {report:?}"
+    );
+    assert!(
+        report
+            .final_status
+            .iter()
+            .any(|line| line.contains(WEAVE_LOCK)),
+        "manual report should surface remaining weave.lock status: {report:?}"
+    );
+}
+
+#[test]
+fn recovery_preserves_untracked_weave_lock_change_after_snapshot() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("repo");
+    init_recovery_test_repo(&project_root, false);
+    let snapshot = PlanFailureRecoverySnapshot::capture(&project_root);
+    std::fs::write(project_root.join(WEAVE_LOCK), "user concurrent edit\n")
+        .expect("write untracked weave.lock");
+
+    let report = snapshot.recover_after_failure(&project_root);
+
+    assert_eq!(report.status.as_str(), "manual-required");
+    assert_eq!(current_branch(&project_root), "main");
+    assert_eq!(
+        std::fs::read_to_string(project_root.join(WEAVE_LOCK))
+            .expect("untracked weave.lock should remain"),
+        "user concurrent edit\n"
+    );
+    assert!(
+        report
+            .final_status
+            .iter()
+            .any(|line| line.starts_with("?? ") && line.contains(WEAVE_LOCK)),
+        "manual report should surface untracked weave.lock status: {report:?}"
+    );
+}

--- a/crates/cli-sub-agent/src/plan_cmd_step_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_step_failure.rs
@@ -1,6 +1,6 @@
 use weave::compiler::PlanStep;
 
-use super::StepTarget;
+use super::{StepResult, StepTarget};
 
 const STEP_FAILURE_STDERR_TAIL_LINES: usize = 20;
 const STEP_FAILURE_STDERR_TAIL_MAX_CHARS: usize = 4000;
@@ -50,6 +50,11 @@ pub(super) fn format_step_failure_error(exit_code: i32, stderr: &str) -> String 
     error
 }
 
+pub(super) fn serialize_step_result_json(result: &StepResult) -> String {
+    let json = serde_json::to_string(result).expect("serialize StepResult");
+    csa_session::redact_event(&json)
+}
+
 pub(super) fn stderr_tail(stderr: &str) -> Option<String> {
     let mut lines = stderr
         .lines()
@@ -74,3 +79,7 @@ pub(super) fn stderr_tail(stderr: &str) -> Option<String> {
     }
     Some(tail)
 }
+
+#[cfg(test)]
+#[path = "plan_cmd_steps_serialization_tests.rs"]
+mod step_result_serialization_tests;

--- a/crates/cli-sub-agent/src/plan_cmd_step_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_step_failure.rs
@@ -1,0 +1,76 @@
+use weave::compiler::PlanStep;
+
+use super::StepTarget;
+
+const STEP_FAILURE_STDERR_TAIL_LINES: usize = 20;
+const STEP_FAILURE_STDERR_TAIL_MAX_CHARS: usize = 4000;
+
+pub(super) fn describe_step_command(
+    target: &StepTarget,
+    step: &PlanStep,
+    forwarded_session: Option<&str>,
+) -> String {
+    match target {
+        StepTarget::DirectBash => {
+            super::super::plan_cmd_exec::extract_bash_code_block(&step.prompt)
+                .unwrap_or(&step.prompt)
+                .to_string()
+        }
+        StepTarget::CsaTool {
+            tool_name,
+            model_spec,
+            tier_name,
+        } => {
+            let mut parts = vec![format!("csa plan step via tool={}", tool_name.as_str())];
+            if let Some(tier_name) = tier_name.as_deref() {
+                parts.push(format!("tier={tier_name}"));
+            }
+            if let Some(model_spec) = model_spec.as_deref() {
+                parts.push(format!("model_spec={model_spec}"));
+            }
+            if let Some(session) = forwarded_session {
+                parts.push(format!("session={session}"));
+            }
+            parts.join(" ")
+        }
+        StepTarget::WeaveInclude => "weave include".to_string(),
+        StepTarget::Note => "note".to_string(),
+        StepTarget::Manual => "manual handoff".to_string(),
+        StepTarget::AwaitUser => "await user".to_string(),
+    }
+}
+
+pub(super) fn format_step_failure_error(exit_code: i32, stderr: &str) -> String {
+    let mut error = format!("Exit code {exit_code}");
+    if let Some(stderr_tail) = stderr_tail(stderr) {
+        error.push_str(&format!(
+            "\nstderr (last {STEP_FAILURE_STDERR_TAIL_LINES} lines):\n{stderr_tail}"
+        ));
+    }
+    error
+}
+
+pub(super) fn stderr_tail(stderr: &str) -> Option<String> {
+    let mut lines = stderr
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .rev()
+        .take(STEP_FAILURE_STDERR_TAIL_LINES)
+        .collect::<Vec<_>>();
+    if lines.is_empty() {
+        return None;
+    }
+    lines.reverse();
+    let mut tail = lines.join("\n");
+    if tail.len() > STEP_FAILURE_STDERR_TAIL_MAX_CHARS {
+        let keep_from = tail
+            .char_indices()
+            .rev()
+            .find_map(|(idx, _)| {
+                (tail.len() - idx <= STEP_FAILURE_STDERR_TAIL_MAX_CHARS).then_some(idx)
+            })
+            .unwrap_or(0);
+        tail = format!("...{}", &tail[keep_from..]);
+    }
+    Some(tail)
+}

--- a/crates/cli-sub-agent/src/plan_cmd_steps.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps.rs
@@ -27,11 +27,11 @@ use super::{
 };
 use crate::startup_env::StartupSubtreeEnv;
 
-const STEP_FAILURE_STDERR_TAIL_LINES: usize = 20;
-const STEP_FAILURE_STDERR_TAIL_MAX_CHARS: usize = 4000;
-
+#[path = "plan_cmd_step_failure.rs"]
+mod step_failure;
 #[path = "plan_cmd_step_target.rs"]
 mod step_target;
+use step_failure::{describe_step_command, format_step_failure_error, stderr_tail};
 #[cfg(test)]
 pub(crate) use step_target::resolve_step_tool;
 pub(crate) use step_target::{
@@ -51,6 +51,12 @@ pub(crate) struct StepResult {
     pub(crate) output: Option<String>,
     /// CSA meta session ID, exposed to later steps as `${STEP_<id>_SESSION}`.
     pub(crate) session_id: Option<String>,
+    /// Human-readable command or dispatch description for failure reports.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) command: Option<String>,
+    /// Captured stderr from the final attempt, kept out of step output variables.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) stderr: Option<String>,
 }
 
 pub(super) struct PlanRunContext<'a> {
@@ -288,6 +294,8 @@ pub(crate) async fn execute_step_with_workflow(
                 error: None,
                 output: None,
                 session_id: None,
+                command: None,
+                stderr: None,
             };
         }
         info!("{} - Condition '{}' met, proceeding", label, condition);
@@ -303,6 +311,8 @@ pub(crate) async fn execute_step_with_workflow(
             error: Some("Loop steps not supported in v1".to_string()),
             output: None,
             session_id: None,
+            command: None,
+            stderr: None,
         };
     }
 
@@ -326,6 +336,8 @@ pub(crate) async fn execute_step_with_workflow(
                 error: Some(format!("Tool resolution failed: {e}")),
                 output: None,
                 session_id: None,
+                command: None,
+                stderr: None,
             };
         }
     };
@@ -365,6 +377,8 @@ pub(crate) async fn execute_step_with_workflow(
                 error: None,
                 output: None,
                 session_id: None,
+                command: None,
+                stderr: None,
             };
         }
         StepTarget::Note => {
@@ -379,6 +393,8 @@ pub(crate) async fn execute_step_with_workflow(
                 error: None,
                 output: None,
                 session_id: None,
+                command: None,
+                stderr: None,
             };
         }
         StepTarget::Manual => {
@@ -398,6 +414,8 @@ pub(crate) async fn execute_step_with_workflow(
                 error: Some(status),
                 output: Some(message),
                 session_id: None,
+                command: None,
+                stderr: None,
             };
         }
         StepTarget::AwaitUser => {
@@ -417,6 +435,8 @@ pub(crate) async fn execute_step_with_workflow(
                 error: Some(status),
                 output: Some(message),
                 session_id: None,
+                command: None,
+                stderr: None,
             };
         }
         StepTarget::DirectBash | StepTarget::CsaTool { .. } => {}
@@ -463,6 +483,7 @@ pub(crate) async fn execute_step_with_workflow(
     };
 
     let mut last_failure = None;
+    let command = describe_step_command(&target, step, csa_session.as_deref());
 
     for attempt in 1..=max_attempts {
         if attempt > 1 {
@@ -547,6 +568,8 @@ pub(crate) async fn execute_step_with_workflow(
                 error: None,
                 output,
                 session_id: outcome.session_id,
+                command: Some(command.clone()),
+                stderr: None,
             };
         }
 
@@ -562,6 +585,7 @@ pub(crate) async fn execute_step_with_workflow(
         .as_ref()
         .map(|outcome| outcome.stderr.as_str())
         .unwrap_or_default();
+    let failure_stderr_tail = stderr_tail(failure_stderr);
     let failure_error = format_step_failure_error(exit_code, failure_stderr);
 
     // Handle on_fail
@@ -581,6 +605,8 @@ pub(crate) async fn execute_step_with_workflow(
                 error: Some(format!("Skipped after failure ({failure_error})")),
                 output: None,
                 session_id: None,
+                command: Some(command.clone()),
+                stderr: failure_stderr_tail,
             }
         }
         FailAction::Delegate(target) => {
@@ -600,6 +626,8 @@ pub(crate) async fn execute_step_with_workflow(
                 )),
                 output: None,
                 session_id: None,
+                command: Some(command.clone()),
+                stderr: failure_stderr_tail,
             }
         }
         _ => {
@@ -615,42 +643,9 @@ pub(crate) async fn execute_step_with_workflow(
                 error: Some(failure_error),
                 output: None,
                 session_id: None,
+                command: Some(command),
+                stderr: failure_stderr_tail,
             }
         }
     }
-}
-
-fn format_step_failure_error(exit_code: i32, stderr: &str) -> String {
-    let mut error = format!("Exit code {exit_code}");
-    if let Some(stderr_tail) = stderr_tail(stderr) {
-        error.push_str(&format!(
-            "\nstderr (last {STEP_FAILURE_STDERR_TAIL_LINES} lines):\n{stderr_tail}"
-        ));
-    }
-    error
-}
-
-fn stderr_tail(stderr: &str) -> Option<String> {
-    let mut lines = stderr
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .rev()
-        .take(STEP_FAILURE_STDERR_TAIL_LINES)
-        .collect::<Vec<_>>();
-    if lines.is_empty() {
-        return None;
-    }
-    lines.reverse();
-    let mut tail = lines.join("\n");
-    if tail.len() > STEP_FAILURE_STDERR_TAIL_MAX_CHARS {
-        let keep_from = tail
-            .char_indices()
-            .rev()
-            .find_map(|(idx, _)| {
-                (tail.len() - idx <= STEP_FAILURE_STDERR_TAIL_MAX_CHARS).then_some(idx)
-            })
-            .unwrap_or(0);
-        tail = format!("...{}", &tail[keep_from..]);
-    }
-    Some(tail)
 }

--- a/crates/cli-sub-agent/src/plan_cmd_steps.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps.rs
@@ -31,7 +31,9 @@ use crate::startup_env::StartupSubtreeEnv;
 mod step_failure;
 #[path = "plan_cmd_step_target.rs"]
 mod step_target;
-use step_failure::{describe_step_command, format_step_failure_error, stderr_tail};
+use step_failure::{
+    describe_step_command, format_step_failure_error, serialize_step_result_json, stderr_tail,
+};
 #[cfg(test)]
 pub(crate) use step_target::resolve_step_tool;
 pub(crate) use step_target::{
@@ -189,8 +191,7 @@ pub(super) async fn execute_plan_with_journal(
                 persist_plan_journal(path, run_ctx.journal)?;
             }
             if run_ctx.chunked {
-                let json = serde_json::to_string(&result)
-                    .expect("StepResult serialization should never fail");
+                let json = serialize_step_result_json(&result);
                 println!("{json}");
                 results.push(result);
                 break;
@@ -215,8 +216,7 @@ pub(super) async fn execute_plan_with_journal(
         }
 
         if run_ctx.chunked && !result.skipped {
-            let json =
-                serde_json::to_string(&result).expect("StepResult serialization should never fail");
+            let json = serialize_step_result_json(&result);
             println!("{json}");
             results.push(result);
             break;

--- a/crates/cli-sub-agent/src/plan_cmd_steps_serialization_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps_serialization_tests.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+#[test]
+fn serialize_step_result_json_redacts_failure_metadata() {
+    let result = StepResult {
+        step_id: 1,
+        title: "secret failure".to_string(),
+        exit_code: 1,
+        duration_secs: 0.0,
+        skipped: false,
+        error: Some("Exit code 1\nstderr:\npassword=hunter2".to_string()),
+        output: None,
+        session_id: None,
+        command: Some(
+            "curl -H 'Authorization: Bearer abcDEF123._-token' api_key=key-prod_987654321"
+                .to_string(),
+        ),
+        stderr: Some("client_secret=top-secret-value".to_string()),
+    };
+
+    let json = serialize_step_result_json(&result);
+
+    assert!(
+        json.contains("[REDACTED]"),
+        "redacted JSON must mark secrets: {json}"
+    );
+    assert!(
+        !json.contains("abcDEF123._-token"),
+        "bearer token leaked: {json}"
+    );
+    assert!(
+        !json.contains("key-prod_987654321"),
+        "api key leaked: {json}"
+    );
+    assert!(!json.contains("hunter2"), "password leaked: {json}");
+    assert!(
+        !json.contains("top-secret-value"),
+        "client secret leaked: {json}"
+    );
+    serde_json::from_str::<serde_json::Value>(&json).expect("redacted chunk must stay JSON");
+}

--- a/crates/cli-sub-agent/src/plan_cmd_tests_step_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_step_failure.rs
@@ -41,4 +41,14 @@ async fn execute_step_failure_reports_stderr_tail() {
         !error.contains("err-01"),
         "failure summary must keep only the stderr tail: {error}"
     );
+    let command = result.command.as_deref().unwrap_or_default();
+    assert!(
+        command.contains("exit 1"),
+        "failure report command must include the executed bash script: {command}"
+    );
+    let stderr = result.stderr.as_deref().unwrap_or_default();
+    assert!(
+        stderr.contains("err-25") && !stderr.contains("err-01"),
+        "structured stderr excerpt must keep the same tail as the error summary: {stderr}"
+    );
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.947"
-weave = "0.1.947"
+csa = "0.1.948"
+weave = "0.1.948"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- emit structured diagnostics for failed `csa plan run --pattern pr-bot` runs
- make failed pr-bot plan recovery preserve user/concurrent `weave.lock` changes and avoid unsafe cleanup commands
- redact secrets in failure artifacts
- ignore CSA-owned plan journal dirt when deciding whether recovery is safe

Closes #1959
Closes #1960

## Verification
- CSA writer: 01KTK2YJVX16EVFA7550YV6C92
- Review finding fixes: 01KTK5D6PT1CTBQ0FQQNCE0KGA, 01KTK6K4DYNS59TBHDNZ4GCJJY, 01KTK833NEMJ6RBMD128SMVMK1
- CSA Codex tier-4 review PASS: 01KTK8W6R1647B9BVCCAEKTSGH
- pre-push review-check passed for 7cde7de09ce

## Follow-up
- Filed #1963 for first `session wait` returning exit 1 while fallback is pending.