### PR TITLE
fix(session): fall back to metadata.toml for tool name in daemon completion (#1996, #2000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.967"
+version = "0.1.968"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.967"
+version = "0.1.968"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
@@ -161,6 +161,13 @@ pub(crate) fn daemon_completion_result(
         .iter()
         .max_by_key(|(_, state)| state.updated_at)
         .map(|(tool, _)| tool.clone())
+        .or_else(|| {
+            let metadata_path = session_dir.join(csa_session::metadata::METADATA_FILE_NAME);
+            std::fs::read_to_string(metadata_path)
+                .ok()
+                .and_then(|c| toml::from_str::<csa_session::metadata::SessionMetadata>(&c).ok())
+                .map(|m| m.tool)
+        })
         .unwrap_or_else(|| "unknown".to_string());
     let summary_prefix = format!(
         "daemon completion recorded status={} exit_code={}{} before result.toml was written; committed or staged work may be salvageable on the session branch",

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.967"
-weave = "0.1.967"
+csa = "0.1.968"
+weave = "0.1.968"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- When a session fails before any tool state is recorded, `daemon_completion_result` now reads the tool name from `metadata.toml` (written at session creation) instead of defaulting to "unknown"
- Provides actionable diagnostics in `csa session wait` output

Closes #1996
Closes #2000

## Test plan

- [x] Compiles clean
- [x] `metadata.toml` is written at session creation with the tool name
- [x] Fallback chain: `session.tools` → `metadata.toml` → "unknown"

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>