### PR TITLE
fix(review): fail closed on blocking summaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.956"
+version = "0.1.957"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.956"
+version = "0.1.957"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -68,10 +68,6 @@ fn current_round_review_prose_contents(
         }
     }
 
-    let blocking_summary = latest_summary.as_deref().is_some_and(|summary| {
-        contains_blocking_issue_signal(summary) || detect_prose_fail_conclusion(summary)
-    });
-
     let mut contents = Vec::new();
     if let Some(content) = latest_summary {
         push_review_content(&mut contents, "summary", content);
@@ -80,6 +76,7 @@ fn current_round_review_prose_contents(
     if let Some(content) = latest_details {
         push_review_content(&mut contents, "details", content);
     }
+    let indexed_review_content_count = contents.len();
 
     if let Some(content) =
         crate::review_cmd::findings_toml::load_canonical_review_text(session_dir)?
@@ -88,10 +85,23 @@ fn current_round_review_prose_contents(
         push_review_content(&mut contents, "canonical", content);
     }
 
+    let blocking_summary = contents
+        .iter()
+        .take(if indexed_review_content_count == 0 {
+            contents.len()
+        } else {
+            indexed_review_content_count
+        })
+        .any(|(_, content)| content_has_blocking_review_outcome(content));
+
     Ok(CurrentRoundReviewProseContents {
         blocking_summary,
         contents,
     })
+}
+
+fn content_has_blocking_review_outcome(content: &str) -> bool {
+    contains_blocking_issue_signal(content) || detect_prose_fail_conclusion(content)
 }
 
 fn push_review_content(contents: &mut Vec<(String, String)>, section_id: &str, content: String) {

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -465,6 +465,11 @@ pub(in crate::review_cmd) fn is_findings_header(line: &str) -> bool {
 }
 
 fn line_has_blocking_review_signal(line: &str) -> bool {
+    line.split(['.', ';', ':'])
+        .any(blocking_review_clause_has_signal)
+}
+
+fn blocking_review_clause_has_signal(clause: &str) -> bool {
     const ISSUE_NOUNS: &[&str] = &[
         "issue",
         "issues",
@@ -485,7 +490,7 @@ fn line_has_blocking_review_signal(line: &str) -> bool {
     const MAX_TOKENS_AFTER_BLOCKING: usize = 8;
     const MAX_NEGATION_LOOKBACK: usize = 3;
 
-    let tokens = line
+    let tokens = clause
         .split(|ch: char| !ch.is_ascii_alphanumeric())
         .filter(|token| !token.is_empty())
         .map(str::to_ascii_lowercase)
@@ -498,12 +503,7 @@ fn line_has_blocking_review_signal(line: &str) -> bool {
         if token != "blocking" {
             continue;
         }
-        if tokens[..index]
-            .iter()
-            .rev()
-            .take(MAX_NEGATION_LOOKBACK)
-            .any(|candidate| NEGATIONS.contains(&candidate.as_str()))
-        {
+        if blocking_token_is_negated(&tokens, index, MAX_NEGATION_LOOKBACK, NEGATIONS) {
             continue;
         }
         if ((index + 1)..tokens.len()).any(|candidate| {
@@ -515,6 +515,32 @@ fn line_has_blocking_review_signal(line: &str) -> bool {
     }
 
     false
+}
+
+fn blocking_token_is_negated(
+    tokens: &[String],
+    index: usize,
+    max_negation_lookback: usize,
+    negations: &[&str],
+) -> bool {
+    tokens[..index]
+        .iter()
+        .rev()
+        .take(max_negation_lookback)
+        .any(|candidate| negations.contains(&candidate.as_str()))
+        || leading_clause_negation_applies(tokens, index)
+}
+
+fn leading_clause_negation_applies(tokens: &[String], index: usize) -> bool {
+    matches!(
+        tokens.first().map(String::as_str),
+        Some("no" | "none" | "without")
+    ) && !tokens[..index].iter().any(|token| {
+        matches!(
+            token.as_str(),
+            "but" | "however" | "except" | "though" | "although"
+        )
+    })
 }
 
 fn findings_section_body_has_unparseable_text(
@@ -576,6 +602,25 @@ mod tests {
         ));
         assert!(!contains_blocking_review_signal(
             "Found one non-blocking test reliability regression."
+        ));
+    }
+
+    #[test]
+    fn issue_1978_blocking_correctness_finding_summary_is_blocking_signal() {
+        assert!(contains_blocking_review_signal(
+            "One blocking correctness finding was found in csa review --session 01KTMDAQM18XK6R7DDA0ZP6C57 --fix tool selection."
+        ));
+        assert!(contains_blocking_review_signal(
+            "Review found one blocking finding in the wait result classification."
+        ));
+        assert!(!contains_blocking_review_signal(
+            "No blocking correctness findings were found in the review."
+        ));
+        assert!(!contains_blocking_review_signal(
+            "No correctness, regression, security, or blocking test-coverage findings."
+        ));
+        assert!(contains_blocking_review_signal(
+            "No prior context; one blocking finding remains."
         ));
     }
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_1951.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_1951.rs
@@ -177,3 +177,108 @@ fn issue_1971_wait_uses_generated_fail_verdict_for_pass_result() {
     assert_eq!(persisted.status, "failure");
     assert_eq!(persisted.exit_code, 1);
 }
+
+#[test]
+fn issue_1978_wait_uses_generated_fail_verdict_for_blocking_summary_without_fail_token() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-generated-blocking-summary-review-verdict"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write stale success completion packet");
+    save_result(
+        project,
+        &session_id,
+        &SessionResult {
+            summary: "One blocking correctness finding was found in csa review.".to_string(),
+            ..make_result("success", 0)
+        },
+    )
+    .expect("save stale success result");
+    let output_dir = session_dir.join("output");
+    std::fs::create_dir_all(&output_dir).expect("create output dir");
+    std::fs::write(output_dir.join("findings.toml"), "findings = []\n")
+        .expect("write empty findings.toml");
+    std::fs::write(
+        output_dir.join("full.md"),
+        "<!-- CSA:SECTION:summary -->\nOne blocking correctness finding was found in csa review --session 01KTMDAQM18XK6R7DDA0ZP6C57 --fix tool selection.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("write canonical review output");
+
+    let meta = csa_session::state::ReviewSessionMeta {
+        session_id: session_id.clone(),
+        head_sha: "deadbeef".to_string(),
+        decision: csa_core::types::ReviewDecision::Pass.as_str().to_string(),
+        verdict: "CLEAN".to_string(),
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool: "codex".to_string(),
+        scope: "range:main...HEAD".to_string(),
+        exit_code: 0,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+        review_mode: None,
+        fix_convergence: None,
+    };
+    crate::review_cmd::persist_review_verdict_for_tests(project, &meta, &[], Vec::new());
+    let generated_verdict: csa_session::ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json"))
+            .expect("read generated verdict"),
+    )
+    .expect("parse generated verdict");
+    assert_eq!(
+        generated_verdict.decision,
+        csa_core::types::ReviewDecision::Fail,
+        "a blocking correctness finding summary must be the canonical review-verdict decision"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("generated failed review verdict should short-circuit before reconcile");
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should sync generated failed review verdict");
+
+    assert_eq!(exit_code, 1);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id.clone(), "failure".to_string(), 1, false))
+    );
+    let persisted = load_result(project, &session_id)
+        .expect("load result")
+        .expect("result should remain terminal");
+    assert_eq!(persisted.status, "failure");
+    assert_eq!(persisted.exit_code, 1);
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.956"
-weave = "0.1.956"
+csa = "0.1.957"
+weave = "0.1.957"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- classify explicit blocking review summaries as failure even without literal `FAIL`
- extend regression coverage for blocking correctness-finding wording
- prevent false-success machine results for review summaries that clearly report blocking findings

## Verification
- writer session: 01KTMGWY8J079GAMW6HNEWDTEE
- Codex review PASS: 01KTMK78ZV7ZYJ06WH48EJAX33
- csa/weave installed locally at 0.1.957 (c7d7d37f)
- pre-push review and version gates passed

Closes #1978