### PR TITLE
fix(review): lock session fix to recorded tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.955"
+version = "0.1.956"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.955"
+version = "0.1.956"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -495,6 +495,9 @@ async fn run() -> Result<()> {
             memory_cmd::handle_memory_command(command).await?;
         }
         Commands::Review(args) => {
+            if !args.no_daemon && !args.daemon_child && args.session_id.is_none() {
+                review_cmd::validate_session_fix_before_daemon(&args)?;
+            }
             let mut daemon_guard = run_cmd_daemon::check_daemon_flags(
                 "review",
                 args.no_daemon || args.check_verdict,

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -126,8 +126,7 @@ pub(crate) async fn handle_review(
         crate::run_cmd_model_pin::inherited_model_pin_from_startup(startup_env);
     let inherited_trusted_pin = subtree_pin::apply_subtree_pin(&mut args, inherited_model_pin);
     let (effective_tier, args_tool) = resolve_review_effective_tier(&args, config.as_ref())?;
-    let (selection_tool, direct_tool_requested) =
-        session_fix::resolve_selection_tool(&args, &project_root, args_tool)?;
+    let selection = session_fix::resolve_selection_tool(&args, &project_root, args_tool)?;
     crate::run_helpers::enforce_tier_bypass_gate(crate::run_helpers::TierBypassGateCtx {
         project_config: config.as_ref(),
         global_config: &global_config,
@@ -141,7 +140,7 @@ pub(crate) async fn handle_review(
         inherited_trusted_pin,
     })?;
     validate_review_direct_tool_tier_restriction(
-        direct_tool_requested,
+        selection.direct_tool_requested,
         config.as_ref(),
         effective_tier.as_deref(),
         args.force_override_user_config,
@@ -224,7 +223,10 @@ pub(crate) async fn handle_review(
 
     let detected_parent_tool = crate::run_helpers::detect_parent_tool();
     let parent_tool = crate::run_helpers::resolve_tool(detected_parent_tool, &global_config);
-    crate::run_helpers::warn_if_tier_without_tool(args.tier.as_deref(), direct_tool_requested);
+    crate::run_helpers::warn_if_tier_without_tool(
+        args.tier.as_deref(),
+        selection.direct_tool_requested,
+    );
     let resolved_selection =
         session_fix::resolve_selection_or_persist_error(session_fix::SelectionResolutionCtx {
             args: &args,
@@ -233,8 +235,9 @@ pub(crate) async fn handle_review(
             parent_tool: parent_tool.as_deref(),
             project_root: &project_root,
             effective_tier: effective_tier.as_deref(),
-            selection_tool,
-            direct_tool_requested,
+            selection_tool: selection.selection_tool,
+            direct_tool_requested: selection.direct_tool_requested,
+            session_fix: selection.session_fix.as_ref(),
             review_description: &review_description,
         })?;
     let tool = resolved_selection.tool;

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -64,6 +64,8 @@ mod resolve;
 mod result_handling;
 #[path = "review_cmd_reviewers.rs"]
 mod reviewers;
+#[path = "review_cmd_session_fix.rs"]
+mod session_fix;
 #[path = "review_cmd_subtree_pin.rs"]
 mod subtree_pin;
 #[cfg(test)]
@@ -84,8 +86,7 @@ use flow::persist_review_sidecars_if_session_exists_with_diff_size;
 #[cfg(not(test))]
 use flow::{persist_review_sidecars_if_session_exists_with_diff_size, should_run_fix_loop};
 use post_review::{build_post_review_output, emit_post_review_output, review_scope_is_cumulative};
-#[rustfmt::skip]
-use prior_rounds::{ explicit_review_tool, load_prior_rounds_section_or_persist_error, review_pre_exec_session_id };
+use prior_rounds::load_prior_rounds_section_or_persist_error;
 #[cfg(test)]
 use resolve::build_review_instruction;
 #[cfg(test)]
@@ -93,8 +94,8 @@ pub(crate) use resolve::resolve_review_tool;
 use resolve::{
     ReviewProjectPromptOptions, build_review_instruction_for_project, derive_scope_for_project,
     resolve_review_effective_tier, resolve_review_model, resolve_review_readonly_configured,
-    resolve_review_readonly_project_root, resolve_review_selection, resolve_review_stream_mode,
-    resolve_review_thinking, resolve_review_tier_name, review_scope_allows_auto_discovery,
+    resolve_review_readonly_project_root, resolve_review_stream_mode, resolve_review_thinking,
+    resolve_review_tier_name, review_scope_allows_auto_discovery,
     validate_review_direct_tool_tier_restriction, verify_review_skill_available,
 };
 use result_handling::resolve_single_review_result;
@@ -103,6 +104,7 @@ use reviewers::resolve_effective_reviewer_selection_for_args;
 #[cfg(test)]
 #[rustfmt::skip]
 pub(crate) use { fix::persist_fix_final_artifacts_for_tests, output::persist_review_verdict_for_tests };
+pub(crate) use session_fix::validate_session_fix_before_daemon;
 
 pub(crate) async fn handle_review(
     mut args: ReviewArgs,
@@ -124,6 +126,8 @@ pub(crate) async fn handle_review(
         crate::run_cmd_model_pin::inherited_model_pin_from_startup(startup_env);
     let inherited_trusted_pin = subtree_pin::apply_subtree_pin(&mut args, inherited_model_pin);
     let (effective_tier, args_tool) = resolve_review_effective_tier(&args, config.as_ref())?;
+    let (selection_tool, direct_tool_requested) =
+        session_fix::resolve_selection_tool(&args, &project_root, args_tool)?;
     crate::run_helpers::enforce_tier_bypass_gate(crate::run_helpers::TierBypassGateCtx {
         project_config: config.as_ref(),
         global_config: &global_config,
@@ -137,7 +141,7 @@ pub(crate) async fn handle_review(
         inherited_trusted_pin,
     })?;
     validate_review_direct_tool_tier_restriction(
-        args_tool.is_some(),
+        direct_tool_requested,
         config.as_ref(),
         effective_tier.as_deref(),
         args.force_override_user_config,
@@ -220,34 +224,19 @@ pub(crate) async fn handle_review(
 
     let detected_parent_tool = crate::run_helpers::detect_parent_tool();
     let parent_tool = crate::run_helpers::resolve_tool(detected_parent_tool, &global_config);
-    crate::run_helpers::warn_if_tier_without_tool(args.tier.as_deref(), args_tool.is_some());
-    let resolved_selection = match resolve_review_selection(
-        args_tool,
-        args.model_spec.as_deref(),
-        config.as_ref(),
-        &global_config,
-        parent_tool.as_deref(),
-        &project_root,
-        args.force_override_user_config,
-        effective_tier.as_deref(),
-        args.force_ignore_tier_setting,
-    ) {
-        Ok(resolved) => resolved,
-        Err(err) => {
-            return Err(crate::session_guard::persist_pre_exec_error_result(
-                crate::session_guard::PreExecErrorCtx {
-                    project_root: &project_root,
-                    session_id: review_pre_exec_session_id(&args),
-                    description: Some(review_description.as_str()),
-                    parent: None,
-                    tool_name: explicit_review_tool(&args).map(|tool| tool.as_str()),
-                    task_type: Some("review"),
-                    tier_name: effective_tier.as_deref(),
-                    error: err,
-                },
-            ));
-        }
-    };
+    crate::run_helpers::warn_if_tier_without_tool(args.tier.as_deref(), direct_tool_requested);
+    let resolved_selection =
+        session_fix::resolve_selection_or_persist_error(session_fix::SelectionResolutionCtx {
+            args: &args,
+            project_config: config.as_ref(),
+            global_config: &global_config,
+            parent_tool: parent_tool.as_deref(),
+            project_root: &project_root,
+            effective_tier: effective_tier.as_deref(),
+            selection_tool,
+            direct_tool_requested,
+            review_description: &review_description,
+        })?;
     let tool = resolved_selection.tool;
     let resolved_model_spec = resolved_selection.model_spec.clone();
     let tier_preference_order = resolved_selection.tier_preference_order.clone();

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -246,6 +246,11 @@ pub(crate) async fn handle_review(
     let tier_active = resolved_model_spec.is_some()
         && args.model_spec.is_none()
         && !args.force_ignore_tier_setting;
+    // Session-fix resumes must not fail over beyond the recorded tool.
+    let execution_no_failover = session_fix::effective_no_failover_for_session_fix(
+        args.no_failover,
+        selection.session_fix.as_ref(),
+    );
     let resolved_tier_name = if tier_active {
         resolve_review_tier_name(
             config.as_ref(),
@@ -330,7 +335,7 @@ pub(crate) async fn handle_review(
             initial_response_timeout_seconds,
             args.force_override_user_config,
             args.force_ignore_tier_setting,
-            args.no_failover,
+            execution_no_failover,
             args.build_jobs,
             args.fast_but_more_cost,
             true,
@@ -519,7 +524,7 @@ pub(crate) async fn handle_review(
             initial_response_timeout_seconds,
             force_override_user_config: args.force_override_user_config,
             force_ignore_tier_setting: args.force_ignore_tier_setting,
-            no_failover: args.no_failover,
+            no_failover: execution_no_failover,
             build_jobs: args.build_jobs,
             fast_but_more_cost: args.fast_but_more_cost,
             no_fs_sandbox: args.no_fs_sandbox,

--- a/crates/cli-sub-agent/src/review_cmd_resolve_selection.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve_selection.rs
@@ -60,9 +60,10 @@ pub(crate) fn resolve_review_selection(
     force_override_user_config: bool,
     cli_tier: Option<&str>,
     force_ignore_tier_setting: bool,
+    direct_tool_requested: bool,
 ) -> Result<ResolvedReviewSelection> {
     crate::run_helpers::validate_tool_tier_override_flags(
-        arg_tool.is_some(),
+        direct_tool_requested,
         cli_tier,
         force_ignore_tier_setting,
     )?;
@@ -99,7 +100,7 @@ pub(crate) fn resolve_review_selection(
     // Enforce tier routing: block direct --tool when tiers are configured,
     // unless --force-ignore-tier-setting (or --force-override-user-config) is active.
     validate_review_direct_tool_tier_restriction(
-        arg_tool.is_some(),
+        direct_tool_requested,
         project_config,
         cli_tier,
         force_override_user_config,
@@ -269,6 +270,7 @@ pub(crate) fn resolve_review_tool(
         force_override_user_config,
         cli_tier,
         force_ignore_tier_setting,
+        arg_tool.is_some(),
     )?;
     Ok((resolved.tool, resolved.model_spec))
 }

--- a/crates/cli-sub-agent/src/review_cmd_session_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_session_fix.rs
@@ -1,0 +1,240 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use csa_config::{GlobalConfig, ProjectConfig};
+use csa_core::types::ToolName;
+
+use super::resolve::selection::ResolvedReviewSelection;
+use crate::cli::ReviewArgs;
+use crate::review_consensus::review_iteration_resolver;
+
+#[cfg(test)]
+#[path = "review_cmd_tests_session_fix.rs"]
+mod tests;
+
+pub(super) struct SessionFixTool {
+    pub(super) session_id: String,
+    pub(super) tool: Option<ToolName>,
+}
+
+pub(super) struct SelectionResolutionCtx<'a> {
+    pub(super) args: &'a ReviewArgs,
+    pub(super) project_config: Option<&'a ProjectConfig>,
+    pub(super) global_config: &'a GlobalConfig,
+    pub(super) parent_tool: Option<&'a str>,
+    pub(super) project_root: &'a Path,
+    pub(super) effective_tier: Option<&'a str>,
+    pub(super) selection_tool: Option<ToolName>,
+    pub(super) direct_tool_requested: bool,
+    pub(super) review_description: &'a str,
+}
+
+pub(super) fn resolve_selection_tool(
+    args: &ReviewArgs,
+    project_root: &Path,
+    args_tool: Option<ToolName>,
+) -> Result<(Option<ToolName>, bool)> {
+    let session_fix = resolve_session_fix_tool(args, project_root)?;
+    validate_session_fix_explicit_tool(args, session_fix.as_ref())?;
+    let selection_tool = args_tool.or_else(|| session_fix.as_ref().and_then(|fix| fix.tool));
+    Ok((selection_tool, args_tool.is_some()))
+}
+
+pub(super) fn resolve_selection_or_persist_error(
+    ctx: SelectionResolutionCtx<'_>,
+) -> Result<ResolvedReviewSelection> {
+    match super::resolve::resolve_review_selection(
+        ctx.selection_tool,
+        ctx.args.model_spec.as_deref(),
+        ctx.project_config,
+        ctx.global_config,
+        ctx.parent_tool,
+        ctx.project_root,
+        ctx.args.force_override_user_config,
+        ctx.effective_tier,
+        ctx.args.force_ignore_tier_setting,
+        ctx.direct_tool_requested,
+    ) {
+        Ok(resolved) => Ok(resolved),
+        Err(err) => Err(crate::session_guard::persist_pre_exec_error_result(
+            crate::session_guard::PreExecErrorCtx {
+                project_root: ctx.project_root,
+                session_id: super::prior_rounds::review_pre_exec_session_id(ctx.args),
+                description: Some(ctx.review_description),
+                parent: None,
+                tool_name: super::prior_rounds::explicit_review_tool(ctx.args)
+                    .map(|tool| tool.as_str()),
+                task_type: Some("review"),
+                tier_name: ctx.effective_tier,
+                error: err,
+            },
+        )),
+    }
+}
+
+pub(super) fn resolve_session_fix_tool(
+    args: &ReviewArgs,
+    project_root: &Path,
+) -> Result<Option<SessionFixTool>> {
+    if !args.fix {
+        return Ok(None);
+    }
+    let Some(session_ref) = args.session.as_deref() else {
+        return Ok(None);
+    };
+
+    let resolution = csa_session::resolve_fork_source(project_root, session_ref)
+        .with_context(|| format!("failed to resolve --session {session_ref} for review --fix"))?;
+    let session_id = resolution.meta_session_id;
+    let tool = infer_session_tool(project_root, &session_id)?;
+
+    if tool.is_none() && args.tool.is_none() && args.model_spec.is_none() {
+        anyhow::bail!(
+            "Cannot infer review tool for `csa review --session {session_ref} --fix`: \
+             session {session_id} has no metadata.toml tool, review_meta.json tool, or result.toml tool. \
+             Pass --tool <tool> or choose a review session with tool metadata."
+        );
+    }
+
+    Ok(Some(SessionFixTool { session_id, tool }))
+}
+
+pub(super) fn validate_session_fix_explicit_tool(
+    args: &ReviewArgs,
+    session_fix: Option<&SessionFixTool>,
+) -> Result<()> {
+    let Some(session_fix) = session_fix else {
+        return Ok(());
+    };
+    let Some(session_tool) = session_fix.tool else {
+        return Ok(());
+    };
+
+    if let Some(cli_tool) = args.tool
+        && cli_tool != session_tool
+    {
+        anyhow::bail!(
+            "`csa review --session {} --fix` must use the original review tool '{}'; \
+             explicit --tool '{}' would violate the session tool lock.",
+            session_fix.session_id,
+            session_tool,
+            cli_tool
+        );
+    }
+
+    if let Some(spec_tool) = args
+        .model_spec
+        .as_deref()
+        .and_then(|spec| spec.split('/').next())
+        .map(crate::run_helpers::parse_tool_name)
+        .transpose()?
+        && spec_tool != session_tool
+    {
+        anyhow::bail!(
+            "`csa review --session {} --fix` must use the original review tool '{}'; \
+             --model-spec selects '{}'.",
+            session_fix.session_id,
+            session_tool,
+            spec_tool
+        );
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_session_fix_before_daemon(args: &ReviewArgs) -> Result<()> {
+    let project_root = crate::pipeline::determine_project_root(args.cd.as_deref())?;
+    let project_config = ProjectConfig::load(&project_root)?;
+    let global_config = GlobalConfig::load()?;
+    let parent_tool =
+        crate::run_helpers::resolve_tool(crate::run_helpers::detect_parent_tool(), &global_config);
+
+    resolve_session_fix_selection(
+        args,
+        &project_root,
+        project_config.as_ref(),
+        &global_config,
+        parent_tool.as_deref(),
+    )?;
+
+    Ok(())
+}
+
+pub(super) fn resolve_session_fix_selection(
+    args: &ReviewArgs,
+    project_root: &Path,
+    project_config: Option<&ProjectConfig>,
+    global_config: &GlobalConfig,
+    parent_tool: Option<&str>,
+) -> Result<Option<ToolName>> {
+    let Some(session_fix) = resolve_session_fix_tool(args, project_root)? else {
+        return Ok(None);
+    };
+    validate_session_fix_explicit_tool(args, Some(&session_fix))?;
+
+    let (effective_tier, args_tool) =
+        super::resolve::resolve_review_effective_tier(args, project_config)?;
+    let selection_tool = args_tool.or(session_fix.tool);
+    let resolved = super::resolve::resolve_review_selection(
+        selection_tool,
+        args.model_spec.as_deref(),
+        project_config,
+        global_config,
+        parent_tool,
+        project_root,
+        args.force_override_user_config,
+        effective_tier.as_deref(),
+        args.force_ignore_tier_setting,
+        args_tool.is_some(),
+    )?;
+
+    csa_session::resolve_resume_session(
+        project_root,
+        &session_fix.session_id,
+        resolved.tool.as_str(),
+    )
+    .with_context(|| {
+        format!(
+            "resolved review --session --fix tool '{}' cannot access session {}",
+            resolved.tool, session_fix.session_id
+        )
+    })?;
+
+    Ok(Some(resolved.tool))
+}
+
+fn infer_session_tool(project_root: &Path, session_id: &str) -> Result<Option<ToolName>> {
+    if let Some(tool) = csa_session::load_metadata(project_root, session_id)
+        .with_context(|| format!("failed to load metadata for review session {session_id}"))?
+        .map(|metadata| metadata.tool)
+        && let Some(tool) = parse_recorded_tool("metadata.toml", session_id, &tool)?
+    {
+        return Ok(Some(tool));
+    }
+
+    if let Some(meta) = review_iteration_resolver::load_review_meta(project_root, session_id)?
+        && let Some(tool) = parse_recorded_tool("review_meta.json", session_id, &meta.tool)?
+    {
+        return Ok(Some(tool));
+    }
+
+    if let Some(result) = csa_session::load_result(project_root, session_id)
+        .with_context(|| format!("failed to load result.toml for review session {session_id}"))?
+        && let Some(tool) = parse_recorded_tool("result.toml", session_id, &result.tool)?
+    {
+        return Ok(Some(tool));
+    }
+
+    Ok(None)
+}
+
+fn parse_recorded_tool(source: &str, session_id: &str, tool: &str) -> Result<Option<ToolName>> {
+    if tool.trim().is_empty() || tool == "unknown" {
+        return Ok(None);
+    }
+    crate::run_helpers::parse_tool_name(tool)
+        .with_context(|| {
+            format!("{source} for review session {session_id} records invalid tool '{tool}'")
+        })
+        .map(Some)
+}

--- a/crates/cli-sub-agent/src/review_cmd_session_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_session_fix.rs
@@ -26,24 +26,35 @@ pub(super) struct SelectionResolutionCtx<'a> {
     pub(super) effective_tier: Option<&'a str>,
     pub(super) selection_tool: Option<ToolName>,
     pub(super) direct_tool_requested: bool,
+    pub(super) session_fix: Option<&'a SessionFixTool>,
     pub(super) review_description: &'a str,
+}
+
+pub(super) struct SelectionToolResolution {
+    pub(super) selection_tool: Option<ToolName>,
+    pub(super) direct_tool_requested: bool,
+    pub(super) session_fix: Option<SessionFixTool>,
 }
 
 pub(super) fn resolve_selection_tool(
     args: &ReviewArgs,
     project_root: &Path,
     args_tool: Option<ToolName>,
-) -> Result<(Option<ToolName>, bool)> {
+) -> Result<SelectionToolResolution> {
     let session_fix = resolve_session_fix_tool(args, project_root)?;
     validate_session_fix_explicit_tool(args, session_fix.as_ref())?;
     let selection_tool = args_tool.or_else(|| session_fix.as_ref().and_then(|fix| fix.tool));
-    Ok((selection_tool, args_tool.is_some()))
+    Ok(SelectionToolResolution {
+        selection_tool,
+        direct_tool_requested: args_tool.is_some(),
+        session_fix,
+    })
 }
 
 pub(super) fn resolve_selection_or_persist_error(
     ctx: SelectionResolutionCtx<'_>,
 ) -> Result<ResolvedReviewSelection> {
-    match super::resolve::resolve_review_selection(
+    let resolved = match super::resolve::resolve_review_selection(
         ctx.selection_tool,
         ctx.args.model_spec.as_deref(),
         ctx.project_config,
@@ -55,21 +66,47 @@ pub(super) fn resolve_selection_or_persist_error(
         ctx.args.force_ignore_tier_setting,
         ctx.direct_tool_requested,
     ) {
-        Ok(resolved) => Ok(resolved),
-        Err(err) => Err(crate::session_guard::persist_pre_exec_error_result(
-            crate::session_guard::PreExecErrorCtx {
-                project_root: ctx.project_root,
-                session_id: super::prior_rounds::review_pre_exec_session_id(ctx.args),
-                description: Some(ctx.review_description),
-                parent: None,
-                tool_name: super::prior_rounds::explicit_review_tool(ctx.args)
-                    .map(|tool| tool.as_str()),
-                task_type: Some("review"),
-                tier_name: ctx.effective_tier,
-                error: err,
-            },
-        )),
+        Ok(resolved) => resolved,
+        Err(err) => return Err(persist_selection_error(&ctx, err)),
+    };
+    validate_session_fix_resolved_tool(ctx.session_fix, resolved.tool)
+        .map_err(|err| persist_selection_error(&ctx, err))?;
+    Ok(resolved)
+}
+
+fn persist_selection_error(ctx: &SelectionResolutionCtx<'_>, err: anyhow::Error) -> anyhow::Error {
+    crate::session_guard::persist_pre_exec_error_result(crate::session_guard::PreExecErrorCtx {
+        project_root: ctx.project_root,
+        session_id: super::prior_rounds::review_pre_exec_session_id(ctx.args),
+        description: Some(ctx.review_description),
+        parent: None,
+        tool_name: super::prior_rounds::explicit_review_tool(ctx.args).map(|tool| tool.as_str()),
+        task_type: Some("review"),
+        tier_name: ctx.effective_tier,
+        error: err,
+    })
+}
+
+fn validate_session_fix_resolved_tool(
+    session_fix: Option<&SessionFixTool>,
+    resolved_tool: ToolName,
+) -> Result<()> {
+    let Some(session_fix) = session_fix else {
+        return Ok(());
+    };
+    let Some(session_tool) = session_fix.tool else {
+        return Ok(());
+    };
+    if resolved_tool != session_tool {
+        anyhow::bail!(
+            "`csa review --session {} --fix` must use the original review tool '{}'; \
+             tier/model routing resolved '{}'.",
+            session_fix.session_id,
+            session_tool,
+            resolved_tool
+        );
     }
+    Ok(())
 }
 
 pub(super) fn resolve_session_fix_tool(
@@ -187,6 +224,7 @@ pub(super) fn resolve_session_fix_selection(
         args.force_ignore_tier_setting,
         args_tool.is_some(),
     )?;
+    validate_session_fix_resolved_tool(Some(&session_fix), resolved.tool)?;
 
     csa_session::resolve_resume_session(
         project_root,

--- a/crates/cli-sub-agent/src/review_cmd_session_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_session_fix.rs
@@ -74,6 +74,13 @@ pub(super) fn resolve_selection_or_persist_error(
     Ok(resolved)
 }
 
+pub(super) fn effective_no_failover_for_session_fix(
+    no_failover: bool,
+    session_fix: Option<&SessionFixTool>,
+) -> bool {
+    no_failover || session_fix.and_then(|fix| fix.tool).is_some()
+}
+
 fn persist_selection_error(ctx: &SelectionResolutionCtx<'_>, err: anyhow::Error) -> anyhow::Error {
     crate::session_guard::persist_pre_exec_error_result(crate::session_guard::PreExecErrorCtx {
         project_root: ctx.project_root,

--- a/crates/cli-sub-agent/src/review_cmd_tests_session_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_session_fix.rs
@@ -1,0 +1,293 @@
+use super::{resolve_session_fix_selection, validate_session_fix_before_daemon};
+use crate::cli::{Cli, Commands, ReviewArgs, validate_review_args};
+use crate::test_env_lock::ScopedEnvVarRestore;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use clap::Parser;
+use csa_config::{GlobalConfig, ProjectConfig, ProjectMeta, ResourcesConfig, ReviewConfig};
+use csa_config::{TierStrategy, ToolConfig};
+use csa_core::types::ToolName;
+use std::collections::HashMap;
+use std::path::Path;
+
+fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
+    let mut tool_map = HashMap::new();
+    for tool in csa_config::global::all_known_tools() {
+        tool_map.insert(
+            tool.as_str().to_string(),
+            ToolConfig {
+                enabled: false,
+                restrictions: None,
+                suppress_notify: true,
+                ..Default::default()
+            },
+        );
+    }
+    for tool in tools {
+        tool_map.insert(
+            (*tool).to_string(),
+            ToolConfig {
+                enabled: true,
+                restrictions: None,
+                suppress_notify: true,
+                ..Default::default()
+            },
+        );
+    }
+
+    ProjectConfig {
+        schema_version: 1,
+        project: ProjectMeta::default(),
+        resources: ResourcesConfig {
+            min_free_memory_mb: 1,
+            ..Default::default()
+        },
+        acp: Default::default(),
+        tools: tool_map,
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        github: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        run: Default::default(),
+        execution: Default::default(),
+        session_wait: None,
+        preflight: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    }
+}
+
+fn parse_review_args(argv: &[&str]) -> ReviewArgs {
+    let cli = Cli::try_parse_from(argv).expect("review CLI args should parse");
+    match cli.command {
+        Commands::Review(args) => {
+            validate_review_args(&args).expect("review CLI args should validate");
+            args
+        }
+        _ => panic!("expected review subcommand"),
+    }
+}
+
+fn write_review_project_config(project_root: &Path, config: &ProjectConfig) {
+    let config_path = ProjectConfig::config_path(project_root);
+    std::fs::create_dir_all(config_path.parent().expect("config parent")).unwrap();
+    std::fs::write(config_path, toml::to_string_pretty(config).unwrap()).unwrap();
+}
+
+fn write_session_metadata(project_root: &Path, session_id: &str, tool: &str, tool_locked: bool) {
+    let session_dir = csa_session::get_session_dir(project_root, session_id).unwrap();
+    let metadata = csa_session::SessionMetadata {
+        tool: tool.to_string(),
+        tool_locked,
+        runtime_binary: None,
+    };
+    std::fs::write(
+        session_dir.join(csa_session::metadata::METADATA_FILE_NAME),
+        toml::to_string_pretty(&metadata).unwrap(),
+    )
+    .unwrap();
+}
+
+fn write_session_result(project_root: &Path, session_id: &str, tool: &str) {
+    let now = chrono::Utc::now();
+    let result = csa_session::SessionResult {
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "failed review".to_string(),
+        tool: tool.to_string(),
+        started_at: now,
+        completed_at: now,
+        ..Default::default()
+    };
+    csa_session::save_result(project_root, session_id, &result).unwrap();
+}
+
+fn review_config_with_quality_tier() -> ProjectConfig {
+    let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    config.tiers.insert(
+        "quality".to_string(),
+        csa_config::config::TierConfig {
+            description: "Test quality tier".to_string(),
+            models: vec![
+                "gemini-cli/google/default/xhigh".to_string(),
+                "codex/openai/gpt-5.5/xhigh".to_string(),
+            ],
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    config.review = Some(ReviewConfig {
+        tier: Some("quality".to_string()),
+        ..Default::default()
+    });
+    config
+}
+
+fn parse_session_fix_args(project_root: &Path, session_id: &str, extra: &[&str]) -> ReviewArgs {
+    let cd = project_root.display().to_string();
+    let mut argv = vec![
+        "csa",
+        "review",
+        "--cd",
+        cd.as_str(),
+        "--files",
+        "src/lib.rs",
+        "--session",
+        session_id,
+        "--fix",
+    ];
+    argv.extend_from_slice(extra);
+    parse_review_args(&argv)
+}
+
+#[test]
+fn review_session_fix_skips_non_concrete_metadata_and_uses_result_tool() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _tools_available =
+        ScopedEnvVarRestore::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    let config = review_config_with_quality_tier();
+    write_review_project_config(project_dir.path(), &config);
+    let source = csa_session::create_session(project_dir.path(), Some("failed review"), None, None)
+        .expect("source session should be created");
+    write_session_metadata(
+        project_dir.path(),
+        &source.meta_session_id,
+        "unknown",
+        false,
+    );
+    write_session_result(project_dir.path(), &source.meta_session_id, "codex");
+    let args = parse_session_fix_args(project_dir.path(), &source.meta_session_id, &[]);
+
+    let resolved_tool = resolve_session_fix_selection(
+        &args,
+        project_dir.path(),
+        Some(&config),
+        &GlobalConfig::default(),
+        Some("claude-code"),
+    )
+    .expect("session fix selection should use concrete result tool");
+
+    assert_eq!(resolved_tool, Some(ToolName::Codex));
+}
+
+#[test]
+fn review_session_fix_selects_original_tool_without_direct_tool_restriction() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _tools_available =
+        ScopedEnvVarRestore::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    let config = review_config_with_quality_tier();
+    write_review_project_config(project_dir.path(), &config);
+    let source = csa_session::create_session(
+        project_dir.path(),
+        Some("failed review"),
+        None,
+        Some("codex"),
+    )
+    .expect("source session should be created");
+    let args = parse_session_fix_args(project_dir.path(), &source.meta_session_id, &[]);
+
+    let resolved_tool = resolve_session_fix_selection(
+        &args,
+        project_dir.path(),
+        Some(&config),
+        &GlobalConfig::default(),
+        Some("claude-code"),
+    )
+    .expect("session fix selection should resolve");
+
+    assert_eq!(resolved_tool, Some(ToolName::Codex));
+    let resume = csa_session::resolve_resume_session(
+        project_dir.path(),
+        &source.meta_session_id,
+        ToolName::Codex.as_str(),
+    )
+    .expect("resolved tool must satisfy session lock");
+    assert_eq!(resume.meta_session_id, source.meta_session_id);
+}
+
+#[test]
+fn review_session_fix_without_recorded_tool_fails_before_child_session_creation() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    let config = review_config_with_quality_tier();
+    write_review_project_config(project_dir.path(), &config);
+    let source =
+        csa_session::create_session(project_dir.path(), Some("legacy failed review"), None, None)
+            .expect("source session should be created");
+    let args = parse_session_fix_args(project_dir.path(), &source.meta_session_id, &[]);
+
+    let err = validate_session_fix_before_daemon(&args)
+        .expect_err("missing recorded tool must fail before daemon spawn");
+
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("Cannot infer review tool"),
+        "unexpected error: {msg}"
+    );
+    assert!(
+        msg.contains("metadata.toml tool, review_meta.json tool, or result.toml tool"),
+        "unexpected error: {msg}"
+    );
+    let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
+    assert_eq!(
+        sessions.len(),
+        1,
+        "pre-daemon validation must not create a child session"
+    );
+}
+
+#[test]
+fn review_session_fix_rejects_explicit_tool_mismatch_before_child_session_creation() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    let config = review_config_with_quality_tier();
+    write_review_project_config(project_dir.path(), &config);
+    let source = csa_session::create_session(
+        project_dir.path(),
+        Some("failed review"),
+        None,
+        Some("codex"),
+    )
+    .expect("source session should be created");
+    let args = parse_session_fix_args(
+        project_dir.path(),
+        &source.meta_session_id,
+        &["--tool", "gemini-cli"],
+    );
+
+    let err = validate_session_fix_before_daemon(&args)
+        .expect_err("explicit tool mismatch must fail before daemon spawn");
+
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("must use the original review tool 'codex'"),
+        "unexpected error: {msg}"
+    );
+    assert!(
+        msg.contains("explicit --tool 'gemini-cli'"),
+        "unexpected error: {msg}"
+    );
+    let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
+    assert_eq!(
+        sessions.len(),
+        1,
+        "pre-daemon validation must not create a child session"
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_session_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_session_fix.rs
@@ -1,4 +1,7 @@
-use super::{resolve_session_fix_selection, validate_session_fix_before_daemon};
+use super::{
+    SelectionResolutionCtx, resolve_selection_or_persist_error, resolve_selection_tool,
+    resolve_session_fix_selection, validate_session_fix_before_daemon,
+};
 use crate::cli::{Cli, Commands, ReviewArgs, validate_review_args};
 use crate::test_env_lock::ScopedEnvVarRestore;
 use crate::test_session_sandbox::ScopedSessionSandbox;
@@ -130,6 +133,25 @@ fn review_config_with_quality_tier() -> ProjectConfig {
     config
 }
 
+fn review_config_with_gemini_only_quality_tier() -> ProjectConfig {
+    let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    config.tiers.insert(
+        "quality".to_string(),
+        csa_config::config::TierConfig {
+            description: "Test quality tier".to_string(),
+            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    config.review = Some(ReviewConfig {
+        tier: Some("quality".to_string()),
+        ..Default::default()
+    });
+    config
+}
+
 fn parse_session_fix_args(project_root: &Path, session_id: &str, extra: &[&str]) -> ReviewArgs {
     let cd = project_root.display().to_string();
     let mut argv = vec![
@@ -178,6 +200,101 @@ fn review_session_fix_skips_non_concrete_metadata_and_uses_result_tool() {
     .expect("session fix selection should use concrete result tool");
 
     assert_eq!(resolved_tool, Some(ToolName::Codex));
+}
+
+#[test]
+fn review_session_fix_rejects_tier_fallback_when_recorded_result_tool_missing_from_tier() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _tools_available =
+        ScopedEnvVarRestore::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    let config = review_config_with_gemini_only_quality_tier();
+    write_review_project_config(project_dir.path(), &config);
+    let source = csa_session::create_session(project_dir.path(), Some("failed review"), None, None)
+        .expect("source session should be created");
+    write_session_metadata(
+        project_dir.path(),
+        &source.meta_session_id,
+        "unknown",
+        false,
+    );
+    write_session_result(project_dir.path(), &source.meta_session_id, "codex");
+    let args = parse_session_fix_args(project_dir.path(), &source.meta_session_id, &[]);
+
+    let err = resolve_session_fix_selection(
+        &args,
+        project_dir.path(),
+        Some(&config),
+        &GlobalConfig::default(),
+        Some("claude-code"),
+    )
+    .expect_err("recorded tool missing from tier must not fall back to another tool");
+
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("must use the original review tool 'codex'"),
+        "unexpected error: {msg}"
+    );
+    assert!(
+        msg.contains("tier/model routing resolved 'gemini-cli'"),
+        "unexpected error: {msg}"
+    );
+    let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
+    assert_eq!(
+        sessions.len(),
+        1,
+        "pre-daemon validation must not create a child session"
+    );
+}
+
+#[test]
+fn review_session_fix_runtime_resolution_rejects_tier_fallback_to_non_recorded_tool() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _tools_available =
+        ScopedEnvVarRestore::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    let config = review_config_with_gemini_only_quality_tier();
+    let global_config = GlobalConfig::default();
+    let source = csa_session::create_session(project_dir.path(), Some("failed review"), None, None)
+        .expect("source session should be created");
+    write_session_metadata(
+        project_dir.path(),
+        &source.meta_session_id,
+        "unknown",
+        false,
+    );
+    write_session_result(project_dir.path(), &source.meta_session_id, "codex");
+    let args = parse_session_fix_args(project_dir.path(), &source.meta_session_id, &[]);
+    let selection = resolve_selection_tool(&args, project_dir.path(), None)
+        .expect("session fix selection tool should resolve");
+
+    let err = resolve_selection_or_persist_error(SelectionResolutionCtx {
+        args: &args,
+        project_config: Some(&config),
+        global_config: &global_config,
+        parent_tool: Some("claude-code"),
+        project_root: project_dir.path(),
+        effective_tier: Some("quality"),
+        selection_tool: selection.selection_tool,
+        direct_tool_requested: selection.direct_tool_requested,
+        session_fix: selection.session_fix.as_ref(),
+        review_description: "review: src/lib.rs",
+    })
+    .expect_err("runtime selection must enforce recorded session tool after tier routing");
+
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("must use the original review tool 'codex'"),
+        "unexpected error: {msg}"
+    );
+    assert!(
+        msg.contains("tier/model routing resolved 'gemini-cli'"),
+        "unexpected error: {msg}"
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_tests_session_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_session_fix.rs
@@ -1,6 +1,7 @@
 use super::{
-    SelectionResolutionCtx, resolve_selection_or_persist_error, resolve_selection_tool,
-    resolve_session_fix_selection, validate_session_fix_before_daemon,
+    SelectionResolutionCtx, effective_no_failover_for_session_fix,
+    resolve_selection_or_persist_error, resolve_selection_tool, resolve_session_fix_selection,
+    validate_session_fix_before_daemon,
 };
 use crate::cli::{Cli, Commands, ReviewArgs, validate_review_args};
 use crate::test_env_lock::ScopedEnvVarRestore;
@@ -200,6 +201,83 @@ fn review_session_fix_skips_non_concrete_metadata_and_uses_result_tool() {
     .expect("session fix selection should use concrete result tool");
 
     assert_eq!(resolved_tool, Some(ToolName::Codex));
+}
+
+#[test]
+fn review_without_session_fix_preserves_failover_setting() {
+    assert!(!effective_no_failover_for_session_fix(false, None));
+    assert!(effective_no_failover_for_session_fix(true, None));
+}
+
+#[test]
+fn review_session_fix_suppresses_cross_tool_tier_candidates_after_selection() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _tools_available =
+        ScopedEnvVarRestore::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    let config = review_config_with_quality_tier();
+    let global_config = GlobalConfig::default();
+    let source = csa_session::create_session(project_dir.path(), Some("failed review"), None, None)
+        .expect("source session should be created");
+    write_session_metadata(
+        project_dir.path(),
+        &source.meta_session_id,
+        "unknown",
+        false,
+    );
+    write_session_result(project_dir.path(), &source.meta_session_id, "codex");
+    let args = parse_session_fix_args(project_dir.path(), &source.meta_session_id, &[]);
+    let selection = resolve_selection_tool(&args, project_dir.path(), None)
+        .expect("session fix selection tool should resolve");
+
+    let resolved = resolve_selection_or_persist_error(SelectionResolutionCtx {
+        args: &args,
+        project_config: Some(&config),
+        global_config: &global_config,
+        parent_tool: Some("claude-code"),
+        project_root: project_dir.path(),
+        effective_tier: Some("quality"),
+        selection_tool: selection.selection_tool,
+        direct_tool_requested: selection.direct_tool_requested,
+        session_fix: selection.session_fix.as_ref(),
+        review_description: "review: src/lib.rs",
+    })
+    .expect("runtime selection should accept the recorded result tool");
+
+    assert_eq!(resolved.tool, ToolName::Codex);
+    assert_eq!(
+        resolved.model_spec.as_deref(),
+        Some("codex/openai/gpt-5.5/xhigh")
+    );
+    assert_eq!(resolved.tier_preference_order, vec!["codex".to_string()]);
+
+    let execution_no_failover =
+        effective_no_failover_for_session_fix(args.no_failover, selection.session_fix.as_ref());
+    assert!(execution_no_failover);
+    let tier_active = resolved.model_spec.is_some()
+        && args.model_spec.is_none()
+        && !args.force_ignore_tier_setting;
+    assert!(tier_active);
+
+    let candidates = crate::tier_model_fallback::ordered_tier_candidates(
+        resolved.tool,
+        resolved.model_spec.as_deref(),
+        Some("quality"),
+        Some(&config),
+        Some(&global_config),
+        tier_active && !execution_no_failover,
+        &resolved.tier_preference_order,
+    );
+
+    assert_eq!(
+        candidates,
+        vec![(
+            ToolName::Codex,
+            Some("codex/openai/gpt-5.5/xhigh".to_string())
+        )]
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::review_cmd::resolve::resolve_review_selection;
 use crate::test_env_lock::ScopedTestEnvVar;
 use csa_config::{ReviewConfig, ToolConfig, ToolSelection};
 use std::collections::HashMap;
@@ -229,6 +230,7 @@ fn test_review_tool_plus_tier_force_override_resolves_disabled_requested_tool() 
         true,
         Some("quality"),
         false,
+        true,
     )
     .expect("force override should honor disabled requested review tool");
 
@@ -262,6 +264,7 @@ fn test_review_tool_plus_tier_keeps_full_tier_failover_chain() {
         false,
         Some("quality"),
         false,
+        true,
     )
     .expect("tool+tier should resolve requested review tool");
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.955"
-weave = "0.1.955"
+csa = "0.1.956"
+weave = "0.1.956"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- make `csa review --session --fix` resolve to the original recorded review tool
- prevent legacy/unlocked session-fix runs from drifting to tier failover candidates
- add focused coverage for recorded-tool locking and session-fix selection

## Verification
- interrupted writer session: 01KTM9JPWX675CHTHFY32G803E (filed #1977)
- salvage writer session: 01KTMBZZYM7TNGCK1ZD3ZT3H50
- review finding fix sessions: 01KTMDN4B01DGYXFW525BTTBA3, 01KTMF7DV0QFSWRQ6ND9CG34M5
- final Codex review PASS: 01KTMGER3PNGD2EZ3Y28QCGZEV
- csa/weave installed locally at 0.1.956 (3c333dd2)
- pre-push review and version gates passed

Operational note: global CSA memory config was temporarily lowered during this work due #1976: `resources.memory_max_mb=10240`, `resources.min_free_memory_mb=512`, `tools.codex.memory_max_mb=10240`.

Closes #1974