### PR TITLE
fix(hooks): stop wiping target/ after post-merge install (#1790)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.964"
+version = "0.1.965"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.964"
+version = "0.1.965"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/scripts/hooks/post-merge-rebuild.sh
+++ b/scripts/hooks/post-merge-rebuild.sh
@@ -17,10 +17,6 @@ fi
 echo "[post-merge] Rebuilding csa..."
 if just install; then
     echo "[post-merge] csa installed successfully."
-    if [ -e target ]; then
-        echo "[post-merge] Clearing target contents (preserving ./target symlink)..."
-        find target/ -mindepth 1 -delete
-    fi
 else
     echo "[post-merge] WARNING: just install failed (exit $?). csa binary may be stale." >&2
 fi


### PR DESCRIPTION
## Summary

- Remove `find target/ -mindepth 1 -delete` from post-merge-rebuild.sh
- The wipe destroyed the build cache after every merge, forcing 20-30 min cold rebuilds on next pre-commit clippy
- This caused codex writers to timeout during git commit (their exec timeout < cold build time)

Closes #1790

## Test plan

- [x] post-merge hook still runs `just install` and reports success
- [x] `target/` preserved for incremental builds

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>