### PR TITLE
fix(config): make Codex wait hint configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.951"
+version = "0.1.952"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.951"
+version = "0.1.952"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -11,6 +11,9 @@ use csa_core::types::OutputFormat;
 #[path = "config_cmds_helpers.rs"]
 mod helpers;
 use helpers::{format_missing_key_message, format_toml_value, resolve_key, suggest_key_paths};
+#[path = "config_cmds_key_scope.rs"]
+mod key_scope;
+use key_scope::{global_key_prefers_raw_lookup, is_global_only_key};
 #[path = "config_cmds_display.rs"]
 mod display;
 use display::{build_execution_toml, build_project_display_json, build_project_display_toml};
@@ -370,12 +373,6 @@ struct LookupResolution {
     diagnostics: LookupDiagnostics,
 }
 
-fn is_global_only_key(key: &str) -> bool {
-    key.starts_with("experimental.")
-        || key.starts_with("kv_cache.")
-        || key.starts_with("state_dir.")
-}
-
 #[derive(Debug, Clone)]
 enum LookupSourceSpec {
     EffectiveProject {
@@ -606,10 +603,6 @@ fn prefers_effective_lookup(key: &str) -> Result<bool> {
         return Ok(false);
     };
     Ok(known_effective_top_level_sections()?.contains(top_level))
-}
-
-fn global_key_prefers_raw_lookup(key: &str) -> bool {
-    key.starts_with("kv_cache.") || key.starts_with("state_dir.")
 }
 
 fn known_effective_top_level_sections() -> Result<BTreeSet<String>> {

--- a/crates/cli-sub-agent/src/config_cmds_key_scope.rs
+++ b/crates/cli-sub-agent/src/config_cmds_key_scope.rs
@@ -1,0 +1,16 @@
+pub(super) fn is_global_only_key(key: &str) -> bool {
+    has_section(
+        key,
+        &["caller_hints", "experimental", "kv_cache", "state_dir"],
+    )
+}
+
+pub(super) fn global_key_prefers_raw_lookup(key: &str) -> bool {
+    has_section(key, &["caller_hints", "kv_cache", "state_dir"])
+}
+
+fn has_section(key: &str, sections: &[&str]) -> bool {
+    key.split('.')
+        .next()
+        .is_some_and(|section| sections.contains(&section))
+}

--- a/crates/cli-sub-agent/src/config_cmds_lookup_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_lookup_tests.rs
@@ -75,6 +75,51 @@ tool = "auto"
 }
 
 #[test]
+fn resolve_effective_key_ignores_project_caller_hints_override() {
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let dir = tempfile::tempdir().unwrap();
+    let config_root = dir.path().join("xdg-config");
+    std::fs::create_dir_all(&config_root).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", dir.path());
+    let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
+
+    write_global_config(
+        r#"
+[caller_hints]
+codex_session_wait_yield_ms = 450000
+"#,
+    );
+
+    let csa_dir = dir.path().join(".csa");
+    std::fs::create_dir_all(&csa_dir).unwrap();
+    std::fs::write(
+        csa_dir.join("config.toml"),
+        r#"
+schema_version = 1
+[caller_hints]
+codex_session_wait_yield_ms = 9999
+"#,
+    )
+    .unwrap();
+
+    let key = "caller_hints.codex_session_wait_yield_ms";
+    let lookup =
+        build_config_get_lookup(Some(dir.path()), key, false, is_global_only_key(key)).unwrap();
+    assert!(matches!(
+        lookup.sources.as_slice(),
+        [LookupSourceSpec::RawGlobal { .. }]
+    ));
+
+    let runtime_ms = GlobalConfig::resolve_codex_session_wait_yield_ms();
+    let value = resolve_effective_key(Some(dir.path()), key, false, false)
+        .unwrap()
+        .expect("caller hint interval should resolve from the raw global config");
+
+    assert_eq!(runtime_ms, 450_000);
+    assert_eq!(value.as_integer(), Some(i64::try_from(runtime_ms).unwrap()));
+}
+
+#[test]
 fn resolve_lookup_sources_global_raw_match_survives_invalid_unrelated_global_field() {
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();

--- a/crates/cli-sub-agent/src/process_tree.rs
+++ b/crates/cli-sub-agent/src/process_tree.rs
@@ -71,18 +71,23 @@ pub(crate) fn detect_ancestor_tool() -> Option<String> {
     None
 }
 
-const CODEX_YIELD_TIME_MS: u64 = 300_000;
-
 pub(crate) fn codex_yield_hint() -> String {
     if detect_ancestor_tool().as_deref() != Some("codex") {
         return String::new();
     }
+    format_codex_yield_hint(csa_config::GlobalConfig::resolve_codex_session_wait_yield_ms())
+}
+
+pub(crate) fn format_codex_yield_hint(yield_time_ms: u64) -> String {
     format!(
         "\n<!-- CSA:CODEX_HINT yield_time_ms={ms} \
          rule=\"You are running inside Codex. When calling 'csa session wait', \
-         pass yield_time_ms: {ms} (5 min) to avoid 10s re-polling that wastes tokens. \
+         pass yield_time_ms: {ms}. The default 300000 ms (5 minutes) is a conservative \
+         OpenAI in-memory prompt-cache TTL tradeoff: short high-frequency polling wastes \
+         tokens, while overly long waits can let the caller cache go cold. Do not manually \
+         poll every 10-30s; use this interval unless there is a concrete failure signal. \
          Example tool call: shell({{ command: 'csa session wait --session <ID> --cd <PATH>', yield_time_ms: {ms} }})\" -->",
-        ms = CODEX_YIELD_TIME_MS,
+        ms = yield_time_ms,
     )
 }
 
@@ -328,6 +333,31 @@ mod tests {
     fn test_detect_ancestor_tool_does_not_panic() {
         // Just verify it doesn't panic. Result depends on runtime context.
         let _result = detect_ancestor_tool();
+    }
+
+    #[test]
+    fn test_format_codex_yield_hint_describes_cache_tradeoff_and_polling_interval() {
+        let hint = format_codex_yield_hint(csa_config::DEFAULT_CODEX_SESSION_WAIT_YIELD_MS);
+
+        assert!(hint.contains("CSA:CODEX_HINT"));
+        assert!(hint.contains("yield_time_ms=300000"));
+        assert!(hint.contains("yield_time_ms: 300000"));
+        assert!(hint.contains("default 300000 ms (5 minutes)"));
+        assert!(hint.contains("OpenAI in-memory prompt-cache TTL tradeoff"));
+        assert!(hint.contains("short high-frequency polling wastes"));
+        assert!(hint.contains("caller cache go cold"));
+        assert!(hint.contains("Do not manually poll every"));
+        assert!(hint.contains("10-30s"));
+        assert!(hint.contains("unless there is a concrete failure signal"));
+    }
+
+    #[test]
+    fn test_format_codex_yield_hint_uses_configured_interval() {
+        let hint = format_codex_yield_hint(450_000);
+
+        assert!(hint.contains("yield_time_ms=450000"));
+        assert!(hint.contains("yield_time_ms: 450000"));
+        assert!(hint.contains("default 300000 ms (5 minutes)"));
     }
 
     /// Verify that every `Executor::runtime_binary_name()` value is recognized

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -14,7 +14,6 @@ pub use crate::tool_selection::ToolSelection;
 use csa_core::types::ToolName;
 
 const DEFAULT_MAX_CONCURRENT: u32 = 3;
-
 /// Global configuration loaded from `~/.config/cli-sub-agent/config.toml`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GlobalConfig {
@@ -779,23 +778,18 @@ fn default_max_concurrent() -> u32 {
 #[cfg(test)]
 #[path = "global_tests.rs"]
 mod tests;
-
-#[cfg(test)]
-#[path = "global_tests_heterogeneous.rs"]
-mod tests_heterogeneous;
-
-#[cfg(test)]
-#[path = "global_tests_priority.rs"]
-mod tests_priority;
-
-#[cfg(test)]
-#[path = "global_tests_review_batch.rs"]
-mod tests_review_batch;
-
 #[cfg(test)]
 #[path = "global_tests_github.rs"]
 mod tests_github;
-
+#[cfg(test)]
+#[path = "global_tests_heterogeneous.rs"]
+mod tests_heterogeneous;
+#[cfg(test)]
+#[path = "global_tests_priority.rs"]
+mod tests_priority;
+#[cfg(test)]
+#[path = "global_tests_review_batch.rs"]
+mod tests_review_batch;
 #[cfg(test)]
 #[path = "global_tests_state_dir.rs"]
 mod tests_state_dir;

--- a/crates/csa-config/src/global_caller_hints.rs
+++ b/crates/csa-config/src/global_caller_hints.rs
@@ -1,0 +1,122 @@
+//! Global caller hint configuration.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+use crate::global::GlobalConfig;
+use crate::paths;
+
+/// Default Codex shell `yield_time_ms` recommended for `csa session wait`.
+pub const DEFAULT_CODEX_SESSION_WAIT_YIELD_MS: u64 = 300_000;
+
+/// Configuration for hints emitted to parent tool callers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CallerHintsConfig {
+    /// Codex shell tool `yield_time_ms` to recommend for `csa session wait`.
+    #[serde(default = "default_codex_session_wait_yield_ms")]
+    pub codex_session_wait_yield_ms: u64,
+}
+
+const fn default_codex_session_wait_yield_ms() -> u64 {
+    DEFAULT_CODEX_SESSION_WAIT_YIELD_MS
+}
+
+impl Default for CallerHintsConfig {
+    fn default() -> Self {
+        Self {
+            codex_session_wait_yield_ms: default_codex_session_wait_yield_ms(),
+        }
+    }
+}
+
+impl CallerHintsConfig {
+    pub fn is_default(&self) -> bool {
+        self.codex_session_wait_yield_ms == default_codex_session_wait_yield_ms()
+    }
+}
+
+impl GlobalConfig {
+    /// Resolve the Codex caller hint `yield_time_ms` from global config.
+    ///
+    /// Missing, unreadable, or invalid config falls back to the conservative
+    /// OpenAI prompt-cache retention default so hint emission never fails a CSA
+    /// command.
+    pub fn resolve_codex_session_wait_yield_ms() -> u64 {
+        let config_dir = paths::config_dir();
+        let path = config_dir.map(|dir| dir.join("config.toml"));
+        Self::resolve_codex_session_wait_yield_ms_from_path(path.as_deref())
+    }
+
+    /// Resolve `[caller_hints].codex_session_wait_yield_ms` from an explicit path.
+    ///
+    /// This testable variant mirrors the runtime resolver while avoiding host
+    /// config state in unit tests.
+    pub fn resolve_codex_session_wait_yield_ms_from_path(path: Option<&Path>) -> u64 {
+        let Some(path) = path else {
+            return DEFAULT_CODEX_SESSION_WAIT_YIELD_MS;
+        };
+
+        let content = match std::fs::read_to_string(path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return DEFAULT_CODEX_SESSION_WAIT_YIELD_MS;
+            }
+            Err(err) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %err,
+                    "Failed to read global config while resolving Codex caller hint yield interval"
+                );
+                return DEFAULT_CODEX_SESSION_WAIT_YIELD_MS;
+            }
+        };
+
+        let raw: toml::Value = match toml::from_str(&content) {
+            Ok(raw) => raw,
+            Err(err) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %err,
+                    "Failed to parse global config while resolving Codex caller hint yield interval"
+                );
+                return DEFAULT_CODEX_SESSION_WAIT_YIELD_MS;
+            }
+        };
+
+        let Some(caller_hints) = raw.get("caller_hints").and_then(toml::Value::as_table) else {
+            return DEFAULT_CODEX_SESSION_WAIT_YIELD_MS;
+        };
+
+        match caller_hints.get("codex_session_wait_yield_ms") {
+            None => DEFAULT_CODEX_SESSION_WAIT_YIELD_MS,
+            Some(value) => match value.as_integer() {
+                Some(ms) if ms > 0 => match u64::try_from(ms) {
+                    Ok(ms) => ms,
+                    Err(_) => {
+                        tracing::warn!(
+                            path = %path.display(),
+                            key = "caller_hints.codex_session_wait_yield_ms",
+                            value = ms,
+                            fallback = DEFAULT_CODEX_SESSION_WAIT_YIELD_MS,
+                            "Ignoring out-of-range Codex caller hint yield interval; using default"
+                        );
+                        DEFAULT_CODEX_SESSION_WAIT_YIELD_MS
+                    }
+                },
+                _ => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        key = "caller_hints.codex_session_wait_yield_ms",
+                        fallback = DEFAULT_CODEX_SESSION_WAIT_YIELD_MS,
+                        "Ignoring invalid Codex caller hint yield interval; using default"
+                    );
+                    DEFAULT_CODEX_SESSION_WAIT_YIELD_MS
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "global_caller_hints_tests.rs"]
+mod tests;

--- a/crates/csa-config/src/global_caller_hints_tests.rs
+++ b/crates/csa-config/src/global_caller_hints_tests.rs
@@ -1,0 +1,48 @@
+use super::*;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct CallerHintsRoot {
+    #[serde(default)]
+    caller_hints: CallerHintsConfig,
+}
+
+#[test]
+fn test_caller_hints_defaults_parse_when_section_omitted() {
+    let config: CallerHintsRoot = toml::from_str("").unwrap();
+    assert_eq!(
+        config.caller_hints.codex_session_wait_yield_ms,
+        DEFAULT_CODEX_SESSION_WAIT_YIELD_MS
+    );
+}
+
+#[test]
+fn test_caller_hints_codex_session_wait_yield_ms_parses_from_config() {
+    let config: CallerHintsRoot = toml::from_str(
+        r#"
+[caller_hints]
+codex_session_wait_yield_ms = 450000
+"#,
+    )
+    .unwrap();
+    assert_eq!(config.caller_hints.codex_session_wait_yield_ms, 450_000);
+}
+
+#[test]
+fn test_resolve_codex_session_wait_yield_ms_uses_configured_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        r#"
+[caller_hints]
+codex_session_wait_yield_ms = 450000
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        GlobalConfig::resolve_codex_session_wait_yield_ms_from_path(Some(&path)),
+        450_000
+    );
+}

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -107,6 +107,12 @@ task_pool_workers = 1
 frequent_poll_seconds = 60
 long_poll_seconds = 240
 
+# Parent-tool caller hints.
+# Codex shell calls should pass this `yield_time_ms` for `csa session wait`.
+# The default 300000 ms (5 minutes) is conservative for OpenAI in-memory prompt-cache TTL retention.
+# [caller_hints]
+# codex_session_wait_yield_ms = 300000
+
 # Optional early-exit warning for `csa session wait`.
 # When the watched session's process tree RSS exceeds this threshold,
 # `csa session wait` prints a CSA:MEMORY_WARN marker and exits 33.

--- a/crates/csa-config/src/lib.rs
+++ b/crates/csa-config/src/lib.rs
@@ -13,6 +13,7 @@ mod config_tiers;
 pub mod config_tool;
 pub mod gc;
 pub mod global;
+mod global_caller_hints;
 mod global_env;
 mod global_impl;
 mod global_kv_cache;
@@ -50,6 +51,7 @@ pub use global::{
     ReviewConfig, SessionWaitConfig, StateDirConfig, StateDirOnExceed, TierPolicyConfig,
     ToolSelection,
 };
+pub use global_caller_hints::{CallerHintsConfig, DEFAULT_CODEX_SESSION_WAIT_YIELD_MS};
 pub use init::{detect_installed_tools, init_project};
 pub use mcp::{McpFilter, McpRegistry, McpServerConfig, McpTransport};
 pub use memory::{MemoryBackend, MemoryConfig, MemoryEphemeralConfig, MemoryLlmConfig};

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.951"
-weave = "0.1.951"
+csa = "0.1.952"
+weave = "0.1.952"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- make the Codex wait hint text configurable and include the prompt-cache TTL tradeoff
- keep the default wait interval at 300000ms to avoid high-frequency polling without letting caller cache go cold
- classify caller_hints as global-only so config reporting matches runtime behavior

## Verification
- csa writer session: 01KTKPAEW4T15WGASGA5M0CXSZ
- csa fix session: 01KTKR8WBFV56HVXTSA0Y739WY
- final Codex review PASS: 01KTKSEZKE06C8AK83RP27S6D1
- pre-push review gate passed

Closes #1933