### PR TITLE
fix(run): keep codex quota failover tier-aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.960"
+version = "0.1.961"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.960"
+version = "0.1.961"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -393,7 +393,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             .await
         }?;
 
-        let (exec_result, exec_changed_paths) = match attempt_execution {
+        let (mut exec_result, exec_changed_paths) = match attempt_execution {
             AttemptExecution::TimedOut => {
                 let timeout_resume_session = executed_session_id
                     .clone()
@@ -488,7 +488,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
 
         match evaluate_post_attempt_retry(
             PostAttemptRequest {
-                exec_result: &exec_result,
+                exec_result: &mut exec_result,
                 exec_changed_paths,
                 runtime_fallback_enabled,
                 max_runtime_fallback_attempts,
@@ -554,6 +554,9 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
     })))
 }
 
+#[cfg(test)]
+#[path = "run_cmd_attempt_codex_quota_tests.rs"]
+mod codex_quota_tests;
 #[cfg(test)]
 #[path = "run_cmd_attempt_git_push_tests.rs"]
 mod git_push_tests;

--- a/crates/cli-sub-agent/src/run_cmd_attempt_codex_quota_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_codex_quota_tests.rs
@@ -1,0 +1,208 @@
+use crate::run_cmd_post::{
+    RateLimitAction, evaluate_error_rate_limit_failover, evaluate_rate_limit_failover,
+};
+use chrono::Utc;
+use csa_config::{ProjectConfig, ProjectMeta, TierConfig, TierStrategy};
+use csa_process::ExecutionResult;
+use std::{collections::HashMap, path::Path};
+
+fn make_config(tier_name: &str, models: &[&str]) -> ProjectConfig {
+    let mut tiers = HashMap::new();
+    tiers.insert(
+        tier_name.to_string(),
+        TierConfig {
+            description: "test".to_string(),
+            models: models.iter().map(|model| (*model).to_string()).collect(),
+            strategy: TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+
+    ProjectConfig {
+        schema_version: 1,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: Default::default(),
+        acp: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers,
+        tier_mapping: HashMap::from([("default".to_string(), tier_name.to_string())]),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        github: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        run: Default::default(),
+        execution: Default::default(),
+        session_wait: None,
+        preflight: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    }
+}
+
+fn assert_retry_to(action: RateLimitAction, expected_tool: &str, expected_spec: &str) {
+    match action {
+        RateLimitAction::Retry {
+            new_tool,
+            new_model_spec,
+        } => {
+            assert_eq!(new_tool.as_str(), expected_tool);
+            assert_eq!(new_model_spec.as_deref(), Some(expected_spec));
+        }
+        RateLimitAction::NoRateLimit => panic!("expected failover retry, got no rate limit"),
+        RateLimitAction::ExhaustedFailovers { .. } => {
+            panic!("expected failover retry, got exhausted failovers")
+        }
+    }
+}
+
+fn codex_spark_quota_result() -> ExecutionResult {
+    ExecutionResult {
+        output: String::new(),
+        stderr_output: "You've hit your usage limit for GPT-5.3-Codex-Spark. \
+         Switch to another model now, or try again at Jun 11th, 2026 7:42 AM."
+            .to_string(),
+        summary: "Codex Spark quota reached".to_string(),
+        exit_code: 1,
+        peak_memory_mb: None,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn explicit_tool_in_tier_codex_model_scoped_quota_tries_next_codex_model() {
+    let config = make_config(
+        "tier-3-complex",
+        &[
+            "codex/openai/gpt-5.3-codex-spark/xhigh",
+            "codex/openai/gpt-5.5/xhigh",
+            "claude-code/anthropic/claude-sonnet/high",
+        ],
+    );
+    let mut tried_tools = Vec::new();
+    let mut tried_specs = Vec::new();
+    let mut fallback_chain = Vec::new();
+
+    let action = evaluate_error_rate_limit_failover(
+        "codex",
+        r#"Internal error: {"message":"You've hit your usage limit for GPT-5.3-Codex-Spark. Switch to another model now, or try again at Jun 11th, 2026 7:42 AM."}"#,
+        1,
+        4,
+        &mut tried_tools,
+        &mut tried_specs,
+        true,
+        true,
+        Some("tier-3-complex"),
+        None,
+        None,
+        true,
+        "recover from codex rate limit",
+        Path::new("."),
+        Some(&config),
+        None,
+        Some("codex/openai/gpt-5.3-codex-spark/xhigh"),
+        &mut fallback_chain,
+        None,
+    )
+    .expect("evaluate failover");
+
+    assert_retry_to(action, "codex", "codex/openai/gpt-5.5/xhigh");
+    assert_eq!(tried_tools, vec!["codex".to_string()]);
+    assert_eq!(
+        tried_specs,
+        vec!["codex/openai/gpt-5.3-codex-spark/xhigh".to_string()]
+    );
+    assert_eq!(fallback_chain.len(), 1);
+    assert!(!fallback_chain[0].quota_exhausted);
+}
+
+#[test]
+fn codex_model_scoped_quota_result_tries_next_codex_model() {
+    let config = make_config(
+        "tier-3-complex",
+        &[
+            "codex/openai/gpt-5.3-codex-spark/xhigh",
+            "codex/openai/gpt-5.5/xhigh",
+            "claude-code/anthropic/claude-sonnet/high",
+        ],
+    );
+    let mut tried_tools = Vec::new();
+    let mut tried_specs = Vec::new();
+    let mut fallback_chain = Vec::new();
+
+    let action = evaluate_rate_limit_failover(
+        "codex",
+        &codex_spark_quota_result(),
+        1,
+        4,
+        &mut tried_tools,
+        &mut tried_specs,
+        true,
+        Some("tier-3-complex"),
+        None,
+        None,
+        true,
+        "recover from codex rate limit",
+        Path::new("."),
+        Some(&config),
+        None,
+        Some("codex/openai/gpt-5.3-codex-spark/xhigh"),
+        &mut fallback_chain,
+        None,
+    )
+    .expect("evaluate failover");
+
+    assert_retry_to(action, "codex", "codex/openai/gpt-5.5/xhigh");
+    assert_eq!(fallback_chain.len(), 1);
+    assert!(!fallback_chain[0].quota_exhausted);
+}
+
+#[test]
+fn codex_model_scoped_quota_explains_when_no_fallback_candidate_exists() {
+    let config = make_config(
+        "tier-3-complex",
+        &["codex/openai/gpt-5.3-codex-spark/xhigh"],
+    );
+    let mut tried_tools = Vec::new();
+    let mut tried_specs = Vec::new();
+    let mut fallback_chain = Vec::new();
+
+    let action = evaluate_rate_limit_failover(
+        "codex",
+        &codex_spark_quota_result(),
+        1,
+        4,
+        &mut tried_tools,
+        &mut tried_specs,
+        true,
+        Some("tier-3-complex"),
+        None,
+        None,
+        true,
+        "recover from codex rate limit",
+        Path::new("."),
+        Some(&config),
+        None,
+        Some("codex/openai/gpt-5.3-codex-spark/xhigh"),
+        &mut fallback_chain,
+        None,
+    )
+    .expect("evaluate failover");
+
+    match action {
+        RateLimitAction::ExhaustedFailovers { reason } => {
+            assert!(reason.contains("All tools in tier 'tier-3-complex'"));
+        }
+        RateLimitAction::Retry { .. } => panic!("expected exhausted failover, got retry"),
+        RateLimitAction::NoRateLimit => panic!("expected exhausted failover, got no rate limit"),
+    }
+}

--- a/crates/cli-sub-agent/src/run_cmd_attempt_codex_quota_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_codex_quota_tests.rs
@@ -167,6 +167,59 @@ fn codex_model_scoped_quota_result_tries_next_codex_model() {
 }
 
 #[test]
+fn codex_provider_quota_ignores_model_hint_quoted_outside_stderr() {
+    let config = make_config(
+        "tier-3-complex",
+        &[
+            "codex/openai/gpt-5.3-codex-spark/xhigh",
+            "codex/openai/gpt-5.5/xhigh",
+            "claude-code/anthropic/claude-sonnet/high",
+        ],
+    );
+    let exec_result = ExecutionResult {
+        output: "Reviewed text includes: switch to another model.".to_string(),
+        stderr_output: "You've hit your account usage limit. Try again later.".to_string(),
+        summary: "Agent summary quotes: switch to another model.".to_string(),
+        exit_code: 1,
+        peak_memory_mb: None,
+        ..Default::default()
+    };
+    let mut tried_tools = Vec::new();
+    let mut tried_specs = Vec::new();
+    let mut fallback_chain = Vec::new();
+
+    let action = evaluate_rate_limit_failover(
+        "codex",
+        &exec_result,
+        1,
+        4,
+        &mut tried_tools,
+        &mut tried_specs,
+        true,
+        Some("tier-3-complex"),
+        None,
+        None,
+        true,
+        "review a prompt that mentions switching models",
+        Path::new("."),
+        Some(&config),
+        None,
+        Some("codex/openai/gpt-5.3-codex-spark/xhigh"),
+        &mut fallback_chain,
+        None,
+    )
+    .expect("evaluate failover");
+
+    assert_retry_to(
+        action,
+        "claude-code",
+        "claude-code/anthropic/claude-sonnet/high",
+    );
+    assert_eq!(fallback_chain.len(), 1);
+    assert!(fallback_chain[0].quota_exhausted);
+}
+
+#[test]
 fn codex_model_scoped_quota_explains_when_no_fallback_candidate_exists() {
     let config = make_config(
         "tier-3-complex",

--- a/crates/cli-sub-agent/src/run_cmd_attempt_http_failover_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_http_failover_tests.rs
@@ -59,7 +59,7 @@ fn assert_retry_to(action: RateLimitAction, expected_tool: &str, expected_spec: 
             assert_eq!(new_model_spec.as_deref(), Some(expected_spec));
         }
         RateLimitAction::NoRateLimit => panic!("expected failover retry, got no rate limit"),
-        RateLimitAction::ExhaustedFailovers => {
+        RateLimitAction::ExhaustedFailovers { .. } => {
             panic!("expected failover retry, got exhausted failovers")
         }
     }
@@ -69,7 +69,7 @@ fn assert_no_rate_limit(action: RateLimitAction) {
     match action {
         RateLimitAction::NoRateLimit => {}
         RateLimitAction::Retry { .. } => panic!("expected no failover, got retry"),
-        RateLimitAction::ExhaustedFailovers => {
+        RateLimitAction::ExhaustedFailovers { .. } => {
             panic!("expected no failover, got exhausted failovers")
         }
     }

--- a/crates/cli-sub-agent/src/run_cmd_attempt_outcome.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_outcome.rs
@@ -221,7 +221,13 @@ pub(super) fn handle_attempt_error(
                 failover_context: FailoverContextUpdate::Replace(failover_context),
             }))
         }
-        _ => {
+        RateLimitAction::ExhaustedFailovers { reason } => {
+            cleanup_pre_created_fork_session(pre_created_fork_session_id, request.project_root);
+            Ok(AttemptErrorAction::Error(
+                error.context(format!("tier failover unavailable: {reason}")),
+            ))
+        }
+        RateLimitAction::NoRateLimit => {
             cleanup_pre_created_fork_session(pre_created_fork_session_id, request.project_root);
             Ok(AttemptErrorAction::Error(error))
         }
@@ -234,7 +240,7 @@ pub(super) enum PostAttemptAction {
 }
 
 pub(super) struct PostAttemptRequest<'a> {
-    pub(super) exec_result: &'a csa_process::ExecutionResult,
+    pub(super) exec_result: &'a mut csa_process::ExecutionResult,
     pub(super) exec_changed_paths: Option<Vec<String>>,
     pub(super) runtime_fallback_enabled: bool,
     pub(super) max_runtime_fallback_attempts: u8,
@@ -364,6 +370,28 @@ pub(super) fn evaluate_post_attempt_retry(
                 failover_context: FailoverContextUpdate::Replace(failover_context),
             }))
         }
-        _ => Ok(PostAttemptAction::Break(request.exec_changed_paths)),
+        RateLimitAction::ExhaustedFailovers { reason } => {
+            annotate_failover_exhaustion(request.exec_result, &reason);
+            Ok(PostAttemptAction::Break(request.exec_changed_paths))
+        }
+        RateLimitAction::NoRateLimit => Ok(PostAttemptAction::Break(request.exec_changed_paths)),
+    }
+}
+
+fn annotate_failover_exhaustion(exec_result: &mut csa_process::ExecutionResult, reason: &str) {
+    let detail = format!("tier failover unavailable: {reason}");
+    if !exec_result.summary.contains(&detail) {
+        if exec_result.summary.trim().is_empty() || exec_result.summary.starts_with("exit code ") {
+            exec_result.summary = detail.clone();
+        } else {
+            exec_result.summary = format!("{}; {detail}", exec_result.summary);
+        }
+    }
+    if !exec_result.stderr_output.contains(&detail) {
+        if !exec_result.stderr_output.is_empty() && !exec_result.stderr_output.ends_with('\n') {
+            exec_result.stderr_output.push('\n');
+        }
+        exec_result.stderr_output.push_str(&detail);
+        exec_result.stderr_output.push('\n');
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
@@ -76,7 +76,7 @@ fn assert_retry_to(action: RateLimitAction, expected_tool: &str, expected_spec: 
             assert_eq!(new_model_spec.as_deref(), Some(expected_spec));
         }
         RateLimitAction::NoRateLimit => panic!("expected failover retry, got no rate limit"),
-        RateLimitAction::ExhaustedFailovers => {
+        RateLimitAction::ExhaustedFailovers { .. } => {
             panic!("expected failover retry, got exhausted failovers")
         }
     }
@@ -86,7 +86,7 @@ fn assert_no_rate_limit(action: RateLimitAction) {
     match action {
         RateLimitAction::NoRateLimit => {}
         RateLimitAction::Retry { .. } => panic!("expected no failover, got retry"),
-        RateLimitAction::ExhaustedFailovers => {
+        RateLimitAction::ExhaustedFailovers { .. } => {
             panic!("expected no failover, got exhausted failovers")
         }
     }
@@ -637,60 +637,6 @@ fn explicit_tool_no_tier_crash_no_failover() {
     assert!(
         tried_specs.is_empty(),
         "disabled crash failover should not mutate retry state"
-    );
-}
-
-#[test]
-fn explicit_tool_in_tier_permanent_quota_no_failover() {
-    // Explicit tool (tier_auto_select=false) with permanent quota:
-    // failover is suppressed (returns NoRateLimit). Behavior is independent
-    // of the #1629 fix: the explicit-tool guard remains the merge gate.
-    let config = make_named_failover_config(
-        "tier-3-complex",
-        &[
-            "codex/openai/o4-mini/high",
-            "claude-code/anthropic/claude-sonnet/high",
-        ],
-    );
-    let mut tried_tools = Vec::new();
-    let mut tried_specs = Vec::new();
-    let mut fallback_chain = Vec::new();
-
-    let action = evaluate_error_rate_limit_failover(
-        "codex",
-        r#"Internal error: {"codex_error_info": "usage_limit_exceeded", "message": "You've hit your usage limit."}"#,
-        1,
-        4,
-        &mut tried_tools,
-        &mut tried_specs,
-        false,
-        true,
-        Some("tier-3-complex"),
-        None,
-        None,
-        true,
-        "recover from codex rate limit",
-        Path::new("."),
-        Some(&config),
-        None,
-        Some("codex/openai/o4-mini/high"),
-        &mut fallback_chain,
-        None,
-    )
-    .expect("evaluate failover");
-
-    assert_no_rate_limit(action);
-    assert!(
-        tried_tools.is_empty(),
-        "explicit-tool guard suppresses failover; tried_tools stays empty"
-    );
-    assert!(
-        tried_specs.is_empty(),
-        "explicit-tool guard suppresses failover; tried_specs stays empty"
-    );
-    assert!(
-        fallback_chain.is_empty(),
-        "explicit-tool guard suppresses failover; no fallback_chain entry"
     );
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_post_failover.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_failover.rs
@@ -18,7 +18,7 @@ pub(crate) enum RateLimitAction {
     /// No rate limit detected; break with result.
     NoRateLimit,
     /// Rate limit detected but no failover possible; break with result.
-    ExhaustedFailovers,
+    ExhaustedFailovers { reason: String },
     /// Retry with a different tool.
     Retry {
         new_tool: ToolName,
@@ -75,19 +75,8 @@ pub(crate) fn detect_permanent_tool_exhaustion_text(
     if exit_code == 0 {
         return None;
     }
-    // PERMANENT tool exhaustion self-kills the session (the caller marks a fatal
-    // gate, blocks failover, and writes `tool_exhausted: ...`). It MUST be
-    // derived only from the provider's own error channel — captured process
-    // stderr, or the anyhow error chain of a transport failure — NEVER from the
-    // agent's stdout (`output`) or the stdout-derived `summary`. A `csa review`
-    // whose reviewed diff/source/commit literally contains a quota phrase (e.g.
-    // "monthly spending cap") must not be misread as a real provider quota
-    // exhaustion (#1736). Both call sites pass the provider-error channel here:
-    // the success path passes `ExecutionResult::stderr_output`, the transport
-    // error path passes the formatted anyhow error chain. `detect_rate_limit`
-    // confirms `quota_exhausted` only from its `stderr` argument, so feeding the
-    // provider channel as stderr (and an empty stdout) yields the permanent
-    // verdict iff the provider itself reported quota exhaustion.
+    // Permanent self-kill must come only from the provider error channel, never
+    // agent stdout/summary that may quote reviewed quota text (#1736).
     csa_scheduler::detect_rate_limit(
         tool_name_str,
         provider_error_channel,
@@ -96,6 +85,13 @@ pub(crate) fn detect_permanent_tool_exhaustion_text(
         current_model_spec,
     )
     .filter(|detected| detected.quota_exhausted)
+    .filter(|detected| {
+        is_provider_wide_quota_exhaustion(
+            tool_name_str,
+            detected.quota_exhausted,
+            provider_error_channel,
+        )
+    })
 }
 
 pub(crate) fn is_permanent_tool_exhaustion_error(
@@ -210,6 +206,23 @@ fn allows_init_failure_failover(
     false
 }
 
+fn is_provider_wide_quota_exhaustion(
+    tool_name_str: &str,
+    quota_exhausted: bool,
+    provider_error_channel: &str,
+) -> bool {
+    quota_exhausted && !is_codex_model_scoped_usage_limit(tool_name_str, provider_error_channel)
+}
+
+fn is_codex_model_scoped_usage_limit(tool_name_str: &str, provider_error_channel: &str) -> bool {
+    if tool_name_str != "codex" {
+        return false;
+    }
+
+    let lower = provider_error_channel.to_ascii_lowercase();
+    lower.contains("usage limit") && lower.contains("switch to another model")
+}
+
 /// Check for 429 rate-limit signals and decide whether to failover.
 ///
 /// Returns `RateLimitAction` to drive `continue`/`break` in the caller loop.
@@ -277,7 +290,9 @@ pub(crate) fn evaluate_rate_limit_failover(
             "Max failover attempts ({}) reached, returning error",
             max_failover_attempts
         );
-        return Ok(RateLimitAction::ExhaustedFailovers);
+        return Ok(RateLimitAction::ExhaustedFailovers {
+            reason: format!("max failover attempts ({max_failover_attempts}) reached"),
+        });
     }
 
     tried_tools.push(tool_name_str.to_string());
@@ -306,16 +321,26 @@ pub(crate) fn evaluate_rate_limit_failover(
         .or_else(|| config.map(|cfg| cfg.can_tool_edit_existing(tool_name_str)));
 
     let Some(cfg) = config else {
-        return Ok(RateLimitAction::ExhaustedFailovers);
+        return Ok(RateLimitAction::ExhaustedFailovers {
+            reason: "project config unavailable; cannot resolve tier fallback candidates"
+                .to_string(),
+        });
     };
 
-    // Permanent quota exhaustion on `tool_name_str` does NOT stop failover
-    // (#1629). Instead, mark its provider as exhausted so `decide_failover`
-    // skips other tools sharing the same upstream quota pool — e.g. gemini-cli
-    // and antigravity-cli both consume Google OAuth quota.
+    let provider_wide_quota_exhaustion = is_provider_wide_quota_exhaustion(
+        tool_name_str,
+        rate_limit.quota_exhausted,
+        &format!(
+            "{}\n{}\n{}",
+            exec_result.stderr_output, exec_result.summary, exec_result.output
+        ),
+    );
+
+    // Provider-wide quota skips shared quota pools (#1629); Codex model-scoped
+    // limits must still allow another `codex/...` tier candidate (#1985).
     let exhausted_providers = collect_exhausted_providers(
         fallback_chain,
-        Some(tool_name_str).filter(|_| rate_limit.quota_exhausted),
+        Some(tool_name_str).filter(|_| provider_wide_quota_exhaustion),
     );
 
     let action = csa_scheduler::decide_failover(
@@ -354,7 +379,7 @@ pub(crate) fn evaluate_rate_limit_failover(
                 tool: tool_name_str.to_string(),
                 model_spec: current_model_spec.map(String::from),
                 skip_reason: rate_limit.matched_pattern.clone(),
-                quota_exhausted: rate_limit.quota_exhausted,
+                quota_exhausted: provider_wide_quota_exhaustion,
                 timestamp: chrono::Utc::now(),
             });
             let tool = crate::run_helpers::parse_tool_name(&new_tool)?;
@@ -369,10 +394,8 @@ pub(crate) fn evaluate_rate_limit_failover(
                 quota_exhausted = rate_limit.quota_exhausted,
                 "Failover not possible, returning original result"
             );
-            // Even when no alternative was found, record the quota-exhaustion
-            // attempt in fallback_chain so result.toml + audit trails reflect
-            // that we recognised the permanent failure (#1629).
-            if rate_limit.quota_exhausted {
+            // Record only provider-wide quota exhaustion as permanent pool state.
+            if provider_wide_quota_exhaustion {
                 fallback_chain.push(FallbackAttempt {
                     tool: tool_name_str.to_string(),
                     model_spec: current_model_spec.map(String::from),
@@ -381,7 +404,7 @@ pub(crate) fn evaluate_rate_limit_failover(
                     timestamp: chrono::Utc::now(),
                 });
             }
-            Ok(RateLimitAction::ExhaustedFailovers)
+            Ok(RateLimitAction::ExhaustedFailovers { reason })
         }
     }
 }
@@ -517,7 +540,9 @@ pub(crate) fn evaluate_error_rate_limit_failover(
             "Max failover attempts ({}) reached for error-path rate limit",
             max_failover_attempts
         );
-        return Ok(RateLimitAction::ExhaustedFailovers);
+        return Ok(RateLimitAction::ExhaustedFailovers {
+            reason: format!("max failover attempts ({max_failover_attempts}) reached"),
+        });
     }
 
     tried_tools.push(tool_name_str.to_string());
@@ -543,14 +568,22 @@ pub(crate) fn evaluate_error_rate_limit_failover(
         .or_else(|| config.map(|cfg| cfg.can_tool_edit_existing(tool_name_str)));
 
     let Some(cfg) = config else {
-        return Ok(RateLimitAction::ExhaustedFailovers);
+        return Ok(RateLimitAction::ExhaustedFailovers {
+            reason: "project config unavailable; cannot resolve tier fallback candidates"
+                .to_string(),
+        });
     };
 
-    // See note in `evaluate_rate_limit_failover`: permanent quota exhaustion
-    // exits the failover for THIS provider's pool only, not the whole chain.
+    let provider_wide_quota_exhaustion = is_provider_wide_quota_exhaustion(
+        tool_name_str,
+        failover_signal.quota_exhausted,
+        error_message,
+    );
+
+    // Same provider-pool semantics as the ExecutionResult path above.
     let exhausted_providers = collect_exhausted_providers(
         fallback_chain,
-        Some(tool_name_str).filter(|_| failover_signal.quota_exhausted),
+        Some(tool_name_str).filter(|_| provider_wide_quota_exhaustion),
     );
 
     let action = csa_scheduler::decide_failover(
@@ -589,7 +622,7 @@ pub(crate) fn evaluate_error_rate_limit_failover(
                 tool: tool_name_str.to_string(),
                 model_spec: current_model_spec.map(String::from),
                 skip_reason: failover_signal.matched_pattern.clone(),
-                quota_exhausted: failover_signal.quota_exhausted,
+                quota_exhausted: provider_wide_quota_exhaustion,
                 timestamp: chrono::Utc::now(),
             });
             let tool = crate::run_helpers::parse_tool_name(&new_tool)?;
@@ -605,7 +638,7 @@ pub(crate) fn evaluate_error_rate_limit_failover(
                 "Error-path failover not possible"
             );
             // See parity comment in `evaluate_rate_limit_failover` (#1629).
-            if failover_signal.quota_exhausted {
+            if provider_wide_quota_exhaustion {
                 fallback_chain.push(FallbackAttempt {
                     tool: tool_name_str.to_string(),
                     model_spec: current_model_spec.map(String::from),
@@ -614,7 +647,7 @@ pub(crate) fn evaluate_error_rate_limit_failover(
                     timestamp: chrono::Utc::now(),
                 });
             }
-            Ok(RateLimitAction::ExhaustedFailovers)
+            Ok(RateLimitAction::ExhaustedFailovers { reason })
         }
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_post_failover.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_failover.rs
@@ -330,10 +330,7 @@ pub(crate) fn evaluate_rate_limit_failover(
     let provider_wide_quota_exhaustion = is_provider_wide_quota_exhaustion(
         tool_name_str,
         rate_limit.quota_exhausted,
-        &format!(
-            "{}\n{}\n{}",
-            exec_result.stderr_output, exec_result.summary, exec_result.output
-        ),
+        &exec_result.stderr_output,
     );
 
     // Provider-wide quota skips shared quota pools (#1629); Codex model-scoped

--- a/crates/cli-sub-agent/src/run_cmd_post_failover_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_failover_tests.rs
@@ -48,6 +48,26 @@ fn provider_quota_error_on_stderr_is_permanent_exhaustion() {
 }
 
 #[test]
+fn codex_model_scoped_usage_limit_is_not_permanent_tool_exhaustion() {
+    let result = result_with(
+        "Codex Spark quota reached",
+        "You've hit your usage limit for GPT-5.3-Codex-Spark. \
+         Switch to another model now, or try again at Jun 11th, 2026 7:42 AM.",
+        "",
+    );
+
+    assert!(
+        detect_permanent_tool_exhaustion_result(
+            "codex",
+            &result,
+            Some("codex/openai/gpt-5.3-codex-spark/xhigh")
+        )
+        .is_none(),
+        "model-scoped Codex quota should fail over by model, not self-kill the tool"
+    );
+}
+
+#[test]
 fn transport_error_chain_quota_is_permanent_exhaustion() {
     // The error path feeds the anyhow error chain as the provider channel; a
     // provider quota error there must still be detected.

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.960"
-weave = "0.1.960"
+csa = "0.1.961"
+weave = "0.1.961"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- keep tier fallback active when an explicit `--tool codex` try-first run hits a model-scoped Codex usage limit
- preserve provider-wide quota protection by limiting model-scoped detection to stderr-only evidence
- improve exhausted-failover reporting when no eligible fallback remains

## Issue
Closes #1985

## Sessions
- Writer: 01KTN0YDK4YB2KN5YBTV82CPGG
- Review FAIL: 01KTN3NSMA39WKFK1ZM57J7JYQ
- Codex fix from review context: 01KTN44YT6FXAE13EYSTXRVJ39
- Final review PASS: 01KTN6ZM1QH9RB5FSDTQY6CS0H

## Verification
- writer reports focused tests and just pre-commit passed
- final pre-push review-check verified full diff for 143e7b7b