### PR TITLE
fix(review): validate prompt files and retry provider errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.952"
+version = "0.1.953"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.952"
+version = "0.1.953"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -7,9 +7,9 @@ use crate::review_consensus::CLEAN;
 use crate::review_consensus::{consensus_strategy_label, parse_consensus_strategy};
 #[cfg(test)]
 use crate::review_context::discover_review_context_for_branch;
-use crate::review_context::resolve_review_context;
 #[cfg(test)]
 use crate::review_context::{ResolvedReviewContext, ResolvedReviewContextKind};
+use crate::review_context::{resolve_review_context, validate_review_prompt_file};
 #[cfg(test)]
 use crate::review_routing::ReviewRoutingMetadata;
 use crate::startup_env::StartupSubtreeEnv;
@@ -93,8 +93,8 @@ pub(crate) use resolve::resolve_review_tool;
 use resolve::{
     ReviewProjectPromptOptions, build_review_instruction_for_project, derive_scope_for_project,
     resolve_review_effective_tier, resolve_review_model, resolve_review_readonly_configured,
-    resolve_review_selection, resolve_review_stream_mode, resolve_review_thinking,
-    resolve_review_tier_name, review_scope_allows_auto_discovery,
+    resolve_review_readonly_project_root, resolve_review_selection, resolve_review_stream_mode,
+    resolve_review_thinking, resolve_review_tier_name, review_scope_allows_auto_discovery,
     validate_review_direct_tool_tier_restriction, verify_review_skill_available,
 };
 use result_handling::resolve_single_review_result;
@@ -113,6 +113,7 @@ pub(crate) async fn handle_review(
     if args.check_verdict {
         return check_verdict::handle_check_verdict(&project_root, &args);
     }
+    validate_review_prompt_file(args.prompt_file.as_deref())?;
     let project_root_for_hooks = project_root.display().to_string();
     let Some((config, global_config)) =
         crate::pipeline::load_and_validate(&project_root, current_depth)?
@@ -609,14 +610,6 @@ pub(crate) async fn handle_review(
         startup_env,
     })
     .await
-}
-
-fn resolve_review_readonly_project_root(fix: bool, configured: Option<bool>) -> bool {
-    if fix {
-        false
-    } else {
-        configured.unwrap_or(true)
-    }
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -31,10 +31,10 @@ use crate::review_routing::{
 };
 use crate::startup_env::StartupSubtreeEnv;
 use crate::tier_model_fallback::{
-    TierAttemptFailure, chain_failure_reasons, classify_next_model_failure_with_elapsed,
-    earliest_backend_reset_window, fallback_reason_for_result,
-    format_all_models_failed_reason_with_reset, ordered_tier_candidates,
-    parse_backend_reset_duration, persist_fallback_chain, persist_fallback_result_fields,
+    TierAttemptFailure, chain_failure_reasons, earliest_backend_reset_window,
+    fallback_reason_for_result, format_all_models_failed_reason_with_reset,
+    ordered_tier_candidates, parse_backend_reset_duration, persist_fallback_chain,
+    persist_fallback_result_fields,
 };
 
 use super::output::{
@@ -46,10 +46,11 @@ use artifact_guard::detect_repo_root_review_artifact_violations;
 #[cfg(test)]
 use failures::read_review_failure_excerpt;
 use failures::{
-    build_gemini_api_key_retry_env, classify_review_failover_reason,
-    classify_review_failure_result, enforce_review_artifact_contract,
-    extract_meta_session_id_from_error, maybe_synthesize_missing_review_result,
-    repair_completed_review_restriction_result, retire_tier_failover_session,
+    build_gemini_api_key_retry_env, classify_review_failover_error,
+    classify_review_failover_reason, classify_review_failure_result,
+    enforce_review_artifact_contract, extract_meta_session_id_from_error,
+    maybe_synthesize_missing_review_result, repair_completed_review_restriction_result,
+    retire_tier_failover_session,
 };
 
 const REVIEWER_SUB_SESSION_TASK_TYPE: &str = "reviewer_sub_session";
@@ -361,12 +362,10 @@ pub(crate) async fn execute_review_with_tier_filter(
                 let error_text = format!("{err:#}");
                 if tier_fallback_enabled
                     && candidates.len() > 1
-                    && let Some(detected) = classify_next_model_failure_with_elapsed(
-                        attempt_tool.as_str(),
-                        &error_text,
-                        "",
-                        1,
+                    && let Some(detected) = classify_review_failover_error(
+                        *attempt_tool,
                         attempt_model_spec.as_deref(),
+                        &error_text,
                         Some(attempt_started_at.elapsed()),
                     )
                 {
@@ -376,10 +375,11 @@ pub(crate) async fn execute_review_with_tier_filter(
                     if let Some(reset_after) = parse_backend_reset_duration(&error_text) {
                         reset_windows.push(reset_after);
                     }
-                    failures.push(TierAttemptFailure::from_rate_limit(
-                        model_label.clone(),
-                        &detected,
-                    ));
+                    failures.push(TierAttemptFailure {
+                        model_spec: model_label.clone(),
+                        reason: detected.reason.clone(),
+                        quota_exhausted: detected.quota_exhausted,
+                    });
                     warn!(
                         failed_tool = %attempt_tool,
                         failed_model = %model_label,

--- a/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
@@ -58,6 +58,20 @@ fn classify_review_failover_reason_uses_late_gemini_http_400_for_review_fallback
 }
 
 #[test]
+fn classify_review_failover_error_uses_late_gemini_http_400_for_review_fallback() {
+    let failure = classify_review_failover_error(
+        ToolName::GeminiCli,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        "provider failed after startup: status: 400 Bad Request",
+        Some(std::time::Duration::from_secs(39)),
+    )
+    .expect("review-specific Gemini status:400 errors must remain fallbackable past init window");
+
+    assert_eq!(failure.reason, "HTTP 400");
+    assert_eq!(failure.quota_exhausted, Some(false));
+}
+
+#[test]
 fn classify_review_failover_reason_detects_gemini_noninteractive_manual_auth() {
     let stderr = "\
 Error authenticating: FatalAuthenticationError: Manual authorization is required but the current session is non-interactive. \

--- a/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::session_tier_failover::TIER_FAILOVER_SUPERSEDED_STATUS;
+use crate::tier_model_fallback::classify_next_model_failure_with_elapsed;
 use csa_session::{PhaseEvent, SessionPhase};
 
 /// A classified review-failover failure: the normalized reason plus, when the
@@ -51,6 +52,27 @@ pub(super) fn classify_review_failover_reason(
     .or_else(|| classify_gemini_cli_runtime_failure(tool, execution))
 }
 
+pub(super) fn classify_review_failover_error(
+    tool: ToolName,
+    model_spec: Option<&str>,
+    error_text: &str,
+    attempt_elapsed: Option<std::time::Duration>,
+) -> Option<ReviewFailoverFailure> {
+    classify_next_model_failure_with_elapsed(
+        tool.as_str(),
+        error_text,
+        "",
+        1,
+        model_spec,
+        attempt_elapsed,
+    )
+    .map(|detected| ReviewFailoverFailure {
+        reason: detected.reason,
+        quota_exhausted: Some(detected.quota_exhausted),
+    })
+    .or_else(|| classify_gemini_cli_runtime_error_text(tool, error_text))
+}
+
 fn classify_gemini_cli_runtime_failure(
     tool: ToolName,
     execution: &crate::pipeline::SessionExecutionResult,
@@ -66,7 +88,18 @@ fn classify_gemini_cli_runtime_failure(
         "{}\n{}\n{}",
         execution.execution.summary, execution.execution.output, execution.execution.stderr_output,
     );
-    let lower = combined.to_ascii_lowercase();
+    classify_gemini_cli_runtime_error_text(tool, &combined)
+}
+
+fn classify_gemini_cli_runtime_error_text(
+    tool: ToolName,
+    error_text: &str,
+) -> Option<ReviewFailoverFailure> {
+    if tool != ToolName::GeminiCli {
+        return None;
+    }
+
+    let lower = error_text.to_ascii_lowercase();
     let reason = if is_gemini_manual_auth_failure(&lower) {
         "auth_unavailable"
     } else if is_gemini_runtime_home_enospc_failure(&lower) {

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_1958_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_1958_tests.rs
@@ -2,8 +2,11 @@ use super::super::*;
 use crate::review_cmd::tests::{
     ScopedEnvVarRestore, project_config_with_enabled_tools, setup_git_repo,
 };
+use crate::session_tier_failover::TIER_FAILOVER_SUPERSEDED_STATUS;
 use crate::test_session_sandbox::ScopedSessionSandbox;
-use csa_config::{GlobalConfig, ProjectProfile, TierStrategy, config::TierConfig};
+use csa_config::{
+    GlobalConfig, ProjectProfile, TierStrategy, config::TierConfig, global::GlobalToolConfig,
+};
 use csa_core::types::ToolName;
 
 fn config_with_review_tier(enabled_tools: &[&str], models: &[&str]) -> csa_config::ProjectConfig {
@@ -125,4 +128,141 @@ async fn execute_review_falls_back_from_gemini_status_400_to_codex() {
     assert_eq!(fallback_chain[0].tool, "gemini-cli");
     assert_eq!(fallback_chain[0].skip_reason, "attempted-and-errored");
     assert!(!fallback_chain[0].quota_exhausted);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn execute_review_falls_back_from_gemini_status_400_transport_error_to_codex() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let project_dir = setup_git_repo();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    let bin_dir = project_dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+
+    std::fs::write(
+        bin_dir.join("gemini"),
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\nprintf 'Gemini fixture should fail before process spawn\\n' >&2\nexit 1\n",
+    )
+    .unwrap();
+    std::fs::write(
+        bin_dir.join("codex"),
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex-cli 1.0.0\\n'\n  exit 0\nfi\nprintf '%s\\n' '<!-- CSA:SECTION:summary -->' 'PASS' '<!-- CSA:SECTION:summary:END -->' '<!-- CSA:SECTION:details -->' 'No blocking issues found.' '<!-- CSA:SECTION:details:END -->'\n",
+    )
+    .unwrap();
+    for binary in ["gemini", "codex"] {
+        let path = bin_dir.join(binary);
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{}:{inherited_path}", bin_dir.display());
+    let _path_guard = ScopedEnvVarRestore::set("PATH", &patched_path);
+
+    let mut config = config_with_review_tier(
+        &["gemini-cli", "codex"],
+        &[
+            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "codex/openai/gpt-5.4/high",
+        ],
+    );
+    config
+        .tools
+        .get_mut("gemini-cli")
+        .expect("gemini tool config")
+        .transport = Some(csa_config::TransportKind::Cli);
+
+    let cache_loop = project_dir.path().join("status 400 cache");
+    std::os::unix::fs::symlink(&cache_loop, &cache_loop).unwrap();
+    let mut env = std::collections::HashMap::new();
+    env.insert(
+        "XDG_CACHE_HOME".to_string(),
+        cache_loop.to_string_lossy().into_owned(),
+    );
+    let mut global = GlobalConfig::default();
+    global.tools.insert(
+        "gemini-cli".to_string(),
+        GlobalToolConfig {
+            env,
+            ..Default::default()
+        },
+    );
+
+    let result = execute_review(
+        ToolName::GeminiCli,
+        "scope=uncommitted mode=review-only security=auto".to_string(),
+        None,
+        None,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string()),
+        Some("quality".to_string()),
+        true,
+        None,
+        "review: gemini-400-transport-err-tier-fallback-success".to_string(),
+        project_dir.path(),
+        Some(&config),
+        &global,
+        None,
+        ReviewRoutingMetadata {
+            project_profile: ProjectProfile::Unknown,
+            detection_method: "auto",
+        },
+        csa_process::StreamMode::BufferOnly,
+        crate::pipeline::DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        false,
+        false,
+        false,
+        false,
+        false,
+        &[],
+        &[],
+        Some(false),
+    )
+    .await
+    .expect("Gemini status 400 transport Err should reach Codex (#1969)");
+
+    assert_eq!(result.executed_tool, ToolName::Codex);
+    assert_eq!(
+        result.routed_to.as_deref(),
+        Some("codex/openai/gpt-5.4/high")
+    );
+    assert!(result.primary_failure.is_none());
+    assert!(result.failure_reason.is_none());
+
+    let persisted = csa_session::load_result(project_dir.path(), &result.execution.meta_session_id)
+        .unwrap()
+        .expect("result.toml should exist");
+    assert_eq!(persisted.original_tool.as_deref(), Some("gemini-cli"));
+    assert_eq!(persisted.fallback_tool.as_deref(), Some("codex"));
+    assert!(persisted.fallback_reason.is_none());
+    let fallback_chain = persisted
+        .fallback_chain
+        .as_ref()
+        .expect("result fallback_chain");
+    assert_eq!(fallback_chain.len(), 1);
+    assert_eq!(fallback_chain[0].tool, "gemini-cli");
+    assert_eq!(
+        fallback_chain[0].model_spec.as_deref(),
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh")
+    );
+    assert_eq!(fallback_chain[0].skip_reason, "attempted-and-errored");
+    assert!(!fallback_chain[0].quota_exhausted);
+
+    let gemini_sessions = csa_session::list_sessions(project_dir.path(), Some(&["gemini-cli"]))
+        .expect("list gemini sessions");
+    assert_eq!(gemini_sessions.len(), 1);
+    let failed_session = &gemini_sessions[0];
+    assert_eq!(failed_session.phase, csa_session::SessionPhase::Retired);
+    let failed_result =
+        csa_session::load_result(project_dir.path(), &failed_session.meta_session_id)
+            .unwrap()
+            .expect("failed gemini result.toml should exist");
+    assert_eq!(failed_result.status, TIER_FAILOVER_SUPERSEDED_STATUS);
+    assert!(
+        failed_result.summary.contains("status 400"),
+        "failed result should preserve transport error text, got: {}",
+        failed_result.summary
+    );
 }

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_1958_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_1958_tests.rs
@@ -135,6 +135,11 @@ async fn execute_review_falls_back_from_gemini_status_400_to_codex() {
 async fn execute_review_falls_back_from_gemini_status_400_transport_error_to_codex() {
     use std::os::unix::fs::PermissionsExt;
 
+    if which::which("bwrap").is_err() {
+        eprintln!("skipping: bwrap not installed (CI gap, see #987)");
+        return;
+    }
+
     let project_dir = setup_git_repo();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let bin_dir = project_dir.path().join("bin");

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -179,6 +179,14 @@ pub(crate) fn resolve_review_readonly_configured(
         .or(global_config.review.readonly_sandbox)
 }
 
+pub(crate) fn resolve_review_readonly_project_root(fix: bool, configured: Option<bool>) -> bool {
+    if fix {
+        false
+    } else {
+        configured.unwrap_or(true)
+    }
+}
+
 fn resolve_review_tool_from_selection(
     selection: &csa_config::ToolSelection,
     parent_tool: Option<&str>,

--- a/crates/cli-sub-agent/src/review_cmd_tests_pre_exec.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_pre_exec.rs
@@ -1,6 +1,32 @@
 use super::*;
 
 #[tokio::test]
+async fn handle_review_rejects_missing_prompt_file_before_pre_exec() {
+    let project_dir = tempdir().unwrap();
+    let cd = project_dir.path().display().to_string();
+    let missing = project_dir.path().join("missing-review-prompt.md");
+    let args = parse_review_args(&[
+        "csa",
+        "review",
+        "--cd",
+        &cd,
+        "--diff",
+        "--prompt-file",
+        missing.to_str().expect("utf-8 path"),
+    ]);
+
+    let err = handle_review(args, 0, &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV)
+        .await
+        .expect_err("missing --prompt-file must fail before review execution");
+
+    assert!(
+        err.chain()
+            .any(|cause| cause.to_string().contains("--prompt-file: failed to read")),
+        "unexpected error chain: {err:#}"
+    );
+}
+
+#[tokio::test]
 async fn handle_review_persists_result_for_prior_rounds_summary_parse_failure() {
     let project_dir = tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;

--- a/crates/cli-sub-agent/src/review_context.rs
+++ b/crates/cli-sub-agent/src/review_context.rs
@@ -32,6 +32,16 @@ pub(crate) fn resolve_review_context(
     }
 }
 
+pub(crate) fn validate_review_prompt_file(path: Option<&Path>) -> Result<()> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+
+    std::fs::read_to_string(path)
+        .with_context(|| format!("--prompt-file: failed to read '{}'", path.display()))?;
+    Ok(())
+}
+
 fn resolve_explicit_review_context(path: &str) -> Result<ResolvedReviewContext> {
     let path_ref = Path::new(path);
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.952"
-weave = "0.1.952"
+csa = "0.1.953"
+weave = "0.1.953"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- fail fast when `csa review --prompt-file` points to a missing or unreadable file
- retry configured review failover after provider-style errors such as `gemini-cli` status 400
- add coverage for provider-error helper and production `execute_review` Err failover behavior, with bwrap guard for reliability

## Verification
- writer session: 01KTKSWFNAVH27GNKDJKRA8J64
- review finding fix session: 01KTKWV37ABTF3PAPSA9D99V6M
- test reliability fix session: 01KTKY77CJV95EN5CSDS4CK6H8
- final Codex review PASS: 01KTKYKZ6BTG3NX0BFE3DP6RHJ
- csa/weave installed locally at 0.1.953 (cf847096)
- pre-push review and version gates passed

Note: filed #1971 for a separate CSA verdict inconsistency observed during an intermediate review wait.

Closes #1968
Closes #1969