### PR TITLE
fix(test): set low memory_max_mb in tier/pre-exec tests (#1997, #1995)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.966"
+version = "0.1.967"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.966"
+version = "0.1.967"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_1958_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_1958_tests.rs
@@ -11,6 +11,9 @@ use csa_core::types::ToolName;
 
 fn config_with_review_tier(enabled_tools: &[&str], models: &[&str]) -> csa_config::ProjectConfig {
     let mut config = project_config_with_enabled_tools(enabled_tools);
+    for tool_config in config.tools.values_mut() {
+        tool_config.memory_max_mb = Some(256);
+    }
     if enabled_tools.contains(&"codex") {
         config.tools.get_mut("codex").unwrap().transport = Some(csa_config::TransportKind::Cli);
     }

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
@@ -10,6 +10,9 @@ use csa_session::{ReviewVerdictArtifact, state::ReviewSessionMeta};
 
 fn config_with_review_tier(enabled_tools: &[&str], models: &[&str]) -> csa_config::ProjectConfig {
     let mut config = project_config_with_enabled_tools(enabled_tools);
+    for tool_config in config.tools.values_mut() {
+        tool_config.memory_max_mb = Some(256);
+    }
     if enabled_tools.contains(&"codex") {
         config.tools.get_mut("codex").unwrap().transport = Some(csa_config::TransportKind::Cli);
     }

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -18,6 +18,7 @@ fn run_config_with_tier(
             name.to_string(),
             ToolConfig {
                 enabled: enabled_tools.contains(&name),
+                memory_max_mb: Some(256),
                 ..Default::default()
             },
         );

--- a/scripts/monolith/baseline.toml
+++ b/scripts/monolith/baseline.toml
@@ -204,10 +204,10 @@ rationale = "pre-existing monolith debt grandfathered by #1880 calibration; no-g
 [[files]]
 path = "crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs"
 kind = "test"
-baseline_tokens = 10389
-baseline_lines = 831
+baseline_tokens = 10440
+baseline_lines = 835
 issue = "1880"
-rationale = "pre-existing monolith debt grandfathered by #1880 calibration; no-growth ratchet"
+rationale = "pre-existing monolith debt grandfathered by #1880; bumped for test memory_max_mb fix (#1997); no-growth ratchet"
 
 [[files]]
 path = "crates/cli-sub-agent/src/review_cmd_findings_toml_tests.rs"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.966"
-weave = "0.1.966"
+csa = "0.1.967"
+weave = "0.1.967"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Set `memory_max_mb = Some(256)` in all test tool configs for tier fallback and worktree pre-exec tests
- Default codex memory_max_mb (12288 MB) caused host memory admission to fail on tight-memory hosts despite no active sessions
- Also fixes #1995 where tier failover exhaustion surfaced before the worktree lock check

Closes #1997
Closes #1995

## Test plan

- [x] `execute_review_advances_tier_fallback_when_explicit_tool_and_tier` passes
- [x] `execute_review_falls_back_from_gemini_status_400_to_codex` passes  
- [x] `handle_run_fails_fast_when_worktree_write_lock_is_held` passes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>