### PR TITLE
fix(cli-sub-agent): add MCP session wait guidance for Codex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.974"
+version = "0.1.975"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.974"
+version = "0.1.975"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -161,6 +161,29 @@ fn caller_hint_blocks_ignores_unrelated_mentions_in_comments() {
 }
 
 #[test]
+fn codex_yield_hint_prefers_mcp_wait_and_keeps_shell_fallback_yield() {
+    let hint = crate::process_tree::format_codex_yield_hint(450_000);
+
+    assert!(hint.contains("mcp_tool=\"csa_session_wait\""), "{hint}");
+    assert!(hint.contains("tool_timeout_sec=7200"), "{hint}");
+    assert!(hint.contains("timeout_seconds=6900"), "{hint}");
+    assert!(
+        hint.contains("outer tool_timeout_sec: 7200") && hint.contains("timeout_seconds: 6900"),
+        "{hint}"
+    );
+    assert!(
+        hint.contains("Prefer the CSA MCP tool csa_session_wait"),
+        "{hint}"
+    );
+    assert!(hint.contains("Shell fallback only"), "{hint}");
+    assert!(hint.contains("yield_time_ms: 450000"), "{hint}");
+    assert!(
+        !hint.contains("prompt-cache TTL") && !hint.contains("24h"),
+        "hint must not claim undocumented Codex cache TTLs: {hint}"
+    );
+}
+
+#[test]
 fn run_cmd_daemon_wait_hint_warns_no_stack_wakeup() {
     let blocks = caller_hint_blocks(RUN_CMD_DAEMON_SRC);
     assert_eq!(blocks.len(), 1, "run_cmd_daemon emits one CALLER_HINT");

--- a/crates/cli-sub-agent/src/mcp_server.rs
+++ b/crates/cli-sub-agent/src/mcp_server.rs
@@ -19,6 +19,9 @@ use run_tool::resolve_mcp_model_pin;
 #[cfg(test)]
 use run_tool::{direct_entry_resolved_timeout, parse_tool_name};
 
+const DEFAULT_MCP_SESSION_WAIT_TIMEOUT_SECONDS: u64 =
+    csa_config::DEFAULT_CODEX_SESSION_WAIT_MCP_INTERNAL_TIMEOUT_SEC;
+
 /// MCP server implementation
 ///
 /// Exposes CSA session management as MCP tools over JSON-RPC 2.0 stdio protocol.
@@ -141,6 +144,45 @@ fn get_tools() -> Vec<McpToolDef> {
                     "session_id": {
                         "type": "string",
                         "description": "Session ULID or prefix to delete"
+                    }
+                },
+                "required": ["session_id"]
+            }),
+        },
+        McpToolDef {
+            name: "csa_session_wait".to_string(),
+            description: "Wait for a CSA session to complete and return its terminal summary"
+                .to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session ULID or prefix to wait for"
+                    },
+                    "project_root": {
+                        "type": "string",
+                        "description": "Project root used to resolve the session (alias of cd)"
+                    },
+                    "cd": {
+                        "type": "string",
+                        "description": "Project root used to resolve the session"
+                    },
+                    "timeout_seconds": {
+                        "type": "number",
+                        "description": "Maximum wait duration before returning an alive/timeout result"
+                    },
+                    "memory_warn_mb": {
+                        "type": "number",
+                        "description": "Return early with exit code 33 if the session process tree exceeds this RSS limit"
+                    },
+                    "verbose": {
+                        "type": "boolean",
+                        "description": "Return bounded stdout.log output instead of the compact summary"
+                    },
+                    "json": {
+                        "type": "boolean",
+                        "description": "Return the compact wait summary as JSON text"
                     }
                 },
                 "required": ["session_id"]
@@ -310,6 +352,7 @@ async fn handle_tool_call(params: Option<Value>, state: &McpServerState) -> Resu
     match name {
         "csa_session_list" => handle_session_list_tool(arguments).await,
         "csa_session_delete" => handle_session_delete_tool(arguments).await,
+        "csa_session_wait" => handle_session_wait_tool(arguments).await,
         "csa_gc" => handle_gc_tool(arguments, &state.startup_env).await,
         "csa_run" => handle_run_tool(arguments, &state.startup_env).await,
         _ => anyhow::bail!("Unknown tool: {name}"),
@@ -425,6 +468,79 @@ async fn handle_session_delete_tool(args: Value) -> Result<Value> {
             }
         ]
     }))
+}
+
+async fn handle_session_wait_tool(args: Value) -> Result<Value> {
+    let session_id = args
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .context("Missing session_id argument")?
+        .to_string();
+    let cd = match (
+        optional_string_arg(&args, "cd")?,
+        optional_string_arg(&args, "project_root")?,
+    ) {
+        (Some(cd), _) => Some(cd),
+        (None, project_root) => project_root,
+    };
+    let timeout_seconds = optional_u64_arg(&args, "timeout_seconds")?
+        .filter(|seconds| *seconds > 0)
+        .unwrap_or(DEFAULT_MCP_SESSION_WAIT_TIMEOUT_SECONDS);
+    let memory_warn_mb = optional_u64_arg(&args, "memory_warn_mb")?.filter(|mb| *mb > 0);
+    let verbose = optional_bool_arg(&args, "verbose")?.unwrap_or(false);
+    let json = optional_bool_arg(&args, "json")?.unwrap_or(false);
+    let output_mode = crate::session_cmds::SessionWaitOutputMode::from_flags(verbose, json);
+
+    let wait_output = tokio::task::spawn_blocking(move || {
+        crate::session_cmds::handle_session_wait_for_mcp(
+            session_id,
+            cd,
+            timeout_seconds,
+            memory_warn_mb,
+            output_mode,
+        )
+    })
+    .await
+    .context("MCP csa_session_wait worker task failed")??;
+
+    Ok(serde_json::json!({
+        "content": [
+            {
+                "type": "text",
+                "text": wait_output.text
+            }
+        ]
+    }))
+}
+
+fn optional_string_arg(args: &Value, name: &str) -> Result<Option<String>> {
+    let Some(value) = args.get(name) else {
+        return Ok(None);
+    };
+    value
+        .as_str()
+        .map(|value| Some(value.to_string()))
+        .with_context(|| format!("{name} must be a string"))
+}
+
+fn optional_u64_arg(args: &Value, name: &str) -> Result<Option<u64>> {
+    let Some(value) = args.get(name) else {
+        return Ok(None);
+    };
+    value
+        .as_u64()
+        .map(Some)
+        .with_context(|| format!("{name} must be a positive integer"))
+}
+
+fn optional_bool_arg(args: &Value, name: &str) -> Result<Option<bool>> {
+    let Some(value) = args.get(name) else {
+        return Ok(None);
+    };
+    value
+        .as_bool()
+        .map(Some)
+        .with_context(|| format!("{name} must be a boolean"))
 }
 
 /// Handle csa_gc tool

--- a/crates/cli-sub-agent/src/mcp_server_tests.rs
+++ b/crates/cli-sub-agent/src/mcp_server_tests.rs
@@ -1,8 +1,36 @@
 use super::*;
-use csa_session::{SessionPhase, ToolState, create_session, get_session_root, save_session};
+use csa_session::{
+    SessionPhase, SessionResult, ToolState, create_session, get_session_root, save_result,
+    save_session,
+};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
+
+#[cfg(target_os = "linux")]
+fn read_process_start_time_ticks(pid: u32) -> u64 {
+    let stat_path = format!("/proc/{pid}/stat");
+    let content = std::fs::read_to_string(stat_path).expect("read /proc stat");
+    let close_paren = content.rfind(')').expect("stat comm terminator");
+    let after_comm = &content[close_paren + 1..];
+    let mut parts = after_comm.split_whitespace();
+    parts.next().expect("state");
+    parts.next().expect("ppid");
+    parts.next().expect("pgrp");
+    for _ in 0..16 {
+        parts.next().expect("intermediate stat field");
+    }
+    parts
+        .next()
+        .expect("starttime")
+        .parse::<u64>()
+        .expect("starttime parse")
+}
+
+#[cfg(target_os = "linux")]
+fn daemon_pid_record(pid: u32) -> String {
+    format!("{pid} {}\n", read_process_start_time_ticks(pid))
+}
 
 struct EnvVarGuard {
     key: &'static str,
@@ -85,7 +113,35 @@ fn seed_retired_runtime_session(project_root: &Path) -> (String, PathBuf) {
     (session.meta_session_id, runtime_dir)
 }
 
-// --- parse_tool_name tests ---
+fn seed_completed_session(
+    project_root: &Path,
+    status: &str,
+    exit_code: i32,
+    summary: &str,
+) -> String {
+    std::fs::create_dir_all(project_root).expect("create project root");
+    let mut session = create_session(project_root, Some("mcp wait test"), None, Some("codex"))
+        .expect("create session");
+    session.phase = SessionPhase::Retired;
+    save_session(&session).expect("save retired session");
+
+    let now = chrono::Utc::now();
+    save_result(
+        project_root,
+        &session.meta_session_id,
+        &SessionResult {
+            status: status.to_string(),
+            exit_code,
+            summary: summary.to_string(),
+            tool: "codex".to_string(),
+            started_at: now,
+            completed_at: now,
+            ..Default::default()
+        },
+    )
+    .expect("save result");
+    session.meta_session_id
+}
 
 #[test]
 fn mcp_parse_tool_name_all_valid_tools() {
@@ -114,16 +170,10 @@ fn mcp_parse_tool_name_empty_errors() {
     assert!(parse_tool_name("").is_err());
 }
 
-// --- get_tools tests ---
-
 #[test]
 fn get_tools_returns_expected_tool_count() {
     let tools = get_tools();
-    assert_eq!(
-        tools.len(),
-        4,
-        "Expected 4 MCP tools (session_list, session_delete, gc, run)"
-    );
+    assert_eq!(tools.len(), 5, "MCP tool count changed");
 }
 
 #[test]
@@ -195,6 +245,175 @@ fn get_tools_csa_session_delete_requires_session_id() {
             .any(|v| v.as_str() == Some("session_id")),
         "csa_session_delete must require 'session_id' parameter"
     );
+}
+
+#[test]
+fn get_tools_csa_session_wait_requires_session_id() {
+    let tools = get_tools();
+    let wait_tool = tools.iter().find(|t| t.name == "csa_session_wait").unwrap();
+    let required = wait_tool.input_schema.get("required").unwrap();
+    let required_arr = required.as_array().unwrap();
+    assert!(
+        required_arr
+            .iter()
+            .any(|v| v.as_str() == Some("session_id")),
+        "csa_session_wait must require 'session_id' parameter"
+    );
+}
+
+#[test]
+fn mcp_session_wait_default_cap_is_below_advertised_codex_tool_timeout() {
+    assert_eq!(DEFAULT_MCP_SESSION_WAIT_TIMEOUT_SECONDS, 6_900);
+    assert!(
+        DEFAULT_MCP_SESSION_WAIT_TIMEOUT_SECONDS
+            < csa_config::DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC
+    );
+}
+
+#[tokio::test]
+async fn mcp_session_wait_returns_nonzero_session_result_without_mcp_error() {
+    let tmp = tempdir().expect("tempdir");
+    let _sandbox = crate::test_session_sandbox::ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path().join("project");
+    let session_id =
+        seed_completed_session(&project_root, "failure", 42, "focused test command failed");
+    let _cwd_guard = CurrentDirGuard::set(&project_root);
+    let state = McpServerState {
+        startup_env: crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV.clone(),
+    };
+
+    let response = handle_tool_call(
+        Some(serde_json::json!({
+            "name": "csa_session_wait",
+            "arguments": {
+                "session_id": session_id,
+                "timeout_seconds": 1
+            }
+        })),
+        &state,
+    )
+    .await
+    .expect("wait failure response");
+
+    let text = response
+        .get("content")
+        .and_then(|content| content.get(0))
+        .and_then(|entry| entry.get("text"))
+        .and_then(|text| text.as_str())
+        .expect("response text");
+    assert!(text.contains("Status: failure"), "{text}");
+    assert!(text.contains("Exit code: 42"), "{text}");
+    assert!(
+        text.contains("Summary: focused test command failed"),
+        "{text}"
+    );
+    assert!(text.contains("MCP csa_session_wait exit_code=1"), "{text}");
+}
+
+#[tokio::test]
+async fn mcp_session_wait_json_returns_parseable_document_with_wait_exit_code() {
+    let tmp = tempdir().expect("tempdir");
+    let _sandbox = crate::test_session_sandbox::ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path().join("project");
+    let session_id =
+        seed_completed_session(&project_root, "failure", 42, "focused test command failed");
+    let _cwd_guard = CurrentDirGuard::set(&project_root);
+    let state = McpServerState {
+        startup_env: crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV.clone(),
+    };
+
+    let response = handle_tool_call(
+        Some(serde_json::json!({
+            "name": "csa_session_wait",
+            "arguments": {
+                "session_id": session_id,
+                "timeout_seconds": 1,
+                "json": true
+            }
+        })),
+        &state,
+    )
+    .await
+    .expect("wait JSON response");
+
+    let text = response
+        .get("content")
+        .and_then(|content| content.get(0))
+        .and_then(|entry| entry.get("text"))
+        .and_then(|text| text.as_str())
+        .expect("response text");
+    let parsed: serde_json::Value = serde_json::from_str(text).expect("valid wait JSON");
+    assert_eq!(parsed["exit_code"], serde_json::json!(42));
+    assert_eq!(parsed["mcp_wait_exit_code"], serde_json::json!(1));
+    assert!(!text.contains("MCP csa_session_wait exit_code="), "{text}");
+    assert!(!text.contains("CSA:SESSION_WAIT_COMPLETED"), "{text}");
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn mcp_session_wait_alive_at_timeout_returns_rewait_content() {
+    let tmp = tempdir().expect("tempdir");
+    let _sandbox = crate::test_session_sandbox::ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path().join("project");
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    let session = create_session(
+        &project_root,
+        Some("mcp wait alive timeout test"),
+        None,
+        Some("codex"),
+    )
+    .expect("create active session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_root(&project_root)
+        .expect("session root")
+        .join("sessions")
+        .join(&session_id);
+    let mut child = std::process::Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("spawn child");
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id()),
+    )
+    .expect("write daemon pid");
+    assert!(
+        csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir),
+        "daemon should be live"
+    );
+
+    let _cwd_guard = CurrentDirGuard::set(&project_root);
+    let state = McpServerState {
+        startup_env: crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV.clone(),
+    };
+
+    let response = handle_tool_call(
+        Some(serde_json::json!({
+            "name": "csa_session_wait",
+            "arguments": {
+                "session_id": session_id,
+                "timeout_seconds": 1
+            }
+        })),
+        &state,
+    )
+    .await
+    .expect("wait alive response");
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    let text = response
+        .get("content")
+        .and_then(|content| content.get(0))
+        .and_then(|entry| entry.get("text"))
+        .and_then(|text| text.as_str())
+        .expect("response text");
+    assert!(text.contains("status=alive"), "{text}");
+    assert!(text.contains("action=re-wait"), "{text}");
+    assert!(text.contains("Call csa_session_wait again"), "{text}");
+    assert!(text.contains("MCP csa_session_wait exit_code=0"), "{text}");
+    assert!(!text.contains("CSA:SESSION_WAIT_COMPLETED"), "{text}");
 }
 
 #[tokio::test]
@@ -434,8 +653,6 @@ fn direct_entry_resolved_timeout_preserves_pipeline_semantics() {
     );
 }
 
-// --- JSON-RPC protocol structure tests ---
-
 #[test]
 fn jsonrpc_request_parses_valid_initialize() {
     let json = r#"{"jsonrpc":"2.0","method":"initialize","id":1}"#;
@@ -502,7 +719,6 @@ fn jsonrpc_response_omits_null_fields() {
         id: None,
     };
     let json_str = serde_json::to_string(&response).unwrap();
-    // Neither result nor error should appear thanks to skip_serializing_if
     assert!(!json_str.contains("\"result\""));
     assert!(!json_str.contains("\"error\""));
 }

--- a/crates/cli-sub-agent/src/process_tree.rs
+++ b/crates/cli-sub-agent/src/process_tree.rs
@@ -79,15 +79,19 @@ pub(crate) fn codex_yield_hint() -> String {
 }
 
 pub(crate) fn format_codex_yield_hint(yield_time_ms: u64) -> String {
+    let mcp_tool_timeout_sec = csa_config::DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC;
+    let mcp_internal_timeout_sec = csa_config::DEFAULT_CODEX_SESSION_WAIT_MCP_INTERNAL_TIMEOUT_SEC;
     format!(
-        "\n<!-- CSA:CODEX_HINT yield_time_ms={ms} \
-         rule=\"You are running inside Codex. When calling 'csa session wait', \
-         pass yield_time_ms: {ms}. The default 300000 ms (5 minutes) is a conservative \
-         OpenAI in-memory prompt-cache TTL tradeoff: short high-frequency polling wastes \
-         tokens, while overly long waits can let the caller cache go cold. Do not manually \
-         poll every 10-30s; use this interval unless there is a concrete failure signal. \
-         Example tool call: shell({{ command: 'csa session wait --session <ID> --cd <PATH>', yield_time_ms: {ms} }})\" -->",
+        "\n<!-- CSA:CODEX_HINT mcp_tool=\"csa_session_wait\" tool_timeout_sec={mcp_tool_timeout_sec} timeout_seconds={mcp_internal_timeout_sec} yield_time_ms={ms} \
+         rule=\"You are running inside Codex. Prefer the CSA MCP tool csa_session_wait with outer tool_timeout_sec: {mcp_tool_timeout_sec} \
+         and csa_session_wait timeout_seconds: {mcp_internal_timeout_sec}; it blocks inside the MCP server and avoids repeated shell wakeups. \
+         Shell fallback only: call csa session wait in one shell tool call with yield_time_ms: {ms}. \
+         Do not manually poll every 10-30s or reissue shell waits while a wait is already running. \
+         Example MCP tool call: csa_session_wait({{ session_id: '<ID>', cd: '<PATH>', timeout_seconds: {mcp_internal_timeout_sec} }}) with outer tool_timeout_sec: {mcp_tool_timeout_sec}. \
+         Example shell fallback: shell({{ command: 'csa session wait --session <ID> --cd <PATH>', yield_time_ms: {ms} }})\" -->",
         ms = yield_time_ms,
+        mcp_tool_timeout_sec = mcp_tool_timeout_sec,
+        mcp_internal_timeout_sec = mcp_internal_timeout_sec,
     )
 }
 
@@ -336,28 +340,34 @@ mod tests {
     }
 
     #[test]
-    fn test_format_codex_yield_hint_describes_cache_tradeoff_and_polling_interval() {
+    fn test_format_codex_yield_hint_prefers_mcp_wait_with_shell_fallback() {
         let hint = format_codex_yield_hint(csa_config::DEFAULT_CODEX_SESSION_WAIT_YIELD_MS);
 
         assert!(hint.contains("CSA:CODEX_HINT"));
+        assert!(hint.contains("mcp_tool=\"csa_session_wait\""));
+        assert!(hint.contains("tool_timeout_sec=7200"));
+        assert!(hint.contains("timeout_seconds=6900"));
+        assert!(hint.contains("outer tool_timeout_sec: 7200"));
+        assert!(hint.contains("timeout_seconds: 6900"));
         assert!(hint.contains("yield_time_ms=300000"));
         assert!(hint.contains("yield_time_ms: 300000"));
-        assert!(hint.contains("default 300000 ms (5 minutes)"));
-        assert!(hint.contains("OpenAI in-memory prompt-cache TTL tradeoff"));
-        assert!(hint.contains("short high-frequency polling wastes"));
-        assert!(hint.contains("caller cache go cold"));
+        assert!(hint.contains("Prefer the CSA MCP tool csa_session_wait"));
+        assert!(hint.contains("avoids repeated shell wakeups"));
+        assert!(hint.contains("Shell fallback only"));
         assert!(hint.contains("Do not manually poll every"));
         assert!(hint.contains("10-30s"));
-        assert!(hint.contains("unless there is a concrete failure signal"));
     }
 
     #[test]
     fn test_format_codex_yield_hint_uses_configured_interval() {
         let hint = format_codex_yield_hint(450_000);
 
+        assert!(hint.contains("mcp_tool=\"csa_session_wait\""));
+        assert!(hint.contains("tool_timeout_sec=7200"));
+        assert!(hint.contains("timeout_seconds=6900"));
         assert!(hint.contains("yield_time_ms=450000"));
         assert!(hint.contains("yield_time_ms: 450000"));
-        assert!(hint.contains("default 300000 ms (5 minutes)"));
+        assert!(hint.contains("Shell fallback only"));
     }
 
     /// Verify that every `Executor::runtime_binary_name()` value is recognized

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -584,7 +584,7 @@ pub(crate) fn handle_session_checkpoints(cd: Option<String>) -> Result<()> {
 pub(crate) use crate::session_cmds_daemon::handle_session_wait;
 pub(crate) use crate::session_cmds_daemon::{
     SessionWaitOutputMode, handle_session_attach, handle_session_attach_with_prompt,
-    handle_session_kill, handle_session_wait_with_options,
+    handle_session_kill, handle_session_wait_for_mcp, handle_session_wait_with_options,
 };
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -45,7 +45,9 @@ pub(crate) use wait::{
     handle_session_wait_with_hooks_and_sampler, synthesized_wait_next_step,
     try_acquire_session_wait_lock,
 };
-pub(crate) use wait::{SessionWaitOutputMode, handle_session_wait_with_options};
+pub(crate) use wait::{
+    SessionWaitOutputMode, handle_session_wait_for_mcp, handle_session_wait_with_options,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AttachPrimaryOutput {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -1,6 +1,7 @@
 use super::*;
 use chrono::Utc;
 use csa_config::GlobalConfig;
+use std::cell::RefCell;
 use std::time::{Duration, Instant, SystemTime};
 
 #[path = "session_cmds_daemon_wait_completion.rs"]
@@ -28,13 +29,19 @@ use result_loader::{
     load_completed_daemon_result_with_fallback, refresh_result_for_wait,
     suppress_pending_tier_failover_result,
 };
-use summary::emit_wait_terminal_output;
 #[cfg(test)]
 pub(crate) use summary::render_wait_result_summary;
+use summary::{emit_wait_terminal_output, render_wait_terminal_output};
 use types::WaitExecutionOptions;
 #[cfg(test)]
 pub(crate) use types::WaitLoopTiming;
 pub(crate) use types::{SessionWaitOutputMode, WaitBehavior, WaitReconciliationOutcome};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionWaitMcpOutput {
+    pub(crate) exit_code: i32,
+    pub(crate) text: String,
+}
 
 /// Wait for a daemon session to reach a terminal result.
 /// Exits 0 on session success, 1 on terminal session failure, 124 when the
@@ -89,6 +96,159 @@ pub(crate) fn handle_session_wait_with_options(
         },
         emit_wait_completion_signal,
     )
+}
+
+pub(crate) fn handle_session_wait_for_mcp(
+    session: String,
+    cd: Option<String>,
+    wait_timeout_secs: u64,
+    memory_warn_mb: Option<u64>,
+    output_mode: SessionWaitOutputMode,
+) -> Result<SessionWaitMcpOutput> {
+    let compact_json = output_mode == SessionWaitOutputMode::CompactJson;
+    let mut cached_memory_sampler: Option<csa_session::SessionTreeMemorySampler> = None;
+    let session_arg = session.clone();
+    let text = RefCell::new(String::new());
+    let exit_code = core::handle_session_wait_with_emitters(
+        session,
+        cd,
+        WaitExecutionOptions {
+            behavior: WaitBehavior::new(wait_timeout_secs, memory_warn_mb),
+            output_mode,
+        },
+        core::WaitEmitters {
+            reconcile_dead_active_session: Box::new(|project_root, session_id, trigger| {
+                let reconciled =
+                    crate::session_cmds::ensure_terminal_result_for_dead_active_session(
+                        project_root,
+                        session_id,
+                        trigger,
+                    )?;
+                Ok(WaitReconciliationOutcome {
+                    result_became_available: reconciled.result_became_available(),
+                    synthetic: reconciled.synthesized_failure(),
+                })
+            }),
+            emit_completion_signal: Box::new(
+                |session_id, status, exit_code, synthetic, _mirror_to_stdout| {
+                    if compact_json {
+                        return;
+                    }
+                    append_mcp_wait_line(
+                        &mut text.borrow_mut(),
+                        format!(
+                            "<!-- CSA:SESSION_WAIT_COMPLETED session={session_id} status={status} exit={exit_code} synthetic={synthetic} -->"
+                        ),
+                    );
+                },
+            ),
+            sample_session_tree_rss_mb: Box::new(|project_root, session_id| {
+                if cached_memory_sampler.is_none() {
+                    cached_memory_sampler = Some(csa_session::SessionTreeMemorySampler::new(
+                        project_root,
+                        session_id,
+                    )?);
+                }
+                cached_memory_sampler
+                    .as_ref()
+                    .expect("cached sampler initialized above")
+                    .sample_rss_mb()
+            }),
+            emit_memory_warn_marker: Box::new(|session_id, rss_mb, limit_mb| {
+                append_mcp_wait_line(
+                    &mut text.borrow_mut(),
+                    format!(
+                        "<!-- CSA:MEMORY_WARN session={session_id} rss_mb={rss_mb} limit_mb={limit_mb} -->"
+                    ),
+                );
+            }),
+            emit_terminal_output: Box::new(|session_dir, session_id, result, mode| {
+                let Some(rendered) =
+                    render_wait_terminal_output(session_dir, session_id, result, mode)?
+                else {
+                    return Ok(false);
+                };
+                append_mcp_wait_line(&mut text.borrow_mut(), rendered);
+                Ok(true)
+            }),
+            emit_next_step: Box::new(|session_dir| {
+                if compact_json {
+                    return Ok(());
+                }
+                if let Some(directive) = synthesized_wait_next_step(session_dir)? {
+                    append_mcp_wait_line(&mut text.borrow_mut(), directive);
+                }
+                Ok(())
+            }),
+        },
+    )?;
+
+    let mut text = text.into_inner();
+    if compact_json && inject_mcp_wait_exit_code_into_json(&mut text, exit_code)? {
+        return Ok(SessionWaitMcpOutput { exit_code, text });
+    }
+    append_mcp_wait_nonterminal_status_if_needed(
+        &mut text,
+        &session_arg,
+        wait_timeout_secs,
+        exit_code,
+    );
+    append_mcp_wait_line(
+        &mut text,
+        format!("MCP csa_session_wait exit_code={exit_code}"),
+    );
+    Ok(SessionWaitMcpOutput { exit_code, text })
+}
+
+fn inject_mcp_wait_exit_code_into_json(text: &mut String, exit_code: i32) -> Result<bool> {
+    let Ok(mut value) = serde_json::from_str::<serde_json::Value>(text.trim()) else {
+        return Ok(false);
+    };
+    let Some(object) = value.as_object_mut() else {
+        return Ok(false);
+    };
+    object.insert(
+        "mcp_wait_exit_code".to_string(),
+        serde_json::Value::from(exit_code),
+    );
+    *text = serde_json::to_string_pretty(&value)?;
+    Ok(true)
+}
+
+fn append_mcp_wait_nonterminal_status_if_needed(
+    text: &mut String,
+    session: &str,
+    wait_timeout_secs: u64,
+    exit_code: i32,
+) {
+    if text.contains("CSA:SESSION_WAIT_COMPLETED") || text.contains("CSA:MEMORY_WARN") {
+        return;
+    }
+
+    let status_line = if exit_code == completion::SESSION_WAIT_KV_WARM_EXIT_CODE {
+        format!(
+            "MCP csa_session_wait status=alive session_arg={session} timeout_seconds={wait_timeout_secs} action=re-wait; no terminal result yet. Call csa_session_wait again with a long tool_timeout_sec."
+        )
+    } else if exit_code == completion::SESSION_WAIT_TIMEOUT_EXIT_CODE {
+        format!(
+            "MCP csa_session_wait status=timeout session_arg={session} timeout_seconds={wait_timeout_secs}; no live daemon process or terminal result was available. Run csa session result for diagnostics."
+        )
+    } else {
+        format!(
+            "MCP csa_session_wait status=failed session_arg={session} exit_code={exit_code}; no terminal summary was emitted. Another wait may be active, or the session may need csa session result diagnostics."
+        )
+    };
+    append_mcp_wait_line(text, status_line);
+}
+
+fn append_mcp_wait_line(text: &mut String, line: impl AsRef<str>) {
+    if !text.is_empty() && !text.ends_with('\n') {
+        text.push('\n');
+    }
+    text.push_str(line.as_ref());
+    if !text.ends_with('\n') {
+        text.push('\n');
+    }
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -25,6 +25,31 @@ use crate::session_cmds_daemon::{
     load_daemon_completion_packet, session_has_terminal_process,
 };
 
+type ReconcileEmitter<'a> =
+    Box<dyn FnMut(&Path, &str, &str) -> Result<WaitReconciliationOutcome> + 'a>;
+type CompletionSignalEmitter<'a> = Box<dyn FnMut(&str, &str, i32, bool, bool) + 'a>;
+type MemorySampler<'a> = Box<dyn FnMut(&Path, &str) -> std::io::Result<u64> + 'a>;
+type MemoryWarnEmitter<'a> = Box<dyn FnMut(&str, u64, u64) + 'a>;
+type TerminalOutputEmitter<'a> = Box<
+    dyn FnMut(
+            &Path,
+            &str,
+            Option<&csa_session::SessionResult>,
+            super::SessionWaitOutputMode,
+        ) -> Result<bool>
+        + 'a,
+>;
+type NextStepEmitter<'a> = Box<dyn FnMut(&Path) -> Result<()> + 'a>;
+
+pub(crate) struct WaitEmitters<'a> {
+    pub(crate) reconcile_dead_active_session: ReconcileEmitter<'a>,
+    pub(crate) emit_completion_signal: CompletionSignalEmitter<'a>,
+    pub(crate) sample_session_tree_rss_mb: MemorySampler<'a>,
+    pub(crate) emit_memory_warn_marker: MemoryWarnEmitter<'a>,
+    pub(crate) emit_terminal_output: TerminalOutputEmitter<'a>,
+    pub(crate) emit_next_step: NextStepEmitter<'a>,
+}
+
 /// Core polling loop implementation for session wait.
 ///
 /// Handles lock acquisition, session resolution, completion detection,
@@ -39,11 +64,32 @@ pub(crate) fn handle_session_wait_with_hooks_and_sampler_output_mode<R, E, S, M>
     mut emit_memory_warn_marker: M,
 ) -> Result<i32>
 where
-    R: FnMut(&Path, &str, &str) -> Result<WaitReconciliationOutcome>,
-    E: FnMut(&str, &str, i32, bool, bool),
-    S: FnMut(&Path, &str) -> std::io::Result<u64>,
-    M: FnMut(&str, u64, u64),
+    R: for<'a, 'b, 'c> FnMut(&'a Path, &'b str, &'c str) -> Result<WaitReconciliationOutcome>,
+    E: for<'a, 'b> FnMut(&'a str, &'b str, i32, bool, bool),
+    S: for<'a, 'b> FnMut(&'a Path, &'b str) -> std::io::Result<u64>,
+    M: for<'a> FnMut(&'a str, u64, u64),
 {
+    handle_session_wait_with_emitters(
+        session,
+        cd,
+        wait_options,
+        WaitEmitters {
+            reconcile_dead_active_session: Box::new(&mut reconcile_dead_active_session),
+            emit_completion_signal: Box::new(&mut emit_completion_signal),
+            sample_session_tree_rss_mb: Box::new(&mut sample_session_tree_rss_mb),
+            emit_memory_warn_marker: Box::new(&mut emit_memory_warn_marker),
+            emit_terminal_output: Box::new(emit_wait_terminal_output),
+            emit_next_step: Box::new(super::emit_wait_next_step_if_needed),
+        },
+    )
+}
+
+pub(crate) fn handle_session_wait_with_emitters(
+    session: String,
+    cd: Option<String>,
+    wait_options: WaitExecutionOptions,
+    mut emitters: WaitEmitters<'_>,
+) -> Result<i32> {
     let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
     let resolved = resolve_session_prefix_with_global_fallback(&project_root, &session)?;
     // For cross-project sessions, derive session_dir from the resolved sessions_dir
@@ -137,7 +183,7 @@ where
                         )
                     });
                 if loaded_result.is_none() {
-                    let reconciled = reconcile_dead_active_session(
+                    let reconciled = (emitters.reconcile_dead_active_session)(
                         effective_root,
                         &resolved.session_id,
                         "session wait",
@@ -154,17 +200,17 @@ where
                 }
             }
             if let Some(result) = loaded_result {
-                let streamed_output = emit_wait_terminal_output(
+                let streamed_output = (emitters.emit_terminal_output)(
                     &session_dir,
                     &resolved.session_id,
                     Some(&result),
                     wait_options.output_mode,
                 )?;
-                super::emit_wait_next_step_if_needed(&session_dir)?;
+                (emitters.emit_next_step)(&session_dir)?;
                 #[rustfmt::skip]
                 let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(completion.status.as_str(), completion.exit_code, synthetic, Some(&result));
                 emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
-                emit_completion_signal(
+                (emitters.emit_completion_signal)(
                     &resolved.session_id,
                     completion_status.as_ref(),
                     exit_code,
@@ -202,17 +248,17 @@ where
                 is_cross_project,
             )?
         {
-            let streamed_output = emit_wait_terminal_output(
+            let streamed_output = (emitters.emit_terminal_output)(
                 &session_dir,
                 &resolved.session_id,
                 Some(&result),
                 wait_options.output_mode,
             )?;
-            super::emit_wait_next_step_if_needed(&session_dir)?;
+            (emitters.emit_next_step)(&session_dir)?;
             #[rustfmt::skip]
             let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, false, Some(&result));
             emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
-            emit_completion_signal(
+            (emitters.emit_completion_signal)(
                 &resolved.session_id,
                 completion_status.as_ref(),
                 exit_code,
@@ -223,8 +269,11 @@ where
         }
 
         // Synthesize terminal result for dead Active sessions.
-        let reconciled =
-            reconcile_dead_active_session(effective_root, &resolved.session_id, "session wait")?;
+        let reconciled = (emitters.reconcile_dead_active_session)(
+            effective_root,
+            &resolved.session_id,
+            "session wait",
+        )?;
         if reconciled.result_became_available
             && let Some(result) = load_completed_daemon_result_with_fallback(
                 effective_root,
@@ -233,17 +282,17 @@ where
                 is_cross_project,
             )?
         {
-            let streamed_output = emit_wait_terminal_output(
+            let streamed_output = (emitters.emit_terminal_output)(
                 &session_dir,
                 &resolved.session_id,
                 Some(&result),
                 wait_options.output_mode,
             )?;
-            super::emit_wait_next_step_if_needed(&session_dir)?;
+            (emitters.emit_next_step)(&session_dir)?;
             #[rustfmt::skip]
             let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, reconciled.synthetic, Some(&result));
             emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
-            emit_completion_signal(
+            (emitters.emit_completion_signal)(
                 &resolved.session_id,
                 completion_status.as_ref(),
                 exit_code,
@@ -266,17 +315,17 @@ where
                 &session_dir,
                 is_cross_project,
             )? {
-                let streamed_output = emit_wait_terminal_output(
+                let streamed_output = (emitters.emit_terminal_output)(
                     &session_dir,
                     &resolved.session_id,
                     Some(&result),
                     wait_options.output_mode,
                 )?;
-                super::emit_wait_next_step_if_needed(&session_dir)?;
+                (emitters.emit_next_step)(&session_dir)?;
                 #[rustfmt::skip]
                 let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, false, Some(&result));
                 emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
-                emit_completion_signal(
+                (emitters.emit_completion_signal)(
                     &resolved.session_id,
                     completion_status.as_ref(),
                     exit_code,
@@ -305,10 +354,14 @@ where
         if let (Some(limit_mb), Some(sample_at)) = (memory_warn_mb, next_memory_sample_at)
             && std::time::Instant::now() >= sample_at
         {
-            match sample_session_tree_rss_mb(effective_root, &resolved.session_id) {
+            match (emitters.sample_session_tree_rss_mb)(effective_root, &resolved.session_id) {
                 Ok(actual_rss_mb) => {
                     if actual_rss_mb > limit_mb {
-                        emit_memory_warn_marker(&resolved.session_id, actual_rss_mb, limit_mb);
+                        (emitters.emit_memory_warn_marker)(
+                            &resolved.session_id,
+                            actual_rss_mb,
+                            limit_mb,
+                        );
                         return Ok(SESSION_WAIT_MEMORY_WARN_EXIT_CODE);
                     }
                     next_memory_sample_at = Some(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -32,6 +32,45 @@ fn stream_wait_output(session_dir: &Path) -> Result<bool> {
     Ok(bytes > 0)
 }
 
+pub(crate) fn render_wait_terminal_output(
+    session_dir: &Path,
+    session_id: &str,
+    result: Option<&csa_session::SessionResult>,
+    output_mode: SessionWaitOutputMode,
+) -> Result<Option<String>> {
+    if output_mode == SessionWaitOutputMode::Verbose {
+        let stdout_log = session_dir.join("stdout.log");
+        if !stdout_log.is_file() {
+            return Ok(None);
+        }
+        let log = read_wait_output_log(&stdout_log)?;
+        let Some(rendered) = render_wait_output_log(&log.raw, log.truncated) else {
+            return Ok(None);
+        };
+        if log.truncated {
+            return Ok(Some(format!(
+                "[csa] stdout.log exceeded {WAIT_OUTPUT_MAX_BYTES} bytes; showing bounded tail output\n{rendered}"
+            )));
+        }
+        return Ok(Some(rendered));
+    }
+
+    let Some(result) = result else {
+        return Ok(None);
+    };
+
+    let rendered = match output_mode {
+        SessionWaitOutputMode::CompactText => {
+            render_wait_result_summary(session_dir, session_id, result)
+        }
+        SessionWaitOutputMode::CompactJson => {
+            render_wait_result_json(session_dir, session_id, result)?
+        }
+        SessionWaitOutputMode::Verbose => unreachable!("handled above"),
+    };
+    Ok(Some(rendered))
+}
+
 pub(super) fn emit_wait_terminal_output(
     session_dir: &Path,
     session_id: &str,

--- a/crates/csa-config/src/global_caller_hints.rs
+++ b/crates/csa-config/src/global_caller_hints.rs
@@ -8,6 +8,14 @@ use crate::paths;
 
 /// Default Codex shell `yield_time_ms` recommended for `csa session wait`.
 pub const DEFAULT_CODEX_SESSION_WAIT_YIELD_MS: u64 = 300_000;
+/// Default Codex MCP tool timeout to recommend for `csa_session_wait`.
+pub const DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC: u64 = 7_200;
+/// Default internal MCP `csa_session_wait.timeout_seconds` cap.
+///
+/// This must stay below `DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC` so
+/// the server can return an alive/re-wait result before the caller's MCP tool
+/// deadline cancels the request.
+pub const DEFAULT_CODEX_SESSION_WAIT_MCP_INTERNAL_TIMEOUT_SEC: u64 = 6_900;
 
 /// Configuration for hints emitted to parent tool callers.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/csa-config/src/global_caller_hints_tests.rs
+++ b/crates/csa-config/src/global_caller_hints_tests.rs
@@ -14,6 +14,12 @@ fn test_caller_hints_defaults_parse_when_section_omitted() {
         config.caller_hints.codex_session_wait_yield_ms,
         DEFAULT_CODEX_SESSION_WAIT_YIELD_MS
     );
+    assert_eq!(DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC, 7_200);
+    assert_eq!(DEFAULT_CODEX_SESSION_WAIT_MCP_INTERNAL_TIMEOUT_SEC, 6_900);
+    assert!(
+        DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC
+            > DEFAULT_CODEX_SESSION_WAIT_MCP_INTERNAL_TIMEOUT_SEC
+    );
 }
 
 #[test]

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -108,8 +108,9 @@ frequent_poll_seconds = 60
 long_poll_seconds = 240
 
 # Parent-tool caller hints.
-# Codex shell calls should pass this `yield_time_ms` for `csa session wait`.
-# The default 300000 ms (5 minutes) is conservative for OpenAI in-memory prompt-cache TTL retention.
+# Codex callers should prefer the CSA MCP `csa_session_wait` tool with a long
+# tool timeout (default hint: 7200 seconds). This shell yield is kept for
+# fallback `csa session wait` calls when MCP is unavailable.
 # [caller_hints]
 # codex_session_wait_yield_ms = 300000
 

--- a/crates/csa-config/src/lib.rs
+++ b/crates/csa-config/src/lib.rs
@@ -51,7 +51,10 @@ pub use global::{
     ReviewConfig, SessionWaitConfig, StateDirConfig, StateDirOnExceed, TierPolicyConfig,
     ToolSelection,
 };
-pub use global_caller_hints::{CallerHintsConfig, DEFAULT_CODEX_SESSION_WAIT_YIELD_MS};
+pub use global_caller_hints::{
+    CallerHintsConfig, DEFAULT_CODEX_SESSION_WAIT_MCP_INTERNAL_TIMEOUT_SEC,
+    DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC, DEFAULT_CODEX_SESSION_WAIT_YIELD_MS,
+};
 pub use init::{detect_installed_tools, init_project};
 pub use mcp::{McpFilter, McpRegistry, McpServerConfig, McpTransport};
 pub use memory::{MemoryBackend, MemoryConfig, MemoryEphemeralConfig, MemoryLlmConfig};


### PR DESCRIPTION
## Summary

- Add MCP `csa_session_wait` so Codex callers can wait through MCP instead of repeated shell polling.
- Keep MCP internal wait timeout below the advertised outer Codex tool timeout and return re-wait guidance for alive sessions.
- Preserve parseable JSON output with explicit `mcp_wait_exit_code`, and keep shell wait guidance as fallback.

Closes #1991

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `just find-monolith-files`
- [x] `cargo test -p cli-sub-agent mcp_server::tests:: -- --nocapture`
- [x] `csa review --sa-mode true --tier tier-4-critical --tool gemini-cli --diff --timeout 7200 --no-daemon` (fell back to Codex due Gemini quota)
- [x] `csa review --sa-mode true --tier tier-4-critical --tool gemini-cli --range main...HEAD --timeout 7200 --no-daemon` (fell back to Codex due Gemini quota)
- [x] pre-commit hook / `just pre-commit-fast` during commit
