### PR TITLE
fix(review): fail closed on severe summary findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.958"
+version = "0.1.959"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.958"
+version = "0.1.959"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -574,3 +574,6 @@ mod terminal_error_reason_tests;
 #[cfg(test)]
 #[path = "review_cmd_output_tests.rs"]
 mod tests;
+#[cfg(test)]
+#[path = "review_cmd_output_verdict_1981_tests.rs"]
+mod verdict_1981_tests;

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1981_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1981_tests.rs
@@ -195,3 +195,35 @@ fn clean_pass_summary_preserves_success_result() {
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
+
+#[test]
+fn zero_count_severity_summary_preserves_success_result() {
+    let session_id = "01KTMZZZZZZZZZZZZZZZZZZZZY";
+    let summary = "PASS: 0 high-severity issues. no high-severity findings. Critical severity issues: 0. High severity issues: 0. Medium findings: 0. P1 findings: 0. P2 violations: 0. Blocking issues: 0.";
+    let (_env_lock, project_root, session_dir) =
+        persist_pass_meta_review("issue-1981-zero-count-clean-control", session_id, summary);
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+
+    let mut result = success_result(summary);
+    crate::session_observability::enrich_result_from_session_dir(
+        &project_root,
+        session_id,
+        &session_dir,
+        &mut result,
+    )
+    .expect("enrich session result");
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.status, "success");
+
+    let wait_summary =
+        crate::session_cmds_daemon::render_wait_result_summary(&session_dir, session_id, &result);
+    assert!(wait_summary.contains("Status: success"));
+    assert!(wait_summary.contains("Exit code: 0"));
+    assert!(wait_summary.contains("Review verdict: PASS"));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1981_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1981_tests.rs
@@ -1,0 +1,197 @@
+use chrono::TimeDelta;
+use csa_core::types::{ReviewDecision, ToolName};
+use csa_session::ReviewVerdictArtifact;
+use csa_session::state::ReviewSessionMeta;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::OwnedMutexGuard;
+
+use super::persist_review_verdict;
+use crate::test_env_lock::TEST_ENV_LOCK;
+
+fn make_review_meta_with_decision(
+    session_id: &str,
+    decision: ReviewDecision,
+    verdict: &str,
+) -> ReviewSessionMeta {
+    ReviewSessionMeta {
+        session_id: session_id.to_string(),
+        head_sha: String::new(),
+        decision: decision.as_str().to_string(),
+        verdict: verdict.to_string(),
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool: ToolName::Codex.as_str().to_string(),
+        scope: "diff".to_string(),
+        exit_code: match decision {
+            ReviewDecision::Pass | ReviewDecision::Skip => 0,
+            ReviewDecision::Fail | ReviewDecision::Uncertain | ReviewDecision::Unavailable => 1,
+        },
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+        review_mode: None,
+        fix_convergence: None,
+    }
+}
+
+fn temp_project_root(test_name: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("csa-{test_name}-{suffix}"));
+    fs::create_dir_all(&path).expect("create temp project root");
+    path
+}
+
+fn create_session_dir(project_root: &Path, session_id: &str) -> PathBuf {
+    let session_dir = csa_session::get_session_root(project_root)
+        .expect("resolve session root")
+        .join("sessions")
+        .join(session_id);
+    fs::create_dir_all(session_dir.join("output")).expect("create session output dir");
+    session_dir
+}
+
+fn lock_test_session(test_name: &str, session_id: &str) -> (OwnedMutexGuard<()>, PathBuf, PathBuf) {
+    let env_lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let project_root = temp_project_root(test_name);
+    let session_dir = create_session_dir(&project_root, session_id);
+    (env_lock, project_root, session_dir)
+}
+
+fn read_verdict(session_dir: &Path) -> ReviewVerdictArtifact {
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+        .expect("parse verdict")
+}
+
+fn write_empty_findings_toml(session_dir: &Path) {
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write empty findings.toml");
+}
+
+fn persist_summary(session_dir: &Path, summary: &str) {
+    csa_session::persist_structured_output(
+        session_dir,
+        &format!("<!-- CSA:SECTION:summary -->\n{summary}\n<!-- CSA:SECTION:summary:END -->\n"),
+    )
+    .expect("persist summary");
+}
+
+fn success_result(summary: &str) -> csa_session::SessionResult {
+    let now = chrono::Utc::now();
+    csa_session::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: summary.to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now + TimeDelta::seconds(65),
+        ..Default::default()
+    }
+}
+
+fn persist_pass_meta_review(
+    test_name: &str,
+    session_id: &str,
+    summary: &str,
+) -> (OwnedMutexGuard<()>, PathBuf, PathBuf) {
+    let (env_lock, project_root, session_dir) = lock_test_session(test_name, session_id);
+    write_empty_findings_toml(&session_dir);
+    persist_summary(&session_dir, summary);
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    (env_lock, project_root, session_dir)
+}
+
+fn assert_summary_fails_canonical_result(test_name: &str, session_id: &str, summary: &str) {
+    let (_env_lock, project_root, session_dir) =
+        persist_pass_meta_review(test_name, session_id, summary);
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+
+    let mut result = success_result(summary);
+    let changed = crate::session_observability::enrich_result_from_session_dir(
+        &project_root,
+        session_id,
+        &session_dir,
+        &mut result,
+    )
+    .expect("enrich session result");
+
+    assert!(changed, "review verdict must repair the success result");
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.status, "failure");
+
+    let wait_summary =
+        crate::session_cmds_daemon::render_wait_result_summary(&session_dir, session_id, &result);
+    assert!(wait_summary.contains("Status: failure"));
+    assert!(wait_summary.contains("Exit code: 1"));
+    assert!(wait_summary.contains("Review verdict: FAIL"));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_1981_high_severity_summary_repairs_success_result_to_failure() {
+    assert_summary_fails_canonical_result(
+        "issue-1981-high-severity-summary",
+        "01KTMNVNV7092C3QHBHT21N09E",
+        "Reviewed `main...HEAD` in read-only mode. Found 1 high-severity issue: `--memory-max-mb` can be accepted and used for admission projection while silently not applying a sandbox memory limit on default-off lightweight/tool-config paths.",
+    );
+}
+
+#[test]
+fn issue_1982_medium_correctness_fail_summary_repairs_success_result_to_failure() {
+    assert_summary_fails_canonical_result(
+        "issue-1982-medium-correctness-summary",
+        "01KTMR3Y88834S8ENRC5WYCVWW",
+        "One medium correctness finding remains after re-verifying the prior stale-FTS assumption. The rejudge-specific hard-delete path is fixed, but the same physical-delete bug still exists in the general database delete/purge paths.  FAIL",
+    );
+}
+
+#[test]
+fn clean_pass_summary_preserves_success_result() {
+    let session_id = "01KTMZZZZZZZZZZZZZZZZZZZZZ";
+    let summary = "PASS: no high or medium severity issues remain after review.";
+    let (_env_lock, project_root, session_dir) =
+        persist_pass_meta_review("issue-1981-clean-pass-control", session_id, summary);
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+
+    let mut result = success_result(summary);
+    crate::session_observability::enrich_result_from_session_dir(
+        &project_root,
+        session_id,
+        &session_dir,
+        &mut result,
+    )
+    .expect("enrich session result");
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.status, "success");
+
+    let wait_summary =
+        crate::session_cmds_daemon::render_wait_result_summary(&session_dir, session_id, &result);
+    assert!(wait_summary.contains("Status: success"));
+    assert!(wait_summary.contains("Exit code: 0"));
+    assert!(wait_summary.contains("Review verdict: PASS"));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -464,38 +464,53 @@ pub(in crate::review_cmd) fn is_findings_header(line: &str) -> bool {
         || normalized.eq_ignore_ascii_case("review findings")
 }
 
+const REVIEW_ISSUE_NOUNS: &[&str] = &[
+    "issue",
+    "issues",
+    "finding",
+    "findings",
+    "problem",
+    "problems",
+    "bug",
+    "bugs",
+    "defect",
+    "defects",
+    "regression",
+    "regressions",
+    "violation",
+    "violations",
+];
+const BLOCKING_REVIEW_SEVERITIES: &[&str] = &["critical", "high", "medium", "p0", "p1", "p2"];
+const ZERO_COUNT_WORDS: &[&str] = &["0", "zero", "none", "no"];
+const MAX_TOKENS_AFTER_REVIEW_SIGNAL: usize = 8;
+
 fn line_has_blocking_review_signal(line: &str) -> bool {
     line.split(['.', ';', ':']).any(|clause| {
-        blocking_review_clause_has_signal(clause) || severe_review_clause_has_signal(clause)
+        let clause = clause.trim();
+        review_clause_has_blocking_signal(clause)
+            && !(zero_count_summary_label_has_signal(clause)
+                && line_has_zero_count_for_clause(line, clause))
     })
 }
 
+fn review_clause_has_blocking_signal(clause: &str) -> bool {
+    blocking_review_clause_has_signal(clause) || severe_review_clause_has_signal(clause)
+}
+
 fn blocking_review_clause_has_signal(clause: &str) -> bool {
-    const ISSUE_NOUNS: &[&str] = &[
-        "issue",
-        "issues",
-        "finding",
-        "findings",
-        "problem",
-        "problems",
-        "bug",
-        "bugs",
-        "defect",
-        "defects",
-        "regression",
-        "regressions",
-        "violation",
-        "violations",
+    const NEGATIONS: &[&str] = &[
+        "0",
+        "zero",
+        "no",
+        "non",
+        "nonblocking",
+        "not",
+        "none",
+        "without",
     ];
-    const NEGATIONS: &[&str] = &["no", "non", "nonblocking", "not", "none", "without"];
-    const MAX_TOKENS_AFTER_BLOCKING: usize = 8;
     const MAX_NEGATION_LOOKBACK: usize = 3;
 
-    let tokens = clause
-        .split(|ch: char| !ch.is_ascii_alphanumeric())
-        .filter(|token| !token.is_empty())
-        .map(str::to_ascii_lowercase)
-        .collect::<Vec<_>>();
+    let tokens = review_signal_tokens(clause);
 
     for (index, token) in tokens.iter().enumerate() {
         if token == "nonblocking" {
@@ -507,35 +522,19 @@ fn blocking_review_clause_has_signal(clause: &str) -> bool {
         if blocking_token_is_negated(&tokens, index, MAX_NEGATION_LOOKBACK, NEGATIONS) {
             continue;
         }
-        if ((index + 1)..tokens.len()).any(|candidate| {
-            candidate - index <= MAX_TOKENS_AFTER_BLOCKING
-                && ISSUE_NOUNS.contains(&tokens[candidate].as_str())
-        }) {
-            return true;
+        let Some(noun_index) = next_review_issue_noun_index(&tokens, index) else {
+            continue;
+        };
+        if review_issue_noun_is_followed_by_zero_count(&tokens, noun_index) {
+            continue;
         }
+        return true;
     }
 
     false
 }
 
 fn severe_review_clause_has_signal(clause: &str) -> bool {
-    const ISSUE_NOUNS: &[&str] = &[
-        "issue",
-        "issues",
-        "finding",
-        "findings",
-        "problem",
-        "problems",
-        "bug",
-        "bugs",
-        "defect",
-        "defects",
-        "regression",
-        "regressions",
-        "violation",
-        "violations",
-    ];
-    const BLOCKING_SEVERITIES: &[&str] = &["critical", "high", "medium", "p0", "p1", "p2"];
     const NEGATIONS: &[&str] = &[
         "0",
         "zero",
@@ -546,31 +545,98 @@ fn severe_review_clause_has_signal(clause: &str) -> bool {
         "none",
         "without",
     ];
-    const MAX_TOKENS_AFTER_SEVERITY: usize = 8;
     const MAX_NEGATION_LOOKBACK: usize = 3;
 
-    let tokens = clause
-        .split(|ch: char| !ch.is_ascii_alphanumeric())
-        .filter(|token| !token.is_empty())
-        .map(str::to_ascii_lowercase)
-        .collect::<Vec<_>>();
+    let tokens = review_signal_tokens(clause);
 
     for (index, token) in tokens.iter().enumerate() {
-        if !BLOCKING_SEVERITIES.contains(&token.as_str()) {
+        if !BLOCKING_REVIEW_SEVERITIES.contains(&token.as_str()) {
             continue;
         }
         if blocking_token_is_negated(&tokens, index, MAX_NEGATION_LOOKBACK, NEGATIONS) {
             continue;
         }
-        if ((index + 1)..tokens.len()).any(|candidate| {
-            candidate - index <= MAX_TOKENS_AFTER_SEVERITY
-                && ISSUE_NOUNS.contains(&tokens[candidate].as_str())
-        }) {
-            return true;
+        let Some(noun_index) = next_review_issue_noun_index(&tokens, index) else {
+            continue;
+        };
+        if review_issue_noun_is_followed_by_zero_count(&tokens, noun_index) {
+            continue;
         }
+        return true;
     }
 
     false
+}
+
+fn zero_count_summary_label_has_signal(clause: &str) -> bool {
+    const NONZERO_OR_REMAINING_WORDS: &[&str] = &[
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "some",
+        "several",
+        "multiple",
+        "remain",
+        "remains",
+        "remaining",
+        "fail",
+        "failed",
+        "failure",
+    ];
+
+    let tokens = review_signal_tokens(clause);
+    !tokens
+        .iter()
+        .any(|token| NONZERO_OR_REMAINING_WORDS.contains(&token.as_str()))
+        && tokens.iter().enumerate().any(|(index, token)| {
+            (token == "blocking" || BLOCKING_REVIEW_SEVERITIES.contains(&token.as_str()))
+                && next_review_issue_noun_index(&tokens, index).is_some()
+        })
+}
+
+fn leading_zero_count_clause(clause: &str) -> bool {
+    review_signal_tokens(clause)
+        .first()
+        .is_some_and(|token| ZERO_COUNT_WORDS.contains(&token.as_str()))
+}
+
+fn line_has_zero_count_for_clause(line: &str, clause: &str) -> bool {
+    line.split(['.', ';']).any(|segment| {
+        let colon_parts = segment.split(':').collect::<Vec<_>>();
+        colon_parts
+            .windows(2)
+            .any(|pair| pair[0].trim() == clause && leading_zero_count_clause(pair[1]))
+    })
+}
+
+fn review_issue_noun_is_followed_by_zero_count(tokens: &[String], noun_index: usize) -> bool {
+    const MAX_TOKENS_AFTER_NOUN_FOR_ZERO_COUNT: usize = 3;
+
+    ((noun_index + 1)..tokens.len()).any(|candidate| {
+        candidate - noun_index <= MAX_TOKENS_AFTER_NOUN_FOR_ZERO_COUNT
+            && ZERO_COUNT_WORDS.contains(&tokens[candidate].as_str())
+    })
+}
+
+fn next_review_issue_noun_index(tokens: &[String], index: usize) -> Option<usize> {
+    ((index + 1)..tokens.len()).find(|candidate| {
+        candidate - index <= MAX_TOKENS_AFTER_REVIEW_SIGNAL
+            && REVIEW_ISSUE_NOUNS.contains(&tokens[*candidate].as_str())
+    })
+}
+
+fn review_signal_tokens(text: &str) -> Vec<String> {
+    text.split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect()
 }
 
 fn blocking_token_is_negated(
@@ -648,65 +714,5 @@ fn priority_severity_from_label(label: &str) -> Option<Severity> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::contains_blocking_review_signal;
-
-    #[test]
-    fn issue_1971_blocking_regression_summary_is_blocking_signal() {
-        assert!(contains_blocking_review_signal(
-            "FAIL: one blocking test reliability regression found in the new provider-error failover coverage."
-        ));
-        assert!(!contains_blocking_review_signal(
-            "Found one non-blocking test reliability regression."
-        ));
-    }
-
-    #[test]
-    fn issue_1978_blocking_correctness_finding_summary_is_blocking_signal() {
-        assert!(contains_blocking_review_signal(
-            "One blocking correctness finding was found in csa review --session 01KTMDAQM18XK6R7DDA0ZP6C57 --fix tool selection."
-        ));
-        assert!(contains_blocking_review_signal(
-            "Review found one blocking finding in the wait result classification."
-        ));
-        assert!(!contains_blocking_review_signal(
-            "No blocking correctness findings were found in the review."
-        ));
-        assert!(!contains_blocking_review_signal(
-            "No correctness, regression, security, or blocking test-coverage findings."
-        ));
-        assert!(contains_blocking_review_signal(
-            "No prior context; one blocking finding remains."
-        ));
-    }
-
-    #[test]
-    fn issue_1981_high_severity_summary_is_blocking_signal() {
-        assert!(contains_blocking_review_signal(
-            "Reviewed `main...HEAD` in read-only mode. Found 1 high-severity issue: `--memory-max-mb` can be accepted and used for admission projection."
-        ));
-        assert!(contains_blocking_review_signal(
-            "Found one P1 correctness finding in the review output classifier."
-        ));
-    }
-
-    #[test]
-    fn issue_1982_medium_correctness_remaining_summary_is_blocking_signal() {
-        assert!(contains_blocking_review_signal(
-            "One medium correctness finding remains after re-verifying the prior stale-FTS assumption. The rejudge-specific hard-delete path is fixed. FAIL"
-        ));
-    }
-
-    #[test]
-    fn severe_summary_signal_respects_clean_negation() {
-        assert!(!contains_blocking_review_signal(
-            "PASS: no high or medium severity issues remain after review."
-        ));
-        assert!(!contains_blocking_review_signal(
-            "No correctness, regression, security, or blocking test-coverage findings."
-        ));
-        assert!(!contains_blocking_review_signal(
-            "Found one low-severity documentation issue."
-        ));
-    }
-}
+#[path = "review_cmd_prose_findings_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -465,8 +465,9 @@ pub(in crate::review_cmd) fn is_findings_header(line: &str) -> bool {
 }
 
 fn line_has_blocking_review_signal(line: &str) -> bool {
-    line.split(['.', ';', ':'])
-        .any(blocking_review_clause_has_signal)
+    line.split(['.', ';', ':']).any(|clause| {
+        blocking_review_clause_has_signal(clause) || severe_review_clause_has_signal(clause)
+    })
 }
 
 fn blocking_review_clause_has_signal(clause: &str) -> bool {
@@ -508,6 +509,61 @@ fn blocking_review_clause_has_signal(clause: &str) -> bool {
         }
         if ((index + 1)..tokens.len()).any(|candidate| {
             candidate - index <= MAX_TOKENS_AFTER_BLOCKING
+                && ISSUE_NOUNS.contains(&tokens[candidate].as_str())
+        }) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn severe_review_clause_has_signal(clause: &str) -> bool {
+    const ISSUE_NOUNS: &[&str] = &[
+        "issue",
+        "issues",
+        "finding",
+        "findings",
+        "problem",
+        "problems",
+        "bug",
+        "bugs",
+        "defect",
+        "defects",
+        "regression",
+        "regressions",
+        "violation",
+        "violations",
+    ];
+    const BLOCKING_SEVERITIES: &[&str] = &["critical", "high", "medium", "p0", "p1", "p2"];
+    const NEGATIONS: &[&str] = &[
+        "0",
+        "zero",
+        "no",
+        "non",
+        "nonblocking",
+        "not",
+        "none",
+        "without",
+    ];
+    const MAX_TOKENS_AFTER_SEVERITY: usize = 8;
+    const MAX_NEGATION_LOOKBACK: usize = 3;
+
+    let tokens = clause
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect::<Vec<_>>();
+
+    for (index, token) in tokens.iter().enumerate() {
+        if !BLOCKING_SEVERITIES.contains(&token.as_str()) {
+            continue;
+        }
+        if blocking_token_is_negated(&tokens, index, MAX_NEGATION_LOOKBACK, NEGATIONS) {
+            continue;
+        }
+        if ((index + 1)..tokens.len()).any(|candidate| {
+            candidate - index <= MAX_TOKENS_AFTER_SEVERITY
                 && ISSUE_NOUNS.contains(&tokens[candidate].as_str())
         }) {
             return true;
@@ -621,6 +677,36 @@ mod tests {
         ));
         assert!(contains_blocking_review_signal(
             "No prior context; one blocking finding remains."
+        ));
+    }
+
+    #[test]
+    fn issue_1981_high_severity_summary_is_blocking_signal() {
+        assert!(contains_blocking_review_signal(
+            "Reviewed `main...HEAD` in read-only mode. Found 1 high-severity issue: `--memory-max-mb` can be accepted and used for admission projection."
+        ));
+        assert!(contains_blocking_review_signal(
+            "Found one P1 correctness finding in the review output classifier."
+        ));
+    }
+
+    #[test]
+    fn issue_1982_medium_correctness_remaining_summary_is_blocking_signal() {
+        assert!(contains_blocking_review_signal(
+            "One medium correctness finding remains after re-verifying the prior stale-FTS assumption. The rejudge-specific hard-delete path is fixed. FAIL"
+        ));
+    }
+
+    #[test]
+    fn severe_summary_signal_respects_clean_negation() {
+        assert!(!contains_blocking_review_signal(
+            "PASS: no high or medium severity issues remain after review."
+        ));
+        assert!(!contains_blocking_review_signal(
+            "No correctness, regression, security, or blocking test-coverage findings."
+        ));
+        assert!(!contains_blocking_review_signal(
+            "Found one low-severity documentation issue."
         ));
     }
 }

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
@@ -1,0 +1,60 @@
+use super::contains_blocking_review_signal;
+
+#[test]
+fn issue_1971_blocking_regression_summary_is_blocking_signal() {
+    assert!(contains_blocking_review_signal(
+        "FAIL: one blocking test reliability regression found in the new provider-error failover coverage."
+    ));
+    assert!(!contains_blocking_review_signal(
+        "Found one non-blocking test reliability regression."
+    ));
+}
+
+#[test]
+fn issue_1978_blocking_correctness_finding_summary_is_blocking_signal() {
+    assert!(contains_blocking_review_signal(
+        "One blocking correctness finding was found in csa review --session 01KTMDAQM18XK6R7DDA0ZP6C57 --fix tool selection."
+    ));
+    assert!(contains_blocking_review_signal(
+        "Review found one blocking finding in the wait result classification."
+    ));
+    assert!(!contains_blocking_review_signal(
+        "No blocking correctness findings were found in the review."
+    ));
+    assert!(!contains_blocking_review_signal(
+        "No correctness, regression, security, or blocking test-coverage findings."
+    ));
+    assert!(contains_blocking_review_signal(
+        "No prior context; one blocking finding remains."
+    ));
+}
+
+#[test]
+fn issue_1981_high_severity_summary_is_blocking_signal() {
+    assert!(contains_blocking_review_signal(
+        "Reviewed `main...HEAD` in read-only mode. Found 1 high-severity issue: `--memory-max-mb` can be accepted and used for admission projection."
+    ));
+    assert!(contains_blocking_review_signal(
+        "Found one P1 correctness finding in the review output classifier."
+    ));
+}
+
+#[test]
+fn issue_1982_medium_correctness_remaining_summary_is_blocking_signal() {
+    assert!(contains_blocking_review_signal(
+        "One medium correctness finding remains after re-verifying the prior stale-FTS assumption. The rejudge-specific hard-delete path is fixed. FAIL"
+    ));
+}
+
+#[test]
+fn severe_summary_signal_respects_clean_negation() {
+    assert!(!contains_blocking_review_signal(
+        "PASS: no high or medium severity issues remain after review."
+    ));
+    assert!(!contains_blocking_review_signal(
+        "No correctness, regression, security, or blocking test-coverage findings."
+    ));
+    assert!(!contains_blocking_review_signal(
+        "Found one low-severity documentation issue."
+    ));
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.958"
-weave = "0.1.958"
+csa = "0.1.959"
+weave = "0.1.959"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- fail closed when review summaries report severe/high/blocking findings even if verdict tokens are missing
- keep zero-count severity summaries non-blocking
- add tests for severe summary detection and zero-count controls

## Issues
Closes #1981
Closes #1982

## Sessions
- Writer: 01KTMRZ9KGW42QAZX9MK31PN4R
- Reviewer finding fixed via fork: 01KTMVQEKXHDT79D5HMFBEC18A
- Final review PASS: 01KTMWT1F9E06PJFM9Y24WHKZ7

## Verification
- just pre-commit
- pre-push review-check verified full diff for b9e6628d
- locally installed csa/weave 0.1.959 (b9e6628d)