### PR TITLE
fix(review): fail closed on blocking summary conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.953"
+version = "0.1.954"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.953"
+version = "0.1.954"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 use anyhow::Result;
 use csa_session::{ReviewFinding, Severity};
 
-use super::clean_detection::{contains_clean_phrase, detect_prose_clean_conclusion};
+use super::clean_detection::{
+    contains_clean_phrase, detect_prose_clean_conclusion, detect_prose_fail_conclusion,
+};
 use super::text::{contains_blocking_issue_signal, zero_severity_counts};
 use crate::review_cmd::prose_findings::{
     FindingsSectionParse, classify_findings_section_body,
@@ -66,9 +68,9 @@ fn current_round_review_prose_contents(
         }
     }
 
-    let blocking_summary = latest_summary
-        .as_deref()
-        .is_some_and(contains_blocking_issue_signal);
+    let blocking_summary = latest_summary.as_deref().is_some_and(|summary| {
+        contains_blocking_issue_signal(summary) || detect_prose_fail_conclusion(summary)
+    });
 
     let mut contents = Vec::new();
     if let Some(content) = latest_summary {

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -476,6 +476,8 @@ fn line_has_blocking_review_signal(line: &str) -> bool {
         "bugs",
         "defect",
         "defects",
+        "regression",
+        "regressions",
         "violation",
         "violations",
     ];
@@ -560,5 +562,20 @@ fn priority_severity_from_label(label: &str) -> Option<Severity> {
         1 => Some(Severity::High),
         2 => Some(Severity::Medium),
         _ => Some(Severity::Low),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::contains_blocking_review_signal;
+
+    #[test]
+    fn issue_1971_blocking_regression_summary_is_blocking_signal() {
+        assert!(contains_blocking_review_signal(
+            "FAIL: one blocking test reliability regression found in the new provider-error failover coverage."
+        ));
+        assert!(!contains_blocking_review_signal(
+            "Found one non-blocking test reliability regression."
+        ));
     }
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_1951.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_1951.rs
@@ -71,3 +71,109 @@ fn handle_session_wait_syncs_failed_review_verdict_before_printing_result() {
     assert_eq!(persisted.status, "failure");
     assert_eq!(persisted.exit_code, 1);
 }
+
+#[test]
+fn issue_1971_wait_uses_generated_fail_verdict_for_pass_result() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-generated-fail-review-verdict"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write stale success completion packet");
+    save_result(
+        project,
+        &session_id,
+        &SessionResult {
+            summary: "FAIL: one blocking test reliability regression found".to_string(),
+            ..make_result("success", 0)
+        },
+    )
+    .expect("save stale success result");
+    std::fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write empty findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nFAIL: one blocking test reliability regression found in the new provider-error failover coverage.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist review summary");
+
+    let meta = csa_session::state::ReviewSessionMeta {
+        session_id: session_id.clone(),
+        head_sha: "deadbeef".to_string(),
+        decision: csa_core::types::ReviewDecision::Pass.as_str().to_string(),
+        verdict: "CLEAN".to_string(),
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool: "codex".to_string(),
+        scope: "range:main...HEAD".to_string(),
+        exit_code: 0,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+        review_mode: None,
+        fix_convergence: None,
+    };
+    crate::review_cmd::persist_review_verdict_for_tests(project, &meta, &[], Vec::new());
+    let generated_verdict: csa_session::ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json"))
+            .expect("read generated verdict"),
+    )
+    .expect("parse generated verdict");
+    assert_eq!(
+        generated_verdict.decision,
+        csa_core::types::ReviewDecision::Fail,
+        "a blocking FAIL summary must be the canonical review-verdict decision"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("generated failed review verdict should short-circuit before reconcile");
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should sync generated failed review verdict");
+
+    assert_eq!(exit_code, 1);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id.clone(), "failure".to_string(), 1, false))
+    );
+    let persisted = load_result(project, &session_id)
+        .expect("load result")
+        .expect("result should remain terminal");
+    assert_eq!(persisted.status, "failure");
+    assert_eq!(persisted.exit_code, 1);
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.953"
-weave = "0.1.953"
+csa = "0.1.954"
+weave = "0.1.954"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- fail closed when review summary/finding text indicates blocking FAIL while stale state still says success
- keep `csa session wait`/result machine signals consistent for orchestrators
- add regression coverage for generated failed review verdict syncing over stale success state

## Verification
- writer session: 01KTKZ4P19V29AR7Z1NXX3E8VR
- Codex review PASS: 01KTM09WAWBG2CW6M9BZ38MS7T
- csa/weave installed locally at 0.1.954 (1d3b5b19)
- pre-push review and version gates passed

Closes #1971