### PR TITLE
fix(config): validate round-trip integrity before writing (#1998)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.962"
+version = "0.1.963"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.962"
+version = "0.1.963"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/config_cmds_set.rs
+++ b/crates/cli-sub-agent/src/config_cmds_set.rs
@@ -33,29 +33,35 @@ fn validate_config_set_value(key: &str, value: &str) -> Result<()> {
 }
 
 fn write_config_value(path: &std::path::Path, key: &str, value: &str) -> Result<()> {
-    let mut doc = match std::fs::read_to_string(path) {
-        Ok(content) if !content.trim().is_empty() => content
+    let original_content = match std::fs::read_to_string(path) {
+        Ok(content) if !content.trim().is_empty() => Some(content),
+        Ok(_) => None,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => return Err(err.into()),
+    };
+    let mut doc = match &original_content {
+        Some(content) => content
             .parse::<toml_edit::DocumentMut>()
             .map_err(|err| anyhow::anyhow!("TOML parse error: {err}"))?,
-        Ok(_) => toml_edit::DocumentMut::new(),
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => toml_edit::DocumentMut::new(),
-        Err(err) => return Err(err.into()),
+        None => toml_edit::DocumentMut::new(),
     };
 
     set_document_config_value(&mut doc, key, value)?;
+
+    let serialized = doc.to_string();
+    validate_round_trip(&serialized, original_content.as_deref(), key)?;
 
     let parent = path
         .parent()
         .ok_or_else(|| anyhow::anyhow!("config path has no parent directory"))?;
     std::fs::create_dir_all(parent)?;
 
-    // Preserve original file permissions if the file already exists.
     let original_permissions = std::fs::metadata(path).ok().map(|m| m.permissions());
 
     let mut tmp = tempfile::NamedTempFile::new_in(parent).map_err(|err| {
         anyhow::anyhow!("failed to create temp file in {}: {err}", parent.display())
     })?;
-    std::io::Write::write_all(&mut tmp, doc.to_string().as_bytes())?;
+    std::io::Write::write_all(&mut tmp, serialized.as_bytes())?;
 
     if let Some(perms) = original_permissions {
         tmp.as_file().set_permissions(perms)?;
@@ -65,6 +71,61 @@ fn write_config_value(path: &std::path::Path, key: &str, value: &str) -> Result<
         .map_err(|err| anyhow::anyhow!("failed to atomically rename config: {err}"))?;
 
     Ok(())
+}
+
+fn validate_round_trip(serialized: &str, original: Option<&str>, key: &str) -> Result<()> {
+    let new: toml::Value = toml::from_str(serialized).map_err(|err| {
+        anyhow::anyhow!("config set '{key}' would produce unparseable TOML: {err}")
+    })?;
+
+    let Some(original) = original else {
+        return Ok(());
+    };
+    let Ok(old) = toml::from_str::<toml::Value>(original) else {
+        return Ok(());
+    };
+
+    let target_top_key = key.split('.').next().unwrap_or(key);
+    let old_table = old.as_table();
+    let new_table = new.as_table();
+    if let (Some(old_t), Some(new_t)) = (old_table, new_table) {
+        for (section_key, old_val) in old_t {
+            if section_key == target_top_key {
+                continue;
+            }
+            match new_t.get(section_key) {
+                Some(new_val) if new_val == old_val => {}
+                Some(new_val) => {
+                    anyhow::bail!(
+                        "config set '{key}' would corrupt unrelated section '[{section_key}]': \
+                         toml_edit round-trip changed its structure. \
+                         Old type: {}, New type: {}. Aborting write.",
+                        toml_type_name(old_val),
+                        toml_type_name(new_val),
+                    );
+                }
+                None => {
+                    anyhow::bail!(
+                        "config set '{key}' would delete unrelated section '[{section_key}]'. \
+                         Aborting write."
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn toml_type_name(v: &toml::Value) -> &'static str {
+    match v {
+        toml::Value::String(_) => "string",
+        toml::Value::Integer(_) => "integer",
+        toml::Value::Float(_) => "float",
+        toml::Value::Boolean(_) => "boolean",
+        toml::Value::Datetime(_) => "datetime",
+        toml::Value::Array(_) => "array",
+        toml::Value::Table(_) => "table",
+    }
 }
 
 fn set_document_config_value(
@@ -270,5 +331,63 @@ mod tests {
                 .contains("Invalid preferences.primary_writer_spec"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn validate_round_trip_detects_tier_corruption() {
+        let original = r#"
+[tools.gemini-cli]
+enabled = true
+
+[tiers.tier-review]
+models = ["codex/openai/gpt-5.5/xhigh"]
+"#;
+        let corrupted = r#"
+[tools.gemini-cli]
+enabled = true
+
+[tools.gemini-cli.env]
+GEMINI_API_KEY = "test-key"
+
+[tiers.tier-review.models]
+1 = "codex/openai/gpt-5.5/xhigh"
+"#;
+        let err = validate_round_trip(
+            corrupted,
+            Some(original),
+            "tools.gemini-cli.env.GEMINI_API_KEY",
+        )
+        .expect_err("corrupted tiers should be rejected");
+        assert!(
+            err.to_string().contains("corrupt"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_round_trip_allows_clean_modification() {
+        let original = r#"
+[tools.gemini-cli]
+enabled = true
+
+[tiers.tier-review]
+models = ["codex/openai/gpt-5.5/xhigh"]
+"#;
+        let modified = r#"
+[tools.gemini-cli]
+enabled = true
+
+[tools.gemini-cli.env]
+GEMINI_API_KEY = "test-key"
+
+[tiers.tier-review]
+models = ["codex/openai/gpt-5.5/xhigh"]
+"#;
+        validate_round_trip(
+            modified,
+            Some(original),
+            "tools.gemini-cli.env.GEMINI_API_KEY",
+        )
+        .expect("clean modification should pass");
     }
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.962"
-weave = "0.1.962"
+csa = "0.1.963"
+weave = "0.1.963"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Add `validate_round_trip()` guard to `csa config set` that compares top-level TOML sections before and after `toml_edit` round-trip serialization
- If any section outside the target key's top-level path changed structure, the write is aborted with a descriptive error
- Prevents silent config corruption where array values get converted to tables with integer keys during `toml_edit` serialization

Closes #1998

## Test plan

- [x] `validate_round_trip_detects_tier_corruption` — catches array→table corruption
- [x] `validate_round_trip_allows_clean_modification` — permits normal edits
- [x] All existing config set tests pass

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>