### PR TITLE
fix(session): gate waitable sessions and signal diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.950"
+version = "0.1.951"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.950"
+version = "0.1.951"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -420,14 +420,11 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             }
             AttemptExecution::Exit(exit_code) => return Ok(RunLoopCompletion::Exit(exit_code)),
             AttemptExecution::Finished {
-                result: Ok(result),
+                result,
                 changed_paths: attempt_changed_paths,
-            } => (result, attempt_changed_paths),
-            AttemptExecution::Finished {
-                result: Err(e),
-                changed_paths: _,
-            } => {
-                match handle_attempt_error(
+            } => match *result {
+                Ok(result) => (result, attempt_changed_paths),
+                Err(e) => match handle_attempt_error(
                     e,
                     AttemptErrorRequest {
                         run_timeout_seconds: request.run_timeout_seconds,
@@ -483,8 +480,8 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                         }
                         continue;
                     }
-                }
-            }
+                },
+            },
         };
 
         match evaluate_post_attempt_retry(

--- a/crates/cli-sub-agent/src/run_cmd_attempt_exec.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_exec.rs
@@ -18,7 +18,7 @@ use crate::startup_env::StartupSubtreeEnv;
 
 pub(super) enum AttemptExecution {
     Finished {
-        result: Result<csa_process::ExecutionResult, anyhow::Error>,
+        result: Box<Result<csa_process::ExecutionResult, anyhow::Error>>,
         changed_paths: Option<Vec<String>>,
     },
     Exit(i32),
@@ -68,7 +68,7 @@ pub(super) async fn run_ephemeral_with_timeout(
     .await
     {
         Ok(result) => AttemptExecution::Finished {
-            result,
+            result: Box::new(result),
             changed_paths: None,
         },
         Err(_) => AttemptExecution::TimedOut,
@@ -86,19 +86,21 @@ pub(super) async fn run_ephemeral_without_timeout(
         request.project_root.display()
     );
     Ok(AttemptExecution::Finished {
-        result: request
-            .executor
-            .execute_in(
-                request.effective_prompt,
-                request.project_root,
-                request.extra_env,
-                request.subtree_pin,
-                request.allow_git_push,
-                request.stream_mode,
-                request.idle_timeout_seconds,
-                direct_entry_resolved_timeout(request.initial_response_timeout_seconds),
-            )
-            .await,
+        result: Box::new(
+            request
+                .executor
+                .execute_in(
+                    request.effective_prompt,
+                    request.project_root,
+                    request.extra_env,
+                    request.subtree_pin,
+                    request.allow_git_push,
+                    request.stream_mode,
+                    request.idle_timeout_seconds,
+                    direct_entry_resolved_timeout(request.initial_response_timeout_seconds),
+                )
+                .await,
+        ),
         changed_paths: None,
     })
 }
@@ -346,7 +348,7 @@ async fn execute_persistent(
         Ok(session_result) => {
             *executed_session_id = Some(session_result.meta_session_id);
             AttemptExecution::Finished {
-                result: Ok(session_result.execution),
+                result: Box::new(Ok(session_result.execution)),
                 changed_paths: session_result.changed_paths,
             }
         }
@@ -366,7 +368,7 @@ async fn execute_persistent(
                 AttemptExecution::Exit(1)
             } else {
                 AttemptExecution::Finished {
-                    result: Err(e),
+                    result: Box::new(Err(e)),
                     changed_paths: None,
                 }
             }

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -363,6 +363,7 @@ pub(crate) fn spawn_and_exit(
     };
 
     let result = csa_process::daemon::spawn_daemon(config)?;
+    verify_daemon_session_waitable(&project_root, &result.session_id)?;
     // stdout: machine-readable session ID (for script capture).
     println!("{}", result.session_id);
     // stderr: structured RPJ directive for orchestrators.
@@ -405,6 +406,35 @@ pub(crate) fn spawn_and_exit(
     let _ = std::io::stdout().flush();
     let _ = std::io::stderr().flush();
     std::process::exit(0);
+}
+
+fn verify_daemon_session_waitable(project_root: &Path, session_id: &str) -> Result<()> {
+    let resolved = crate::session_cmds::resolve_session_prefix_with_global_fallback(
+        project_root,
+        session_id,
+    )
+    .with_context(|| {
+        format!(
+            "daemon session {session_id} was spawned but is not resolvable by `csa session wait`"
+        )
+    })?;
+    anyhow::ensure!(
+        resolved.session_id == session_id,
+        "daemon session {session_id} resolved to unexpected session {}",
+        resolved.session_id
+    );
+
+    let load_project_root = resolved
+        .foreign_project_root
+        .as_deref()
+        .unwrap_or(project_root);
+    csa_session::load_session(load_project_root, session_id).with_context(|| {
+        format!(
+            "daemon session {session_id} was spawned but its state is not readable by `csa session wait`"
+        )
+    })?;
+
+    Ok(())
 }
 
 fn validate_run_daemon_writable_sources(

--- a/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
@@ -377,3 +377,59 @@ fn daemon_child_startup_env_uses_preassigned_session_context() {
     assert_eq!(effective.session_id(), Some(actual_session_id.as_str()));
     assert_eq!(effective.session_dir(), Some(expected_session_dir.as_str()));
 }
+
+#[test]
+fn daemon_started_session_is_waitable_and_listed_before_marker_emit() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("project");
+    std::fs::create_dir_all(&project_root).expect("project root should be created");
+    let session_id = csa_session::new_session_id();
+    let session_root =
+        csa_session::get_session_root(&project_root).expect("session root should resolve");
+    let session_dir = session_root.join("sessions").join(&session_id);
+
+    persist_daemon_placeholder_session(&project_root, &session_dir, &session_id, "review")
+        .expect("placeholder session should persist");
+
+    verify_daemon_session_waitable(&project_root, &session_id)
+        .expect("placeholder session should be waitable before marker emission");
+    let resolved = crate::session_cmds::resolve_session_prefix_with_global_fallback(
+        &project_root,
+        &session_id,
+    )
+    .expect("session wait prefix resolution should see the session");
+    assert_eq!(resolved.session_id, session_id);
+
+    let listed = csa_session::list_sessions(&project_root, None)
+        .expect("session list should load persisted placeholder");
+    assert!(
+        listed
+            .iter()
+            .any(|session| session.meta_session_id == session_id),
+        "session list must include a session id printed in CSA:SESSION_STARTED"
+    );
+    let _ = std::fs::remove_dir_all(session_root);
+}
+
+#[test]
+fn daemon_started_marker_is_blocked_when_session_state_is_unreadable() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("project");
+    std::fs::create_dir_all(&project_root).expect("project root should be created");
+    let session_id = csa_session::new_session_id();
+    let session_root =
+        csa_session::get_session_root(&project_root).expect("session root should resolve");
+    let session_dir = session_root.join("sessions").join(&session_id);
+    std::fs::create_dir_all(session_dir.join("input")).expect("session dir should be created");
+    std::fs::create_dir_all(session_dir.join("output")).expect("session dir should be created");
+
+    let err = verify_daemon_session_waitable(&project_root, &session_id)
+        .expect_err("unreadable state must block CSA:SESSION_STARTED emission");
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("state is not readable by `csa session wait`")
+            || message.contains("Session"),
+        "error should explain why no usable wait command can be printed: {message}"
+    );
+    let _ = std::fs::remove_dir_all(session_root);
+}

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -626,6 +626,9 @@ pub(crate) async fn handle_run(
         require_commit,
         config.as_ref(),
     );
+    if ephemeral && executed_session_id.is_none() {
+        run_output::enrich_ephemeral_signal_diagnostics(&mut result);
+    }
 
     if result.exit_code == 0 {
         let post_exec_gate_env = crate::build_jobs_env::build_jobs_env(build_jobs);

--- a/crates/cli-sub-agent/src/run_cmd_execute_output.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_output.rs
@@ -7,6 +7,30 @@ use csa_process::ExecutionResult;
 use crate::error_hints::sandbox_fs_denial_hint;
 use crate::pipeline_sandbox::filesystem_sandbox_active;
 
+pub(super) fn enrich_ephemeral_signal_diagnostics(result: &mut ExecutionResult) {
+    if result.exit_signal.is_none() {
+        return;
+    }
+    let Some(diagnostic) = crate::session_kill_diagnostics::diagnose_ephemeral_signal_kill(
+        result.exit_code,
+        result.terminal_reason.as_deref(),
+    ) else {
+        return;
+    };
+
+    let line = diagnostic
+        .stderr_line()
+        .unwrap_or_else(|| diagnostic.ephemeral_line());
+    result.kill_hint = Some(diagnostic.hint.as_result_hint().to_string());
+    result.resource_diagnostics = Some(line.clone());
+    result.summary = line.clone();
+    if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
+        result.stderr_output.push('\n');
+    }
+    result.stderr_output.push_str(&line);
+    result.stderr_output.push('\n');
+}
+
 pub(super) fn emit_run_result_output(
     project_root: &Path,
     output_format: OutputFormat,
@@ -16,6 +40,13 @@ pub(super) fn emit_run_result_output(
     match output_format {
         OutputFormat::Text => {
             print!("{}", result.output);
+            if executed_session_id.is_none()
+                && result.exit_code != 0
+                && result.exit_signal.is_some()
+                && let Some(line) = result.resource_diagnostics.as_deref()
+            {
+                eprintln!("{line}");
+            }
             if result.exit_code != 0
                 && let Some(sid) = executed_session_id
                 && sandbox_fs_denial_hint(&result.stderr_output, &result.output, true, sid)
@@ -47,4 +78,47 @@ pub(super) fn emit_run_result_output(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ephemeral_signal_diagnostic_adds_no_session_metadata() {
+        let mut result = ExecutionResult {
+            output: String::new(),
+            stderr_output: "process killed by signal 9 (SIGKILL)\n".to_string(),
+            summary: "process killed by signal 9 (SIGKILL)".to_string(),
+            exit_code: 137,
+            raw_process_exit_code: Some(137),
+            exit_signal: Some(9),
+            terminal_reason: Some("signal".to_string()),
+            model_completed: Some(false),
+            ..Default::default()
+        };
+
+        enrich_ephemeral_signal_diagnostics(&mut result);
+
+        assert!(result.kill_hint.is_some());
+        assert!(
+            result
+                .resource_diagnostics
+                .as_deref()
+                .is_some_and(|line| line.contains("CSA diagnostic")),
+            "ephemeral signal result should carry caller-visible diagnostics"
+        );
+        assert!(
+            result
+                .stderr_output
+                .contains("No persistent session metadata")
+                || result.stderr_output.contains("signal kill hint"),
+            "stderr should explain that there is no session result to inspect: {}",
+            result.stderr_output
+        );
+        let json = serde_json::to_value(&result).expect("ExecutionResult should serialize");
+        assert_eq!(json["exit_signal"], serde_json::json!(9));
+        assert!(json["kill_hint"].is_string());
+        assert!(json["resource_diagnostics"].is_string());
+    }
 }

--- a/crates/cli-sub-agent/src/session_kill_diagnostics.rs
+++ b/crates/cli-sub-agent/src/session_kill_diagnostics.rs
@@ -83,14 +83,7 @@ pub(crate) struct KillDiagnostic {
 }
 
 impl KillDiagnostic {
-    pub(crate) fn stderr_line(&self) -> Option<String> {
-        let hint = match self.hint {
-            KillHint::Earlyoom => "earlyoom",
-            KillHint::MemoryPressure => "memory pressure",
-            KillHint::PossibleMemoryPressure => "possible memory pressure",
-            KillHint::CsaTimeout | KillHint::UnknownSignal => return None,
-        };
-
+    fn detail_parts(&self) -> Vec<String> {
         let mut details = Vec::new();
         if let Some(meminfo) = &self.observations.meminfo {
             details.push(format!(
@@ -112,11 +105,29 @@ impl KillDiagnostic {
                 events.oom, events.oom_kill
             ));
         }
+        details
+    }
+
+    pub(crate) fn stderr_line(&self) -> Option<String> {
+        let hint = match self.hint {
+            KillHint::Earlyoom => "earlyoom",
+            KillHint::MemoryPressure => "memory pressure",
+            KillHint::PossibleMemoryPressure => "possible memory pressure",
+            KillHint::CsaTimeout | KillHint::UnknownSignal => return None,
+        };
 
         Some(format!(
             "CSA diagnostic: signal kill hint: {hint} ({}). Re-dispatch when host memory frees.",
-            details.join(", ")
+            self.detail_parts().join(", ")
         ))
+    }
+
+    pub(crate) fn ephemeral_line(&self) -> String {
+        format!(
+            "CSA diagnostic: ephemeral run ended by signal (kill_hint={}, {}). No persistent session metadata was created.",
+            self.hint.as_result_hint(),
+            self.detail_parts().join(", ")
+        )
     }
 }
 
@@ -129,6 +140,17 @@ pub(crate) fn diagnose_signal_kill(
     diagnose_signal_kill_with(exit_code, terminal_reason, || {
         collect_signal_observations(tool_name, session_id)
     })
+}
+
+pub(crate) fn diagnose_ephemeral_signal_kill(
+    exit_code: i32,
+    terminal_reason: Option<&str>,
+) -> Option<KillDiagnostic> {
+    diagnose_signal_kill_with(
+        exit_code,
+        terminal_reason,
+        collect_ephemeral_signal_observations,
+    )
 }
 
 pub(crate) fn diagnose_signal_kill_with(
@@ -286,6 +308,20 @@ fn collect_signal_observations(tool_name: &str, session_id: &str) -> KillSignalO
 
 #[cfg(not(target_os = "linux"))]
 fn collect_signal_observations(_tool_name: &str, _session_id: &str) -> KillSignalObservations {
+    KillSignalObservations::default()
+}
+
+#[cfg(target_os = "linux")]
+fn collect_ephemeral_signal_observations() -> KillSignalObservations {
+    KillSignalObservations {
+        meminfo: read_meminfo_from_path(Path::new("/proc/meminfo")),
+        earlyoom_running: earlyoom_running(),
+        cgroup_memory_events: None,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn collect_ephemeral_signal_observations() -> KillSignalObservations {
     KillSignalObservations::default()
 }
 

--- a/crates/csa-process/src/lib.rs
+++ b/crates/csa-process/src/lib.rs
@@ -23,6 +23,7 @@ mod process_activity;
 pub use process_activity::{ProcessTreeActivity, ProcessTreeStatus, process_tree_cpu_ticks};
 #[path = "lib_output_helpers.rs"]
 mod output_helpers;
+mod signal_exit;
 #[path = "lib_subprocess_helpers.rs"]
 mod subprocess_helpers;
 mod tool_liveness;
@@ -266,6 +267,9 @@ mod tests_heartbeat;
 #[cfg(test)]
 #[path = "lib_tests_retry.rs"]
 mod tests_retry;
+#[cfg(test)]
+#[path = "lib_tests_signal_exit.rs"]
+mod tests_signal_exit;
 #[cfg(test)]
 #[path = "lib_tests_stderr_dedup.rs"]
 mod tests_stderr_dedup;

--- a/crates/csa-process/src/lib_execution_result.rs
+++ b/crates/csa-process/src/lib_execution_result.rs
@@ -44,6 +44,22 @@ pub struct ExecutionResult {
     /// session can still be diagnosed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_process_exit_code: Option<i32>,
+    /// Unix signal number that terminated the process, when available.
+    ///
+    /// This is orthogonal to `exit_code`: on Unix, signal 9 is represented as
+    /// exit code 137 for shell/caller compatibility while this field preserves
+    /// the raw signal for diagnostics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_signal: Option<i32>,
+    /// Best-effort signal/kill classification attached by callers that can
+    /// inspect host or session resources. `csa-process` only captures the raw
+    /// signal; higher layers decide whether it was OOM, earlyoom, timeout, etc.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kill_hint: Option<String>,
+    /// Human-readable resource context for no-session executions, such as
+    /// ephemeral runs where no `result.toml` can carry `kill_hint`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_diagnostics: Option<String>,
     /// CSA-own deterministic gate failure marker. `Some(reason)` means one of CSA's
     /// own post-run gates (edit guard / new-file guard / commit policy / no-op /
     /// worker-blocked / no-progress / tool exhaustion) fired and the nonzero

--- a/crates/csa-process/src/lib_tests_signal_exit.rs
+++ b/crates/csa-process/src/lib_tests_signal_exit.rs
@@ -1,0 +1,21 @@
+use super::*;
+
+#[cfg(unix)]
+#[tokio::test]
+async fn wait_and_capture_preserves_signal_exit_diagnostics() {
+    let mut cmd = Command::new("bash");
+    cmd.args(["-c", "kill -KILL $$"]);
+
+    let child = spawn_tool(cmd, None).await.expect("Failed to spawn");
+    let result = wait_and_capture(child, StreamMode::BufferOnly)
+        .await
+        .expect("Failed to wait for signaled child");
+
+    assert_eq!(result.exit_code, 137);
+    assert_eq!(result.raw_process_exit_code, Some(137));
+    assert_eq!(result.exit_signal, Some(9));
+    assert_eq!(result.terminal_reason.as_deref(), Some("signal"));
+    assert_eq!(result.model_completed, Some(false));
+    assert!(result.summary.contains("signal 9"));
+    assert!(result.stderr_output.contains("SIGKILL"));
+}

--- a/crates/csa-process/src/lib_wait_capture.rs
+++ b/crates/csa-process/src/lib_wait_capture.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::signal_exit::{append_signal_exit_note, process_exit_status};
 
 /// Wait for a spawned child process, capturing output and enforcing idle-timeout.
 ///
@@ -393,11 +394,8 @@ pub async fn wait_and_capture_with_idle_timeout(
     }
 
     let status = child.wait().await.context("Failed to wait for command")?;
-
-    let mut exit_code = status.code().unwrap_or_else(|| {
-        warn!("Process terminated by signal, using exit code 1");
-        1
-    });
+    let process_exit = process_exit_status(status);
+    let mut exit_code = process_exit.code;
     if let Some(note) = persistent_rate_limit_note.as_deref() {
         exit_code = 1;
         if !stderr_output.is_empty() && !stderr_output.ends_with('\n') {
@@ -427,6 +425,8 @@ pub async fn wait_and_capture_with_idle_timeout(
         }
         stderr_output.push_str(&workspace_boundary_note);
         stderr_output.push('\n');
+    } else if let Some(note) = process_exit.note.as_deref() {
+        append_signal_exit_note(&mut stderr_output, note);
     }
 
     let summary = if let Some(note) = persistent_rate_limit_note {
@@ -435,6 +435,8 @@ pub async fn wait_and_capture_with_idle_timeout(
         timeout_note
     } else if child_exited_early {
         child_exited_early_note.clone()
+    } else if let Some(note) = process_exit.note.clone() {
+        note
     } else if exit_code == 0 {
         extract_summary(&output)
     } else if workspace_boundary_timed_out {
@@ -452,18 +454,21 @@ pub async fn wait_and_capture_with_idle_timeout(
     let raw_process_exit_code = exit_code;
     let terminal_reason = if idle_timed_out || workspace_boundary_timed_out {
         Some("idle_timeout".to_string())
+    } else if process_exit.signal.is_some() {
+        Some("signal".to_string())
     } else {
         parse_legacy_terminal_reason(&output)
     };
-    let model_completed = if idle_timed_out || workspace_boundary_timed_out {
-        Some(false)
-    } else if terminal_reason.is_some() {
-        crate::model_completed_from_terminal_reason(terminal_reason.as_deref())
-    } else if child_exited_early {
-        Some(false)
-    } else {
-        None
-    };
+    let model_completed =
+        if idle_timed_out || workspace_boundary_timed_out || process_exit.signal.is_some() {
+            Some(false)
+        } else if terminal_reason.is_some() {
+            crate::model_completed_from_terminal_reason(terminal_reason.as_deref())
+        } else if child_exited_early {
+            Some(false)
+        } else {
+            None
+        };
 
     let output = sanitize_opaque_object_payloads(&output);
     let mut stderr_output = sanitize_opaque_object_payloads(&stderr_output);
@@ -505,6 +510,7 @@ pub async fn wait_and_capture_with_idle_timeout(
         raw_process_exit_code: Some(raw_process_exit_code),
         model_completed,
         terminal_reason,
+        exit_signal: process_exit.signal,
         peak_memory_mb: None,
         ..Default::default()
     })

--- a/crates/csa-process/src/signal_exit.rs
+++ b/crates/csa-process/src/signal_exit.rs
@@ -1,0 +1,66 @@
+use tracing::warn;
+
+pub(crate) struct ProcessExitStatus {
+    pub(crate) code: i32,
+    pub(crate) signal: Option<i32>,
+    pub(crate) note: Option<String>,
+}
+
+pub(crate) fn process_exit_status(status: std::process::ExitStatus) -> ProcessExitStatus {
+    let signal = exit_status_signal(status);
+    let code = status.code().unwrap_or_else(|| {
+        if let Some(signal) = signal {
+            let code = 128 + signal;
+            warn!(signal, exit_code = code, "Process terminated by signal");
+            code
+        } else {
+            warn!("Process terminated without exit code or signal, using exit code 1");
+            1
+        }
+    });
+    ProcessExitStatus {
+        code,
+        signal,
+        note: signal.map(format_signal_exit_note),
+    }
+}
+
+pub(crate) fn append_signal_exit_note(stderr_output: &mut String, note: &str) {
+    if !stderr_output.is_empty() && !stderr_output.ends_with('\n') {
+        stderr_output.push('\n');
+    }
+    stderr_output.push_str(note);
+    stderr_output.push('\n');
+}
+
+#[cfg(unix)]
+fn exit_status_signal(status: std::process::ExitStatus) -> Option<i32> {
+    use std::os::unix::process::ExitStatusExt;
+    status.signal()
+}
+
+#[cfg(not(unix))]
+fn exit_status_signal(_status: std::process::ExitStatus) -> Option<i32> {
+    None
+}
+
+fn format_signal_exit_note(signal: i32) -> String {
+    format!(
+        "process killed by signal {signal} ({})",
+        signal_name(signal)
+    )
+}
+
+fn signal_name(signal: i32) -> &'static str {
+    match signal {
+        1 => "SIGHUP",
+        2 => "SIGINT",
+        3 => "SIGQUIT",
+        6 => "SIGABRT",
+        9 => "SIGKILL",
+        11 => "SIGSEGV",
+        13 => "SIGPIPE",
+        15 => "SIGTERM",
+        _ => "UNKNOWN",
+    }
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.950"
-weave = "0.1.950"
+csa = "0.1.951"
+weave = "0.1.951"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- avoid emitting usable `CSA:SESSION_STARTED` wait commands before sessions are registered/waitable
- improve registration/persistence failure handling so callers do not get unwaitable ids
- emit structured signal/kill diagnostics for ephemeral no-daemon failures

Closes #1935
Closes #1939
Closes #1940

## Verification
- CSA writer: 01KTKKG48E9EAG7SR8GNA81FRF
- Gemini-first CSA review PASS with Codex fallback: 01KTKNV1FMXFY0ES0GB9JQAEFH
- pre-push review-check passed for 41a46ac0ee4