### PR TITLE
fix(pr-bot): derive default PR title

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.975"
+version = "0.1.976"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.975"
+version = "0.1.976"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -234,6 +234,32 @@ fi
 set -euo pipefail
 PR_WAS_EXISTING=false
 
+derive_default_pr_title() {
+  local branch_title title
+  title="$(git log -1 --pretty=%s 2>/dev/null || true)"
+  title="$(printf '%s\n' "${title}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | sed -n '1p')"
+  if [ -n "${title}" ]; then
+    printf '%s\n' "${title}"
+    return 0
+  fi
+
+  branch_title="$(
+    printf '%s\n' "${WORKFLOW_BRANCH}" \
+      | sed -E 's#[-/_]+# #g; s#[[:space:]]+# #g; s#^[[:space:]]+##; s#[[:space:]]+$##' \
+      | sed -n '1p'
+  )"
+  if [ -z "${branch_title}" ]; then
+    branch_title="Update ${WORKFLOW_BRANCH}"
+  fi
+  printf '%s\n' "${branch_title}" | awk '{ print toupper(substr($0, 1, 1)) substr($0, 2) }'
+}
+
+PR_TITLE="${PR_TITLE:-}"
+if [ -z "${PR_TITLE}" ]; then
+  PR_TITLE="$(derive_default_pr_title)"
+  echo "INFO: PR_TITLE unset; using derived title: ${PR_TITLE}" >&2
+fi
+
 # --- Early-push detection: warn if branch was already pushed before review ---
 if git ls-remote --heads "${REMOTE_NAME}" "${WORKFLOW_BRANCH}" 2>/dev/null | grep -q .; then
   echo "WARNING: Branch '${WORKFLOW_BRANCH}' was already pushed to remote before this skill ran."
@@ -423,6 +449,7 @@ REPO="${REPO_SLUG}"
 echo "CSA_VAR:PR_NUM=$PR_NUM"
 echo "CSA_VAR:REPO=$REPO"
 echo "CSA_VAR:PR_WAS_EXISTING=$PR_WAS_EXISTING"
+echo "CSA_VAR:PR_TITLE=$PR_TITLE"
 echo '<!-- CSA:NEXT_STEP cmd="trigger cloud bot review or merge (Step 4a/5)" required=true -->'
 ```
 

--- a/patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
+++ b/patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
@@ -7,6 +7,7 @@ scenario="${GH_STUB_SCENARIO:?}"
 expected_list_head="${GH_STUB_EXPECTED_LIST_HEAD:?}"
 expected_create_head="${GH_STUB_EXPECTED_CREATE_HEAD:?}"
 expected_base="${GH_STUB_EXPECTED_BASE:?}"
+expected_title="${GH_STUB_EXPECTED_TITLE:-}"
 
 count_call() {
   local name="$1"
@@ -60,7 +61,7 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
   case "${scenario}" in
     create-success)
       if [ "${list_call}" -ge 2 ]; then
-        printf '[{"number":101,"baseRefName":"main","headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"},"state":"OPEN","mergedAt":null}]\n'
+        printf '[{"number":101,"baseRefName":"main","headRefName":"%s","headRepositoryOwner":{"login":"test-owner"},"state":"OPEN","mergedAt":null}]\n' "${expected_list_head}"
       else
         printf '[]\n'
       fi
@@ -134,7 +135,7 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "view" ]; then
       ;;
     create-success)
       if [ -f "${state_dir}/pr-create-count" ] && [ "${view_call}" -ge 2 ]; then
-        printf '{"number":101,"baseRefName":"main","headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"},"state":"OPEN","mergedAt":null}\n'
+        printf '{"number":101,"baseRefName":"main","headRefName":"%s","headRepositoryOwner":{"login":"test-owner"},"state":"OPEN","mergedAt":null}\n' "${expected_list_head}"
       else
         exit 1
       fi
@@ -152,12 +153,17 @@ fi
 if [ "${1:-}" = "pr" ] && [ "${2:-}" = "create" ]; then
   head_arg="$(arg_value "--head" "$@")"
   base_arg="$(arg_value "--base" "$@")"
+  title_arg="$(arg_value "--title" "$@")"
   if [ "${head_arg}" != "${expected_create_head}" ]; then
     echo "unexpected create --head: ${head_arg}" >&2
     exit 1
   fi
   if [ "${base_arg}" != "${expected_base}" ]; then
     echo "unexpected create --base: ${base_arg}" >&2
+    exit 1
+  fi
+  if [ -n "${expected_title}" ] && [ "${title_arg}" != "${expected_title}" ]; then
+    echo "unexpected create --title: ${title_arg}" >&2
     exit 1
   fi
   count_call pr-create >/dev/null

--- a/patterns/pr-bot/scripts/tests/_stubs/git-stub.sh
+++ b/patterns/pr-bot/scripts/tests/_stubs/git-stub.sh
@@ -23,6 +23,11 @@ if [ "${1:-}" = "push" ]; then
   exit 0
 fi
 
+if [ "${1:-}" = "log" ] && [ "${2:-}" = "-1" ] && [ "${3:-}" = "--pretty=%s" ]; then
+  printf '%s\n' "${GIT_STUB_HEAD_SUBJECT-Fix 1171}"
+  exit 0
+fi
+
 if [ "${1:-}" = "remote" ] && [ "${2:-}" = "get-url" ] && [ "${3:-}" = "--push" ]; then
   printf 'git@github.com:%s/test-repo.git\n' "${source_owner}"
   exit 0

--- a/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
+++ b/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
@@ -48,6 +48,9 @@ run_case() {
   local workflow_branch="${8:-fix/1171}"
   local expected_list_head="${9:-${workflow_branch}}"
   local expected_create_head="${10:-test-owner:${workflow_branch}}"
+  local expected_title="${11:-Fix 1171}"
+  local pr_title_mode="${12:-set}"
+  local git_head_subject="${13-Fix 1171}"
   local case_dir="${TMP_ROOT}/${case_name}"
   local bin_dir="${case_dir}/bin"
   local stdout_file="${case_dir}/stdout.txt"
@@ -62,22 +65,28 @@ run_case() {
 
   set +e
   (
-    PATH="${bin_dir}:${PATH}" \
-    GIT_STUB_STATE_DIR="${case_dir}" \
-    GIT_STUB_BRANCH_PUSHED="${branch_pushed}" \
-    GIT_STUB_SOURCE_OWNER="test-owner" \
-    GH_STUB_STATE_DIR="${case_dir}" \
-    GH_STUB_SCENARIO="${scenario}" \
-    GH_STUB_EXPECTED_LIST_HEAD="${expected_list_head}" \
-    GH_STUB_EXPECTED_CREATE_HEAD="${expected_create_head}" \
-    GH_STUB_EXPECTED_BASE="main" \
-    REVIEW_COMPLETED="true" \
-    REMOTE_NAME="origin" \
-    WORKFLOW_BRANCH="${workflow_branch}" \
-    REPO_SLUG="test-owner/test-repo" \
-    DEFAULT_BRANCH="main" \
-    PR_TITLE="Fix 1171" \
-    PR_BODY="Body" \
+    export PATH="${bin_dir}:${PATH}"
+    export GIT_STUB_STATE_DIR="${case_dir}"
+    export GIT_STUB_BRANCH_PUSHED="${branch_pushed}"
+    export GIT_STUB_SOURCE_OWNER="test-owner"
+    export GIT_STUB_HEAD_SUBJECT="${git_head_subject}"
+    export GH_STUB_STATE_DIR="${case_dir}"
+    export GH_STUB_SCENARIO="${scenario}"
+    export GH_STUB_EXPECTED_LIST_HEAD="${expected_list_head}"
+    export GH_STUB_EXPECTED_CREATE_HEAD="${expected_create_head}"
+    export GH_STUB_EXPECTED_BASE="main"
+    export GH_STUB_EXPECTED_TITLE="${expected_title}"
+    export REVIEW_COMPLETED="true"
+    export REMOTE_NAME="origin"
+    export WORKFLOW_BRANCH="${workflow_branch}"
+    export REPO_SLUG="test-owner/test-repo"
+    export DEFAULT_BRANCH="main"
+    export PR_BODY="Body"
+    if [ "${pr_title_mode}" = "unset" ]; then
+      unset PR_TITLE
+    else
+      export PR_TITLE="${expected_title}"
+    fi
     "${script_path}" >"${stdout_file}" 2>"${stderr_file}"
   )
   rc=$?
@@ -111,6 +120,8 @@ run_case "branch-pushed-create" "true" "create-success" "0" "101" "1"
 run_case "lookup-hits-reuse" "true" "preexisting" "0" "202" "0"
 run_case "lookup-hits-merged-noop" "true" "merged" "0" "909" "0"
 run_case "cross-owner-create" "true" "cross-owner" "0" "101" "1"
+run_case "unset-title-derives-head" "true" "create-success" "0" "101" "1" "PR_TITLE unset; using derived title: fix(pr-bot): derive title" "fix/1171" "fix/1171" "test-owner:fix/1171" "fix(pr-bot): derive title" "unset" "fix(pr-bot): derive title"
+run_case "unset-title-falls-back-to-branch" "true" "create-success" "0" "101" "1" "PR_TITLE unset; using derived title: Topic custom title" "topic/custom_title" "topic/custom_title" "test-owner:topic/custom_title" "Topic custom title" "unset" ""
 run_case "create-already-exists-reresolve" "true" "missed-already-exists" "0" "303" "1" "PR already exists for test-owner:fix/1171; re-resolving"
 run_case "stale-list-create-race-recovery" "true" "stale-already-exists" "0" "808" "1" "PR already exists for test-owner:fix/1171; re-resolving"
 run_case "ambiguous-fail-closed" "true" "ambiguous" "1" "" "0" "Multiple PRs found for test-owner:fix/1171"

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -722,6 +722,32 @@ fi
 set -euo pipefail
 PR_WAS_EXISTING=false
 
+derive_default_pr_title() {
+  local branch_title title
+  title="$(git log -1 --pretty=%s 2>/dev/null || true)"
+  title="$(printf '%s\n' "${title}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | sed -n '1p')"
+  if [ -n "${title}" ]; then
+    printf '%s\n' "${title}"
+    return 0
+  fi
+
+  branch_title="$(
+    printf '%s\n' "${WORKFLOW_BRANCH}" \
+      | sed -E 's#[-/_]+# #g; s#[[:space:]]+# #g; s#^[[:space:]]+##; s#[[:space:]]+$##' \
+      | sed -n '1p'
+  )"
+  if [ -z "${branch_title}" ]; then
+    branch_title="Update ${WORKFLOW_BRANCH}"
+  fi
+  printf '%s\n' "${branch_title}" | awk '{ print toupper(substr($0, 1, 1)) substr($0, 2) }'
+}
+
+PR_TITLE="${PR_TITLE:-}"
+if [ -z "${PR_TITLE}" ]; then
+  PR_TITLE="$(derive_default_pr_title)"
+  echo "INFO: PR_TITLE unset; using derived title: ${PR_TITLE}" >&2
+fi
+
 # --- Early-push detection: warn if branch was already pushed before review ---
 if git ls-remote --heads "${REMOTE_NAME}" "${WORKFLOW_BRANCH}" 2>/dev/null | grep -q .; then
   echo "WARNING: Branch '${WORKFLOW_BRANCH}' was already pushed to remote before this skill ran."
@@ -911,6 +937,7 @@ REPO="${REPO_SLUG}"
 echo "CSA_VAR:PR_NUM=$PR_NUM"
 echo "CSA_VAR:REPO=$REPO"
 echo "CSA_VAR:PR_WAS_EXISTING=$PR_WAS_EXISTING"
+echo "CSA_VAR:PR_TITLE=$PR_TITLE"
 echo '<!-- CSA:NEXT_STEP cmd="trigger cloud bot review or merge (Step 4a/5)" required=true -->'
 ```'''
 on_fail = "abort"

--- a/scripts/monolith/baseline.toml
+++ b/scripts/monolith/baseline.toml
@@ -764,15 +764,15 @@ rationale = "pre-existing monolith debt grandfathered by #1880 calibration; no-g
 [[files]]
 path = "patterns/pr-bot/PATTERN.md"
 kind = "doc"
-baseline_tokens = 33758
-baseline_lines = 2280
+baseline_tokens = 34027
+baseline_lines = 2307
 issue = "1880"
-rationale = "pre-existing monolith debt grandfathered by #1880 calibration; no-growth ratchet"
+rationale = "pre-existing monolith debt grandfathered by #1880; cap re-baselined for PR title default derivation (#2050); no-growth ratchet"
 
 [[files]]
 path = "patterns/pr-bot/workflow.toml"
 kind = "config"
-baseline_tokens = 36819
-baseline_lines = 2774
+baseline_tokens = 37088
+baseline_lines = 2801
 issue = "1880"
-rationale = "pre-existing monolith debt grandfathered by #1880 calibration; no-growth ratchet"
+rationale = "pre-existing monolith debt grandfathered by #1880; cap re-baselined for PR title default derivation (#2050); no-growth ratchet"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.974"
-weave = "0.1.974"
+csa = "0.1.976"
+weave = "0.1.976"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Derive a default PR title when PR_TITLE is unset.
- Add regression coverage for commit-subject and branch-name title fallback paths.
- Bump the workspace to 0.1.976.

## Test plan
- [x] just pre-commit-fast
- [x] bash patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
- [x] bash -n patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh patterns/pr-bot/scripts/tests/_stubs/git-stub.sh patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
- [x] taplo fmt --check patterns/pr-bot/workflow.toml
- [x] git diff --check
- [x] csa review --sa-mode true --tier tier-4-critical --tool gemini-cli --range main...HEAD

Closes #2050