### PR TITLE
fix(resource): add host memory admission control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.954"
+version = "0.1.955"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.954"
+version = "0.1.955"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/build_jobs_env.rs
+++ b/crates/cli-sub-agent/src/build_jobs_env.rs
@@ -57,9 +57,47 @@ pub(crate) fn apply_build_jobs_env_with_host(
     inherited_env: impl Fn(&str) -> Option<String>,
     host_memory: Option<BuildJobsHostMemory>,
 ) {
-    if let Some(updates) = build_jobs_env_with_host(build_jobs, inherited_env, host_memory) {
-        extra_env.get_or_insert_with(HashMap::new).extend(updates);
+    if let Some(build_jobs) = build_jobs {
+        let value = build_jobs.to_string();
+        extra_env
+            .get_or_insert_with(HashMap::new)
+            .extend(HashMap::from([
+                (CARGO_BUILD_JOBS_ENV.to_string(), value.clone()),
+                (NEXTEST_TEST_THREADS_ENV.to_string(), value),
+            ]));
+        return;
     }
+
+    let auto_jobs = host_memory.and_then(auto_build_jobs_cap);
+    apply_build_jobs_env_key(extra_env, CARGO_BUILD_JOBS_ENV, &inherited_env, auto_jobs);
+    apply_build_jobs_env_key(
+        extra_env,
+        NEXTEST_TEST_THREADS_ENV,
+        &inherited_env,
+        auto_jobs,
+    );
+}
+
+fn apply_build_jobs_env_key(
+    extra_env: &mut Option<HashMap<String, String>>,
+    key: &str,
+    inherited_env: impl Fn(&str) -> Option<String>,
+    auto_jobs: Option<u32>,
+) {
+    if let Some(value) = inherited_env(key) {
+        extra_env
+            .get_or_insert_with(HashMap::new)
+            .insert(key.to_string(), value);
+        return;
+    }
+
+    let Some(auto_jobs) = auto_jobs else { return };
+    if extra_env.as_ref().is_some_and(|env| env.contains_key(key)) {
+        return;
+    }
+    extra_env
+        .get_or_insert_with(HashMap::new)
+        .insert(key.to_string(), auto_jobs.to_string());
 }
 
 pub(crate) fn build_jobs_env_with_host(
@@ -263,6 +301,59 @@ mod tests {
             }),
         )
         .expect("mixed env");
+
+        assert_eq!(env.get(CARGO_BUILD_JOBS_ENV).map(String::as_str), Some("6"));
+        assert_eq!(
+            env.get(NEXTEST_TEST_THREADS_ENV).map(String::as_str),
+            Some("2")
+        );
+    }
+
+    #[test]
+    fn auto_build_jobs_does_not_overwrite_existing_extra_env() {
+        let mut env = Some(HashMap::from([(
+            CARGO_BUILD_JOBS_ENV.to_string(),
+            "7".to_string(),
+        )]));
+
+        apply_build_jobs_env_with_host(
+            &mut env,
+            None,
+            |_| None,
+            Some(BuildJobsHostMemory {
+                available_mb: 18_000,
+                free_mb: 900,
+            }),
+        );
+        let env = env.expect("existing config env should remain present");
+
+        assert_eq!(env.get(CARGO_BUILD_JOBS_ENV).map(String::as_str), Some("7"));
+        assert_eq!(
+            env.get(NEXTEST_TEST_THREADS_ENV).map(String::as_str),
+            Some("2")
+        );
+    }
+
+    #[test]
+    fn inherited_env_overrides_existing_extra_env() {
+        let mut env = Some(HashMap::from([(
+            CARGO_BUILD_JOBS_ENV.to_string(),
+            "7".to_string(),
+        )]));
+
+        apply_build_jobs_env_with_host(
+            &mut env,
+            None,
+            |key| match key {
+                CARGO_BUILD_JOBS_ENV => Some("6".to_string()),
+                _ => None,
+            },
+            Some(BuildJobsHostMemory {
+                available_mb: 18_000,
+                free_mb: 900,
+            }),
+        );
+        let env = env.expect("env should remain present");
 
         assert_eq!(env.get(CARGO_BUILD_JOBS_ENV).map(String::as_str), Some("6"));
         assert_eq!(

--- a/crates/cli-sub-agent/src/build_jobs_env.rs
+++ b/crates/cli-sub-agent/src/build_jobs_env.rs
@@ -2,18 +2,37 @@ use std::collections::HashMap;
 
 pub(crate) const CARGO_BUILD_JOBS_ENV: &str = "CARGO_BUILD_JOBS";
 pub(crate) const NEXTEST_TEST_THREADS_ENV: &str = "NEXTEST_TEST_THREADS";
+const AUTO_BUILD_JOB_MEMORY_BUDGET_MB: u64 = 8192;
+const LOW_FREE_MEMORY_MB: u64 = 2048;
+const LOW_FREE_MEMORY_BUILD_JOBS: u32 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BuildJobsHostMemory {
+    pub(crate) available_mb: u64,
+    pub(crate) free_mb: u64,
+}
 
 pub(crate) fn apply_build_jobs_env(
     extra_env: &mut Option<HashMap<String, String>>,
     build_jobs: Option<u32>,
 ) {
-    apply_build_jobs_env_with(extra_env, build_jobs, |key| std::env::var(key).ok());
+    apply_build_jobs_env_with_host(
+        extra_env,
+        build_jobs,
+        |key| std::env::var(key).ok(),
+        detect_build_jobs_host_memory(),
+    );
 }
 
 pub(crate) fn build_jobs_env(build_jobs: Option<u32>) -> Option<HashMap<String, String>> {
-    build_jobs_env_with(build_jobs, |key| std::env::var(key).ok())
+    build_jobs_env_with_host(
+        build_jobs,
+        |key| std::env::var(key).ok(),
+        detect_build_jobs_host_memory(),
+    )
 }
 
+#[cfg(test)]
 pub(crate) fn apply_build_jobs_env_with(
     extra_env: &mut Option<HashMap<String, String>>,
     build_jobs: Option<u32>,
@@ -24,9 +43,29 @@ pub(crate) fn apply_build_jobs_env_with(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn build_jobs_env_with(
     build_jobs: Option<u32>,
     inherited_env: impl Fn(&str) -> Option<String>,
+) -> Option<HashMap<String, String>> {
+    build_jobs_env_with_host(build_jobs, inherited_env, None)
+}
+
+pub(crate) fn apply_build_jobs_env_with_host(
+    extra_env: &mut Option<HashMap<String, String>>,
+    build_jobs: Option<u32>,
+    inherited_env: impl Fn(&str) -> Option<String>,
+    host_memory: Option<BuildJobsHostMemory>,
+) {
+    if let Some(updates) = build_jobs_env_with_host(build_jobs, inherited_env, host_memory) {
+        extra_env.get_or_insert_with(HashMap::new).extend(updates);
+    }
+}
+
+pub(crate) fn build_jobs_env_with_host(
+    build_jobs: Option<u32>,
+    inherited_env: impl Fn(&str) -> Option<String>,
+    host_memory: Option<BuildJobsHostMemory>,
 ) -> Option<HashMap<String, String>> {
     let mut updates = HashMap::new();
     if let Some(build_jobs) = build_jobs {
@@ -34,10 +73,15 @@ pub(crate) fn build_jobs_env_with(
         updates.insert(CARGO_BUILD_JOBS_ENV.to_string(), value.clone());
         updates.insert(NEXTEST_TEST_THREADS_ENV.to_string(), value);
     } else {
-        if let Some(value) = inherited_env(CARGO_BUILD_JOBS_ENV) {
+        let auto_jobs = host_memory.and_then(auto_build_jobs_cap);
+        if let Some(value) =
+            inherited_env(CARGO_BUILD_JOBS_ENV).or_else(|| auto_jobs.map(|jobs| jobs.to_string()))
+        {
             updates.insert(CARGO_BUILD_JOBS_ENV.to_string(), value);
         }
-        if let Some(value) = inherited_env(NEXTEST_TEST_THREADS_ENV) {
+        if let Some(value) = inherited_env(NEXTEST_TEST_THREADS_ENV)
+            .or_else(|| auto_jobs.map(|jobs| jobs.to_string()))
+        {
             updates.insert(NEXTEST_TEST_THREADS_ENV.to_string(), value);
         }
     }
@@ -46,6 +90,37 @@ pub(crate) fn build_jobs_env_with(
         None
     } else {
         Some(updates)
+    }
+}
+
+fn detect_build_jobs_host_memory() -> Option<BuildJobsHostMemory> {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    let available_mb = sys.available_memory() / 1024 / 1024;
+    let free_mb = sys.free_memory() / 1024 / 1024;
+    if available_mb == 0 {
+        None
+    } else {
+        Some(BuildJobsHostMemory {
+            available_mb,
+            free_mb,
+        })
+    }
+}
+
+fn auto_build_jobs_cap(memory: BuildJobsHostMemory) -> Option<u32> {
+    if memory.available_mb == 0 {
+        return None;
+    }
+
+    let jobs_from_available = (memory.available_mb / AUTO_BUILD_JOB_MEMORY_BUDGET_MB)
+        .max(1)
+        .min(u64::from(u32::MAX)) as u32;
+
+    if memory.free_mb > 0 && memory.free_mb < LOW_FREE_MEMORY_MB {
+        Some(jobs_from_available.clamp(1, LOW_FREE_MEMORY_BUILD_JOBS))
+    } else {
+        Some(jobs_from_available)
     }
 }
 
@@ -143,5 +218,56 @@ mod tests {
         let env = build_jobs_env_with(None, |_| None);
 
         assert!(env.is_none());
+    }
+
+    #[test]
+    fn auto_build_jobs_caps_from_available_memory() {
+        let jobs = auto_build_jobs_cap(BuildJobsHostMemory {
+            available_mb: 18_000,
+            free_mb: 900,
+        });
+
+        assert_eq!(jobs, Some(2));
+    }
+
+    #[test]
+    fn auto_build_jobs_applies_when_env_is_absent() {
+        let env = build_jobs_env_with_host(
+            None,
+            |_| None,
+            Some(BuildJobsHostMemory {
+                available_mb: 18_000,
+                free_mb: 900,
+            }),
+        )
+        .expect("auto env");
+
+        assert_eq!(env.get(CARGO_BUILD_JOBS_ENV).map(String::as_str), Some("2"));
+        assert_eq!(
+            env.get(NEXTEST_TEST_THREADS_ENV).map(String::as_str),
+            Some("2")
+        );
+    }
+
+    #[test]
+    fn inherited_env_takes_precedence_over_auto_cap_per_key() {
+        let env = build_jobs_env_with_host(
+            None,
+            |key| match key {
+                CARGO_BUILD_JOBS_ENV => Some("6".to_string()),
+                _ => None,
+            },
+            Some(BuildJobsHostMemory {
+                available_mb: 18_000,
+                free_mb: 900,
+            }),
+        )
+        .expect("mixed env");
+
+        assert_eq!(env.get(CARGO_BUILD_JOBS_ENV).map(String::as_str), Some("6"));
+        assert_eq!(
+            env.get(NEXTEST_TEST_THREADS_ENV).map(String::as_str),
+            Some("2")
+        );
     }
 }

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -62,6 +62,7 @@ mod process_exit;
 mod process_tree;
 mod push_cmd;
 mod recall_cmd;
+mod resource_admission;
 mod review_cmd;
 mod review_consensus;
 mod review_context;

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -488,10 +488,10 @@ fn should_skip_balloon_prewarm(available_memory_mb: u64, active_session_count: u
 pub(crate) fn record_sandbox_telemetry(
     execute_options: &ExecuteOptions,
     session: &mut MetaSessionState,
-) {
-    if execute_options.sandbox.is_none() || session.sandbox_info.is_some() {
-        return;
-    }
+) -> bool {
+    let Some(sandbox_context) = execute_options.sandbox.as_ref() else {
+        return false;
+    };
 
     let capability = csa_resource::detect_resource_capability();
     let mode = match capability {
@@ -499,32 +499,28 @@ pub(crate) fn record_sandbox_telemetry(
         csa_resource::ResourceCapability::Setrlimit => "rlimit",
         csa_resource::ResourceCapability::None => "none",
     };
-    let memory: Option<u64> = execute_options
-        .sandbox
-        .as_ref()
-        .and_then(|ctx| ctx.isolation_plan.memory_max_mb);
+    let memory: Option<u64> = sandbox_context.isolation_plan.memory_max_mb;
 
     // Capture filesystem isolation mode from the isolation plan.
-    let fs_mode = execute_options
-        .sandbox
-        .as_ref()
-        .map(|ctx| match ctx.isolation_plan.filesystem {
-            csa_resource::FilesystemCapability::Bwrap => "bwrap".to_string(),
-            csa_resource::FilesystemCapability::Landlock => "landlock".to_string(),
-            csa_resource::FilesystemCapability::None => "none".to_string(),
-        });
+    let fs_mode = Some(match sandbox_context.isolation_plan.filesystem {
+        csa_resource::FilesystemCapability::Bwrap => "bwrap".to_string(),
+        csa_resource::FilesystemCapability::Landlock => "landlock".to_string(),
+        csa_resource::FilesystemCapability::None => "none".to_string(),
+    });
 
-    let readonly = execute_options
-        .sandbox
-        .as_ref()
-        .map(|ctx| ctx.isolation_plan.readonly_project_root);
+    let readonly = Some(sandbox_context.isolation_plan.readonly_project_root);
 
-    session.sandbox_info = Some(csa_session::SandboxInfo {
+    let sandbox_info = csa_session::SandboxInfo {
         mode: mode.to_string(),
         memory_max_mb: memory,
         filesystem_mode: fs_mode.clone(),
         readonly_project_root: readonly,
-    });
+    };
+    if session.sandbox_info.as_ref() == Some(&sandbox_info) {
+        return false;
+    }
+
+    session.sandbox_info = Some(sandbox_info);
 
     info!(
         session = %session.meta_session_id,
@@ -533,6 +529,7 @@ pub(crate) fn record_sandbox_telemetry(
         filesystem_mode = ?fs_mode,
         "Sandbox telemetry recorded in session state"
     );
+    true
 }
 
 pub(crate) fn filesystem_sandbox_active(sandbox_info: Option<&csa_session::SandboxInfo>) -> bool {

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -483,14 +483,15 @@ fn should_skip_balloon_prewarm(available_memory_mb: u64, active_session_count: u
 
 /// Record sandbox telemetry in session state (first turn only).
 ///
-/// If sandbox options are present and `session.sandbox_info` is still `None`,
-/// detects the active capability and writes a `SandboxInfo` snapshot.
+/// If sandbox options are present, detects the active capability and writes a
+/// `SandboxInfo` snapshot. If runtime preparation resolves to no sandbox,
+/// clears any transient pre-spawn admission marker.
 pub(crate) fn record_sandbox_telemetry(
     execute_options: &ExecuteOptions,
     session: &mut MetaSessionState,
 ) -> bool {
     let Some(sandbox_context) = execute_options.sandbox.as_ref() else {
-        return false;
+        return crate::resource_admission::clear_spawn_memory_projection(session);
     };
 
     let capability = csa_resource::detect_resource_capability();

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -431,7 +431,7 @@ pub(crate) fn resolve_sandbox_options(
 /// Pre-warms RAM by `mmap`-ing a large anonymous mapping with `MAP_POPULATE`, forcing
 /// the kernel to swap out other processes.  The balloon is dropped (deflated) right
 /// away so the freed physical pages are available for the tool process about to launch.
-pub(crate) fn maybe_inflate_balloon(tool_name: &str) {
+pub(crate) fn maybe_inflate_balloon(tool_name: &str, project_root: &Path, session_id: &str) {
     use csa_resource::memory_balloon::{MemoryBalloon, should_enable_balloon};
 
     if tool_name != "claude-code" {
@@ -443,6 +443,18 @@ pub(crate) fn maybe_inflate_balloon(tool_name: &str) {
     sys.refresh_memory();
     let available_memory = sys.available_memory();
     let available_swap = sys.free_swap();
+    let available_memory_mb = available_memory / 1024 / 1024;
+    let active_session_count =
+        crate::resource_admission::active_session_count_for_balloon(project_root, session_id);
+
+    if should_skip_balloon_prewarm(available_memory_mb, active_session_count) {
+        warn!(
+            available_memory_mb,
+            active_session_count,
+            "Skipping MemoryBalloon prewarm under host memory or concurrent-session pressure"
+        );
+        return;
+    }
 
     if !should_enable_balloon(available_memory, available_swap, BALLOON_SIZE as u64) {
         return;
@@ -461,6 +473,12 @@ pub(crate) fn maybe_inflate_balloon(tool_name: &str) {
             warn!(error = %e, "Memory balloon inflation failed; continuing without pre-warming");
         }
     }
+}
+
+const BALLOON_MIN_AVAILABLE_MEMORY_MB: u64 = 8192;
+
+fn should_skip_balloon_prewarm(available_memory_mb: u64, active_session_count: u64) -> bool {
+    available_memory_mb < BALLOON_MIN_AVAILABLE_MEMORY_MB || active_session_count > 0
 }
 
 /// Record sandbox telemetry in session state (first turn only).

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
@@ -92,6 +92,66 @@ fn record_sandbox_telemetry_overwrites_pre_spawn_projection() {
 }
 
 #[test]
+fn record_sandbox_telemetry_clears_pre_spawn_projection_without_sandbox() {
+    let execute_options = csa_executor::ExecuteOptions::new(StreamMode::BufferOnly, 600);
+    let mut session = csa_session::MetaSessionState {
+        meta_session_id: "test-session".to_string(),
+        sandbox_info: Some(csa_session::SandboxInfo {
+            mode: "admission".to_string(),
+            memory_max_mb: Some(12_288),
+            filesystem_mode: None,
+            readonly_project_root: None,
+        }),
+        ..Default::default()
+    };
+
+    assert!(record_sandbox_telemetry(&execute_options, &mut session));
+
+    assert_eq!(session.sandbox_info, None);
+}
+
+#[test]
+fn record_sandbox_telemetry_overwrites_pre_spawn_projection_without_memory_limit() {
+    let isolation_plan = csa_resource::isolation_plan::IsolationPlanBuilder::new(
+        csa_resource::isolation_plan::EnforcementMode::BestEffort,
+    )
+    .with_resource_capability(csa_resource::ResourceCapability::None)
+    .with_filesystem_capability(csa_resource::FilesystemCapability::None)
+    .with_resource_limits(None, None, None)
+    .with_readonly_project_root(false)
+    .build()
+    .expect("test isolation plan");
+    let execute_options = csa_executor::ExecuteOptions::new(StreamMode::BufferOnly, 600)
+        .with_sandbox(csa_executor::SandboxContext {
+            isolation_plan,
+            tool_name: "gemini-cli".to_string(),
+            session_id: "test-session".to_string(),
+            best_effort: true,
+        });
+    let mut session = csa_session::MetaSessionState {
+        meta_session_id: "test-session".to_string(),
+        sandbox_info: Some(csa_session::SandboxInfo {
+            mode: "admission".to_string(),
+            memory_max_mb: Some(4096),
+            filesystem_mode: None,
+            readonly_project_root: None,
+        }),
+        ..Default::default()
+    };
+
+    assert!(record_sandbox_telemetry(&execute_options, &mut session));
+    let info = session
+        .sandbox_info
+        .as_ref()
+        .expect("runtime telemetry should replace admission marker");
+
+    assert_ne!(info.mode, "admission");
+    assert_eq!(info.memory_max_mb, None);
+    assert_eq!(info.filesystem_mode.as_deref(), Some("none"));
+    assert_eq!(info.readonly_project_root, Some(false));
+}
+
+#[test]
 fn balloon_prewarm_skips_when_available_memory_is_low() {
     assert!(should_skip_balloon_prewarm(4096, 0));
 }

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
@@ -50,6 +50,21 @@ fn test_filesystem_sandbox_active_helper() {
     assert!(!filesystem_sandbox_active(Some(&inactive)));
 }
 
+#[test]
+fn balloon_prewarm_skips_when_available_memory_is_low() {
+    assert!(should_skip_balloon_prewarm(4096, 0));
+}
+
+#[test]
+fn balloon_prewarm_skips_when_other_sessions_are_active() {
+    assert!(should_skip_balloon_prewarm(16_384, 1));
+}
+
+#[test]
+fn balloon_prewarm_allows_idle_host_with_memory_headroom() {
+    assert!(!should_skip_balloon_prewarm(16_384, 0));
+}
+
 /// Heavyweight tools (claude-code) with no project config should get setting_sources=Some(vec![]).
 #[test]
 fn test_none_config_sets_setting_sources_for_heavyweight() {

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
@@ -51,6 +51,47 @@ fn test_filesystem_sandbox_active_helper() {
 }
 
 #[test]
+fn record_sandbox_telemetry_overwrites_pre_spawn_projection() {
+    let isolation_plan = csa_resource::isolation_plan::IsolationPlanBuilder::new(
+        csa_resource::isolation_plan::EnforcementMode::BestEffort,
+    )
+    .with_resource_capability(csa_resource::ResourceCapability::None)
+    .with_filesystem_capability(csa_resource::FilesystemCapability::None)
+    .with_resource_limits(Some(8192), None, None)
+    .with_readonly_project_root(true)
+    .build()
+    .expect("test isolation plan");
+    let execute_options = csa_executor::ExecuteOptions::new(StreamMode::BufferOnly, 600)
+        .with_sandbox(csa_executor::SandboxContext {
+            isolation_plan,
+            tool_name: "codex".to_string(),
+            session_id: "test-session".to_string(),
+            best_effort: true,
+        });
+    let mut session = csa_session::MetaSessionState {
+        meta_session_id: "test-session".to_string(),
+        sandbox_info: Some(csa_session::SandboxInfo {
+            mode: "admission".to_string(),
+            memory_max_mb: Some(12_288),
+            filesystem_mode: None,
+            readonly_project_root: None,
+        }),
+        ..Default::default()
+    };
+
+    assert!(record_sandbox_telemetry(&execute_options, &mut session));
+    let info = session
+        .sandbox_info
+        .as_ref()
+        .expect("sandbox telemetry should remain present");
+
+    assert_ne!(info.mode, "admission");
+    assert_eq!(info.memory_max_mb, Some(8192));
+    assert_eq!(info.filesystem_mode.as_deref(), Some("none"));
+    assert_eq!(info.readonly_project_root, Some(true));
+}
+
+#[test]
 fn balloon_prewarm_skips_when_available_memory_is_low() {
     assert!(should_skip_balloon_prewarm(4096, 0));
 }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
@@ -125,15 +125,19 @@ pub(super) fn persist_pipeline_pre_exec_failure(
     termination_reason: Option<&str>,
 ) -> anyhow::Error {
     write_pre_exec_error_result(project_root, &session.meta_session_id, tool_name, &err);
+    let cleared_admission_projection =
+        crate::resource_admission::clear_spawn_memory_projection(session);
     if let Some(reason) = termination_reason {
         session.termination_reason = Some(reason.to_string());
+    }
+    if termination_reason.is_some() || cleared_admission_projection {
         session.last_accessed = chrono::Utc::now();
         if let Err(save_err) = save_session(session) {
             warn!(
                 session = %session.meta_session_id,
                 error = %save_err,
-                termination_reason = reason,
-                "Failed to persist pre-exec termination reason"
+                termination_reason = ?termination_reason,
+                "Failed to persist pre-exec failure session state"
             );
         }
     }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
@@ -23,6 +23,18 @@ pub(super) fn check_resources_before_spawn(
             .unwrap_or(default_resources.min_free_memory_mb),
     });
     let projected_spawn_mb = spawn_memory_projection_mb(config, executor.tool_name());
+    if let Err(err) =
+        crate::resource_admission::persist_spawn_memory_projection(session, projected_spawn_mb)
+    {
+        return Err(persist_pipeline_pre_exec_failure(
+            project_root,
+            session,
+            executor.tool_name(),
+            err.context("Failed to persist pre-spawn memory projection"),
+            cleanup_guard,
+            None,
+        ));
+    }
     let admission =
         build_spawn_memory_admission(project_root, &session.meta_session_id, projected_spawn_mb);
 

--- a/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
@@ -6,6 +6,7 @@ use csa_resource::{ResourceGuard, ResourceLimits};
 use csa_session::{MetaSessionState, save_session};
 use tracing::warn;
 
+use crate::resource_admission::{build_spawn_memory_admission, spawn_memory_projection_mb};
 use crate::session_guard::{SessionCleanupGuard, write_pre_exec_error_result};
 
 pub(super) fn check_resources_before_spawn(
@@ -15,13 +16,18 @@ pub(super) fn check_resources_before_spawn(
     session: &mut MetaSessionState,
     cleanup_guard: &mut Option<SessionCleanupGuard>,
 ) -> anyhow::Result<()> {
-    let mut resource_guard = config.map(|cfg| {
-        ResourceGuard::new(ResourceLimits {
-            min_free_memory_mb: cfg.resources.min_free_memory_mb,
-        })
+    let default_resources = csa_config::ResourcesConfig::default();
+    let mut resource_guard = ResourceGuard::new(ResourceLimits {
+        min_free_memory_mb: config
+            .map(|cfg| cfg.resources.min_free_memory_mb)
+            .unwrap_or(default_resources.min_free_memory_mb),
     });
-    if let Some(ref mut guard) = resource_guard
-        && let Err(err) = guard.check_availability(executor.tool_name())
+    let projected_spawn_mb = spawn_memory_projection_mb(config, executor.tool_name());
+    let admission =
+        build_spawn_memory_admission(project_root, &session.meta_session_id, projected_spawn_mb);
+
+    if let Err(err) =
+        resource_guard.check_availability_with_admission(executor.tool_name(), Some(admission))
     {
         return Err(persist_pipeline_pre_exec_failure(
             project_root,
@@ -32,8 +38,8 @@ pub(super) fn check_resources_before_spawn(
             Some("low_memory"),
         ));
     }
-    if let (Some(guard), Some(cfg)) = (&mut resource_guard, config) {
-        guard.check_health(
+    if let Some(cfg) = config {
+        resource_guard.check_health(
             cfg.sandbox_memory_max_mb(executor.tool_name()),
             cfg.sandbox_memory_swap_max_mb(executor.tool_name()),
             60,

--- a/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
@@ -350,7 +350,15 @@ pub(super) async fn prepare_session_runtime(
     if let Some(pre_session_hook) = input.pre_session_hook {
         execute_options = execute_options.with_pre_session_hook(pre_session_hook);
     }
-    crate::pipeline_sandbox::record_sandbox_telemetry(&execute_options, session);
+    if crate::pipeline_sandbox::record_sandbox_telemetry(&execute_options, session)
+        && let Err(err) = csa_session::save_session(session)
+    {
+        warn!(
+            session = %session.meta_session_id,
+            error = %err,
+            "Failed to persist sandbox telemetry"
+        );
+    }
     crate::pipeline_sandbox::maybe_inflate_balloon(
         input.tool.as_str(),
         input.project_root,

--- a/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
@@ -351,7 +351,11 @@ pub(super) async fn prepare_session_runtime(
         execute_options = execute_options.with_pre_session_hook(pre_session_hook);
     }
     crate::pipeline_sandbox::record_sandbox_telemetry(&execute_options, session);
-    crate::pipeline_sandbox::maybe_inflate_balloon(input.tool.as_str());
+    crate::pipeline_sandbox::maybe_inflate_balloon(
+        input.tool.as_str(),
+        input.project_root,
+        &session.meta_session_id,
+    );
     if let Err(err) =
         session_exec_metadata::persist_session_runtime_binary(input.session_dir, input.executor)
     {

--- a/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
@@ -95,6 +95,27 @@ pub(super) async fn prepare_session_runtime(
     session: &mut MetaSessionState,
     cleanup_guard: &mut Option<SessionCleanupGuard>,
 ) -> Result<SessionRuntimePlan> {
+    let project_root = input.project_root;
+    let tool_name = input.executor.tool_name().to_string();
+
+    prepare_session_runtime_inner(input, session)
+        .await
+        .map_err(|err| {
+            persist_pipeline_pre_exec_failure(
+                project_root,
+                session,
+                &tool_name,
+                err,
+                cleanup_guard,
+                None,
+            )
+        })
+}
+
+async fn prepare_session_runtime_inner(
+    input: SessionRuntimeInput<'_>,
+    session: &mut MetaSessionState,
+) -> Result<SessionRuntimePlan> {
     let can_edit = input
         .config
         .is_none_or(|cfg| cfg.can_tool_edit_existing(input.executor.tool_name()));
@@ -112,24 +133,12 @@ pub(super) async fn prepare_session_runtime(
         .global_config
         .is_some_and(|cfg| cfg.experimental.enable_prompt_caching);
     let mut prompt_assembly = PromptAssembly::new(raw_prompt.clone(), prompt_caching_enabled);
-    let state_dir_warning = match state_preflight::run(
+    let state_dir_warning = state_preflight::run(
         input.global_config,
         &session.meta_session_id,
         input.startup_env.session_id(),
         input.session_arg.is_none() || input.fresh_spawn_preflight_override,
-    ) {
-        Ok(warning) => warning,
-        Err(err) => {
-            return Err(persist_pipeline_pre_exec_failure(
-                input.project_root,
-                session,
-                input.executor.tool_name(),
-                err,
-                cleanup_guard,
-                None,
-            ));
-        }
-    };
+    )?;
     if let Some(w) = state_dir_warning {
         prompt_assembly.prepend_dynamic(&w);
     }
@@ -302,15 +311,7 @@ pub(super) async fn prepare_session_runtime(
     ) {
         crate::pipeline_sandbox::SandboxResolution::Ok(opts) => *opts,
         crate::pipeline_sandbox::SandboxResolution::RequiredButUnavailable(msg) => {
-            let err = anyhow::anyhow!(msg);
-            return Err(persist_pipeline_pre_exec_failure(
-                input.project_root,
-                session,
-                input.executor.tool_name(),
-                err,
-                cleanup_guard,
-                None,
-            ));
+            return Err(anyhow::anyhow!(msg));
         }
     };
     crate::pipeline::ensure_tool_runtime_prerequisites(

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -358,6 +358,104 @@ async fn low_memory_pre_spawn_failure_sets_termination_reason() {
 }
 
 #[tokio::test]
+async fn resumed_pre_run_failure_clears_admission_projection() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let executor = Executor::Opencode {
+        model_override: None,
+        agent: None,
+        thinking_budget: None,
+    };
+
+    let mut session =
+        csa_session::create_session(project_root, Some("resume target"), None, Some("opencode"))
+            .expect("create resume session");
+    session
+        .apply_phase_event(csa_session::PhaseEvent::Compressed)
+        .expect("mark session available for resume");
+    csa_session::save_session(&session).expect("persist available resume session");
+
+    let session_root = csa_session::get_session_root(project_root).expect("session root");
+    fs::write(
+        session_root.join("hooks.toml"),
+        r#"
+[pre_run]
+enabled = true
+command = "exit 42"
+timeout_secs = 1
+fail_policy = "closed"
+"#,
+    )
+    .expect("write closed pre-run hook");
+
+    let err = match execute_with_session_and_meta(
+        &executor,
+        &ToolName::Opencode,
+        "fail during runtime preparation",
+        OutputFormat::Json,
+        Some(session.meta_session_id.clone()),
+        false,
+        Some("resume-pre-run-failure".to_string()),
+        None,
+        project_root,
+        None,
+        None,
+        None, // subtree_pin (#1741)
+        Some("run"),
+        None,
+        None,
+        csa_process::StreamMode::BufferOnly,
+        DEFAULT_IDLE_TIMEOUT_SECONDS,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        false,
+        &[],
+        &[],
+        None,  // error_marker_scan_override: defer to marker/config (#1745/#1847)
+        false, // cli_no_hook_bypass_scan: no CLI flag here; defer to config
+        &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
+    )
+    .await
+    {
+        Ok(_) => panic!("closed pre-run hook must reject resumed execution"),
+        Err(err) => err,
+    };
+
+    assert!(
+        err.to_string().contains("Hook PreRun exited with code 42"),
+        "pre-run hook failure should propagate: {err:#}"
+    );
+
+    let loaded =
+        csa_session::load_session(project_root, &session.meta_session_id).expect("load session");
+    assert_eq!(
+        loaded.phase,
+        csa_session::SessionPhase::Active,
+        "resume path should mark the session active before runtime preparation"
+    );
+    assert_eq!(
+        loaded.sandbox_info, None,
+        "runtime-preparation failure must clear the transient admission marker"
+    );
+
+    let result = csa_session::load_result(project_root, &session.meta_session_id)
+        .expect("load result")
+        .expect("result exists");
+    assert_eq!(result.status, "failure");
+    assert!(result.summary.starts_with("pre-exec:"));
+    assert!(
+        result.summary.contains("Hook PreRun exited with code 42"),
+        "result should preserve the runtime-preparation failure: {}",
+        result.summary
+    );
+}
+
+#[tokio::test]
 async fn state_dir_cap_failure_overwrites_stale_result_for_resume() {
     let tmp = tempfile::tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new(&tmp).await;

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -344,6 +344,10 @@ async fn low_memory_pre_spawn_failure_sets_termination_reason() {
     let session_id = &sessions[0].meta_session_id;
     let session = csa_session::load_session(project_root, session_id).expect("load session");
     assert_eq!(session.termination_reason.as_deref(), Some("low_memory"));
+    assert_eq!(
+        session.sandbox_info, None,
+        "pre-spawn failure must clear the transient admission marker"
+    );
 
     let result = csa_session::load_result(project_root, session_id)
         .expect("load result")

--- a/crates/cli-sub-agent/src/resource_admission.rs
+++ b/crates/cli-sub-agent/src/resource_admission.rs
@@ -43,28 +43,27 @@ pub(crate) fn persist_spawn_memory_projection(
 }
 
 fn update_spawn_memory_projection(session: &mut MetaSessionState, projected_spawn_mb: u64) -> bool {
-    let projected = Some(projected_spawn_mb);
-    match session.sandbox_info.as_mut() {
-        Some(info) if info.memory_max_mb == projected => {
-            session.last_accessed = Utc::now();
-            true
-        }
-        Some(info) => {
-            info.memory_max_mb = projected;
-            session.last_accessed = Utc::now();
-            true
-        }
-        None => {
-            session.sandbox_info = Some(SandboxInfo {
-                mode: PRE_SPAWN_ADMISSION_MODE.to_string(),
-                memory_max_mb: projected,
-                filesystem_mode: None,
-                readonly_project_root: None,
-            });
-            session.last_accessed = Utc::now();
-            true
-        }
+    session.sandbox_info = Some(SandboxInfo {
+        mode: PRE_SPAWN_ADMISSION_MODE.to_string(),
+        memory_max_mb: Some(projected_spawn_mb),
+        filesystem_mode: None,
+        readonly_project_root: None,
+    });
+    session.last_accessed = Utc::now();
+    true
+}
+
+pub(crate) fn clear_spawn_memory_projection(session: &mut MetaSessionState) -> bool {
+    if session
+        .sandbox_info
+        .as_ref()
+        .is_none_or(|info| info.mode != PRE_SPAWN_ADMISSION_MODE)
+    {
+        return false;
     }
+
+    session.sandbox_info = None;
+    true
 }
 
 pub(crate) fn build_spawn_memory_admission(
@@ -167,6 +166,14 @@ fn recent_pending_projection_mb(
     now: DateTime<Utc>,
     sandbox_projection: Option<u64>,
 ) -> u64 {
+    if session
+        .sandbox_info
+        .as_ref()
+        .is_none_or(|sandbox| sandbox.mode != PRE_SPAWN_ADMISSION_MODE)
+    {
+        return 0;
+    }
+
     let age = now.signed_duration_since(session.last_accessed);
     if age <= TimeDelta::seconds(RECENT_ACTIVE_FALLBACK_WINDOW_SECS) {
         sandbox_projection.unwrap_or(RECENT_ACTIVE_FALLBACK_PROJECTION_MB)
@@ -236,6 +243,25 @@ mod tests {
         }
     }
 
+    fn admission_session(
+        id: &str,
+        last_accessed: DateTime<Utc>,
+        memory_max_mb: Option<u64>,
+    ) -> MetaSessionState {
+        MetaSessionState {
+            meta_session_id: id.to_string(),
+            phase: SessionPhase::Active,
+            last_accessed,
+            sandbox_info: Some(SandboxInfo {
+                mode: PRE_SPAWN_ADMISSION_MODE.to_string(),
+                memory_max_mb,
+                filesystem_mode: None,
+                readonly_project_root: None,
+            }),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn spawn_projection_uses_configured_tool_limit() {
         let cfg: ProjectConfig =
@@ -275,7 +301,7 @@ mod tests {
     #[test]
     fn active_memory_adds_recent_pending_sandbox_projection_without_rss() {
         let now = Utc::now();
-        let sessions = vec![active_session(
+        let sessions = vec![admission_session(
             "pending",
             now - TimeDelta::minutes(2),
             Some(12_288),
@@ -291,13 +317,11 @@ mod tests {
     #[test]
     fn active_memory_uses_fallback_for_recent_pending_without_sandbox_projection() {
         let now = Utc::now();
-        let sessions = vec![MetaSessionState {
-            meta_session_id: "pending".to_string(),
-            phase: SessionPhase::Active,
-            last_accessed: now - TimeDelta::minutes(2),
-            sandbox_info: None,
-            ..Default::default()
-        }];
+        let sessions = vec![admission_session(
+            "pending",
+            now - TimeDelta::minutes(2),
+            None,
+        )];
 
         let memory = aggregate_active_session_memory(&sessions, "current", now, |_| None);
 
@@ -307,20 +331,29 @@ mod tests {
     }
 
     #[test]
+    fn active_memory_ignores_recent_runtime_session_without_live_signal() {
+        let now = Utc::now();
+        let sessions = vec![active_session(
+            "completed",
+            now - TimeDelta::minutes(2),
+            Some(12_288),
+        )];
+
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| None);
+
+        assert_eq!(memory.active_count, 0);
+        assert_eq!(memory.sampled_count, 0);
+        assert_eq!(memory.projected_mb, 0);
+    }
+
+    #[test]
     fn active_memory_ignores_old_pending_session_without_live_signal() {
         let now = Utc::now();
-        let sessions = vec![MetaSessionState {
-            meta_session_id: "old".to_string(),
-            phase: SessionPhase::Active,
-            last_accessed: now - TimeDelta::hours(2),
-            sandbox_info: Some(SandboxInfo {
-                mode: "cgroup".to_string(),
-                memory_max_mb: Some(12_288),
-                filesystem_mode: None,
-                readonly_project_root: None,
-            }),
-            ..Default::default()
-        }];
+        let sessions = vec![admission_session(
+            "old",
+            now - TimeDelta::hours(2),
+            Some(12_288),
+        )];
 
         let memory = aggregate_active_session_memory(&sessions, "current", now, |_| None);
 
@@ -349,13 +382,27 @@ mod tests {
     fn balloon_count_ignores_stale_active_without_live_signal() {
         let now = Utc::now();
         let sessions = vec![
-            active_session("recent", now - TimeDelta::minutes(2), Some(4096)),
-            active_session("old", now - TimeDelta::hours(2), Some(4096)),
+            admission_session("recent", now - TimeDelta::minutes(2), Some(4096)),
+            admission_session("old", now - TimeDelta::hours(2), Some(4096)),
         ];
 
         let count = count_observable_active_sessions(&sessions, "current", now, |_| None);
 
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn balloon_count_ignores_recent_runtime_active_without_live_signal() {
+        let now = Utc::now();
+        let sessions = vec![active_session(
+            "completed",
+            now - TimeDelta::minutes(2),
+            Some(4096),
+        )];
+
+        let count = count_observable_active_sessions(&sessions, "current", now, |_| None);
+
+        assert_eq!(count, 0);
     }
 
     #[test]
@@ -382,6 +429,36 @@ mod tests {
         assert!(
             session.last_accessed > old,
             "unchanged pre-spawn projection must still refresh the pending-start window"
+        );
+        let info = session
+            .sandbox_info
+            .as_ref()
+            .expect("projection should stay recorded");
+        assert_eq!(info.mode, PRE_SPAWN_ADMISSION_MODE);
+        assert_eq!(info.filesystem_mode, None);
+        assert_eq!(info.readonly_project_root, None);
+    }
+
+    #[test]
+    fn clear_spawn_projection_removes_admission_marker() {
+        let now = Utc::now();
+        let mut session = admission_session("pending", now, Some(12_288));
+
+        assert!(clear_spawn_memory_projection(&mut session));
+
+        assert_eq!(session.sandbox_info, None);
+    }
+
+    #[test]
+    fn clear_spawn_projection_preserves_runtime_sandbox_info() {
+        let now = Utc::now();
+        let mut session = active_session("completed", now, Some(12_288));
+
+        assert!(!clear_spawn_memory_projection(&mut session));
+
+        assert_eq!(
+            session.sandbox_info.as_ref().map(|info| info.mode.as_str()),
+            Some("cgroup")
         );
     }
 }

--- a/crates/cli-sub-agent/src/resource_admission.rs
+++ b/crates/cli-sub-agent/src/resource_admission.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{io, path::Path};
 
 use chrono::{DateTime, TimeDelta, Utc};
 use csa_config::ProjectConfig;
@@ -23,6 +23,13 @@ struct ActiveSessionMemory {
 struct ActiveSessionObservation {
     sampled_rss_mb: Option<u64>,
     projected_mb: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionMemorySample {
+    RssMb(u64),
+    UnsupportedLiveProcess,
+    Unavailable,
 }
 
 pub(crate) fn spawn_memory_projection_mb(config: Option<&ProjectConfig>, tool_name: &str) -> u64 {
@@ -76,7 +83,7 @@ pub(crate) fn build_spawn_memory_admission(
             &sessions,
             current_session_id,
             Utc::now(),
-            sample_session_tree_rss_mb,
+            sample_session_memory,
         ),
         Err(err) => {
             warn!(
@@ -97,17 +104,36 @@ pub(crate) fn build_spawn_memory_admission(
     }
 }
 
-fn sample_session_tree_rss_mb(session: &MetaSessionState) -> Option<u64> {
+fn sample_session_memory(session: &MetaSessionState) -> SessionMemorySample {
     let project_root = Path::new(&session.project_path);
-    let sampler = SessionTreeMemorySampler::new(project_root, &session.meta_session_id).ok()?;
-    sampler.sample_rss_mb().ok()
+    match SessionTreeMemorySampler::new(project_root, &session.meta_session_id)
+        .and_then(|sampler| sampler.sample_rss_mb())
+    {
+        Ok(rss_mb) => SessionMemorySample::RssMb(rss_mb),
+        Err(err)
+            if err.kind() == io::ErrorKind::Unsupported
+                && session_has_live_process_signal(project_root, &session.meta_session_id) =>
+        {
+            SessionMemorySample::UnsupportedLiveProcess
+        }
+        Err(_) => SessionMemorySample::Unavailable,
+    }
+}
+
+fn session_has_live_process_signal(project_root: &Path, session_id: &str) -> bool {
+    let Ok(session_dir) = csa_session::get_session_dir(project_root, session_id) else {
+        return false;
+    };
+
+    csa_process::ToolLiveness::has_live_process(&session_dir)
+        || csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir)
 }
 
 fn aggregate_active_session_memory(
     sessions: &[MetaSessionState],
     current_session_id: &str,
     now: DateTime<Utc>,
-    sample_rss_mb: impl Fn(&MetaSessionState) -> Option<u64>,
+    sample_memory: impl Fn(&MetaSessionState) -> SessionMemorySample,
 ) -> ActiveSessionMemory {
     let mut memory = ActiveSessionMemory::default();
 
@@ -119,7 +145,7 @@ fn aggregate_active_session_memory(
             continue;
         }
 
-        let Some(observation) = active_session_observation(session, now, &sample_rss_mb) else {
+        let Some(observation) = active_session_observation(session, now, &sample_memory) else {
             continue;
         };
 
@@ -139,19 +165,28 @@ fn aggregate_active_session_memory(
 fn active_session_observation(
     session: &MetaSessionState,
     now: DateTime<Utc>,
-    sample_rss_mb: impl Fn(&MetaSessionState) -> Option<u64>,
+    sample_memory: impl Fn(&MetaSessionState) -> SessionMemorySample,
 ) -> Option<ActiveSessionObservation> {
-    let sampled_rss = sample_rss_mb(session);
+    let sample = sample_memory(session);
     let sandbox_projection = session
         .sandbox_info
         .as_ref()
         .and_then(|sandbox| sandbox.memory_max_mb);
 
-    if let Some(rss_mb) = sampled_rss {
-        return Some(ActiveSessionObservation {
-            sampled_rss_mb: Some(rss_mb),
-            projected_mb: rss_mb.max(sandbox_projection.unwrap_or(0)),
-        });
+    match sample {
+        SessionMemorySample::RssMb(rss_mb) => {
+            return Some(ActiveSessionObservation {
+                sampled_rss_mb: Some(rss_mb),
+                projected_mb: rss_mb.max(sandbox_projection.unwrap_or(0)),
+            });
+        }
+        SessionMemorySample::UnsupportedLiveProcess => {
+            return Some(ActiveSessionObservation {
+                sampled_rss_mb: None,
+                projected_mb: sandbox_projection.unwrap_or(FALLBACK_SPAWN_PROJECTION_MB),
+            });
+        }
+        SessionMemorySample::Unavailable => {}
     }
 
     let recent_pending_projection = recent_pending_projection_mb(session, now, sandbox_projection);
@@ -191,7 +226,7 @@ pub(crate) fn active_session_count_for_balloon(
             &sessions,
             current_session_id,
             Utc::now(),
-            sample_session_tree_rss_mb,
+            sample_session_memory,
         ),
         Err(err) => {
             warn!(
@@ -208,13 +243,13 @@ fn count_observable_active_sessions(
     sessions: &[MetaSessionState],
     current_session_id: &str,
     now: DateTime<Utc>,
-    sample_rss_mb: impl Fn(&MetaSessionState) -> Option<u64>,
+    sample_memory: impl Fn(&MetaSessionState) -> SessionMemorySample,
 ) -> u64 {
     sessions
         .iter()
         .filter(|session| session.meta_session_id != current_session_id)
         .filter(|session| matches!(session.phase, SessionPhase::Active))
-        .filter(|session| active_session_observation(session, now, &sample_rss_mb).is_some())
+        .filter(|session| active_session_observation(session, now, &sample_memory).is_some())
         .count()
         .try_into()
         .unwrap_or(u64::MAX)
@@ -229,12 +264,21 @@ mod tests {
         last_accessed: DateTime<Utc>,
         memory_max_mb: Option<u64>,
     ) -> MetaSessionState {
+        active_session_with_mode(id, last_accessed, "cgroup", memory_max_mb)
+    }
+
+    fn active_session_with_mode(
+        id: &str,
+        last_accessed: DateTime<Utc>,
+        mode: &str,
+        memory_max_mb: Option<u64>,
+    ) -> MetaSessionState {
         MetaSessionState {
             meta_session_id: id.to_string(),
             phase: SessionPhase::Active,
             last_accessed,
             sandbox_info: Some(SandboxInfo {
-                mode: "cgroup".to_string(),
+                mode: mode.to_string(),
                 memory_max_mb,
                 filesystem_mode: None,
                 readonly_project_root: None,
@@ -286,9 +330,9 @@ mod tests {
 
         let memory = aggregate_active_session_memory(&sessions, "current", now, |session| {
             match session.meta_session_id.as_str() {
-                "a" => Some(1024),
-                "b" => Some(4096),
-                _ => None,
+                "a" => SessionMemorySample::RssMb(1024),
+                "b" => SessionMemorySample::RssMb(4096),
+                _ => SessionMemorySample::Unavailable,
             }
         });
 
@@ -307,7 +351,9 @@ mod tests {
             Some(12_288),
         )];
 
-        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| None);
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| {
+            SessionMemorySample::Unavailable
+        });
 
         assert_eq!(memory.active_count, 1);
         assert_eq!(memory.sampled_count, 0);
@@ -323,7 +369,9 @@ mod tests {
             None,
         )];
 
-        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| None);
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| {
+            SessionMemorySample::Unavailable
+        });
 
         assert_eq!(memory.active_count, 1);
         assert_eq!(memory.sampled_count, 0);
@@ -339,7 +387,9 @@ mod tests {
             Some(12_288),
         )];
 
-        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| None);
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| {
+            SessionMemorySample::Unavailable
+        });
 
         assert_eq!(memory.active_count, 0);
         assert_eq!(memory.sampled_count, 0);
@@ -355,7 +405,9 @@ mod tests {
             Some(12_288),
         )];
 
-        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| None);
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| {
+            SessionMemorySample::Unavailable
+        });
 
         assert_eq!(memory.active_count, 0);
         assert_eq!(memory.projected_mb, 0);
@@ -370,12 +422,53 @@ mod tests {
             Some(12_288),
         )];
 
-        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| Some(1024));
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| {
+            SessionMemorySample::RssMb(1024)
+        });
 
         assert_eq!(memory.active_count, 1);
         assert_eq!(memory.sampled_count, 1);
         assert_eq!(memory.sampled_rss_mb, 1024);
         assert_eq!(memory.projected_mb, 12_288);
+    }
+
+    #[test]
+    fn active_memory_counts_live_runtime_projection_when_sampler_unsupported() {
+        let now = Utc::now();
+        let sessions = vec![active_session_with_mode(
+            "live",
+            now - TimeDelta::hours(2),
+            "rlimit",
+            Some(12_288),
+        )];
+
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| {
+            SessionMemorySample::UnsupportedLiveProcess
+        });
+
+        assert_eq!(memory.active_count, 1);
+        assert_eq!(memory.sampled_count, 0);
+        assert_eq!(memory.sampled_rss_mb, 0);
+        assert_eq!(memory.projected_mb, 12_288);
+    }
+
+    #[test]
+    fn active_memory_uses_fallback_for_live_runtime_without_projection_when_sampler_unsupported() {
+        let now = Utc::now();
+        let sessions = vec![active_session_with_mode(
+            "live",
+            now - TimeDelta::hours(2),
+            "none",
+            None,
+        )];
+
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| {
+            SessionMemorySample::UnsupportedLiveProcess
+        });
+
+        assert_eq!(memory.active_count, 1);
+        assert_eq!(memory.sampled_count, 0);
+        assert_eq!(memory.projected_mb, FALLBACK_SPAWN_PROJECTION_MB);
     }
 
     #[test]
@@ -386,7 +479,9 @@ mod tests {
             admission_session("old", now - TimeDelta::hours(2), Some(4096)),
         ];
 
-        let count = count_observable_active_sessions(&sessions, "current", now, |_| None);
+        let count = count_observable_active_sessions(&sessions, "current", now, |_| {
+            SessionMemorySample::Unavailable
+        });
 
         assert_eq!(count, 1);
     }
@@ -400,9 +495,28 @@ mod tests {
             Some(4096),
         )];
 
-        let count = count_observable_active_sessions(&sessions, "current", now, |_| None);
+        let count = count_observable_active_sessions(&sessions, "current", now, |_| {
+            SessionMemorySample::Unavailable
+        });
 
         assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn balloon_count_counts_live_runtime_when_sampler_unsupported() {
+        let now = Utc::now();
+        let sessions = vec![active_session_with_mode(
+            "live",
+            now - TimeDelta::hours(2),
+            "rlimit",
+            Some(4096),
+        )];
+
+        let count = count_observable_active_sessions(&sessions, "current", now, |_| {
+            SessionMemorySample::UnsupportedLiveProcess
+        });
+
+        assert_eq!(count, 1);
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/resource_admission.rs
+++ b/crates/cli-sub-agent/src/resource_admission.rs
@@ -1,0 +1,241 @@
+use std::path::Path;
+
+use chrono::{DateTime, TimeDelta, Utc};
+use csa_config::ProjectConfig;
+use csa_resource::SpawnMemoryAdmission;
+#[cfg(test)]
+use csa_session::SandboxInfo;
+use csa_session::{MetaSessionState, SessionPhase, SessionTreeMemorySampler};
+use tracing::warn;
+
+const FALLBACK_SPAWN_PROJECTION_MB: u64 = 4096;
+const RECENT_ACTIVE_FALLBACK_PROJECTION_MB: u64 = 4096;
+const RECENT_ACTIVE_FALLBACK_WINDOW_SECS: i64 = 15 * 60;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct ActiveSessionMemory {
+    active_count: u64,
+    sampled_count: u64,
+    sampled_rss_mb: u64,
+    projected_mb: u64,
+}
+
+pub(crate) fn spawn_memory_projection_mb(config: Option<&ProjectConfig>, tool_name: &str) -> u64 {
+    config
+        .and_then(|cfg| cfg.sandbox_memory_max_mb(tool_name))
+        .or_else(|| csa_config::default_sandbox_for_tool(tool_name).memory_max_mb)
+        .unwrap_or(FALLBACK_SPAWN_PROJECTION_MB)
+}
+
+pub(crate) fn build_spawn_memory_admission(
+    project_root: &Path,
+    current_session_id: &str,
+    projected_spawn_mb: u64,
+) -> SpawnMemoryAdmission {
+    let active = match csa_session::list_all_sessions_all_projects() {
+        Ok(sessions) => aggregate_active_session_memory(
+            &sessions,
+            current_session_id,
+            Utc::now(),
+            sample_session_tree_rss_mb,
+        ),
+        Err(err) => {
+            warn!(
+                error = %err,
+                project_root = %project_root.display(),
+                "Failed to list active CSA sessions for host-memory admission"
+            );
+            ActiveSessionMemory::default()
+        }
+    };
+
+    SpawnMemoryAdmission {
+        projected_spawn_mb,
+        active_session_rss_mb: active.sampled_rss_mb,
+        active_session_projected_mb: active.projected_mb,
+        active_session_count: active.active_count,
+        sampled_session_count: active.sampled_count,
+    }
+}
+
+fn sample_session_tree_rss_mb(session: &MetaSessionState) -> Option<u64> {
+    let project_root = Path::new(&session.project_path);
+    let sampler = SessionTreeMemorySampler::new(project_root, &session.meta_session_id).ok()?;
+    sampler.sample_rss_mb().ok()
+}
+
+fn aggregate_active_session_memory(
+    sessions: &[MetaSessionState],
+    current_session_id: &str,
+    now: DateTime<Utc>,
+    sample_rss_mb: impl Fn(&MetaSessionState) -> Option<u64>,
+) -> ActiveSessionMemory {
+    let mut memory = ActiveSessionMemory::default();
+
+    for session in sessions {
+        if session.meta_session_id == current_session_id {
+            continue;
+        }
+        if !matches!(session.phase, SessionPhase::Active) {
+            continue;
+        }
+
+        memory.active_count = memory.active_count.saturating_add(1);
+
+        let sampled_rss = sample_rss_mb(session);
+        if let Some(rss_mb) = sampled_rss {
+            memory.sampled_count = memory.sampled_count.saturating_add(1);
+            memory.sampled_rss_mb = memory.sampled_rss_mb.saturating_add(rss_mb);
+        }
+
+        let sandbox_projection = session
+            .sandbox_info
+            .as_ref()
+            .and_then(|sandbox| sandbox.memory_max_mb);
+        let recent_pending_projection =
+            recent_pending_projection_mb(session, now, sampled_rss, sandbox_projection);
+        let session_projection = sampled_rss
+            .unwrap_or(0)
+            .max(sandbox_projection.unwrap_or(0))
+            .max(recent_pending_projection);
+        memory.projected_mb = memory.projected_mb.saturating_add(session_projection);
+    }
+
+    memory
+}
+
+fn recent_pending_projection_mb(
+    session: &MetaSessionState,
+    now: DateTime<Utc>,
+    sampled_rss: Option<u64>,
+    sandbox_projection: Option<u64>,
+) -> u64 {
+    if sampled_rss.is_some() || sandbox_projection.is_some() {
+        return 0;
+    }
+
+    let age = now.signed_duration_since(session.last_accessed);
+    if age <= TimeDelta::seconds(RECENT_ACTIVE_FALLBACK_WINDOW_SECS) {
+        RECENT_ACTIVE_FALLBACK_PROJECTION_MB
+    } else {
+        0
+    }
+}
+
+pub(crate) fn active_session_count_for_balloon(
+    project_root: &Path,
+    current_session_id: &str,
+) -> u64 {
+    match csa_session::list_all_sessions_all_projects() {
+        Ok(sessions) => sessions
+            .iter()
+            .filter(|session| session.meta_session_id != current_session_id)
+            .filter(|session| matches!(session.phase, SessionPhase::Active))
+            .count()
+            .try_into()
+            .unwrap_or(u64::MAX),
+        Err(err) => {
+            warn!(
+                error = %err,
+                project_root = %project_root.display(),
+                "Failed to count active CSA sessions for memory-balloon admission"
+            );
+            0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn active_session(
+        id: &str,
+        last_accessed: DateTime<Utc>,
+        memory_max_mb: Option<u64>,
+    ) -> MetaSessionState {
+        MetaSessionState {
+            meta_session_id: id.to_string(),
+            phase: SessionPhase::Active,
+            last_accessed,
+            sandbox_info: Some(SandboxInfo {
+                mode: "cgroup".to_string(),
+                memory_max_mb,
+                filesystem_mode: None,
+                readonly_project_root: None,
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn spawn_projection_uses_configured_tool_limit() {
+        let cfg: ProjectConfig =
+            toml::from_str("[resources]\nmemory_max_mb = 8192\n").expect("config should parse");
+
+        assert_eq!(spawn_memory_projection_mb(Some(&cfg), "codex"), 8192);
+    }
+
+    #[test]
+    fn spawn_projection_uses_tool_default_without_config() {
+        assert_eq!(spawn_memory_projection_mb(None, "codex"), 12_288);
+    }
+
+    #[test]
+    fn active_memory_uses_max_of_rss_and_sandbox_projection() {
+        let now = Utc::now();
+        let sessions = vec![
+            active_session("current", now, Some(12_288)),
+            active_session("a", now, Some(8192)),
+            active_session("b", now, Some(2048)),
+        ];
+
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |session| {
+            match session.meta_session_id.as_str() {
+                "a" => Some(1024),
+                "b" => Some(4096),
+                _ => None,
+            }
+        });
+
+        assert_eq!(memory.active_count, 2);
+        assert_eq!(memory.sampled_count, 2);
+        assert_eq!(memory.sampled_rss_mb, 5120);
+        assert_eq!(memory.projected_mb, 12_288);
+    }
+
+    #[test]
+    fn active_memory_adds_recent_pending_projection_without_rss_or_sandbox() {
+        let now = Utc::now();
+        let sessions = vec![MetaSessionState {
+            meta_session_id: "pending".to_string(),
+            phase: SessionPhase::Active,
+            last_accessed: now - TimeDelta::minutes(2),
+            sandbox_info: None,
+            ..Default::default()
+        }];
+
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| None);
+
+        assert_eq!(memory.active_count, 1);
+        assert_eq!(memory.sampled_count, 0);
+        assert_eq!(memory.projected_mb, RECENT_ACTIVE_FALLBACK_PROJECTION_MB);
+    }
+
+    #[test]
+    fn active_memory_ignores_old_pending_session_without_rss_or_sandbox() {
+        let now = Utc::now();
+        let sessions = vec![MetaSessionState {
+            meta_session_id: "old".to_string(),
+            phase: SessionPhase::Active,
+            last_accessed: now - TimeDelta::hours(2),
+            sandbox_info: None,
+            ..Default::default()
+        }];
+
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| None);
+
+        assert_eq!(memory.active_count, 1);
+        assert_eq!(memory.projected_mb, 0);
+    }
+}

--- a/crates/cli-sub-agent/src/resource_admission.rs
+++ b/crates/cli-sub-agent/src/resource_admission.rs
@@ -3,14 +3,13 @@ use std::path::Path;
 use chrono::{DateTime, TimeDelta, Utc};
 use csa_config::ProjectConfig;
 use csa_resource::SpawnMemoryAdmission;
-#[cfg(test)]
-use csa_session::SandboxInfo;
-use csa_session::{MetaSessionState, SessionPhase, SessionTreeMemorySampler};
+use csa_session::{MetaSessionState, SandboxInfo, SessionPhase, SessionTreeMemorySampler};
 use tracing::warn;
 
 const FALLBACK_SPAWN_PROJECTION_MB: u64 = 4096;
 const RECENT_ACTIVE_FALLBACK_PROJECTION_MB: u64 = 4096;
 const RECENT_ACTIVE_FALLBACK_WINDOW_SECS: i64 = 15 * 60;
+const PRE_SPAWN_ADMISSION_MODE: &str = "admission";
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct ActiveSessionMemory {
@@ -20,11 +19,52 @@ struct ActiveSessionMemory {
     projected_mb: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ActiveSessionObservation {
+    sampled_rss_mb: Option<u64>,
+    projected_mb: u64,
+}
+
 pub(crate) fn spawn_memory_projection_mb(config: Option<&ProjectConfig>, tool_name: &str) -> u64 {
     config
         .and_then(|cfg| cfg.sandbox_memory_max_mb(tool_name))
         .or_else(|| csa_config::default_sandbox_for_tool(tool_name).memory_max_mb)
         .unwrap_or(FALLBACK_SPAWN_PROJECTION_MB)
+}
+
+pub(crate) fn persist_spawn_memory_projection(
+    session: &mut MetaSessionState,
+    projected_spawn_mb: u64,
+) -> anyhow::Result<()> {
+    if update_spawn_memory_projection(session, projected_spawn_mb) {
+        csa_session::save_session(session)?;
+    }
+    Ok(())
+}
+
+fn update_spawn_memory_projection(session: &mut MetaSessionState, projected_spawn_mb: u64) -> bool {
+    let projected = Some(projected_spawn_mb);
+    match session.sandbox_info.as_mut() {
+        Some(info) if info.memory_max_mb == projected => {
+            session.last_accessed = Utc::now();
+            true
+        }
+        Some(info) => {
+            info.memory_max_mb = projected;
+            session.last_accessed = Utc::now();
+            true
+        }
+        None => {
+            session.sandbox_info = Some(SandboxInfo {
+                mode: PRE_SPAWN_ADMISSION_MODE.to_string(),
+                memory_max_mb: projected,
+                filesystem_mode: None,
+                readonly_project_root: None,
+            });
+            session.last_accessed = Utc::now();
+            true
+        }
+    }
 }
 
 pub(crate) fn build_spawn_memory_admission(
@@ -80,43 +120,56 @@ fn aggregate_active_session_memory(
             continue;
         }
 
+        let Some(observation) = active_session_observation(session, now, &sample_rss_mb) else {
+            continue;
+        };
+
         memory.active_count = memory.active_count.saturating_add(1);
 
-        let sampled_rss = sample_rss_mb(session);
-        if let Some(rss_mb) = sampled_rss {
+        if let Some(rss_mb) = observation.sampled_rss_mb {
             memory.sampled_count = memory.sampled_count.saturating_add(1);
             memory.sampled_rss_mb = memory.sampled_rss_mb.saturating_add(rss_mb);
         }
 
-        let sandbox_projection = session
-            .sandbox_info
-            .as_ref()
-            .and_then(|sandbox| sandbox.memory_max_mb);
-        let recent_pending_projection =
-            recent_pending_projection_mb(session, now, sampled_rss, sandbox_projection);
-        let session_projection = sampled_rss
-            .unwrap_or(0)
-            .max(sandbox_projection.unwrap_or(0))
-            .max(recent_pending_projection);
-        memory.projected_mb = memory.projected_mb.saturating_add(session_projection);
+        memory.projected_mb = memory.projected_mb.saturating_add(observation.projected_mb);
     }
 
     memory
 }
 
+fn active_session_observation(
+    session: &MetaSessionState,
+    now: DateTime<Utc>,
+    sample_rss_mb: impl Fn(&MetaSessionState) -> Option<u64>,
+) -> Option<ActiveSessionObservation> {
+    let sampled_rss = sample_rss_mb(session);
+    let sandbox_projection = session
+        .sandbox_info
+        .as_ref()
+        .and_then(|sandbox| sandbox.memory_max_mb);
+
+    if let Some(rss_mb) = sampled_rss {
+        return Some(ActiveSessionObservation {
+            sampled_rss_mb: Some(rss_mb),
+            projected_mb: rss_mb.max(sandbox_projection.unwrap_or(0)),
+        });
+    }
+
+    let recent_pending_projection = recent_pending_projection_mb(session, now, sandbox_projection);
+    (recent_pending_projection > 0).then_some(ActiveSessionObservation {
+        sampled_rss_mb: None,
+        projected_mb: recent_pending_projection,
+    })
+}
+
 fn recent_pending_projection_mb(
     session: &MetaSessionState,
     now: DateTime<Utc>,
-    sampled_rss: Option<u64>,
     sandbox_projection: Option<u64>,
 ) -> u64 {
-    if sampled_rss.is_some() || sandbox_projection.is_some() {
-        return 0;
-    }
-
     let age = now.signed_duration_since(session.last_accessed);
     if age <= TimeDelta::seconds(RECENT_ACTIVE_FALLBACK_WINDOW_SECS) {
-        RECENT_ACTIVE_FALLBACK_PROJECTION_MB
+        sandbox_projection.unwrap_or(RECENT_ACTIVE_FALLBACK_PROJECTION_MB)
     } else {
         0
     }
@@ -127,13 +180,12 @@ pub(crate) fn active_session_count_for_balloon(
     current_session_id: &str,
 ) -> u64 {
     match csa_session::list_all_sessions_all_projects() {
-        Ok(sessions) => sessions
-            .iter()
-            .filter(|session| session.meta_session_id != current_session_id)
-            .filter(|session| matches!(session.phase, SessionPhase::Active))
-            .count()
-            .try_into()
-            .unwrap_or(u64::MAX),
+        Ok(sessions) => count_observable_active_sessions(
+            &sessions,
+            current_session_id,
+            Utc::now(),
+            sample_session_tree_rss_mb,
+        ),
         Err(err) => {
             warn!(
                 error = %err,
@@ -143,6 +195,22 @@ pub(crate) fn active_session_count_for_balloon(
             0
         }
     }
+}
+
+fn count_observable_active_sessions(
+    sessions: &[MetaSessionState],
+    current_session_id: &str,
+    now: DateTime<Utc>,
+    sample_rss_mb: impl Fn(&MetaSessionState) -> Option<u64>,
+) -> u64 {
+    sessions
+        .iter()
+        .filter(|session| session.meta_session_id != current_session_id)
+        .filter(|session| matches!(session.phase, SessionPhase::Active))
+        .filter(|session| active_session_observation(session, now, &sample_rss_mb).is_some())
+        .count()
+        .try_into()
+        .unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
@@ -205,7 +273,23 @@ mod tests {
     }
 
     #[test]
-    fn active_memory_adds_recent_pending_projection_without_rss_or_sandbox() {
+    fn active_memory_adds_recent_pending_sandbox_projection_without_rss() {
+        let now = Utc::now();
+        let sessions = vec![active_session(
+            "pending",
+            now - TimeDelta::minutes(2),
+            Some(12_288),
+        )];
+
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| None);
+
+        assert_eq!(memory.active_count, 1);
+        assert_eq!(memory.sampled_count, 0);
+        assert_eq!(memory.projected_mb, 12_288);
+    }
+
+    #[test]
+    fn active_memory_uses_fallback_for_recent_pending_without_sandbox_projection() {
         let now = Utc::now();
         let sessions = vec![MetaSessionState {
             meta_session_id: "pending".to_string(),
@@ -223,19 +307,81 @@ mod tests {
     }
 
     #[test]
-    fn active_memory_ignores_old_pending_session_without_rss_or_sandbox() {
+    fn active_memory_ignores_old_pending_session_without_live_signal() {
         let now = Utc::now();
         let sessions = vec![MetaSessionState {
             meta_session_id: "old".to_string(),
             phase: SessionPhase::Active,
             last_accessed: now - TimeDelta::hours(2),
-            sandbox_info: None,
+            sandbox_info: Some(SandboxInfo {
+                mode: "cgroup".to_string(),
+                memory_max_mb: Some(12_288),
+                filesystem_mode: None,
+                readonly_project_root: None,
+            }),
             ..Default::default()
         }];
 
         let memory = aggregate_active_session_memory(&sessions, "current", now, |_| None);
 
-        assert_eq!(memory.active_count, 1);
+        assert_eq!(memory.active_count, 0);
         assert_eq!(memory.projected_mb, 0);
+    }
+
+    #[test]
+    fn active_memory_counts_old_session_with_live_sample() {
+        let now = Utc::now();
+        let sessions = vec![active_session(
+            "live",
+            now - TimeDelta::hours(2),
+            Some(12_288),
+        )];
+
+        let memory = aggregate_active_session_memory(&sessions, "current", now, |_| Some(1024));
+
+        assert_eq!(memory.active_count, 1);
+        assert_eq!(memory.sampled_count, 1);
+        assert_eq!(memory.sampled_rss_mb, 1024);
+        assert_eq!(memory.projected_mb, 12_288);
+    }
+
+    #[test]
+    fn balloon_count_ignores_stale_active_without_live_signal() {
+        let now = Utc::now();
+        let sessions = vec![
+            active_session("recent", now - TimeDelta::minutes(2), Some(4096)),
+            active_session("old", now - TimeDelta::hours(2), Some(4096)),
+        ];
+
+        let count = count_observable_active_sessions(&sessions, "current", now, |_| None);
+
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn spawn_projection_update_records_pre_spawn_memory_limit() {
+        let mut session = MetaSessionState::default();
+
+        assert!(update_spawn_memory_projection(&mut session, 12_288));
+        let info = session.sandbox_info.expect("projection should be recorded");
+
+        assert_eq!(info.mode, PRE_SPAWN_ADMISSION_MODE);
+        assert_eq!(info.memory_max_mb, Some(12_288));
+        assert_eq!(info.filesystem_mode, None);
+        assert_eq!(info.readonly_project_root, None);
+    }
+
+    #[test]
+    fn spawn_projection_update_refreshes_existing_projection_timestamp() {
+        let old = Utc::now() - TimeDelta::hours(2);
+        let mut session = active_session("current", old, Some(12_288));
+        session.last_accessed = old;
+
+        assert!(update_spawn_memory_projection(&mut session, 12_288));
+
+        assert!(
+            session.last_accessed > old,
+            "unchanged pre-spawn projection must still refresh the pending-start window"
+        );
     }
 }

--- a/crates/csa-resource/src/guard.rs
+++ b/crates/csa-resource/src/guard.rs
@@ -21,6 +21,21 @@ impl Default for ResourceLimits {
     }
 }
 
+/// Host-memory projection for a session spawn admission decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SpawnMemoryAdmission {
+    /// Memory the new session is expected to be allowed to consume.
+    pub projected_spawn_mb: u64,
+    /// Aggregate sampled RSS from already-active CSA session trees.
+    pub active_session_rss_mb: u64,
+    /// Aggregate active-session pressure after per-session projections are applied.
+    pub active_session_projected_mb: u64,
+    /// Number of active CSA sessions considered, excluding the session being spawned.
+    pub active_session_count: u64,
+    /// Number of active sessions whose process tree RSS was sampled successfully.
+    pub sampled_session_count: u64,
+}
+
 /// Guards resource availability before launching tools.
 pub struct ResourceGuard {
     sys: System,
@@ -40,12 +55,23 @@ impl ResourceGuard {
     /// - **Hard block**: MemAvailable < reserve_mb → refuse to launch.
     /// - **Warning**: MemAvailable < 150% of reserve_mb → warn but allow.
     pub fn check_availability(&mut self, tool_name: &str) -> Result<()> {
+        self.check_availability_with_admission(tool_name, None)
+    }
+
+    /// Check host memory with active-session and new-spawn projection.
+    pub fn check_availability_with_admission(
+        &mut self,
+        tool_name: &str,
+        admission: Option<SpawnMemoryAdmission>,
+    ) -> Result<()> {
         self.sys.refresh_memory();
 
         let available_phys_bytes = self.sys.available_memory();
         let available_swap_bytes = self.sys.free_swap();
+        let total_ram_bytes = self.sys.total_memory();
         let available_phys = available_phys_bytes / 1024 / 1024;
         let available_swap = available_swap_bytes / 1024 / 1024;
+        let total_ram = total_ram_bytes / 1024 / 1024;
         let available_combined = available_phys.saturating_add(available_swap);
 
         evaluate_memory_availability(
@@ -53,7 +79,9 @@ impl ResourceGuard {
             available_phys,
             available_swap,
             available_combined,
+            total_ram,
             self.limits.min_free_memory_mb,
+            admission,
         )
     }
 
@@ -98,6 +126,10 @@ impl ResourceGuard {
 /// Multiplier for the warning threshold (150% of reserve).
 const WARNING_MULTIPLIER_NUM: u64 = 3;
 const WARNING_MULTIPLIER_DEN: u64 = 2;
+const ACTIVE_SESSION_SAFE_FRACTION_NUM: u64 = 3;
+const ACTIVE_SESSION_SAFE_FRACTION_DEN: u64 = 4;
+const ACTIVE_SESSION_WARNING_FRACTION_NUM: u64 = 9;
+const ACTIVE_SESSION_WARNING_FRACTION_DEN: u64 = 10;
 
 /// Pure evaluation of memory availability against reserve.
 ///
@@ -109,7 +141,9 @@ fn evaluate_memory_availability(
     available_phys_mb: u64,
     available_swap_mb: u64,
     available_combined_mb: u64,
+    total_ram_mb: u64,
     reserve_mb: u64,
+    admission: Option<SpawnMemoryAdmission>,
 ) -> Result<()> {
     if available_phys_mb < reserve_mb {
         let message = format!(
@@ -140,6 +174,77 @@ fn evaluate_memory_availability(
              (reserve {reserve_mb}MB, warning threshold {warn_threshold}MB). \
              Session will proceed but may hit OOM pressure."
         );
+    }
+
+    if let Some(admission) = admission
+        && admission.projected_spawn_mb > 0
+    {
+        let required_available_mb = reserve_mb.saturating_add(admission.projected_spawn_mb);
+        if available_phys_mb < required_available_mb {
+            let message = format!(
+                "CSA: host memory admission denied — available={available_phys_mb}MB < \
+                 required={required_available_mb}MB (reserve={reserve_mb}MB + \
+                 projected_spawn={projected_spawn_mb}MB). active_sessions={active_sessions} \
+                 sampled_sessions={sampled_sessions} active_session_rss_mb={active_rss} \
+                 active_session_projected_mb={active_projected} swap_available_mb={available_swap_mb} \
+                 combined_available_mb={available_combined_mb}",
+                projected_spawn_mb = admission.projected_spawn_mb,
+                active_sessions = admission.active_session_count,
+                sampled_sessions = admission.sampled_session_count,
+                active_rss = admission.active_session_rss_mb,
+                active_projected = admission.active_session_projected_mb,
+            );
+            eprintln!("{message}");
+            bail!(
+                "{message}. Free host memory, wait for active CSA sessions to finish, or lower \
+                 tool memory limits before spawning more work."
+            );
+        }
+
+        let host_safe_limit_mb = total_ram_mb.saturating_mul(ACTIVE_SESSION_SAFE_FRACTION_NUM)
+            / ACTIVE_SESSION_SAFE_FRACTION_DEN;
+        let projected_active_mb = admission
+            .active_session_projected_mb
+            .saturating_add(admission.projected_spawn_mb);
+        if host_safe_limit_mb > 0 && projected_active_mb > host_safe_limit_mb {
+            let message = format!(
+                "CSA: active-session memory admission denied — projected_active={projected_active_mb}MB \
+                 > host_safe_limit={host_safe_limit_mb}MB ({safe_num}/{safe_den} of total_ram={total_ram_mb}MB). \
+                 active_sessions={active_sessions} sampled_sessions={sampled_sessions} \
+                 active_session_rss_mb={active_rss} active_session_projected_mb={active_projected} \
+                 projected_spawn_mb={projected_spawn_mb} available_mb={available_phys_mb}",
+                safe_num = ACTIVE_SESSION_SAFE_FRACTION_NUM,
+                safe_den = ACTIVE_SESSION_SAFE_FRACTION_DEN,
+                active_sessions = admission.active_session_count,
+                sampled_sessions = admission.sampled_session_count,
+                active_rss = admission.active_session_rss_mb,
+                active_projected = admission.active_session_projected_mb,
+                projected_spawn_mb = admission.projected_spawn_mb,
+            );
+            eprintln!("{message}");
+            bail!(
+                "{message}. CSA is refusing to launch work that could collectively exhaust host RAM."
+            );
+        }
+
+        let host_warning_limit_mb = host_safe_limit_mb
+            .saturating_mul(ACTIVE_SESSION_WARNING_FRACTION_NUM)
+            / ACTIVE_SESSION_WARNING_FRACTION_DEN;
+        if host_warning_limit_mb > 0 && projected_active_mb > host_warning_limit_mb {
+            eprintln!(
+                "CSA: active-session memory warning — projected_active={projected_active_mb}MB is \
+                 near host_safe_limit={host_safe_limit_mb}MB; active_sessions={active_sessions}.",
+                active_sessions = admission.active_session_count,
+            );
+            warn!(
+                tool = tool_name,
+                projected_active_mb,
+                host_safe_limit_mb,
+                active_sessions = admission.active_session_count,
+                sampled_sessions = admission.sampled_session_count,
+                "Active CSA session memory is near host admission limit"
+            );
+        }
     }
 
     Ok(())
@@ -222,7 +327,8 @@ mod tests {
 
     #[test]
     fn test_evaluate_hard_block_when_available_below_reserve() {
-        let result = evaluate_memory_availability("test_tool", 3000, 1000, 4000, 4096);
+        let result =
+            evaluate_memory_availability("test_tool", 3000, 1000, 4000, 32_000, 4096, None);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -242,14 +348,16 @@ mod tests {
     #[test]
     fn test_evaluate_warning_when_available_between_100_and_150_percent() {
         // reserve=4096, 150% = 6144. available=5000 is between 4096..6144.
-        let result = evaluate_memory_availability("test_tool", 5000, 1000, 6000, 4096);
+        let result =
+            evaluate_memory_availability("test_tool", 5000, 1000, 6000, 32_000, 4096, None);
         // Should succeed (warning only, no error).
         assert!(result.is_ok(), "Should warn but not block: {result:?}");
     }
 
     #[test]
     fn test_evaluate_blocks_when_memavailable_below_reserve_even_with_swap() {
-        let result = evaluate_memory_availability("test_tool", 3900, 4096, 7996, 4096);
+        let result =
+            evaluate_memory_availability("test_tool", 3900, 4096, 7996, 32_000, 4096, None);
         assert!(
             result.is_err(),
             "swap must not satisfy min_free_memory_mb when MemAvailable is low"
@@ -263,25 +371,89 @@ mod tests {
     #[test]
     fn test_evaluate_no_warning_when_available_above_150_percent() {
         // reserve=4096, 150% = 6144. available=7000 is above 6144.
-        let result = evaluate_memory_availability("test_tool", 7000, 1000, 8000, 4096);
+        let result =
+            evaluate_memory_availability("test_tool", 7000, 1000, 8000, 32_000, 4096, None);
         assert!(result.is_ok(), "Should pass without warning: {result:?}");
     }
 
     #[test]
     fn test_evaluate_exact_boundary_at_reserve() {
         // Exactly at reserve — should pass (not strictly less than).
-        let result = evaluate_memory_availability("test_tool", 4096, 1096, 5192, 4096);
+        let result =
+            evaluate_memory_availability("test_tool", 4096, 1096, 5192, 32_000, 4096, None);
         assert!(result.is_ok(), "Exact reserve should pass: {result:?}");
     }
 
     #[test]
     fn test_evaluate_exact_boundary_at_warning_threshold() {
         // reserve=4096, 150% = 6144. available=6144 is exactly at warning threshold.
-        let result = evaluate_memory_availability("test_tool", 6144, 1144, 7288, 4096);
+        let result =
+            evaluate_memory_availability("test_tool", 6144, 1144, 7288, 32_000, 4096, None);
         // 6144 is NOT < 6144, so no warning.
         assert!(
             result.is_ok(),
             "Exact warning threshold should pass: {result:?}"
         );
+    }
+
+    #[test]
+    fn test_evaluate_blocks_when_spawn_projection_exceeds_available_headroom() {
+        let admission = SpawnMemoryAdmission {
+            projected_spawn_mb: 8192,
+            active_session_rss_mb: 2048,
+            active_session_projected_mb: 4096,
+            active_session_count: 1,
+            sampled_session_count: 1,
+        };
+
+        let result =
+            evaluate_memory_availability("codex", 10_000, 0, 10_000, 32_000, 4096, Some(admission));
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("host memory admission denied"));
+        assert!(msg.contains("projected_spawn=8192MB"));
+    }
+
+    #[test]
+    fn test_evaluate_blocks_when_active_projection_exceeds_host_safe_limit() {
+        let admission = SpawnMemoryAdmission {
+            projected_spawn_mb: 8192,
+            active_session_rss_mb: 16_000,
+            active_session_projected_mb: 20_000,
+            active_session_count: 3,
+            sampled_session_count: 2,
+        };
+
+        let result =
+            evaluate_memory_availability("codex", 20_000, 0, 20_000, 32_000, 4096, Some(admission));
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("active-session memory admission denied"));
+        assert!(msg.contains("projected_active=28192MB"));
+    }
+
+    #[test]
+    fn test_evaluate_allows_safe_spawn_projection() {
+        let admission = SpawnMemoryAdmission {
+            projected_spawn_mb: 4096,
+            active_session_rss_mb: 2048,
+            active_session_projected_mb: 4096,
+            active_session_count: 1,
+            sampled_session_count: 1,
+        };
+
+        let result = evaluate_memory_availability(
+            "claude-code",
+            12_000,
+            0,
+            12_000,
+            32_000,
+            4096,
+            Some(admission),
+        );
+
+        assert!(result.is_ok(), "safe projection should pass: {result:?}");
     }
 }

--- a/crates/csa-resource/src/lib.rs
+++ b/crates/csa-resource/src/lib.rs
@@ -21,7 +21,7 @@ pub use cgroup::{
     scope_unit_name,
 };
 pub use filesystem_sandbox::{FilesystemCapability, detect_filesystem_capability};
-pub use guard::{ResourceGuard, ResourceLimits};
+pub use guard::{ResourceGuard, ResourceLimits, SpawnMemoryAdmission};
 pub use isolation_plan::{EnforcementMode, IsolationPlan, IsolationPlanBuilder};
 pub use landlock::apply_landlock_rules;
 pub use rlimit::apply_rlimits;

--- a/crates/csa-session/src/process_tree_memory.rs
+++ b/crates/csa-session/src/process_tree_memory.rs
@@ -26,7 +26,7 @@ impl SessionTreeMemorySampler {
         #[cfg(not(target_os = "linux"))]
         {
             let _ = (project_root, session_id);
-            return Ok(Self {});
+            return Err(unsupported_process_tree_memory());
         }
 
         #[cfg(target_os = "linux")]
@@ -52,7 +52,7 @@ impl SessionTreeMemorySampler {
     pub fn sample_rss_mb(&self) -> io::Result<u64> {
         #[cfg(not(target_os = "linux"))]
         {
-            return Ok(0);
+            return Err(unsupported_process_tree_memory());
         }
 
         #[cfg(target_os = "linux")]
@@ -77,13 +77,21 @@ pub fn session_tree_rss_mb(project_root: &Path, session_id: &str) -> io::Result<
     #[cfg(not(target_os = "linux"))]
     {
         let _ = (project_root, session_id);
-        return Ok(0);
+        return Err(unsupported_process_tree_memory());
     }
 
     #[cfg(target_os = "linux")]
     {
         SessionTreeMemorySampler::new(project_root, session_id)?.sample_rss_mb()
     }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn unsupported_process_tree_memory() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        "session process-tree memory sampling is only available on Linux",
+    )
 }
 
 #[cfg(target_os = "linux")]
@@ -178,6 +186,29 @@ fn read_vmrss_kib(pid: u32) -> Option<u64> {
 #[cfg(any(target_os = "linux", test))]
 fn bytes_to_mb_ceil(bytes: u64) -> u64 {
     bytes.saturating_add(BYTES_PER_MB - 1) / BYTES_PER_MB
+}
+
+#[cfg(all(test, not(target_os = "linux")))]
+mod non_linux_tests {
+    use super::*;
+
+    #[test]
+    fn sampler_reports_memory_sampling_unavailable() {
+        let err = match SessionTreeMemorySampler::new(Path::new("."), "session") {
+            Ok(_) => panic!("non-Linux sampler should be unavailable"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn one_shot_sampler_reports_memory_sampling_unavailable() {
+        let err = session_tree_rss_mb(Path::new("."), "session")
+            .expect_err("non-Linux one-shot sampler should be unavailable");
+
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
 }
 
 #[cfg(test)]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.954"
-weave = "0.1.954"
+csa = "0.1.955"
+weave = "0.1.955"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- add host-memory-aware admission control for CSA spawns
- account for live/pending sessions without trusting stale persisted Active state
- clear admission markers across failure and no-sandbox normal-completion paths
- add focused regression coverage for resource-admission edge cases

## Verification
- writer session: 01KTM0S2QEKXSK1TKTHEB8TQ8H
- review/fix sessions: 01KTM364DTXWD5JK7DZK8VJJWA, 01KTM4JRMEJ6J4WB7S13P1432H, 01KTM5MMBQJERKPRNKG9KYRDNT, 01KTM73H97JV21TDEM5EMV6WSV, 01KTM87N8GCWK8P0FS70BR5R0A
- final Codex review PASS: 01KTM8YGCDR5BJGW2ZMZRDJ138
- csa/weave installed locally at 0.1.955 (53fab277)
- pre-push review and version gates passed

Closes #1715