### PR TITLE
fix(session): wait for live daemon before accepting result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.973"
+version = "0.1.974"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.973"
+version = "0.1.974"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -194,12 +194,14 @@ where
             }
         }
 
-        if let Some(result) = load_completed_daemon_result_with_fallback(
-            effective_root,
-            &resolved.session_id,
-            &session_dir,
-            is_cross_project,
-        )? {
+        if !session_has_terminal_process(&session_dir)
+            && let Some(result) = load_completed_daemon_result_with_fallback(
+                effective_root,
+                &resolved.session_id,
+                &session_dir,
+                is_cross_project,
+            )?
+        {
             let streamed_output = emit_wait_terminal_output(
                 &session_dir,
                 &resolved.session_id,

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
@@ -449,7 +449,7 @@ fn ensure_terminal_result_for_dead_active_session_preserves_session_with_recent_
 
 #[cfg(unix)]
 #[test]
-fn handle_session_wait_returns_on_terminal_result_before_daemon_exit() {
+fn handle_session_wait_defers_terminal_result_until_daemon_exit() {
     use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
 
@@ -494,19 +494,17 @@ fn handle_session_wait_returns_on_terminal_result_before_daemon_exit() {
     .unwrap();
 
     assert_eq!(exit_code, 0);
+    let status = child
+        .try_wait()
+        .unwrap()
+        .expect("terminal result.toml should wait until the live daemon exits");
+    assert!(status.success());
     assert!(
-        child.try_wait().unwrap().is_none(),
-        "terminal result.toml should complete wait before delayed daemon stdout is written"
-    );
-    assert!(
-        !std::fs::read_to_string(&stdout_path)
+        std::fs::read_to_string(&stdout_path)
             .unwrap_or_default()
             .contains("CSA:NEXT_STEP"),
-        "wait should not wait for post-result stdout once terminal result.toml exists"
+        "wait should keep polling long enough to preserve post-result daemon stdout"
     );
-
-    let status = child.wait().unwrap();
-    assert!(status.success());
 }
 
 #[cfg(unix)]

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_liveness.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_liveness.rs
@@ -127,7 +127,7 @@ fn handle_session_wait_continues_polling_when_pid_missing_but_liveness_signals_p
 
 #[cfg(target_os = "linux")]
 #[test]
-fn handle_session_wait_exits_on_terminal_result_even_when_daemon_pid_still_alive() {
+fn handle_session_wait_defers_terminal_result_while_daemon_pid_still_alive() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
@@ -192,8 +192,7 @@ fn handle_session_wait_exits_on_terminal_result_even_when_daemon_pid_still_alive
     let exit_code = wait_result.expect("wait should succeed");
     assert_eq!(exit_code, 0);
     assert_eq!(
-        emitted_completion,
-        Some((session_id, "success".to_string(), 0, false)),
-        "terminal result.toml should complete wait despite stale/live daemon liveness signals"
+        emitted_completion, None,
+        "live daemon sessions must not emit terminal completion from an intermediate result.toml"
     );
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
@@ -32,6 +32,31 @@ impl Drop for EnvVarGuard {
 }
 
 #[cfg(target_os = "linux")]
+fn read_process_start_time_ticks(pid: u32) -> u64 {
+    let stat_path = format!("/proc/{pid}/stat");
+    let content = std::fs::read_to_string(stat_path).expect("read /proc stat");
+    let close_paren = content.rfind(')').expect("stat comm terminator");
+    let after_comm = &content[close_paren + 1..];
+    let mut parts = after_comm.split_whitespace();
+    parts.next().expect("state");
+    parts.next().expect("ppid");
+    parts.next().expect("pgrp");
+    for _ in 0..16 {
+        parts.next().expect("intermediate stat field");
+    }
+    parts
+        .next()
+        .expect("starttime")
+        .parse::<u64>()
+        .expect("starttime parse")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_pid_record(pid: u32) -> String {
+    format!("{pid} {}\n", read_process_start_time_ticks(pid))
+}
+
+#[cfg(target_os = "linux")]
 #[test]
 fn handle_session_wait_completes_terminal_result_with_stale_daemon_pid() {
     let td = tempdir().unwrap();
@@ -96,6 +121,109 @@ fn handle_session_wait_completes_terminal_result_with_stale_daemon_pid() {
     assert_eq!(
         emitted_completion,
         Some((session_id, "success".to_string(), 0, false))
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn handle_session_wait_ignores_intermediate_success_result_while_daemon_pid_alive() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-intermediate-success-live-daemon"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    save_result(
+        project,
+        &session_id,
+        &SessionResult {
+            summary: "intermediate self-report success".to_string(),
+            ..make_result("success", 0)
+        },
+    )
+    .unwrap();
+
+    let mut child = std::process::Command::new("sleep")
+        .arg("0.2")
+        .spawn()
+        .unwrap();
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        format!("{} 0\n", child.id()),
+    )
+    .unwrap();
+    assert!(
+        !csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir),
+        "start-time mismatch must make daemon.pid stale"
+    );
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id()),
+    )
+    .unwrap();
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
+
+    let session_dir_for_writer = session_dir.clone();
+    let failure_result = SessionResult {
+        summary: "POST-EXEC GATE FAILED (exit=1, step=just find-monolith-files)".to_string(),
+        ..make_result("failure", 1)
+    };
+    let writer = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let encoded = toml::to_string_pretty(&failure_result).unwrap();
+        std::fs::write(session_dir_for_writer.join("result.toml"), encoded).unwrap();
+        std::fs::write(
+            session_dir_for_writer.join("daemon-completion.toml"),
+            "exit_code = 1\nstatus = \"failure\"\n",
+        )
+        .unwrap();
+    });
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let wait_result = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(5),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    );
+
+    writer.join().unwrap();
+    child.wait().ok();
+
+    let exit_code = wait_result.unwrap();
+    assert_eq!(
+        exit_code, 1,
+        "wait must not return the intermediate success while daemon gates are still running"
+    );
+    assert_eq!(
+        emitted_completion,
+        Some((session_id, "failure".to_string(), 1, false))
     );
 }
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.973"
-weave = "0.1.973"
+csa = "0.1.974"
+weave = "0.1.974"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Fix `csa session wait` so a bare `result.toml` is not accepted while the daemon process is still alive.
- Preserve stale-daemon behavior so completed sessions still resolve after liveness is gone.
- Add regression coverage for intermediate success being superseded by a final post-exec gate failure.
- Bump workspace version to `0.1.974`.

Fixes #2034.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p cli-sub-agent tail_tests`
- [x] `cargo test -p cli-sub-agent daemon_pid_tail_tests::handle_session_wait_ignores_completion_packet_while_raw_daemon_pid_is_alive`
- [x] `just pre-commit`
- [x] `csa review --range main...HEAD --sa-mode true`
