### PR TITLE
fix(session): surface signal kill evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.959"
+version = "0.1.960"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.959"
+version = "0.1.960"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -243,12 +243,18 @@ fn spawn_daemon_signal_handler() {
             tokio::select! {
                 _ = sigterm.recv() => {
                     // 128 + 15 (SIGTERM) = 143
-                    crate::session_cmds_daemon::persist_daemon_completion_from_env(143);
+                    crate::session_cmds_daemon::persist_daemon_completion_from_env_with_reason(
+                        143,
+                        Some("daemon_sigterm"),
+                    );
                     std::process::exit(143);
                 }
                 _ = sigint.recv() => {
                     // 128 + 2 (SIGINT) = 130
-                    crate::session_cmds_daemon::persist_daemon_completion_from_env(130);
+                    crate::session_cmds_daemon::persist_daemon_completion_from_env_with_reason(
+                        130,
+                        Some("daemon_sigint"),
+                    );
                     std::process::exit(130);
                 }
             }

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -30,8 +30,8 @@ const POST_REVIEW_PR_BOT_CMD: &str = "csa plan run --sa-mode true --pattern pr-b
 pub(crate) use completion::{
     DaemonCompletionPacket, daemon_completion_exists, daemon_completion_result,
     finalize_daemon_completion_if_present, load_daemon_completion_packet,
-    persist_daemon_completion_from_env, retire_session_from_daemon_completion,
-    seed_daemon_session_env,
+    persist_daemon_completion_from_env, persist_daemon_completion_from_env_with_reason,
+    retire_session_from_daemon_completion, seed_daemon_session_env,
 };
 #[cfg(test)]
 pub(crate) use wait::render_wait_result_summary;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
@@ -16,13 +16,23 @@ const DAEMON_COMPLETION_FILE: &str = "daemon-completion.toml";
 pub(crate) struct DaemonCompletionPacket {
     pub(crate) exit_code: i32,
     pub(crate) status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) reason: Option<String>,
 }
 
 impl DaemonCompletionPacket {
     fn from_exit_code(exit_code: i32) -> Self {
+        Self::from_exit_code_and_reason(exit_code, None)
+    }
+
+    fn from_exit_code_and_reason(exit_code: i32, reason: Option<&str>) -> Self {
         Self {
             exit_code,
             status: csa_session::SessionResult::status_from_exit_code(exit_code),
+            reason: reason
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned),
         }
     }
 }
@@ -45,10 +55,17 @@ pub(crate) fn seed_daemon_session_env(session_id: &str, cd: Option<&str>) {
 }
 
 pub(crate) fn persist_daemon_completion_from_env(exit_code: i32) {
+    persist_daemon_completion_from_env_with_reason(exit_code, None);
+}
+
+pub(crate) fn persist_daemon_completion_from_env_with_reason(exit_code: i32, reason: Option<&str>) {
     let Some(session_dir) = resolve_daemon_session_dir_from_env() else {
         return;
     };
-    let packet = DaemonCompletionPacket::from_exit_code(exit_code);
+    let packet = match reason {
+        Some(reason) => DaemonCompletionPacket::from_exit_code_and_reason(exit_code, Some(reason)),
+        None => DaemonCompletionPacket::from_exit_code(exit_code),
+    };
     if let Err(err) = persist_daemon_completion(&session_dir, &packet) {
         warn!(
             path = %daemon_completion_path(&session_dir).display(),
@@ -146,8 +163,14 @@ pub(crate) fn daemon_completion_result(
         .map(|(tool, _)| tool.clone())
         .unwrap_or_else(|| "unknown".to_string());
     let summary_prefix = format!(
-        "daemon completion recorded status={} exit_code={} before result.toml was written; committed or staged work may be salvageable on the session branch",
-        packet.status, packet.exit_code
+        "daemon completion recorded status={} exit_code={}{} before result.toml was written; committed or staged work may be salvageable on the session branch",
+        packet.status,
+        packet.exit_code,
+        packet
+            .reason
+            .as_deref()
+            .map(|reason| format!(" reason={reason}"))
+            .unwrap_or_default()
     );
 
     SessionResult {
@@ -184,11 +207,16 @@ pub(crate) fn retire_session_from_daemon_completion(
 
     session.last_accessed = completed_at;
     session.termination_reason.get_or_insert_with(|| {
-        if packet.exit_code == 0 {
-            "completed".to_string()
-        } else {
-            "daemon_completion".to_string()
-        }
+        packet.reason.as_deref().map_or_else(
+            || {
+                if packet.exit_code == 0 {
+                    "completed".to_string()
+                } else {
+                    "daemon_completion".to_string()
+                }
+            },
+            ToOwned::to_owned,
+        )
     });
     if let Err(err) = session.apply_phase_event(PhaseEvent::Retired) {
         warn!(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -121,6 +121,39 @@ fn compact_summary_includes_signal_kill_hint() {
 }
 
 #[test]
+fn compact_summary_includes_unknown_signal_evidence() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let now = Utc::now();
+    let diagnostic = "CSA diagnostic: signal kill hint: unknown_signal (termination_reason=sigterm, MemAvailable: 12000 MB / MemTotal: 16000 MB, earlyoom not running, cgroup memory.events oom=0 oom_kill=0). No timeout or cgroup OOM evidence was found, and memory checks did not identify a concrete kill source; reason remains unknown.";
+    let result = csa_session::SessionResult {
+        post_exec_gate: None,
+        status: "signal".to_string(),
+        exit_code: 143,
+        summary: diagnostic.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        kill_hint: Some("unknown_signal".to_string()),
+        last_item: None,
+        fallback_chain: None,
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITUNKNOWN", &result);
+
+    assert!(summary.contains("Kill hint: unknown_signal"));
+    assert!(summary.contains("termination_reason=sigterm"));
+    assert!(summary.contains("cgroup memory.events oom=0 oom_kill=0"));
+    assert!(summary.contains("reason remains unknown"));
+}
+
+#[test]
 fn compact_summary_labels_fix_loop_noop_from_review_meta() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let output_dir = temp.path().join("output");

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -548,6 +548,11 @@ where
         before_write,
         after_publish,
     } = hooks;
+    if let Some(reason) = packet.reason.as_deref() {
+        session
+            .termination_reason
+            .get_or_insert_with(|| reason.to_string());
+    }
     let result = crate::session_cmds_daemon::daemon_completion_result(
         project_root,
         session_dir,

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics_tests.rs
@@ -186,6 +186,54 @@ fn daemon_completion_packet_present_finalizes_dead_active_session() {
 
 #[cfg(unix)]
 #[test]
+fn daemon_completion_sigterm_reason_reaches_signal_diagnostic() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(project, Some("diagnostic-daemon-sigterm"), None, None).unwrap();
+    let session_id = session.meta_session_id.clone();
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 143\nstatus = \"signal\"\nreason = \"daemon_sigterm\"\n",
+    )
+    .unwrap();
+    fs::write(session_dir.join("daemon.pid"), "424242 1\n").unwrap();
+    fs::write(
+        session_dir.join("output.log"),
+        "[csa-heartbeat] ACP prompt still running: elapsed=44s idle=15s\n",
+    )
+    .unwrap();
+    backdate_tree(&session_dir, 120);
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session wait")
+            .unwrap();
+
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::DaemonCompletionFinalized
+    );
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("daemon completion result");
+    assert_eq!(result.status, "signal");
+    assert_eq!(result.exit_code, 143);
+    assert!(
+        result.summary.contains("termination_reason=daemon_sigterm"),
+        "signal diagnostic should include daemon SIGTERM reason: {}",
+        result.summary
+    );
+    let persisted = load_session(project, &session_id).unwrap();
+    assert_eq!(
+        persisted.termination_reason.as_deref(),
+        Some("daemon_sigterm")
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn daemon_completion_result_survives_state_save_failure() {
     let td = tempfile::tempdir().expect("tempdir");
     let _env = SessionTestEnv::new(&td);

--- a/crates/cli-sub-agent/src/session_kill_diagnostics.rs
+++ b/crates/cli-sub-agent/src/session_kill_diagnostics.rs
@@ -80,11 +80,22 @@ impl KillHint {
 pub(crate) struct KillDiagnostic {
     pub(crate) hint: KillHint,
     pub(crate) observations: KillSignalObservations,
+    pub(crate) terminal_reason: Option<String>,
 }
 
 impl KillDiagnostic {
     fn detail_parts(&self) -> Vec<String> {
         let mut details = Vec::new();
+        details.push(match self.terminal_reason.as_deref() {
+            Some(reason) if !reason.trim().is_empty() => {
+                format!("termination_reason={}", reason.trim())
+            }
+            _ => "termination_reason: missing".to_string(),
+        });
+        if self.hint == KillHint::CsaTimeout {
+            details.push("CSA supervisor timeout metadata matched signal exit".to_string());
+            return details;
+        }
         if let Some(meminfo) = &self.observations.meminfo {
             details.push(format!(
                 "MemAvailable: {} MB / MemTotal: {} MB",
@@ -94,16 +105,23 @@ impl KillDiagnostic {
         } else {
             details.push("MemAvailable: unavailable".to_string());
         }
-        if self.observations.earlyoom_running {
-            details.push("earlyoom running".to_string());
-        }
-        if let Some(events) = self.observations.cgroup_memory_events
-            && events.has_oom_event()
-        {
-            details.push(format!(
-                "cgroup memory.events oom={} oom_kill={}",
-                events.oom, events.oom_kill
-            ));
+        details.push(if self.observations.earlyoom_running {
+            "earlyoom running".to_string()
+        } else {
+            "earlyoom not running".to_string()
+        });
+        match self.observations.cgroup_memory_events {
+            Some(events) => {
+                details.push(format!(
+                    "cgroup memory.events oom={} oom_kill={}",
+                    events.oom, events.oom_kill
+                ));
+            }
+            None => {
+                details.push(
+                    "cgroup memory.events: unavailable at expected session scope".to_string(),
+                );
+            }
         }
         details
     }
@@ -113,12 +131,22 @@ impl KillDiagnostic {
             KillHint::Earlyoom => "earlyoom",
             KillHint::MemoryPressure => "memory pressure",
             KillHint::PossibleMemoryPressure => "possible memory pressure",
-            KillHint::CsaTimeout | KillHint::UnknownSignal => return None,
+            KillHint::CsaTimeout => "csa_timeout",
+            KillHint::UnknownSignal => "unknown_signal",
         };
 
+        let details = self.detail_parts().join(", ");
+        let suffix = match self.hint {
+            KillHint::Earlyoom | KillHint::MemoryPressure | KillHint::PossibleMemoryPressure => {
+                "Re-dispatch when host memory frees."
+            }
+            KillHint::CsaTimeout => "The recorded timeout is the concrete kill reason.",
+            KillHint::UnknownSignal => {
+                "No timeout or cgroup OOM evidence was found, and memory checks did not identify a concrete kill source; reason remains unknown."
+            }
+        };
         Some(format!(
-            "CSA diagnostic: signal kill hint: {hint} ({}). Re-dispatch when host memory frees.",
-            self.detail_parts().join(", ")
+            "CSA diagnostic: signal kill hint: {hint} ({details}). {suffix}"
         ))
     }
 
@@ -165,9 +193,13 @@ pub(crate) fn diagnose_signal_kill_with(
         return Some(KillDiagnostic {
             hint: KillHint::CsaTimeout,
             observations: KillSignalObservations::default(),
+            terminal_reason: normalize_terminal_reason(terminal_reason),
         });
     }
-    Some(classify_signal_kill(collect()))
+    Some(classify_signal_kill(
+        collect(),
+        normalize_terminal_reason(terminal_reason),
+    ))
 }
 
 pub(crate) fn last_known_work_item<'a>(
@@ -268,10 +300,23 @@ fn append_stderr_line(stderr_output: Option<&mut String>, line: &str) {
 }
 
 fn csa_timeout_reason(reason: Option<&str>) -> bool {
-    matches!(reason, Some("idle_timeout" | "initial_response_timeout"))
+    matches!(
+        reason.map(str::trim),
+        Some("timeout" | "idle_timeout" | "initial_response_timeout")
+    )
 }
 
-fn classify_signal_kill(observations: KillSignalObservations) -> KillDiagnostic {
+fn normalize_terminal_reason(reason: Option<&str>) -> Option<String> {
+    reason
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn classify_signal_kill(
+    observations: KillSignalObservations,
+    terminal_reason: Option<String>,
+) -> KillDiagnostic {
     let very_low_memory = observations
         .meminfo
         .as_ref()
@@ -294,7 +339,11 @@ fn classify_signal_kill(observations: KillSignalObservations) -> KillDiagnostic 
         KillHint::UnknownSignal
     };
 
-    KillDiagnostic { hint, observations }
+    KillDiagnostic {
+        hint,
+        observations,
+        terminal_reason,
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -395,11 +444,18 @@ fn read_session_cgroup_memory_events(
     session_id: &str,
 ) -> Option<CgroupMemoryEvents> {
     let scope = csa_resource::cgroup::scope_unit_name(tool_name, session_id);
-    cgroup_memory_event_candidates(&scope)
-        .into_iter()
-        .filter_map(|path| std::fs::read_to_string(path).ok())
-        .map(|content| parse_memory_events(&content))
-        .find(|events| events.has_oom_event())
+    let mut first_readable = None;
+    for path in cgroup_memory_event_candidates(&scope) {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let events = parse_memory_events(&content);
+        if events.has_oom_event() {
+            return Some(events);
+        }
+        first_readable.get_or_insert(events);
+    }
+    first_readable
 }
 
 #[cfg(target_os = "linux")]
@@ -511,7 +567,12 @@ MemAvailable:    900000 kB
         .expect("signal exit should produce diagnostic");
 
         assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
-        assert!(diagnostic.stderr_line().is_none());
+        assert!(
+            diagnostic
+                .stderr_line()
+                .expect("unknown signal should render checked evidence")
+                .contains("earlyoom running")
+        );
     }
 
     #[test]
@@ -569,12 +630,17 @@ MemAvailable:    900000 kB
         .expect("signal exit should produce diagnostic");
 
         assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
-        assert!(diagnostic.stderr_line().is_none());
+        assert!(
+            diagnostic
+                .stderr_line()
+                .expect("unknown signal should render checked evidence")
+                .contains("cgroup memory.events oom=1 oom_kill=0")
+        );
     }
 
     #[test]
     fn csa_timeout_terminal_reasons_take_precedence_over_earlyoom() {
-        for terminal_reason in ["idle_timeout", "initial_response_timeout"] {
+        for terminal_reason in ["timeout", "idle_timeout", "initial_response_timeout"] {
             let called = Cell::new(false);
             let diagnostic = diagnose_signal_kill_with(137, Some(terminal_reason), || {
                 called.set(true);
@@ -594,7 +660,11 @@ MemAvailable:    900000 kB
 
             assert_eq!(diagnostic.hint, KillHint::CsaTimeout);
             assert!(!called.get(), "{terminal_reason} should skip memory checks");
-            assert!(diagnostic.stderr_line().is_none());
+            let line = diagnostic
+                .stderr_line()
+                .expect("timeout signal should render timeout reason");
+            assert!(line.contains(terminal_reason));
+            assert!(line.contains("concrete kill reason"));
         }
     }
 
@@ -604,7 +674,41 @@ MemAvailable:    900000 kB
             .expect("signal exit should produce diagnostic");
 
         assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
-        assert!(diagnostic.stderr_line().is_none());
+        let line = diagnostic
+            .stderr_line()
+            .expect("unknown signal should render checked evidence");
+        assert!(line.contains("unknown_signal"));
+        assert!(line.contains("termination_reason: missing"));
+        assert!(line.contains("MemAvailable: unavailable"));
+        assert!(line.contains("earlyoom not running"));
+        assert!(line.contains("reason remains unknown"));
+    }
+
+    #[test]
+    fn unknown_signal_reports_negative_memory_evidence() {
+        let diagnostic =
+            diagnose_signal_kill_with(143, Some("sigterm"), || KillSignalObservations {
+                meminfo: Some(MemInfo {
+                    total_kb: 16_384_000,
+                    available_kb: 12_288_000,
+                }),
+                earlyoom_running: false,
+                cgroup_memory_events: Some(CgroupMemoryEvents {
+                    oom: 0,
+                    oom_kill: 0,
+                }),
+            })
+            .expect("signal exit should produce diagnostic");
+
+        assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
+        let line = diagnostic
+            .stderr_line()
+            .expect("unknown signal should render checked evidence");
+        assert!(line.contains("termination_reason=sigterm"));
+        assert!(line.contains("MemAvailable: 12000 MB / MemTotal: 16000 MB"));
+        assert!(line.contains("earlyoom not running"));
+        assert!(line.contains("cgroup memory.events oom=0 oom_kill=0"));
+        assert!(line.contains("reason remains unknown"));
     }
 
     #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.959"
-weave = "0.1.959"
+csa = "0.1.960"
+weave = "0.1.960"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- record explicit signal termination reason payloads in daemon completion metadata
- surface concrete signal kill evidence in session wait/report output
- report checked memory/OOM evidence instead of only unknown_signal when proof is absent

## Issue
Closes #1977
Related #1781

## Sessions
- Writer: 01KTMXBQSP93TPNH42MZ7RH9HV
- Review PASS: 01KTN0D8YXBR03B0RKH2NQYD1P (gemini-cli)

## Verification
- writer reports focused tests and just pre-commit passed
- pre-push review-check verified full diff for e99b6fa0