### PR TITLE
fix(session): keep wait pending during tier fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.948"
+version = "0.1.949"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.948"
+version = "0.1.949"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -24,7 +24,10 @@ pub(crate) use completion::SESSION_WAIT_MEMORY_WARN_EXIT_CODE;
 pub(crate) use completion::resolve_wait_completion_status_and_exit;
 pub(crate) use lock::try_acquire_session_wait_lock;
 pub(crate) use next_step::synthesized_wait_next_step;
-use result_loader::{load_completed_daemon_result_with_fallback, refresh_result_for_wait};
+use result_loader::{
+    load_completed_daemon_result_with_fallback, refresh_result_for_wait,
+    suppress_pending_tier_failover_result,
+};
 use summary::emit_wait_terminal_output;
 #[cfg(test)]
 pub(crate) use summary::render_wait_result_summary;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -17,7 +17,7 @@ use super::completion::{
 use super::types::{WaitExecutionOptions, WaitReconciliationOutcome};
 use super::{
     emit_wait_terminal_output, load_completed_daemon_result_with_fallback, refresh_result_for_wait,
-    try_acquire_session_wait_lock,
+    suppress_pending_tier_failover_result, try_acquire_session_wait_lock,
 };
 use crate::session_cmds::resolve_session_prefix_with_global_fallback;
 use crate::session_cmds_daemon::{
@@ -127,7 +127,14 @@ where
                     "session wait",
                 )?;
             } else {
-                loaded_result = finalize_daemon_completion_if_present(&session_dir)?;
+                loaded_result =
+                    finalize_daemon_completion_if_present(&session_dir)?.and_then(|result| {
+                        suppress_pending_tier_failover_result(
+                            &resolved.session_id,
+                            &session_dir,
+                            result,
+                        )
+                    });
                 if loaded_result.is_none() {
                     let reconciled = reconcile_dead_active_session(
                         effective_root,

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_result.rs
@@ -5,12 +5,14 @@ use anyhow::Result;
 
 use super::super::session_has_terminal_process;
 
-fn suppress_pending_tier_failover_result(
+pub(super) fn suppress_pending_tier_failover_result(
     session_id: &str,
     session_dir: &Path,
     result: csa_session::SessionResult,
 ) -> Option<csa_session::SessionResult> {
-    if crate::session_tier_failover::is_pending_tier_failover_handoff(session_dir, &result) {
+    if crate::session_tier_failover::is_pending_tier_failover_handoff(session_dir, &result)
+        || is_probable_pending_tier_failover_failure(session_dir, &result)
+    {
         tracing::debug!(
             session_id,
             status = %result.status,
@@ -20,6 +22,36 @@ fn suppress_pending_tier_failover_result(
     } else {
         Some(result)
     }
+}
+
+fn is_probable_pending_tier_failover_failure(
+    session_dir: &Path,
+    result: &csa_session::SessionResult,
+) -> bool {
+    result.status == "failure"
+        && result.exit_code != 0
+        && result.tool == "gemini-cli"
+        && result.summary.to_ascii_lowercase().contains("status: 400")
+        && session_has_review_tier_context(session_dir)
+        && tier_failover_handoff_has_liveness(session_dir)
+}
+
+fn session_has_review_tier_context(session_dir: &Path) -> bool {
+    let state_path = session_dir.join("state.toml");
+    let Ok(contents) = fs::read_to_string(state_path) else {
+        return false;
+    };
+    let Ok(session) = toml::from_str::<csa_session::MetaSessionState>(&contents) else {
+        return false;
+    };
+    session.task_context.task_type.as_deref() == Some("reviewer_sub_session")
+        && session.task_context.tier_name.is_some()
+}
+
+fn tier_failover_handoff_has_liveness(session_dir: &Path) -> bool {
+    csa_process::ToolLiveness::has_live_process(session_dir)
+        || csa_process::ToolLiveness::daemon_pid_is_alive(session_dir)
+        || csa_process::ToolLiveness::is_alive(session_dir)
 }
 
 fn load_completed_daemon_result(
@@ -99,7 +131,10 @@ fn load_completed_daemon_result_adaptive(
     }
 }
 
-fn load_output_result_fallback(session_dir: &Path) -> Result<Option<csa_session::SessionResult>> {
+fn load_output_result_fallback(
+    session_id: &str,
+    session_dir: &Path,
+) -> Result<Option<csa_session::SessionResult>> {
     let output_result_path = session_dir
         .join("output")
         .join(csa_session::result::RESULT_FILE_NAME);
@@ -114,7 +149,11 @@ fn load_output_result_fallback(session_dir: &Path) -> Result<Option<csa_session:
 
     let contents = fs::read_to_string(&output_result_path)?;
     let result: csa_session::SessionResult = toml::from_str(&contents)?;
-    Ok(Some(result))
+    Ok(suppress_pending_tier_failover_result(
+        session_id,
+        session_dir,
+        result,
+    ))
 }
 
 pub(super) fn load_completed_daemon_result_with_fallback(
@@ -133,7 +172,7 @@ pub(super) fn load_completed_daemon_result_with_fallback(
     }
 
     if !session_has_terminal_process(session_dir)
-        && let Some(output_result) = load_output_result_fallback(session_dir)?
+        && let Some(output_result) = load_output_result_fallback(session_id, session_dir)?
     {
         tracing::info!(
             session_id,

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_result.rs
@@ -10,9 +10,7 @@ pub(super) fn suppress_pending_tier_failover_result(
     session_dir: &Path,
     result: csa_session::SessionResult,
 ) -> Option<csa_session::SessionResult> {
-    if crate::session_tier_failover::is_pending_tier_failover_handoff(session_dir, &result)
-        || is_probable_pending_tier_failover_failure(session_dir, &result)
-    {
+    if crate::session_tier_failover::is_pending_tier_failover_handoff(session_dir, &result) {
         tracing::debug!(
             session_id,
             status = %result.status,
@@ -22,36 +20,6 @@ pub(super) fn suppress_pending_tier_failover_result(
     } else {
         Some(result)
     }
-}
-
-fn is_probable_pending_tier_failover_failure(
-    session_dir: &Path,
-    result: &csa_session::SessionResult,
-) -> bool {
-    result.status == "failure"
-        && result.exit_code != 0
-        && result.tool == "gemini-cli"
-        && result.summary.to_ascii_lowercase().contains("status: 400")
-        && session_has_review_tier_context(session_dir)
-        && tier_failover_handoff_has_liveness(session_dir)
-}
-
-fn session_has_review_tier_context(session_dir: &Path) -> bool {
-    let state_path = session_dir.join("state.toml");
-    let Ok(contents) = fs::read_to_string(state_path) else {
-        return false;
-    };
-    let Ok(session) = toml::from_str::<csa_session::MetaSessionState>(&contents) else {
-        return false;
-    };
-    session.task_context.task_type.as_deref() == Some("reviewer_sub_session")
-        && session.task_context.tier_name.is_some()
-}
-
-fn tier_failover_handoff_has_liveness(session_dir: &Path) -> bool {
-    csa_process::ToolLiveness::has_live_process(session_dir)
-        || csa_process::ToolLiveness::daemon_pid_is_alive(session_dir)
-        || csa_process::ToolLiveness::is_alive(session_dir)
 }
 
 fn load_completed_daemon_result(

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
@@ -258,7 +258,7 @@ fn handle_session_wait_ignores_tier_failover_superseded_result_while_liveness_pr
 }
 
 #[test]
-fn handle_session_wait_does_not_terminalize_gemini_failure_during_tier_fallback_handoff() {
+fn handle_session_wait_terminalizes_last_candidate_gemini_failure() {
     let td = tempdir().unwrap();
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
@@ -282,18 +282,14 @@ fn handle_session_wait_does_not_terminalize_gemini_failure_during_tier_fallback_
     };
     save_session(&session_state).unwrap();
     let session_dir = get_session_dir(project, &session_id).unwrap();
-    save_result(
-        project,
-        &session_id,
-        &SessionResult {
-            status: "failure".to_string(),
-            exit_code: 1,
-            summary: "status: 400".to_string(),
-            tool: "gemini-cli".to_string(),
-            ..make_result("failure", 1)
-        },
-    )
-    .unwrap();
+    let terminal_result = SessionResult {
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "status: 400".to_string(),
+        tool: "gemini-cli".to_string(),
+        ..make_result("failure", 1)
+    };
+    save_result(project, &session_id, &terminal_result).unwrap();
     std::fs::write(
         session_dir.join("daemon-completion.toml"),
         "exit_code = 1\nstatus = \"failure\"\n",
@@ -305,7 +301,7 @@ fn handle_session_wait_does_not_terminalize_gemini_failure_during_tier_fallback_
     )
     .unwrap();
 
-    let mut emitted_completion = false;
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
     let exit_code = handle_session_wait_with_hooks(
         session_id.clone(),
         Some(project.to_string_lossy().into_owned()),
@@ -323,18 +319,19 @@ fn handle_session_wait_does_not_terminalize_gemini_failure_during_tier_fallback_
                 synthetic: false,
             })
         },
-        |_sid: &str, _status: &str, _exit_code, _synthetic, _mirror_to_stdout| {
-            emitted_completion = true;
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
         },
     )
     .unwrap();
 
     assert_eq!(
-        exit_code, 0,
-        "Gemini failure must stay nonterminal while tier fallback handoff is live"
+        exit_code, 1,
+        "last-candidate Gemini failure must return the terminal result exit code"
     );
-    assert!(
-        !emitted_completion,
-        "pending fallback handoff must not emit terminal wait completion"
+    assert_eq!(
+        emitted_completion,
+        Some((session_id, "failure".to_string(), 1, false)),
+        "last-candidate Gemini failure must emit terminal wait completion"
     );
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
@@ -207,6 +207,21 @@ fn handle_session_wait_ignores_tier_failover_superseded_result_while_liveness_pr
         "fallback codex review is being scheduled\n",
     )
     .unwrap();
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 1\nstatus = \"failure\"\n",
+    )
+    .unwrap();
+    let pending_result = load_result(project, &session_id)
+        .unwrap()
+        .expect("superseded result should exist");
+    assert!(
+        crate::session_tier_failover::is_pending_tier_failover_handoff(
+            &session_dir,
+            &pending_result
+        ),
+        "same state must make session result report pending tier fallback"
+    );
 
     let mut emitted_completion = false;
     let exit_code = handle_session_wait_with_hooks(
@@ -239,5 +254,87 @@ fn handle_session_wait_ignores_tier_failover_superseded_result_while_liveness_pr
     assert!(
         !emitted_completion,
         "superseded intermediate attempts must not emit terminal wait completion while fallback is live"
+    );
+}
+
+#[test]
+fn handle_session_wait_does_not_terminalize_gemini_failure_during_tier_fallback_handoff() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-tier-failover-gemini-400-live"),
+        None,
+        Some("gemini-cli"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let mut session_state = load_session(project, &session_id).unwrap();
+    session_state.task_context = TaskContext {
+        task_type: Some("reviewer_sub_session".to_string()),
+        tier_name: Some("tier-4-critical".to_string()),
+    };
+    save_session(&session_state).unwrap();
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    save_result(
+        project,
+        &session_id,
+        &SessionResult {
+            status: "failure".to_string(),
+            exit_code: 1,
+            summary: "status: 400".to_string(),
+            tool: "gemini-cli".to_string(),
+            ..make_result("failure", 1)
+        },
+    )
+    .unwrap();
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 1\nstatus = \"failure\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        session_dir.join("stderr.log"),
+        "fallback codex review is being scheduled\n",
+    )
+    .unwrap();
+
+    let mut emitted_completion = false;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |_sid: &str, _status: &str, _exit_code, _synthetic, _mirror_to_stdout| {
+            emitted_completion = true;
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        exit_code, 0,
+        "Gemini failure must stay nonterminal while tier fallback handoff is live"
+    );
+    assert!(
+        !emitted_completion,
+        "pending fallback handoff must not emit terminal wait completion"
     );
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.948"
-weave = "0.1.948"
+csa = "0.1.949"
+weave = "0.1.949"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- prevent `csa session wait` from exiting with the pre-fallback Gemini failure while tier fallback is pending
- require an explicit `tier_failover_superseded` handoff before suppressing a failure as pending
- preserve true terminal last-candidate failures

Closes #1963

## Verification
- CSA writer: 01KTK9AEK63S0R5YSM7H3H7ZEQ
- Review finding fix: 01KTKB7NNWJASZJ41QGKG346H7
- Gemini-first CSA review PASS with Codex fallback: 01KTKBZATVQGD1G93RZZKBXYSD
- pre-push review-check passed for 93b7348ead8