### PR TITLE
fix(session): retire legacy completion markers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.970"
+version = "0.1.971"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.970"
+version = "0.1.971"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -29,9 +29,10 @@ use crate::startup_env::StartupSubtreeEnv;
 const POST_REVIEW_PR_BOT_CMD: &str = "csa plan run --sa-mode true --pattern pr-bot";
 pub(crate) use completion::{
     DaemonCompletionPacket, daemon_completion_exists, daemon_completion_result,
-    finalize_daemon_completion_if_present, load_daemon_completion_packet,
-    persist_daemon_completion_from_env, persist_daemon_completion_from_env_with_reason,
-    retire_session_from_daemon_completion, seed_daemon_session_env,
+    finalize_daemon_completion_if_present, legacy_complete_marker_is_valid,
+    load_daemon_completion_packet, persist_daemon_completion_from_env,
+    persist_daemon_completion_from_env_with_reason, retire_session_from_daemon_completion,
+    seed_daemon_session_env,
 };
 #[cfg(test)]
 pub(crate) use wait::render_wait_result_summary;
@@ -239,7 +240,8 @@ pub(crate) fn handle_session_attach_with_prompt(
         }
 
         if let Some(completion) = load_daemon_completion_packet(&session_dir)?
-            && !session_has_terminal_process(&session_dir)
+            && (completion.is_legacy_complete_marker()
+                || !session_has_terminal_process(&session_dir))
         {
             // Drain remaining stdout.
             loop {
@@ -392,6 +394,7 @@ fn clear_attach_reactivation_artifacts(session_dir: &Path) -> Result<()> {
     // The daemon will create fresh stdout.log/stderr.log/output.log at spawn.
     for path in [
         session_dir.join("daemon-completion.toml"),
+        session_dir.join(".complete"),
         session_dir.join("result.toml"),
         csa_session::contract_result_path(session_dir),
         csa_session::legacy_user_result_path(session_dir),
@@ -607,3 +610,6 @@ mod session_cmds_daemon_routing_proptest;
 #[cfg(test)]
 #[path = "session_cmds_daemon_tests.rs"]
 mod tests;
+#[cfg(test)]
+#[path = "session_cmds_daemon_2016_tests.rs"]
+mod tests_2016;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_2016_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_2016_tests.rs
@@ -1,0 +1,103 @@
+use super::*;
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+use std::process::Command;
+
+#[cfg(target_os = "linux")]
+fn read_process_start_time_ticks(pid: u32) -> u64 {
+    let stat_path = format!("/proc/{pid}/stat");
+    let content = std::fs::read_to_string(stat_path).expect("read /proc stat");
+    let close_paren = content.rfind(')').expect("stat comm terminator");
+    let after_comm = &content[close_paren + 1..];
+    let mut parts = after_comm.split_whitespace();
+    parts.next().expect("state");
+    parts.next().expect("ppid");
+    parts.next().expect("pgrp");
+    for _ in 0..16 {
+        parts.next().expect("intermediate stat field");
+    }
+    parts
+        .next()
+        .expect("starttime")
+        .parse::<u64>()
+        .expect("starttime parse")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_pid_record(pid: u32) -> String {
+    format!("{pid} {}\n", read_process_start_time_ticks(pid))
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn attach_consumes_legacy_complete_marker_even_with_live_daemon_pid() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let td = tempfile::tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = ScopedEnvVarRestore::set("HOME", td.path());
+    let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = csa_session::create_session(
+        project,
+        Some("attach-legacy-complete-marker"),
+        None,
+        Some("opencode"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = csa_session::get_session_dir(project, &session_id).expect("session dir");
+    std::fs::write(session_dir.join("stdout.log"), "").expect("write stdout log");
+    std::fs::write(session_dir.join(".complete"), "143\n").expect("write legacy marker");
+
+    let mut child = Command::new("sleep").arg("5").spawn().expect("spawn child");
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id()),
+    )
+    .expect("write daemon pid");
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
+
+    let (tx, rx) = mpsc::channel();
+    let attach_session = session_id.clone();
+    let attach_project = project.to_string_lossy().into_owned();
+    let handle = std::thread::spawn(move || {
+        let result = handle_session_attach(
+            attach_session,
+            false,
+            Some(attach_project),
+            &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
+        )
+        .map_err(|err| err.to_string());
+        let _ = tx.send(result);
+    });
+
+    let exit_code = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("attach should consume legacy .complete without waiting on daemon.pid")
+        .expect("attach result");
+    child.kill().ok();
+    let _ = child.wait();
+    handle.join().expect("attach thread join");
+    assert_eq!(exit_code, 143);
+}
+
+#[test]
+fn attach_reactivation_cleanup_removes_legacy_complete_marker() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let session_dir = td.path();
+    std::fs::write(session_dir.join(".complete"), "143\n").expect("write legacy marker");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 1\nstatus = \"failure\"\n",
+    )
+    .expect("write completion packet");
+
+    clear_attach_reactivation_artifacts(session_dir).expect("cleanup");
+
+    assert!(!session_dir.join(".complete").exists());
+    assert!(!session_dir.join("daemon-completion.toml").exists());
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_attach.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_attach.rs
@@ -254,7 +254,7 @@ pub(super) fn resolve_attach_terminal_exit(
     output_log_visible: bool,
 ) -> Result<i32> {
     if let Some(completion) = load_daemon_completion_packet(session_dir)?
-        && !session_has_terminal_process(session_dir)
+        && (completion.is_legacy_complete_marker() || !session_has_terminal_process(session_dir))
     {
         emit_failure_summary_for_empty_output(session_dir, output_streamed, output_log_visible);
         return Ok(completion.exit_code);

--- a/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
@@ -11,6 +11,7 @@ use tracing::{debug, warn};
 const DAEMON_SESSION_DIR_ENV: &str = "CSA_DAEMON_SESSION_DIR";
 const DAEMON_PROJECT_ROOT_ENV: &str = "CSA_DAEMON_PROJECT_ROOT";
 const DAEMON_COMPLETION_FILE: &str = "daemon-completion.toml";
+const LEGACY_COMPLETE_FILE: &str = ".complete";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct DaemonCompletionPacket {
@@ -34,6 +35,10 @@ impl DaemonCompletionPacket {
                 .filter(|value| !value.is_empty())
                 .map(ToOwned::to_owned),
         }
+    }
+
+    pub(crate) fn is_legacy_complete_marker(&self) -> bool {
+        self.reason.as_deref() == Some("legacy_complete_marker")
     }
 }
 
@@ -87,6 +92,11 @@ pub(crate) fn persist_daemon_completion_from_env_with_reason(exit_code: i32, rea
 
 pub(crate) fn daemon_completion_exists(session_dir: &Path) -> bool {
     daemon_completion_path(session_dir).is_file()
+        || legacy_complete_marker_path(session_dir).is_file()
+}
+
+pub(crate) fn legacy_complete_marker_is_valid(session_dir: &Path) -> bool {
+    load_legacy_complete_marker_packet(session_dir).is_ok_and(|packet| packet.is_some())
 }
 
 pub(crate) fn load_daemon_completion_packet(
@@ -94,7 +104,7 @@ pub(crate) fn load_daemon_completion_packet(
 ) -> Result<Option<DaemonCompletionPacket>> {
     let path = daemon_completion_path(session_dir);
     if !path.is_file() {
-        return Ok(None);
+        return load_legacy_complete_marker_packet(session_dir);
     }
 
     let content = fs::read_to_string(&path)?;
@@ -105,10 +115,10 @@ pub(crate) fn load_daemon_completion_packet(
 pub(crate) fn finalize_daemon_completion_if_present(
     session_dir: &Path,
 ) -> Result<Option<SessionResult>> {
-    if load_daemon_completion_packet(session_dir)?.is_none() {
+    let Some(packet) = load_daemon_completion_packet(session_dir)? else {
         return Ok(None);
-    }
-    if super::session_has_terminal_process(session_dir) {
+    };
+    if !packet.is_legacy_complete_marker() && super::session_has_terminal_process(session_dir) {
         debug!(
             path = %daemon_completion_path(session_dir).display(),
             "Ignoring daemon completion packet while session process is still live"
@@ -118,6 +128,11 @@ pub(crate) fn finalize_daemon_completion_if_present(
     let session = load_session_state_from_dir(session_dir)?;
     let project_root = PathBuf::from(&session.project_path);
     crate::session_cmds::ensure_terminal_result_for_dead_active_session(
+        &project_root,
+        &session.meta_session_id,
+        "daemon completion",
+    )?;
+    crate::session_cmds::retire_if_dead_with_result(
         &project_root,
         &session.meta_session_id,
         "daemon completion",
@@ -135,6 +150,31 @@ fn persist_daemon_completion(session_dir: &Path, packet: &DaemonCompletionPacket
 
 fn daemon_completion_path(session_dir: &Path) -> PathBuf {
     session_dir.join(DAEMON_COMPLETION_FILE)
+}
+
+fn legacy_complete_marker_path(session_dir: &Path) -> PathBuf {
+    session_dir.join(LEGACY_COMPLETE_FILE)
+}
+
+fn load_legacy_complete_marker_packet(
+    session_dir: &Path,
+) -> Result<Option<DaemonCompletionPacket>> {
+    let path = legacy_complete_marker_path(session_dir);
+    if !path.is_file() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&path)?;
+    let exit_code = content.trim().parse::<i32>().with_context(|| {
+        format!(
+            "Failed to parse legacy completion marker {} as exit code",
+            path.display()
+        )
+    })?;
+    Ok(Some(DaemonCompletionPacket::from_exit_code_and_reason(
+        exit_code,
+        Some("legacy_complete_marker"),
+    )))
 }
 
 fn resolve_daemon_session_dir_from_env() -> Option<PathBuf> {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -96,7 +96,8 @@ where
 
     loop {
         if let Some(completion) = load_daemon_completion_packet(&session_dir)?
-            && !session_has_terminal_process(&session_dir)
+            && (completion.is_legacy_complete_marker()
+                || !session_has_terminal_process(&session_dir))
         {
             let refreshed_result = refresh_result_for_wait(
                 effective_root,

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -258,7 +258,8 @@ fn dead_active_session_needs_terminal_result(
         return Ok(false);
     }
     let liveness = reconcile_liveness_decision(session_dir);
-    if liveness.blocks_synthesis {
+    let legacy_done = crate::session_cmds_daemon::legacy_complete_marker_is_valid(session_dir);
+    if liveness.blocks_synthesis && !legacy_done {
         debug!(
             session_id = %session_id,
             trigger = %trigger,
@@ -313,7 +314,8 @@ where
         return Ok(DeadActiveSessionReconciliation::NoChange);
     }
     let liveness = reconcile_liveness_decision(session_dir);
-    if liveness.blocks_synthesis {
+    let legacy_done = crate::session_cmds_daemon::legacy_complete_marker_is_valid(session_dir);
+    if liveness.blocks_synthesis && !legacy_done {
         debug!(
             session_id = %session_id,
             trigger = %trigger,
@@ -663,7 +665,8 @@ fn dead_session_with_result_needs_retire(
         return Ok(None);
     }
     let liveness = reconcile_liveness_decision(session_dir);
-    if liveness.blocks_synthesis {
+    let legacy_done = crate::session_cmds_daemon::legacy_complete_marker_is_valid(session_dir);
+    if liveness.blocks_synthesis && !legacy_done {
         debug!(
             session_id = %session_id,
             reason = %liveness.reason,
@@ -689,7 +692,8 @@ fn retire_if_dead_with_result_impl(
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(false);
     }
-    if liveness.blocks_synthesis {
+    let legacy_done = crate::session_cmds_daemon::legacy_complete_marker_is_valid(session_dir);
+    if liveness.blocks_synthesis && !legacy_done {
         debug!(
             session_id = %session_id,
             reason = %liveness.reason,

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics.rs
@@ -30,6 +30,11 @@ pub(super) fn synthetic_failure_diagnostics(
         "daemon_completion",
         &session_dir.join("daemon-completion.toml"),
     );
+    push_file_diagnostic(
+        &mut lines,
+        "legacy_complete",
+        &session_dir.join(".complete"),
+    );
     push_file_diagnostic(&mut lines, "daemon_pid", &session_dir.join("daemon.pid"));
     push_file_diagnostic(&mut lines, "output_log", &session_dir.join("output.log"));
     push_file_diagnostic(&mut lines, "stderr_log", &session_dir.join("stderr.log"));
@@ -46,6 +51,9 @@ pub(super) fn synthetic_failure_diagnostics(
 
     if let Some(packet) = read_daemon_completion_summary(session_dir) {
         lines.push(format!("daemon_completion_packet={packet}"));
+    }
+    if let Some(marker) = read_small_file_compact(&session_dir.join(".complete")) {
+        lines.push(format!("legacy_complete_marker={marker}"));
     }
     if let Some(pid_record) = read_small_file_compact(&session_dir.join("daemon.pid")) {
         lines.push(format!("daemon_pid_record={pid_record}"));

--- a/crates/cli-sub-agent/src/session_cmds_result_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tests.rs
@@ -34,6 +34,9 @@ impl Drop for EnvVarGuard {
     }
 }
 
+#[path = "session_cmds_result_tests_2016.rs"]
+mod issue_2016;
+
 // ── display_structured_output tests ───────────────────────────────
 
 #[test]

--- a/crates/cli-sub-agent/src/session_cmds_result_tests_2016.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tests_2016.rs
@@ -1,0 +1,119 @@
+use super::*;
+
+#[cfg(target_os = "linux")]
+#[test]
+fn handle_session_result_uses_legacy_complete_marker_143_even_while_daemon_alive()
+-> anyhow::Result<()> {
+    use std::process::Command;
+
+    let tmp = tempdir()?;
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = tmp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home)?;
+    let _home_guard = EnvVarGuard::set("HOME", tmp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = tmp.path();
+
+    let session = create_session(
+        project,
+        Some("result-legacy-complete-marker-live"),
+        None,
+        Some("codex"),
+    )?;
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id)?;
+    std::fs::write(session_dir.join(".complete"), "143\n")?;
+
+    let mut child = Command::new("sleep").arg("5").spawn()?;
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id())?,
+    )?;
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
+
+    handle_session_result(
+        session_id.clone(),
+        false,
+        Some(project.to_string_lossy().into_owned()),
+        StructuredOutputOpts::default(),
+    )?;
+
+    let result = load_result(project, &session_id)?
+        .expect("session result should synthesize from legacy .complete");
+    assert_eq!(result.status, "signal");
+    assert_eq!(result.exit_code, 143);
+
+    let persisted = csa_session::load_session(project, &session_id)?;
+    assert_eq!(persisted.phase, csa_session::SessionPhase::Retired);
+    assert_eq!(
+        persisted.termination_reason.as_deref(),
+        Some("legacy_complete_marker")
+    );
+
+    child.kill().ok();
+    let _ = child.wait();
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn handle_session_result_retires_existing_result_after_legacy_complete_marker_with_live_daemon_pid()
+-> anyhow::Result<()> {
+    use std::process::Command;
+
+    let tmp = tempdir()?;
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = tmp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home)?;
+    let _home_guard = EnvVarGuard::set("HOME", tmp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = tmp.path();
+
+    let session = create_session(
+        project,
+        Some("result-existing-legacy-complete-marker-live"),
+        None,
+        Some("codex"),
+    )?;
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id)?;
+    csa_session::save_result(
+        project,
+        &session_id,
+        &SessionResult {
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: "summary".to_string(),
+            tool: "codex".to_string(),
+            ..Default::default()
+        },
+    )?;
+    std::fs::write(session_dir.join(".complete"), "143\n")?;
+
+    let mut child = Command::new("sleep").arg("5").spawn()?;
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id())?,
+    )?;
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
+
+    handle_session_result(
+        session_id.clone(),
+        false,
+        Some(project.to_string_lossy().into_owned()),
+        StructuredOutputOpts::default(),
+    )?;
+
+    let result =
+        load_result(project, &session_id)?.expect("existing result should remain authoritative");
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+
+    let persisted = csa_session::load_session(project, &session_id)?;
+    assert_eq!(persisted.phase, csa_session::SessionPhase::Retired);
+    assert_eq!(persisted.termination_reason.as_deref(), Some("completed"));
+
+    child.kill().ok();
+    let _ = child.wait();
+    Ok(())
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -837,8 +837,6 @@ fn print_content_with_tail_no_panic_on_large_tail() {
     print_content_with_tail("line1\nline2\n", Some(100));
 }
 
-// ── CLI --summary/--section/--full flag parsing ───────────────────
-
 include!("session_cmds_tests_fork_tail.rs");
 
 #[path = "session_cmds_tests_daemon_pid_tail.rs"]
@@ -859,6 +857,8 @@ mod tail_tests_wait;
 mod tail_tests_wait_1951;
 #[path = "session_cmds_tests_tail_wait_2002.rs"]
 mod tail_tests_wait_2002;
+#[path = "session_cmds_tests_tail_wait_2016.rs"]
+mod tail_tests_wait_2016;
 #[path = "session_cmds_tests_tail_wait_liveness.rs"]
 mod tail_tests_wait_liveness;
 #[path = "session_cmds_tests_tail_wait_lock.rs"]

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2016.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2016.rs
@@ -1,0 +1,139 @@
+use super::*;
+use crate::test_env_lock::ScopedEnvVarRestore;
+use std::process::Command;
+
+#[cfg(target_os = "linux")]
+fn read_process_start_time_ticks(pid: u32) -> u64 {
+    let stat_path = format!("/proc/{pid}/stat");
+    let content = std::fs::read_to_string(stat_path).expect("read /proc stat");
+    let close_paren = content.rfind(')').expect("stat comm terminator");
+    let after_comm = &content[close_paren + 1..];
+    let mut parts = after_comm.split_whitespace();
+    parts.next().expect("state");
+    parts.next().expect("ppid");
+    parts.next().expect("pgrp");
+    for _ in 0..16 {
+        parts.next().expect("intermediate stat field");
+    }
+    parts
+        .next()
+        .expect("starttime")
+        .parse::<u64>()
+        .expect("starttime parse")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_pid_record(pid: u32) -> String {
+    format!("{pid} {}\n", read_process_start_time_ticks(pid))
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn handle_session_wait_retires_active_session_after_legacy_complete_marker_143_even_with_live_daemon_pid()
+ {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = ScopedEnvVarRestore::set("HOME", td.path());
+    let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-retire-legacy-complete-marker"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    let mut stale_session = load_session(project, &session_id).unwrap();
+    stale_session.last_accessed = chrono::Utc::now() - chrono::Duration::seconds(7_200);
+    save_session(&stale_session).unwrap();
+    std::fs::write(session_dir.join(".complete"), "143\n").unwrap();
+    let mut child = Command::new("sleep").arg("5").spawn().unwrap();
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id()),
+    )
+    .unwrap();
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
+
+    let exit_code = handle_session_wait(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(exit_code, 1);
+
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("wait should synthesize a terminal result from .complete");
+    assert_eq!(result.status, "signal");
+    assert_eq!(result.exit_code, 143);
+
+    let persisted = load_session(project, &session_id).unwrap();
+    assert_eq!(persisted.phase, SessionPhase::Retired);
+    assert_eq!(
+        persisted.termination_reason.as_deref(),
+        Some("legacy_complete_marker")
+    );
+
+    child.kill().ok();
+    let _ = child.wait();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn handle_session_wait_retires_existing_result_after_legacy_complete_marker_with_live_daemon_pid() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = ScopedEnvVarRestore::set("HOME", td.path());
+    let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-retire-existing-result-legacy-complete"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    save_result(project, &session_id, &make_result("success", 0)).unwrap();
+    std::fs::write(session_dir.join(".complete"), "143\n").unwrap();
+    let mut child = Command::new("sleep").arg("5").spawn().unwrap();
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id()),
+    )
+    .unwrap();
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
+
+    let exit_code = handle_session_wait(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(exit_code, 0);
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("existing result should remain authoritative");
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+
+    let persisted = load_session(project, &session_id).unwrap();
+    assert_eq!(persisted.phase, SessionPhase::Retired);
+    assert_eq!(persisted.termination_reason.as_deref(), Some("completed"));
+
+    child.kill().ok();
+    let _ = child.wait();
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.970"
-weave = "0.1.970"
+csa = "0.1.971"
+weave = "0.1.971"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Treat legacy `.complete` markers as terminal completion packets for wait/result/attach paths.
- Retire dead active sessions and sessions with existing result.toml even when stale daemon.pid still appears live.
- Remove stale `.complete` during attach reactivation cleanup.

## Verification
- cargo test -p cli-sub-agent attach_consumes_legacy_complete_marker_even_with_live_daemon_pid -- --nocapture
- cargo test -p cli-sub-agent attach_reactivation_cleanup_removes_legacy_complete_marker -- --nocapture
- cargo test -p cli-sub-agent handle_session_attach_waits_for_live_daemon_before_consuming_completion_packet -- --nocapture
- cargo test -p cli-sub-agent legacy_complete_marker -- --nocapture
- cargo fmt --all -- --check
- just find-monolith-files
- git diff --cached --check
- pre-commit hooks via git commit --amend
- CSA tier4 Codex review PASS: 01KTTHARM1BXHBQ0B020X1FBY0

Closes #2016