### PR TITLE
fix(dev2merge): keep merged-pr skip check shell-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.972"
+version = "0.1.973"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.972"
+version = "0.1.973"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -565,6 +565,10 @@ mod tests_manual_handoff;
 mod tests_workflows;
 
 #[cfg(test)]
+#[path = "plan_cmd_tests_dev2merge_2031.rs"]
+mod tests_dev2merge_2031;
+
+#[cfg(test)]
 #[path = "plan_cmd_tests_pr_bot.rs"]
 mod tests_pr_bot;
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_dev2merge_2031.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_dev2merge_2031.rs
@@ -1,0 +1,68 @@
+use std::path::{Path, PathBuf};
+use weave::compiler::plan_from_toml;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
+}
+
+fn markdown_step_section<'a>(content: &'a str, heading: &str) -> &'a str {
+    let start = content
+        .find(heading)
+        .unwrap_or_else(|| panic!("missing markdown step heading: {heading}"));
+    let rest = &content[start..];
+    let end = rest[1..]
+        .find("\n## Step ")
+        .map(|offset| offset + 1)
+        .unwrap_or(rest.len());
+    &rest[..end]
+}
+
+fn first_bash_block(content: &str) -> &str {
+    let rest = content
+        .split_once("```bash")
+        .map(|(_, rest)| rest)
+        .expect("missing bash block");
+    rest.split_once("```")
+        .map(|(block, _)| block.trim())
+        .expect("missing bash block terminator")
+}
+
+#[test]
+fn dev2merge_already_resolved_check_does_not_abort_without_merged_pr() {
+    let root = workspace_root();
+    let workflow = std::fs::read_to_string(root.join("patterns/dev2merge/workflow.toml")).unwrap();
+    let pattern = std::fs::read_to_string(root.join("patterns/dev2merge/PATTERN.md")).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+    let already_resolved_step = plan
+        .steps
+        .iter()
+        .find(|step| step.title == "Already-Resolved Check")
+        .expect("missing dev2merge already-resolved step");
+    let workflow_step_0 = first_bash_block(&already_resolved_step.prompt);
+    let pattern_step_0 = first_bash_block(markdown_step_section(
+        &pattern,
+        "## Step 0: Already-Resolved Check",
+    ));
+
+    assert_eq!(
+        pattern_step_0, workflow_step_0,
+        "dev2merge PATTERN.md and workflow.toml Step 0 bash blocks must stay synced"
+    );
+
+    for content in [workflow_step_0, pattern_step_0] {
+        assert!(
+            !content.contains(r#"[ -n "${MERGED_PR}" ] && skip"#),
+            "Step 0 must not use a set -e-sensitive short-circuit skip"
+        );
+        assert!(
+            content.contains(r#"if [ -n "${MERGED_PR}" ]; then"#),
+            "Step 0 must explicitly branch on non-empty MERGED_PR"
+        );
+        assert!(
+            content.contains(
+                r#"skip "dev2merge: branch ${BRANCH} already merged via PR #${MERGED_PR}; HEAD is ancestor of ${DEFAULT_BRANCH} — nothing to do""#,
+            ),
+            "merged-PR skip message must keep the documented nothing-to-do suffix"
+        );
+    }
+}

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -112,8 +112,8 @@ Short-circuit no-op runs before branch validation:
   the current branch.
 - Ancestor success without a merged PR means a fresh branch and continues.
 
-Runs without `--issue` skip the issue check. Any skip prints
-`dev2merge: ... nothing to do`, sets `DEV2MERGE_SKIP=true`, and exits 0.
+`--issue` absent skips issue lookup. Skips print
+`dev2merge: ... nothing to do`, set `DEV2MERGE_SKIP=true`, exit 0.
 Issue and PR lookup failures fail open.
 
 ```bash
@@ -134,13 +134,13 @@ fi
 
 BRANCH="$(git branch --show-current)"
 [ -n "${BRANCH}" ] && [ "${BRANCH}" != "HEAD" ] || exit 0
-DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || true)"
 [ -n "${DEFAULT_BRANCH}" ] || DEFAULT_BRANCH="main"
 [ -z "$(git status --porcelain)" ] || exit 0
 
 if git merge-base --is-ancestor HEAD "origin/${DEFAULT_BRANCH}" 2>/dev/null; then
   MERGED_PR="$(gh pr list --head "${BRANCH}" --state merged --json number -q '.[0].number' 2>/dev/null || true)"
-  [ -n "${MERGED_PR}" ] && skip "dev2merge: branch ${BRANCH} already merged via PR #${MERGED_PR} and HEAD is ancestor of ${DEFAULT_BRANCH} — nothing to do"
+  if [ -n "${MERGED_PR}" ]; then skip "dev2merge: branch ${BRANCH} already merged via PR #${MERGED_PR}; HEAD is ancestor of ${DEFAULT_BRANCH} — nothing to do"; fi
 fi
 ```
 

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -146,7 +146,7 @@ DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's
 
 if git merge-base --is-ancestor HEAD "origin/${DEFAULT_BRANCH}" 2>/dev/null; then
   MERGED_PR="$(gh pr list --head "${BRANCH}" --state merged --json number -q '.[0].number' 2>/dev/null || true)"
-  [ -n "${MERGED_PR}" ] && skip "dev2merge: branch ${BRANCH} already merged via PR #${MERGED_PR} and HEAD is ancestor of ${DEFAULT_BRANCH} — nothing to do"
+  if [ -n "${MERGED_PR}" ]; then skip "dev2merge: branch ${BRANCH} already merged via PR #${MERGED_PR}; HEAD is ancestor of ${DEFAULT_BRANCH} — nothing to do"; fi
 fi
 ```'''
 on_fail = "abort"

--- a/scripts/monolith/check.sh
+++ b/scripts/monolith/check.sh
@@ -243,6 +243,19 @@ line_count() {
     printf '%s\n' "$lines"
 }
 
+byte_count() {
+    local file="$1"
+    local bytes
+    if ! bytes="$(wc -c <"$file" 2>/dev/null)"; then
+        die "failed to count bytes for $file"
+    fi
+    bytes="$(printf '%s' "$bytes" | tr -d '[:space:]')"
+    case "$bytes" in
+        ''|*[!0-9]*) die "unparsable byte count for $file: $bytes" ;;
+    esac
+    printf '%s\n' "$bytes"
+}
+
 token_count() {
     local file="$1"
     local output
@@ -313,7 +326,11 @@ while IFS= read -r -d '' file; do
 
     checked=$((checked + 1))
     lines="$(line_count "$file")"
-    tokens="$(token_count "$file")"
+    bytes="$(byte_count "$file")"
+    tokens=0
+    if [ -n "${baseline_tokens[$file]+set}" ] || [ "$lines" -gt "$line_threshold" ] || [ "$bytes" -gt "$token_threshold" ]; then
+        tokens="$(token_count "$file")"
+    fi
     kind="$(classify_kind "$file")"
 
     over_limit=false

--- a/scripts/tests/monolith-check-tests.sh
+++ b/scripts/tests/monolith-check-tests.sh
@@ -277,6 +277,22 @@ test_tokenizer_unparsable_fails_closed() {
         run_checker "$repo" "$baseline" --scope all
 }
 
+test_small_unbaselined_file_skips_tokenizer() {
+    local repo bin_dir baseline
+    repo="$(new_tmp_dir)"
+    bin_dir="$(new_tmp_dir)"
+    setup_repo "$repo"
+    write_fake_csa "$bin_dir"
+    mkdir -p "$repo/src"
+    printf 'x\n' >"$repo/src/small.rs"
+    baseline="$repo/baseline.toml"
+    printf '' >"$baseline"
+    git -C "$repo" add src/small.rs
+    git -C "$repo" commit -q -m init
+
+    CSA_FAKE_FAIL=1 PATH="$bin_dir:$PATH" run_checker "$repo" "$baseline" --scope all >/dev/null
+}
+
 test_new_over_budget_test_file_hard_fails() {
     local repo bin_dir baseline
     repo="$(new_tmp_dir)"
@@ -301,6 +317,7 @@ test_empty_issue_hard_fails
 test_report_all_lists_multiple_offenders
 test_tokenizer_unavailable_fails_closed
 test_tokenizer_unparsable_fails_closed
+test_small_unbaselined_file_skips_tokenizer
 test_new_over_budget_test_file_hard_fails
 test_new_over_budget_markdown_file_hard_fails_across_scopes
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.972"
-weave = "0.1.972"
+csa = "0.1.973"
+weave = "0.1.973"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Fixes #2031 by replacing the `set -e`-sensitive merged-PR skip short-circuit with an explicit `if` branch.
- Fixes #2038 by skipping exact tokenizer startup for clearly small unbaselined files in the monolith all-scope check while preserving exact token checks for baselined, line-threshold, and byte-threshold candidates.
- Keeps `patterns/dev2merge/PATTERN.md` and `patterns/dev2merge/workflow.toml` Step 0 synchronized, including the documented `nothing to do` no-op message.
- Adds focused regression coverage for both behaviors and bumps the workspace version to `0.1.973`.

## Review
- Per-diff CSA review for #2031: PASS after fixing two reviewer findings.
- CSA review for the #2038 staged diff: PASS.
- Full current `main...HEAD` CSA review: PASS (`01KTTXAGGDXDAXQJ86WEYGA0P0`).
- Gemini was attempted for review; review fell back to Codex due Gemini quota/OAuth exhaustion.

## Test plan
- [x] `cargo test -p cli-sub-agent dev2merge_already_resolved_check_does_not_abort_without_merged_pr -- --nocapture`
- [x] `bash scripts/tests/monolith-check-tests.sh`
- [x] `scripts/monolith/check.sh --scope all --baseline scripts/monolith/baseline.toml --report-all`
- [x] `cargo fmt --all -- --check`
- [x] `just find-monolith-files`
- [x] `weave compile patterns/dev2merge/PATTERN.md`
- [x] `just pre-commit`

## Tooling follow-ups filed while working
- #2033 for a CSA Codex commit-skill `signal 143` failure.
- #2034 for `csa session wait` reporting success while `result.toml` recorded post-exec gate failure.

Closes #2031
Fixes #2038