### PR TITLE
fix(pr-bot): fail closed on merge command errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.969"
+version = "0.1.970"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.969"
+version = "0.1.970"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -569,6 +569,10 @@ mod tests_workflows;
 mod tests_pr_bot;
 
 #[cfg(test)]
+#[path = "plan_cmd_tests_pr_bot_2014.rs"]
+mod tests_pr_bot_2014;
+
+#[cfg(test)]
 #[path = "plan_cmd_tests_chunked.rs"]
 mod tests_chunked;
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot_2014.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot_2014.rs
@@ -1,0 +1,68 @@
+use std::path::{Path, PathBuf};
+
+const MERGE_COMMAND: &str = r#"gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}"#;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
+}
+
+fn artifact_text(path: &str) -> String {
+    std::fs::read_to_string(workspace_root().join(path)).unwrap()
+}
+
+fn workflow_step(text: &str, step_id: usize) -> String {
+    let marker = format!("id = {step_id}");
+    let start = text.find(&marker).expect("workflow step must exist");
+    let body = &text[start..];
+    let end = body.find("\n[[workflow.steps]]").unwrap_or(body.len());
+    body[..end].to_string()
+}
+
+fn pattern_section(text: &str, heading: &str) -> String {
+    let start = text.find(heading).expect("PATTERN.md heading must exist");
+    let body = &text[start + heading.len()..];
+    let end = body.find("\n## ").unwrap_or(body.len());
+    text[start..start + heading.len() + end].to_string()
+}
+
+fn assert_order(text: &str, first: &str, second: &str, label: &str) {
+    let first_idx = text
+        .find(first)
+        .unwrap_or_else(|| panic!("{label} missing {first}"));
+    let second_idx = text
+        .find(second)
+        .unwrap_or_else(|| panic!("{label} missing {second}"));
+    assert!(first_idx < second_idx, "{label} must guard {second}");
+}
+
+#[test]
+fn pr_bot_final_merge_fails_closed_on_gh_merge_error() {
+    for path in [
+        "patterns/pr-bot/workflow.toml",
+        "patterns/pr-bot/PATTERN.md",
+    ] {
+        let text = artifact_text(path);
+        assert_eq!(
+            text.matches(MERGE_COMMAND).count(),
+            2,
+            "{path} must guard both final merge commands"
+        );
+        assert!(
+            !text.contains("${DELETE_BRANCH_FLAG} --force-skip-pr-bot"),
+            "{path} must not pass the CSA-only bypass flag unconditionally"
+        );
+
+        let sections = if path.ends_with("workflow.toml") {
+            vec![workflow_step(&text, 22), workflow_step(&text, 23)]
+        } else {
+            vec![
+                pattern_section(&text, "## Step 12: Final Merge"),
+                pattern_section(&text, "## Step 12b: Final Merge (Direct or Post-Rebase)"),
+            ]
+        };
+        for section in sections {
+            assert_order(&section, "set -e", MERGE_COMMAND, path);
+            assert_order(&section, MERGE_COMMAND, "MERGE_COMPLETED=true", path);
+        }
+    }
+}

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -2109,7 +2109,7 @@ OnFail: abort
 Merge and update the local default branch.
 
 ```bash
-# --- Hard gate: unconditional pre-merge check ---
+set -e
 if [ "${FALLBACK_REVIEW_HAS_ISSUES}" = "true" ]; then
   echo "ERROR: Reached merge with unresolved fallback review issues."
   echo "This is a workflow violation. Aborting merge."
@@ -2135,7 +2135,7 @@ if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; the
   DELETE_BRANCH_FLAG="--delete-branch"
 fi
 # shellcheck disable=SC2086
-gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
+gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}
 
 # --- Inline post-merge checkout (defense-in-depth for #1401) ---
 _SYNC_BRANCH="${DEFAULT_BRANCH:-}"
@@ -2170,7 +2170,7 @@ OnFail: abort
 First-pass clean review or Step 10.5 post-rebase success: merge the existing PR directly.
 
 ```bash
-# --- Hard gate: unconditional pre-merge check ---
+set -e
 if [ "${FALLBACK_REVIEW_HAS_ISSUES}" = "true" ]; then
   echo "ERROR: Reached merge with unresolved fallback review issues."
   echo "This is a workflow violation. Aborting merge."
@@ -2192,7 +2192,7 @@ if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; the
   DELETE_BRANCH_FLAG="--delete-branch"
 fi
 # shellcheck disable=SC2086
-gh pr merge "${PR_NUM}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
+gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}
 
 # --- Inline post-merge checkout (defense-in-depth for #1401) ---
 _SYNC_BRANCH="${DEFAULT_BRANCH:-}"

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -2603,7 +2603,7 @@ prompt = '''
 Merge and update the local default branch.
 
 ```bash
-# --- Hard gate: unconditional pre-merge check ---
+set -e
 if [ "${FALLBACK_REVIEW_HAS_ISSUES}" = "true" ]; then
   echo "ERROR: Reached merge with unresolved fallback review issues."
   echo "This is a workflow violation. Aborting merge."
@@ -2629,7 +2629,7 @@ if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; the
   DELETE_BRANCH_FLAG="--delete-branch"
 fi
 # shellcheck disable=SC2086
-gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
+gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}
 
 # --- Inline post-merge checkout (defense-in-depth for #1401) ---
 _SYNC_BRANCH="${DEFAULT_BRANCH:-}"
@@ -2665,7 +2665,7 @@ prompt = '''
 First-pass clean review or Step 10.5 post-rebase success: merge the existing PR directly.
 
 ```bash
-# --- Hard gate: unconditional pre-merge check ---
+set -e
 if [ "${FALLBACK_REVIEW_HAS_ISSUES}" = "true" ]; then
   echo "ERROR: Reached merge with unresolved fallback review issues."
   echo "This is a workflow violation. Aborting merge."
@@ -2687,7 +2687,7 @@ if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; the
   DELETE_BRANCH_FLAG="--delete-branch"
 fi
 # shellcheck disable=SC2086
-gh pr merge "${PR_NUM}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} --force-skip-pr-bot
+gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}
 
 # --- Inline post-merge checkout (defense-in-depth for #1401) ---
 _SYNC_BRANCH="${DEFAULT_BRANCH:-}"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.969"
-weave = "0.1.969"
+csa = "0.1.970"
+weave = "0.1.970"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- fail pr-bot final merge steps immediately when `gh pr merge` exits nonzero
- only pass `--force-skip-pr-bot` when the CSA merge-guard wrapper is active
- keep PATTERN.md and workflow.toml synchronized with a regression test

## Verification

- `cargo test -p cli-sub-agent pr_bot_final_merge_fails_closed_on_gh_merge_error -- --nocapture`
- `cargo test -p cli-sub-agent pr_bot_workflow -- --nocapture`
- `cargo test -p cli-sub-agent pr_bot_pattern_and_workflow -- --nocapture`
- `cargo fmt --all -- --check`
- `just find-monolith-files`
- `git diff --cached --check`
- tier4 CSA review: PASS (`01KTTCMJS7HNNWKJ6J7D973EYZ`)

Closes #2014