### PR TITLE
fix(cli-sub-agent): literalize filtered tracked diff paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.976"
+version = "0.1.977"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.976"
+version = "0.1.977"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/mcp_server_tests.rs
+++ b/crates/cli-sub-agent/src/mcp_server_tests.rs
@@ -264,10 +264,12 @@ fn get_tools_csa_session_wait_requires_session_id() {
 #[test]
 fn mcp_session_wait_default_cap_is_below_advertised_codex_tool_timeout() {
     assert_eq!(DEFAULT_MCP_SESSION_WAIT_TIMEOUT_SECONDS, 6_900);
-    assert!(
-        DEFAULT_MCP_SESSION_WAIT_TIMEOUT_SECONDS
-            < csa_config::DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC
-    );
+    const {
+        assert!(
+            DEFAULT_MCP_SESSION_WAIT_TIMEOUT_SECONDS
+                < csa_config::DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/cli-sub-agent/src/pipeline_session_exec_review_guard.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_review_guard.rs
@@ -466,6 +466,23 @@ mod tests {
         );
     }
 
+    /// #2040 regression: untracked files above the line-scan byte cap are sized
+    /// as bytes-only lower bounds, but still represent substantial writer work.
+    #[test]
+    fn build_guard_full_for_resume_with_large_untracked_text_work() {
+        let temp = init_repo_with_commit();
+        let root = temp.path();
+        let long_line = format!("{}\n", "x".repeat(64 * 1024));
+        std::fs::write(root.join("large.txt"), long_line.repeat(17)).unwrap();
+
+        let guard = build_review_writer_guard(false, Some("run"), false, root)
+            .expect("resume writer with large untracked text work must receive a guard");
+        assert!(
+            guard.contains("<review-dimensions>"),
+            "large untracked text work must get the FULL guard, got: {guard}"
+        );
+    }
+
     #[test]
     fn build_guard_brief_for_resume_with_trivial_untracked_work() {
         let temp = init_repo_with_commit();

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -346,6 +346,7 @@ mod tests {
                 warnings: Vec::new(),
                 raw_process_exit_code: None,
                 uncommitted_changes: None,
+                large_diff_warning: None,
                 post_exec_gate: None,
                 manager_fields: Default::default(),
             },

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -502,6 +502,7 @@ async fn state_dir_cap_failure_overwrites_stale_result_for_resume() {
             warnings: Vec::new(),
             raw_process_exit_code: None,
             uncommitted_changes: None,
+            large_diff_warning: None,
             manager_fields: csa_session::SessionManagerFields {
                 report: Some(
                     toml::toml! {

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -37,7 +37,8 @@ pub(crate) use policy::{
 };
 pub(crate) use shell::detect_no_verify_commit_commands;
 pub(crate) use uncommitted::{
-    format_uncommitted_warning, is_writer_session, working_tree_changed_lines,
+    format_large_diff_warning_block, format_uncommitted_warning, is_writer_session,
+    working_tree_changed_lines,
 };
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -619,12 +619,13 @@ pub(crate) async fn handle_run(
     let mut result = loop_outcome.result;
     let current_tool = loop_outcome.current_tool;
     let executed_session_id = loop_outcome.executed_session_id;
-    let changed_paths = loop_outcome.changed_paths;
+    let session_id = executed_session_id.as_deref();
     let fork_resolution = loop_outcome.fork_resolution;
-    super::uncommitted::record_run_dirty(
+    let warning = super::uncommitted::record_run_dirty(
         &project_root,
-        executed_session_id.as_deref(),
+        session_id,
         &mut result,
+        loop_outcome.changed_paths.as_deref(),
         require_commit,
         config.as_ref(),
     );
@@ -637,10 +638,10 @@ pub(crate) async fn handle_run(
         apply_post_exec_gate_after_success_with_runner(
             &project_root,
             &gate_prompt_text,
-            executed_session_id.as_deref(),
+            session_id,
             config.as_ref(),
             PostExecGateApplyOptions {
-                changed_paths: changed_paths.as_deref(),
+                changed_paths: loop_outcome.changed_paths.as_deref(),
                 extra_env: post_exec_gate_env,
                 no_post_exec_gate,
                 planning_only: skill.as_deref() == Some("mktd"),
@@ -656,7 +657,7 @@ pub(crate) async fn handle_run(
             .ok_or_else(|| anyhow::anyhow!("fork-call parent session is unresolved"))?;
         handle_fork_call_resume(
             &project_root,
-            executed_session_id.as_deref(),
+            session_id,
             &parent_session_id,
             &current_tool,
             return_target.is_some(),
@@ -688,8 +689,9 @@ pub(crate) async fn handle_run(
     emit_run_result_output(
         &project_root,
         output_format,
-        executed_session_id.as_deref(),
+        session_id,
         &result,
+        warning.as_ref(),
     )?;
 
     Ok(result.exit_code)

--- a/crates/cli-sub-agent/src/run_cmd_execute_output.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_output.rs
@@ -36,10 +36,11 @@ pub(super) fn emit_run_result_output(
     output_format: OutputFormat,
     executed_session_id: Option<&str>,
     result: &ExecutionResult,
+    large_diff_warning: Option<&csa_session::LargeDiffWarningReport>,
 ) -> Result<()> {
     match output_format {
         OutputFormat::Text => {
-            print!("{}", result.output);
+            print!("{}", render_run_text_output(result, large_diff_warning));
             if executed_session_id.is_none()
                 && result.exit_code != 0
                 && result.exit_signal.is_some()
@@ -72,12 +73,47 @@ pub(super) fn emit_run_result_output(
             }
         }
         OutputFormat::Json => {
-            let json = serde_json::to_string_pretty(result)?;
+            let json = render_run_json_output(result, large_diff_warning)?;
             println!("{json}");
         }
     }
 
     Ok(())
+}
+
+pub(super) fn render_run_json_output(
+    result: &ExecutionResult,
+    large_diff_warning: Option<&csa_session::LargeDiffWarningReport>,
+) -> Result<String> {
+    let mut value = serde_json::to_value(result)?;
+    if let Some(warning) = large_diff_warning
+        && let serde_json::Value::Object(fields) = &mut value
+    {
+        fields.insert(
+            "large_diff_warning".to_string(),
+            serde_json::to_value(warning)?,
+        );
+        fields.insert(
+            "large_diff_warning_block".to_string(),
+            serde_json::Value::String(crate::run_cmd::format_large_diff_warning_block(warning)),
+        );
+    }
+    Ok(serde_json::to_string_pretty(&value)?)
+}
+
+pub(super) fn render_run_text_output(
+    result: &ExecutionResult,
+    large_diff_warning: Option<&csa_session::LargeDiffWarningReport>,
+) -> String {
+    let mut output = result.output.clone();
+    if let Some(warning) = large_diff_warning {
+        if !output.is_empty() && !output.ends_with('\n') {
+            output.push('\n');
+        }
+        output.push_str(&crate::run_cmd::format_large_diff_warning_block(warning));
+        output.push('\n');
+    }
+    output
 }
 
 #[cfg(test)]
@@ -120,5 +156,92 @@ mod tests {
         assert_eq!(json["exit_signal"], serde_json::json!(9));
         assert!(json["kill_hint"].is_string());
         assert!(json["resource_diagnostics"].is_string());
+    }
+
+    #[test]
+    fn run_text_output_appends_large_diff_warning_block() {
+        let result = ExecutionResult {
+            output: "done\n".to_string(),
+            summary: "done".to_string(),
+            exit_code: 0,
+            ..Default::default()
+        };
+        let warning = csa_session::LargeDiffWarningReport {
+            changed_files: 9,
+            changed_lines: 1_420,
+            approx_diff_tokens: 18_000,
+        };
+
+        let rendered = render_run_text_output(&result, Some(&warning));
+
+        assert!(rendered.starts_with("done\n"));
+        assert!(rendered.contains(
+            "<!-- CSA:LARGE_DIFF_WARNING changed_files=9 changed_lines=1420 approx_diff_tokens=18000 -->"
+        ));
+        assert!(rendered.contains("<!-- CSA:LARGE_DIFF_WARNING:END -->"));
+    }
+
+    #[test]
+    fn run_text_output_omits_large_diff_warning_when_absent() {
+        let result = ExecutionResult {
+            output: "done\n".to_string(),
+            summary: "done".to_string(),
+            exit_code: 0,
+            ..Default::default()
+        };
+
+        let rendered = render_run_text_output(&result, None);
+
+        assert_eq!(rendered, "done\n");
+    }
+
+    #[test]
+    fn run_json_output_includes_large_diff_warning_data_and_block() {
+        let result = ExecutionResult {
+            output: "done\n".to_string(),
+            summary: "done".to_string(),
+            exit_code: 0,
+            ..Default::default()
+        };
+        let warning = csa_session::LargeDiffWarningReport {
+            changed_files: 9,
+            changed_lines: 1_420,
+            approx_diff_tokens: 18_000,
+        };
+
+        let rendered = render_run_json_output(&result, Some(&warning))
+            .expect("run JSON output should serialize");
+        let json: serde_json::Value =
+            serde_json::from_str(&rendered).expect("run JSON output should parse");
+
+        assert_eq!(json["output"], serde_json::json!("done\n"));
+        assert_eq!(json["large_diff_warning"]["changed_files"], 9);
+        assert_eq!(json["large_diff_warning"]["changed_lines"], 1_420);
+        assert_eq!(json["large_diff_warning"]["approx_diff_tokens"], 18_000);
+        let block = json["large_diff_warning_block"]
+            .as_str()
+            .expect("large_diff_warning_block should be a string");
+        assert!(block.contains(
+            "<!-- CSA:LARGE_DIFF_WARNING changed_files=9 changed_lines=1420 approx_diff_tokens=18000 -->"
+        ));
+        assert!(block.contains("<!-- CSA:LARGE_DIFF_WARNING:END -->"));
+    }
+
+    #[test]
+    fn run_json_output_omits_large_diff_warning_when_absent() {
+        let result = ExecutionResult {
+            output: "done\n".to_string(),
+            summary: "done".to_string(),
+            exit_code: 0,
+            ..Default::default()
+        };
+
+        let rendered =
+            render_run_json_output(&result, None).expect("run JSON output should serialize");
+        let json: serde_json::Value =
+            serde_json::from_str(&rendered).expect("run JSON output should parse");
+
+        assert!(json.get("large_diff_warning").is_none());
+        assert!(json.get("large_diff_warning_block").is_none());
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -55,6 +55,7 @@ fn project_config_with_gate(gate: PostExecGateConfig) -> ProjectConfig {
         run: RunConfig {
             allow_base_branch_working: false,
             writer_must_commit: false,
+            large_diff_warning: Default::default(),
             post_exec_gate: gate,
         },
         execution: Default::default(),

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -232,12 +232,23 @@ pub(crate) fn format_uncommitted_warning(changes: &csa_session::UncommittedChang
 /// non-ignored lines closes that gap. `.gitignore` is honored (build artifacts do
 /// not inflate the count), and git state is never mutated to measure it (no
 /// `git add`, no intent-to-add).
+/// If untracked sizing proves the line total is only a lower bound (large,
+/// binary, capped, or truncated files), this returns `usize::MAX` so the caller's
+/// size gate fails toward the full guard instead of treating an unknown exact
+/// line count as trivial.
 ///
 /// Returns `0` when `project_root` is not a git worktree or the tree is clean.
 /// Any git/IO failure is non-fatal (fail-open), matching the rest of the guard.
 pub(crate) fn working_tree_changed_lines(project_root: &Path) -> usize {
-    collect_uncommitted_changes_with_filter(project_root, None, None)
-        .map(|changes| usize::try_from(changes.changed_lines()).unwrap_or(usize::MAX))
+    collect_uncommitted_changes_with_filter_and_untracked_size(project_root, None, None)
+        .map(|(changes, untracked)| {
+            let changed_lines = usize::try_from(changes.changed_lines()).unwrap_or(usize::MAX);
+            if untracked.lower_bound {
+                usize::MAX
+            } else {
+                changed_lines
+            }
+        })
         .unwrap_or(0)
 }
 
@@ -297,6 +308,22 @@ fn collect_uncommitted_changes_with_filter(
     path_filter: Option<&BTreeSet<String>>,
     tracked_token_threshold: Option<usize>,
 ) -> Option<csa_session::UncommittedChanges> {
+    collect_uncommitted_changes_with_filter_and_untracked_size(
+        project_root,
+        path_filter,
+        tracked_token_threshold,
+    )
+    .map(|(changes, _)| changes)
+}
+
+fn collect_uncommitted_changes_with_filter_and_untracked_size(
+    project_root: &Path,
+    path_filter: Option<&BTreeSet<String>>,
+    tracked_token_threshold: Option<usize>,
+) -> Option<(
+    csa_session::UncommittedChanges,
+    crate::untracked_size::UntrackedDiffSize,
+)> {
     if !super::git::is_git_worktree(project_root) {
         return None;
     }
@@ -327,13 +354,14 @@ fn collect_uncommitted_changes_with_filter(
         &untracked,
         tracked_token_threshold,
     );
-    summarize_uncommitted_changes_with_stats(
+    let changes = summarize_uncommitted_changes_with_stats(
         &porcelain,
         &numstat,
         untracked_lines,
         approx_diff_tokens,
         path_filter,
-    )
+    )?;
+    Some((changes, untracked))
 }
 
 fn estimate_changed_surface_tokens(

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -534,7 +534,7 @@ fn parse_porcelain_path(entry: &str) -> Option<String> {
     if chars.next()? != ' ' {
         return None;
     }
-    let path = entry.get(3..)?.trim();
+    let path = entry.get(3..)?;
     (!path.is_empty()).then(|| path.to_string())
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -418,6 +418,7 @@ fn estimate_tracked_diff_tokens(
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
     if let Some(filter) = path_filter {
+        command.env("GIT_LITERAL_PATHSPECS", "1");
         command.args(filter);
     }
 
@@ -497,6 +498,7 @@ fn run_git_diff_capture(
     let mut command = Command::new("git");
     command.arg("-C").arg(project_root).args(args).arg("--");
     if let Some(filter) = path_filter {
+        command.env("GIT_LITERAL_PATHSPECS", "1");
         command.args(filter);
     }
     let output = command.output().ok()?;

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -1,13 +1,19 @@
 //! Writer-session dirty-worktree signal for `csa run`.
 
+use std::collections::BTreeSet;
+use std::io::Read;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
+use csa_config::{RunLargeDiffWarningConfig, RunLargeDiffWarningMode};
 use tracing::warn;
 
 const MAX_UNCOMMITTED_FILES: usize = 20;
+const DIFF_BYTES_PER_TOKEN: usize = 4;
+const DIFF_TOKEN_READ_BUF_BYTES: usize = 16 * 1024;
 const REQUIRE_COMMIT_REASON: &str =
     "writer session ended with uncommitted changes (--require-commit set)";
+const LARGE_DIFF_WARNING_TEXT: &str = "This CSA session left a large changed surface. Do not proceed directly to a single commit/PR unless this was explicitly intended. First inspect the file list, split into atomic logical units if possible, and run review per unit. If intentionally large, record that rationale in the commit/PR.";
 
 pub(crate) fn is_writer_session(sa_mode: bool, task_type: Option<&str>) -> bool {
     !sa_mode && matches!(task_type, Some("run"))
@@ -20,11 +26,25 @@ pub(crate) fn effective_writer_must_commit(
     cli_require_commit || config.is_some_and(|cfg| cfg.run.writer_must_commit)
 }
 
+#[cfg(test)]
 pub(crate) fn summarize_uncommitted_changes(
     porcelain: &str,
     numstat: &str,
 ) -> Option<csa_session::UncommittedChanges> {
-    let paths = changed_paths_from_porcelain(porcelain);
+    summarize_uncommitted_changes_with_stats(porcelain, numstat, 0, 0, None)
+}
+
+fn summarize_uncommitted_changes_with_stats(
+    porcelain: &str,
+    numstat: &str,
+    extra_insertions: u64,
+    approx_diff_tokens: usize,
+    path_filter: Option<&BTreeSet<String>>,
+) -> Option<csa_session::UncommittedChanges> {
+    let mut paths = changed_paths_from_porcelain(porcelain);
+    if let Some(filter) = path_filter {
+        paths.retain(|path| filter.contains(path));
+    }
     if paths.is_empty() {
         return None;
     }
@@ -39,35 +59,108 @@ pub(crate) fn summarize_uncommitted_changes(
 
     Some(csa_session::UncommittedChanges {
         file_count,
-        insertions,
+        insertions: insertions.saturating_add(extra_insertions),
         deletions,
+        approx_diff_tokens,
         files,
         truncated,
     })
 }
 
-pub(crate) fn record_writer_uncommitted_changes(
+pub(crate) fn large_diff_warning_report(
+    changes: &csa_session::UncommittedChanges,
+    config: &RunLargeDiffWarningConfig,
+) -> Option<csa_session::LargeDiffWarningReport> {
+    if !config.enabled || config.mode != RunLargeDiffWarningMode::Warn {
+        return None;
+    }
+    let changed_lines = changes.changed_lines();
+    let exceeds_files = config.changed_files > 0 && changes.file_count > config.changed_files;
+    let exceeds_lines = config.changed_lines > 0 && changed_lines > config.changed_lines;
+    let exceeds_tokens =
+        config.approx_diff_tokens > 0 && changes.approx_diff_tokens > config.approx_diff_tokens;
+    if !(exceeds_files || exceeds_lines || exceeds_tokens) {
+        return None;
+    }
+    Some(csa_session::LargeDiffWarningReport {
+        changed_files: changes.file_count,
+        changed_lines,
+        approx_diff_tokens: changes.approx_diff_tokens,
+    })
+}
+
+pub(crate) fn format_large_diff_warning_block(
+    warning: &csa_session::LargeDiffWarningReport,
+) -> String {
+    format!(
+        "<!-- CSA:LARGE_DIFF_WARNING changed_files={} changed_lines={} approx_diff_tokens={} -->\n{}\n<!-- CSA:LARGE_DIFF_WARNING:END -->",
+        warning.changed_files,
+        warning.changed_lines,
+        warning.approx_diff_tokens,
+        LARGE_DIFF_WARNING_TEXT
+    )
+}
+
+pub(crate) fn record_run_dirty(
+    project_root: &Path,
+    session_id: Option<&str>,
+    result: &mut csa_process::ExecutionResult,
+    changed_paths: Option<&[String]>,
+    cli_require_commit: bool,
+    config: Option<&csa_config::ProjectConfig>,
+) -> Option<csa_session::LargeDiffWarningReport> {
+    let sa_mode = std::env::var(crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV)
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1"))
+        .unwrap_or(false);
+    let large_diff_config = config
+        .map(|cfg| cfg.run.large_diff_warning.clone())
+        .unwrap_or_default();
+    record_writer_uncommitted_changes_with_config(
+        project_root,
+        session_id,
+        result,
+        sa_mode,
+        effective_writer_must_commit(cli_require_commit, config),
+        changed_paths,
+        &large_diff_config,
+    )
+}
+
+fn record_writer_uncommitted_changes_with_config(
     project_root: &Path,
     session_id: Option<&str>,
     result: &mut csa_process::ExecutionResult,
     sa_mode: bool,
     require_commit: bool,
-) {
+    changed_paths: Option<&[String]>,
+    large_diff_config: &RunLargeDiffWarningConfig,
+) -> Option<csa_session::LargeDiffWarningReport> {
     if !is_writer_session(sa_mode, Some("run")) {
-        return;
+        return None;
     }
-    let Some(session_id) = session_id else {
-        return;
-    };
-    let Some(changes) = collect_uncommitted_changes(project_root) else {
-        return;
-    };
+    let session_id = session_id?;
+    let token_threshold = tracked_diff_token_threshold(large_diff_config);
+    let changes = collect_uncommitted_changes_with_token_threshold(project_root, token_threshold)?;
+    let warning_changes = changed_paths
+        .map(|paths| {
+            collect_uncommitted_changes_for_changed_paths_with_token_threshold(
+                project_root,
+                paths,
+                token_threshold,
+            )
+        })
+        .unwrap_or_else(|| Some(changes.clone()));
+    let warning = warning_changes
+        .as_ref()
+        .and_then(|changes| large_diff_warning_report(changes, large_diff_config));
 
     match csa_session::load_result(project_root, session_id) {
         Ok(Some(mut session_result)) => {
             apply_uncommitted_changes_to_result(
                 &mut session_result,
                 changes.clone(),
+                warning.clone(),
                 require_commit,
             );
             if let Err(err) = csa_session::save_result(project_root, session_id, &session_result) {
@@ -102,34 +195,17 @@ pub(crate) fn record_writer_uncommitted_changes(
         result.stderr_output.push_str(REQUIRE_COMMIT_REASON);
         result.stderr_output.push('\n');
     }
-}
-
-pub(crate) fn record_run_dirty(
-    project_root: &Path,
-    session_id: Option<&str>,
-    result: &mut csa_process::ExecutionResult,
-    cli_require_commit: bool,
-    config: Option<&csa_config::ProjectConfig>,
-) {
-    let sa_mode = std::env::var(crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV)
-        .ok()
-        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1"))
-        .unwrap_or(false);
-    record_writer_uncommitted_changes(
-        project_root,
-        session_id,
-        result,
-        sa_mode,
-        effective_writer_must_commit(cli_require_commit, config),
-    );
+    warning
 }
 
 pub(crate) fn apply_uncommitted_changes_to_result(
     result: &mut csa_session::SessionResult,
     changes: csa_session::UncommittedChanges,
+    large_diff_warning: Option<csa_session::LargeDiffWarningReport>,
     require_commit: bool,
 ) {
     result.uncommitted_changes = Some(changes);
+    result.large_diff_warning = large_diff_warning;
     if require_commit {
         result.exit_code = 1;
         result.status = csa_session::SessionResult::status_from_exit_code(1);
@@ -160,35 +236,67 @@ pub(crate) fn format_uncommitted_warning(changes: &csa_session::UncommittedChang
 /// Returns `0` when `project_root` is not a git worktree or the tree is clean.
 /// Any git/IO failure is non-fatal (fail-open), matching the rest of the guard.
 pub(crate) fn working_tree_changed_lines(project_root: &Path) -> usize {
-    let tracked = collect_uncommitted_changes(project_root)
-        .map(|changes| changes.insertions.saturating_add(changes.deletions) as usize)
-        .unwrap_or(0);
-    tracked.saturating_add(untracked_non_ignored_lines(project_root))
+    collect_uncommitted_changes_with_filter(project_root, None, None)
+        .map(|changes| usize::try_from(changes.changed_lines()).unwrap_or(usize::MAX))
+        .unwrap_or(0)
 }
 
-/// Sum of line counts across untracked, non-ignored files, delegating to the
-/// shared bounded scanner in [`crate::untracked_size`] so this writer guard and
-/// the `csa review` diff-size report (#1818) share one enumeration
-/// (`git ls-files --others --exclude-standard`) and one bounded per-file line
-/// counter rather than duplicating either.
-///
-/// The per-file read is bounded (streamed through a fixed buffer, never slurped)
-/// and the number of files scanned is capped at
-/// [`crate::untracked_size::MAX_UNTRACKED_FILES`]; beyond the cap the running
-/// total is already far above `TRIVIAL_DIFF_MAX_LINES`, so the
-/// trivial-vs-substantial outcome the guard cares about is unchanged. Non-regular
-/// entries (symlinks, FIFOs, sockets, devices) and unreadable files contribute
-/// `0`. Returns `0` when `project_root` is not a git worktree or git fails
-/// (fail-open), matching the rest of the guard.
-fn untracked_non_ignored_lines(project_root: &Path) -> usize {
-    crate::untracked_size::list_untracked(project_root)
-        .paths
-        .iter()
-        .map(|path| crate::untracked_size::count_file_lines(path))
-        .sum()
-}
-
+#[cfg(test)]
 fn collect_uncommitted_changes(project_root: &Path) -> Option<csa_session::UncommittedChanges> {
+    collect_uncommitted_changes_with_token_threshold(
+        project_root,
+        default_tracked_diff_token_threshold(),
+    )
+}
+
+fn collect_uncommitted_changes_with_token_threshold(
+    project_root: &Path,
+    token_threshold: usize,
+) -> Option<csa_session::UncommittedChanges> {
+    collect_uncommitted_changes_with_filter(project_root, None, Some(token_threshold))
+}
+
+#[cfg(test)]
+fn collect_uncommitted_changes_for_changed_paths(
+    project_root: &Path,
+    changed_paths: &[String],
+) -> Option<csa_session::UncommittedChanges> {
+    let filter = changed_paths
+        .iter()
+        .filter(|path| !path.is_empty())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    if filter.is_empty() {
+        return None;
+    }
+    collect_uncommitted_changes_with_filter(
+        project_root,
+        Some(&filter),
+        Some(default_tracked_diff_token_threshold()),
+    )
+}
+
+fn collect_uncommitted_changes_for_changed_paths_with_token_threshold(
+    project_root: &Path,
+    changed_paths: &[String],
+    token_threshold: usize,
+) -> Option<csa_session::UncommittedChanges> {
+    let filter = changed_paths
+        .iter()
+        .filter(|path| !path.is_empty())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    if filter.is_empty() {
+        return None;
+    }
+    collect_uncommitted_changes_with_filter(project_root, Some(&filter), Some(token_threshold))
+}
+
+fn collect_uncommitted_changes_with_filter(
+    project_root: &Path,
+    path_filter: Option<&BTreeSet<String>>,
+    tracked_token_threshold: Option<usize>,
+) -> Option<csa_session::UncommittedChanges> {
     if !super::git::is_git_worktree(project_root) {
         return None;
     }
@@ -206,9 +314,138 @@ fn collect_uncommitted_changes(project_root: &Path) -> Option<csa_session::Uncom
     if porcelain.is_empty() {
         return None;
     }
-    let numstat =
-        run_git_capture(project_root, &["diff", "--numstat", "HEAD", "--"]).unwrap_or_default();
-    summarize_uncommitted_changes(&porcelain, &numstat)
+    let numstat = run_git_diff_capture(project_root, &["diff", "--numstat", "HEAD"], path_filter)
+        .unwrap_or_default();
+    let untracked = match path_filter {
+        Some(filter) => crate::untracked_size::untracked_diff_size_for_paths(project_root, filter),
+        None => crate::untracked_size::untracked_diff_size(project_root),
+    };
+    let untracked_lines = u64::try_from(untracked.lines).unwrap_or(u64::MAX);
+    let approx_diff_tokens = estimate_changed_surface_tokens(
+        project_root,
+        path_filter,
+        &untracked,
+        tracked_token_threshold,
+    );
+    summarize_uncommitted_changes_with_stats(
+        &porcelain,
+        &numstat,
+        untracked_lines,
+        approx_diff_tokens,
+        path_filter,
+    )
+}
+
+fn estimate_changed_surface_tokens(
+    project_root: &Path,
+    path_filter: Option<&BTreeSet<String>>,
+    untracked: &crate::untracked_size::UntrackedDiffSize,
+    tracked_token_threshold: Option<usize>,
+) -> usize {
+    let untracked_bytes = usize::try_from(untracked.bytes).unwrap_or(usize::MAX);
+    let untracked_tokens = untracked_bytes / DIFF_BYTES_PER_TOKEN;
+    let Some(token_threshold) = tracked_token_threshold else {
+        return untracked_tokens;
+    };
+    if untracked_tokens > token_threshold {
+        return untracked_tokens;
+    }
+
+    let remaining_threshold = token_threshold.saturating_sub(untracked_tokens);
+    let tracked_tokens =
+        estimate_tracked_diff_tokens(project_root, path_filter, remaining_threshold)
+            .unwrap_or_default();
+    untracked_tokens.saturating_add(tracked_tokens)
+}
+
+fn tracked_diff_token_threshold(config: &RunLargeDiffWarningConfig) -> usize {
+    if config.approx_diff_tokens > 0 {
+        config.approx_diff_tokens
+    } else {
+        default_tracked_diff_token_threshold()
+    }
+}
+
+fn default_tracked_diff_token_threshold() -> usize {
+    RunLargeDiffWarningConfig::default().approx_diff_tokens
+}
+
+struct TrackedDiffTokenEstimate {
+    tokens: usize,
+    cap_reached: bool,
+}
+
+fn estimate_tracked_diff_tokens(
+    project_root: &Path,
+    path_filter: Option<&BTreeSet<String>>,
+    token_threshold: usize,
+) -> Option<usize> {
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(project_root)
+        .args(["diff", "--no-ext-diff", "--no-color", "HEAD"])
+        .arg("--")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    if let Some(filter) = path_filter {
+        command.args(filter);
+    }
+
+    let mut child = command.spawn().ok()?;
+    let Some(stdout) = child.stdout.take() else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return None;
+    };
+
+    let estimate = estimate_diff_stream_tokens(stdout, token_threshold)?;
+    if estimate.cap_reached {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Some(token_threshold.saturating_add(1));
+    }
+
+    let status = child.wait().ok()?;
+    status.success().then_some(estimate.tokens)
+}
+
+fn estimate_diff_stream_tokens<R: Read>(
+    mut reader: R,
+    token_threshold: usize,
+) -> Option<TrackedDiffTokenEstimate> {
+    let byte_limit = tracked_diff_byte_limit(token_threshold);
+    let mut bytes_read = 0usize;
+    let mut buffer = [0u8; DIFF_TOKEN_READ_BUF_BYTES];
+
+    while bytes_read < byte_limit {
+        let remaining = byte_limit.saturating_sub(bytes_read);
+        let read_len = remaining.min(buffer.len());
+        let n = reader.read(&mut buffer[..read_len]).ok()?;
+        if n == 0 {
+            return Some(TrackedDiffTokenEstimate {
+                tokens: diff_bytes_to_approx_tokens(bytes_read),
+                cap_reached: false,
+            });
+        }
+        bytes_read = bytes_read.saturating_add(n);
+    }
+
+    Some(TrackedDiffTokenEstimate {
+        tokens: token_threshold.saturating_add(1),
+        cap_reached: true,
+    })
+}
+
+fn tracked_diff_byte_limit(token_threshold: usize) -> usize {
+    token_threshold
+        .saturating_mul(DIFF_BYTES_PER_TOKEN)
+        .saturating_add(1)
+}
+
+fn diff_bytes_to_approx_tokens(bytes: usize) -> usize {
+    bytes.saturating_add(DIFF_BYTES_PER_TOKEN - 1) / DIFF_BYTES_PER_TOKEN
 }
 
 fn run_git_capture(project_root: &Path, args: &[&str]) -> Option<String> {
@@ -218,6 +455,23 @@ fn run_git_capture(project_root: &Path, args: &[&str]) -> Option<String> {
         .args(args)
         .output()
         .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn run_git_diff_capture(
+    project_root: &Path,
+    args: &[&str],
+    path_filter: Option<&BTreeSet<String>>,
+) -> Option<String> {
+    let mut command = Command::new("git");
+    command.arg("-C").arg(project_root).args(args).arg("--");
+    if let Some(filter) = path_filter {
+        command.args(filter);
+    }
+    let output = command.output().ok()?;
     if !output.status.success() {
         return None;
     }
@@ -276,220 +530,5 @@ fn parse_numstat_totals(numstat: &str) -> (u64, u64) {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn writer_predicate_excludes_sa_mode_and_read_only_kinds() {
-        assert!(is_writer_session(false, Some("run")));
-        assert!(!is_writer_session(true, Some("run")));
-        assert!(!is_writer_session(false, Some("review")));
-        assert!(!is_writer_session(false, Some("debate")));
-        assert!(!is_writer_session(false, Some("recon")));
-        assert!(!is_writer_session(false, None));
-    }
-
-    #[test]
-    fn summarize_uncommitted_changes_returns_none_for_clean_status() {
-        assert!(summarize_uncommitted_changes("", "").is_none());
-    }
-
-    #[test]
-    fn summarize_uncommitted_changes_counts_files_and_numstat() {
-        let porcelain = " M crates/a.rs\0A  crates/b.rs\0?? notes/todo.md\0";
-        let numstat = "10\t2\tcrates/a.rs\n5\t0\tcrates/b.rs\n-\t-\tassets/blob.bin\n";
-
-        let changes = summarize_uncommitted_changes(porcelain, numstat)
-            .expect("dirty porcelain should produce changes");
-
-        assert_eq!(changes.file_count, 3);
-        assert_eq!(changes.insertions, 15);
-        assert_eq!(changes.deletions, 2);
-        assert_eq!(
-            changes.files,
-            vec![
-                "crates/a.rs".to_string(),
-                "crates/b.rs".to_string(),
-                "notes/todo.md".to_string()
-            ]
-        );
-        assert_eq!(changes.truncated, 0);
-    }
-
-    #[test]
-    fn summarize_uncommitted_changes_caps_file_list() {
-        let porcelain = (0..25)
-            .map(|idx| format!("?? file-{idx}.txt\0"))
-            .collect::<String>();
-
-        let changes = summarize_uncommitted_changes(&porcelain, "")
-            .expect("dirty porcelain should produce changes");
-
-        assert_eq!(changes.file_count, 25);
-        assert_eq!(changes.files.len(), MAX_UNCOMMITTED_FILES);
-        assert_eq!(changes.truncated, 5);
-    }
-
-    #[test]
-    fn apply_uncommitted_changes_warn_only_preserves_success() {
-        let mut result = session_result("success", 0);
-        let changes = csa_session::UncommittedChanges {
-            file_count: 1,
-            insertions: 2,
-            deletions: 0,
-            files: vec!["src/lib.rs".to_string()],
-            truncated: 0,
-        };
-
-        apply_uncommitted_changes_to_result(&mut result, changes, false);
-
-        assert_eq!(result.status, "success");
-        assert_eq!(result.exit_code, 0);
-        assert!(result.uncommitted_changes.is_some());
-        assert!(result.warnings.is_empty());
-    }
-
-    #[test]
-    fn apply_uncommitted_changes_require_commit_flips_to_failure() {
-        let mut result = session_result("success", 0);
-        let changes = csa_session::UncommittedChanges {
-            file_count: 1,
-            insertions: 2,
-            deletions: 0,
-            files: vec!["src/lib.rs".to_string()],
-            truncated: 0,
-        };
-
-        apply_uncommitted_changes_to_result(&mut result, changes, true);
-
-        assert_eq!(result.status, "failure");
-        assert_eq!(result.exit_code, 1);
-        assert_eq!(result.summary, REQUIRE_COMMIT_REASON);
-        assert!(result.uncommitted_changes.is_some());
-    }
-
-    #[test]
-    fn effective_writer_must_commit_respects_cli_and_config_precedence() {
-        assert!(!effective_writer_must_commit(false, None));
-
-        let config_true: csa_config::ProjectConfig =
-            toml::from_str("[run]\nwriter_must_commit = true\n").unwrap();
-        assert!(effective_writer_must_commit(false, Some(&config_true)));
-
-        let config_false: csa_config::ProjectConfig =
-            toml::from_str("[run]\nwriter_must_commit = false\n").unwrap();
-        assert!(effective_writer_must_commit(true, Some(&config_false)));
-    }
-
-    fn session_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
-        let now = chrono::Utc::now();
-        csa_session::SessionResult {
-            post_exec_gate: None,
-            status: status.to_string(),
-            exit_code,
-            summary: "done".to_string(),
-            tool: "codex".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now,
-            events_count: 0,
-            artifacts: Vec::new(),
-            ..Default::default()
-        }
-    }
-
-    fn run_git(root: &Path, args: &[&str]) {
-        let output = Command::new("git")
-            .arg("-C")
-            .arg(root)
-            .args(args)
-            .output()
-            .expect("git command should execute");
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    /// A throwaway git repo with one commit so `HEAD` exists. Hooks and GPG
-    /// signing are disabled so the test stays hermetic regardless of the host's
-    /// global git config.
-    fn init_repo_with_initial_commit() -> tempfile::TempDir {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let root = temp.path();
-        run_git(root, &["init", "-q"]);
-        run_git(root, &["config", "user.email", "test@example.com"]);
-        run_git(root, &["config", "user.name", "Test User"]);
-        run_git(root, &["config", "commit.gpgsign", "false"]);
-        run_git(
-            root,
-            &["config", "core.hooksPath", "/nonexistent-csa-hooks"],
-        );
-        std::fs::write(root.join("seed.txt"), "seed\n").expect("write seed");
-        run_git(root, &["add", "seed.txt"]);
-        run_git(root, &["commit", "-q", "-m", "initial"]);
-        temp
-    }
-
-    #[test]
-    fn working_tree_changed_lines_counts_untracked_non_ignored_files() {
-        let temp = init_repo_with_initial_commit();
-        let root = temp.path();
-        // Substantial NEW work composed ENTIRELY of untracked files: `git diff
-        // HEAD` sees nothing, so the pre-fix measure would have returned 0.
-        let body: String = (0..50).map(|i| format!("line {i}\n")).collect();
-        std::fs::write(root.join("new_module.rs"), &body).unwrap();
-
-        let measured = working_tree_changed_lines(root);
-        assert!(
-            measured >= 50,
-            "untracked-file lines must count toward the size measure, got {measured}"
-        );
-    }
-
-    #[test]
-    fn working_tree_changed_lines_combines_tracked_and_untracked() {
-        let temp = init_repo_with_initial_commit();
-        let root = temp.path();
-        // Modify a tracked file (appears in `git diff HEAD`)...
-        std::fs::write(root.join("seed.txt"), "seed\nedit-a\nedit-b\n").unwrap();
-        // ...and add an untracked file (does not).
-        std::fs::write(root.join("extra.txt"), "u1\nu2\nu3\nu4\n").unwrap();
-
-        // 2 tracked insertions + 4 untracked lines = 6, all counted, none double.
-        assert_eq!(working_tree_changed_lines(root), 6);
-    }
-
-    #[test]
-    fn working_tree_changed_lines_excludes_gitignored_files() {
-        let temp = init_repo_with_initial_commit();
-        let root = temp.path();
-        // Commit `.gitignore` so it is tracked-and-clean, not itself an untracked
-        // file that would count.
-        std::fs::write(root.join(".gitignore"), "build/\n*.log\n").unwrap();
-        run_git(root, &["add", ".gitignore"]);
-        run_git(root, &["commit", "-q", "-m", "add gitignore"]);
-
-        // Large ignored content must not inflate the measure.
-        std::fs::create_dir_all(root.join("build")).unwrap();
-        let big: String = (0..500).map(|i| format!("artifact {i}\n")).collect();
-        std::fs::write(root.join("build/out.txt"), &big).unwrap();
-        std::fs::write(root.join("debug.log"), &big).unwrap();
-
-        assert_eq!(
-            working_tree_changed_lines(root),
-            0,
-            "ignored files must not inflate the writer-guard size measure"
-        );
-    }
-
-    #[test]
-    fn working_tree_changed_lines_zero_for_non_git_dir() {
-        let temp = tempfile::tempdir().unwrap();
-        assert_eq!(working_tree_changed_lines(temp.path()), 0);
-    }
-}
+#[path = "run_cmd_uncommitted_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
@@ -293,6 +293,29 @@ fn large_diff_warning_changed_paths_counts_large_file_after_untracked_cap() {
 }
 
 #[test]
+fn large_diff_warning_changed_paths_preserves_boundary_whitespace_in_untracked_paths() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    let leading_path = " leading-large.txt";
+    let trailing_path = "trailing-large.txt ";
+    let large_bytes = (default_tracked_diff_token_threshold() + 1) * DIFF_BYTES_PER_TOKEN;
+    for path in [leading_path, trailing_path] {
+        std::fs::write(root.join(path), vec![b'x'; large_bytes]).unwrap();
+    }
+
+    let changed_paths = vec![leading_path.to_string(), trailing_path.to_string()];
+    let changes = collect_uncommitted_changes_for_changed_paths(root, &changed_paths)
+        .expect("filtered untracked files with boundary whitespace should count");
+
+    assert_eq!(changes.file_count, 2);
+    assert_eq!(changes.files, changed_paths);
+    assert!(
+        large_diff_warning_report(&changes, &RunLargeDiffWarningConfig::default()).is_some(),
+        "filtered large paths with boundary whitespace should trigger the warning"
+    );
+}
+
+#[test]
 fn effective_writer_must_commit_respects_cli_and_config_precedence() {
     assert!(!effective_writer_must_commit(false, None));
 

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
@@ -363,6 +363,20 @@ fn working_tree_changed_lines_counts_untracked_non_ignored_files() {
 }
 
 #[test]
+fn working_tree_changed_lines_treats_large_uncounted_untracked_file_as_substantial() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    let long_line = format!("{}\n", "x".repeat(64 * 1024));
+    std::fs::write(root.join("large.txt"), long_line.repeat(17)).unwrap();
+
+    let measured = working_tree_changed_lines(root);
+    assert!(
+        measured > 10,
+        "lower-bound untracked size must not look trivial to the writer guard, got {measured}"
+    );
+}
+
+#[test]
 fn working_tree_changed_lines_combines_tracked_and_untracked() {
     let temp = init_repo_with_initial_commit();
     let root = temp.path();

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
@@ -266,6 +266,33 @@ fn large_diff_warning_changed_paths_counts_filtered_untracked_file() {
 }
 
 #[test]
+fn large_diff_warning_changed_paths_counts_large_file_after_untracked_cap() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    for i in 0..=crate::untracked_size::MAX_UNTRACKED_FILES {
+        std::fs::write(root.join(format!("aa-preexisting-{i:04}.txt")), "x\n").unwrap();
+    }
+    let large_path = "zz-large.txt";
+    let large_bytes = (default_tracked_diff_token_threshold() + 1) * DIFF_BYTES_PER_TOKEN;
+    std::fs::write(root.join(large_path), vec![b'x'; large_bytes]).unwrap();
+
+    let changes = collect_uncommitted_changes_for_changed_paths(root, &[large_path.to_string()])
+        .expect("changed untracked file should count despite noisy worktree");
+
+    assert_eq!(changes.file_count, 1);
+    assert_eq!(changes.files, vec![large_path.to_string()]);
+    assert!(
+        changes.approx_diff_tokens > default_tracked_diff_token_threshold(),
+        "large changed file should exceed token warning threshold: {:?}",
+        changes
+    );
+    assert!(
+        large_diff_warning_report(&changes, &RunLargeDiffWarningConfig::default()).is_some(),
+        "filtered large changed path should trigger the warning"
+    );
+}
+
+#[test]
 fn effective_writer_must_commit_respects_cli_and_config_precedence() {
     assert!(!effective_writer_must_commit(false, None));
 

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
@@ -1,0 +1,399 @@
+use std::io::Read;
+use std::path::Path;
+use std::process::Command;
+
+use super::*;
+
+#[test]
+fn writer_predicate_excludes_sa_mode_and_read_only_kinds() {
+    assert!(is_writer_session(false, Some("run")));
+    assert!(!is_writer_session(true, Some("run")));
+    assert!(!is_writer_session(false, Some("review")));
+    assert!(!is_writer_session(false, Some("debate")));
+    assert!(!is_writer_session(false, Some("recon")));
+    assert!(!is_writer_session(false, None));
+}
+
+#[test]
+fn summarize_uncommitted_changes_returns_none_for_clean_status() {
+    assert!(summarize_uncommitted_changes("", "").is_none());
+}
+
+#[test]
+fn summarize_uncommitted_changes_counts_files_and_numstat() {
+    let porcelain = " M crates/a.rs\0A  crates/b.rs\0?? notes/todo.md\0";
+    let numstat = "10\t2\tcrates/a.rs\n5\t0\tcrates/b.rs\n-\t-\tassets/blob.bin\n";
+
+    let changes = summarize_uncommitted_changes(porcelain, numstat)
+        .expect("dirty porcelain should produce changes");
+
+    assert_eq!(changes.file_count, 3);
+    assert_eq!(changes.insertions, 15);
+    assert_eq!(changes.deletions, 2);
+    assert_eq!(changes.approx_diff_tokens, 0);
+    assert_eq!(
+        changes.files,
+        vec![
+            "crates/a.rs".to_string(),
+            "crates/b.rs".to_string(),
+            "notes/todo.md".to_string()
+        ]
+    );
+    assert_eq!(changes.truncated, 0);
+}
+
+#[test]
+fn summarize_uncommitted_changes_caps_file_list() {
+    let porcelain = (0..25)
+        .map(|idx| format!("?? file-{idx}.txt\0"))
+        .collect::<String>();
+
+    let changes = summarize_uncommitted_changes(&porcelain, "")
+        .expect("dirty porcelain should produce changes");
+
+    assert_eq!(changes.file_count, 25);
+    assert_eq!(changes.files.len(), MAX_UNCOMMITTED_FILES);
+    assert_eq!(changes.truncated, 5);
+}
+
+#[test]
+fn apply_uncommitted_changes_warn_only_preserves_success() {
+    let mut result = session_result("success", 0);
+    let changes = csa_session::UncommittedChanges {
+        file_count: 1,
+        insertions: 2,
+        deletions: 0,
+        approx_diff_tokens: 16,
+        files: vec!["src/lib.rs".to_string()],
+        truncated: 0,
+    };
+
+    apply_uncommitted_changes_to_result(&mut result, changes, None, false);
+
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+    assert!(result.uncommitted_changes.is_some());
+    assert!(result.large_diff_warning.is_none());
+    assert!(result.warnings.is_empty());
+}
+
+#[test]
+fn apply_uncommitted_changes_require_commit_flips_to_failure() {
+    let mut result = session_result("success", 0);
+    let changes = csa_session::UncommittedChanges {
+        file_count: 1,
+        insertions: 2,
+        deletions: 0,
+        approx_diff_tokens: 16,
+        files: vec!["src/lib.rs".to_string()],
+        truncated: 0,
+    };
+
+    apply_uncommitted_changes_to_result(&mut result, changes, None, true);
+
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.summary, REQUIRE_COMMIT_REASON);
+    assert!(result.uncommitted_changes.is_some());
+}
+
+#[test]
+fn diff_stream_token_estimate_stops_at_threshold_byte_limit() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    struct CountingReader {
+        remaining: usize,
+        read_bytes: Rc<Cell<usize>>,
+    }
+
+    impl Read for CountingReader {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if self.remaining == 0 {
+                return Ok(0);
+            }
+            let n = self.remaining.min(buf.len());
+            buf[..n].fill(b'x');
+            self.remaining -= n;
+            self.read_bytes.set(self.read_bytes.get() + n);
+            Ok(n)
+        }
+    }
+
+    let threshold = 10;
+    let read_bytes = Rc::new(Cell::new(0));
+    let reader = CountingReader {
+        remaining: tracked_diff_byte_limit(threshold) * 10,
+        read_bytes: Rc::clone(&read_bytes),
+    };
+
+    let estimate =
+        estimate_diff_stream_tokens(reader, threshold).expect("stream estimate should succeed");
+
+    assert!(estimate.cap_reached);
+    assert_eq!(estimate.tokens, threshold + 1);
+    assert_eq!(read_bytes.get(), tracked_diff_byte_limit(threshold));
+}
+
+#[test]
+fn collect_uncommitted_changes_caps_tracked_diff_token_estimate() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    let long_line = "x".repeat(tracked_diff_byte_limit(10) * 4);
+    std::fs::write(root.join("seed.txt"), format!("seed\n{long_line}\n")).unwrap();
+
+    let changes = collect_uncommitted_changes_with_token_threshold(root, 10)
+        .expect("tracked mutation should be reported");
+
+    assert_eq!(changes.file_count, 1);
+    assert!(
+        changes.changed_lines() < 100,
+        "test fixture should exercise token threshold, not line threshold"
+    );
+    assert_eq!(changes.approx_diff_tokens, 11);
+
+    let warning = large_diff_warning_report(
+        &changes,
+        &RunLargeDiffWarningConfig {
+            enabled: true,
+            changed_files: 100,
+            changed_lines: 100,
+            approx_diff_tokens: 10,
+            mode: RunLargeDiffWarningMode::Warn,
+        },
+    )
+    .expect("bounded tracked token estimate should still trip token threshold");
+
+    assert_eq!(warning.approx_diff_tokens, 11);
+}
+
+#[test]
+fn large_diff_warning_report_triggers_on_file_count() {
+    let changes = changes(6, 10, 5, 100);
+    let warning = large_diff_warning_report(&changes, &RunLargeDiffWarningConfig::default())
+        .expect("file count above default threshold should warn");
+
+    assert_eq!(warning.changed_files, 6);
+    assert_eq!(warning.changed_lines, 15);
+    assert_eq!(warning.approx_diff_tokens, 100);
+}
+
+#[test]
+fn large_diff_warning_report_triggers_on_changed_lines() {
+    let changes = changes(2, 501, 0, 100);
+    let warning = large_diff_warning_report(&changes, &RunLargeDiffWarningConfig::default())
+        .expect("changed lines above default threshold should warn");
+
+    assert_eq!(warning.changed_files, 2);
+    assert_eq!(warning.changed_lines, 501);
+    assert_eq!(warning.approx_diff_tokens, 100);
+}
+
+#[test]
+fn large_diff_warning_report_triggers_on_approx_tokens() {
+    let changes = changes(2, 10, 5, 8_001);
+    let warning = large_diff_warning_report(&changes, &RunLargeDiffWarningConfig::default())
+        .expect("approx tokens above default threshold should warn");
+
+    assert_eq!(warning.changed_files, 2);
+    assert_eq!(warning.changed_lines, 15);
+    assert_eq!(warning.approx_diff_tokens, 8_001);
+}
+
+#[test]
+fn large_diff_warning_report_suppresses_small_and_disabled_changes() {
+    let changes = changes(5, 250, 250, 8_000);
+
+    assert!(large_diff_warning_report(&changes, &RunLargeDiffWarningConfig::default()).is_none());
+
+    let disabled = RunLargeDiffWarningConfig {
+        enabled: false,
+        changed_files: 1,
+        changed_lines: 1,
+        approx_diff_tokens: 1,
+        mode: RunLargeDiffWarningMode::Warn,
+    };
+    assert!(large_diff_warning_report(&changes, &disabled).is_none());
+}
+
+#[test]
+fn format_large_diff_warning_block_is_parseable() {
+    let warning = csa_session::LargeDiffWarningReport {
+        changed_files: 9,
+        changed_lines: 1_420,
+        approx_diff_tokens: 18_000,
+    };
+    let block = format_large_diff_warning_block(&warning);
+
+    assert!(block.starts_with(
+        "<!-- CSA:LARGE_DIFF_WARNING changed_files=9 changed_lines=1420 approx_diff_tokens=18000 -->"
+    ));
+    assert!(block.contains("This CSA session left a large changed surface."));
+    assert!(block.ends_with("<!-- CSA:LARGE_DIFF_WARNING:END -->"));
+}
+
+#[test]
+fn large_diff_warning_changed_paths_empty_ignores_preexisting_dirty_surface() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    std::fs::write(root.join("preexisting.txt"), "x\n".repeat(600)).unwrap();
+
+    let full_dirty = collect_uncommitted_changes(root).expect("dirty worktree should count");
+    assert!(
+        large_diff_warning_report(&full_dirty, &RunLargeDiffWarningConfig::default()).is_some()
+    );
+
+    let session_delta = collect_uncommitted_changes_for_changed_paths(root, &[]);
+
+    assert!(session_delta.is_none());
+}
+
+#[test]
+fn large_diff_warning_changed_paths_counts_filtered_untracked_file() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    std::fs::write(root.join("preexisting.txt"), "x\n".repeat(600)).unwrap();
+    std::fs::write(root.join("new.txt"), "one\ntwo\nthree\n").unwrap();
+
+    let changes = collect_uncommitted_changes_for_changed_paths(root, &["new.txt".to_string()])
+        .expect("changed untracked file should count");
+
+    assert_eq!(changes.file_count, 1);
+    assert_eq!(changes.insertions, 3);
+    assert_eq!(changes.deletions, 0);
+    assert!(changes.approx_diff_tokens > 0);
+    assert_eq!(changes.files, vec!["new.txt".to_string()]);
+}
+
+#[test]
+fn effective_writer_must_commit_respects_cli_and_config_precedence() {
+    assert!(!effective_writer_must_commit(false, None));
+
+    let config_true: csa_config::ProjectConfig =
+        toml::from_str("[run]\nwriter_must_commit = true\n").unwrap();
+    assert!(effective_writer_must_commit(false, Some(&config_true)));
+
+    let config_false: csa_config::ProjectConfig =
+        toml::from_str("[run]\nwriter_must_commit = false\n").unwrap();
+    assert!(effective_writer_must_commit(true, Some(&config_false)));
+}
+
+fn session_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
+    let now = chrono::Utc::now();
+    csa_session::SessionResult {
+        post_exec_gate: None,
+        status: status.to_string(),
+        exit_code,
+        summary: "done".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    }
+}
+
+fn changes(
+    file_count: usize,
+    insertions: u64,
+    deletions: u64,
+    approx_diff_tokens: usize,
+) -> csa_session::UncommittedChanges {
+    csa_session::UncommittedChanges {
+        file_count,
+        insertions,
+        deletions,
+        approx_diff_tokens,
+        files: Vec::new(),
+        truncated: 0,
+    }
+}
+
+fn run_git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// A throwaway git repo with one commit so `HEAD` exists. Hooks and GPG
+/// signing are disabled so the test stays hermetic regardless of the host's
+/// global git config.
+fn init_repo_with_initial_commit() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    run_git(root, &["init", "-q"]);
+    run_git(root, &["config", "user.email", "test@example.com"]);
+    run_git(root, &["config", "user.name", "Test User"]);
+    run_git(root, &["config", "commit.gpgsign", "false"]);
+    run_git(
+        root,
+        &["config", "core.hooksPath", "/nonexistent-csa-hooks"],
+    );
+    std::fs::write(root.join("seed.txt"), "seed\n").expect("write seed");
+    run_git(root, &["add", "seed.txt"]);
+    run_git(root, &["commit", "-q", "-m", "initial"]);
+    temp
+}
+
+#[test]
+fn working_tree_changed_lines_counts_untracked_non_ignored_files() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    let body: String = (0..50).map(|i| format!("line {i}\n")).collect();
+    std::fs::write(root.join("new_module.rs"), &body).unwrap();
+
+    let measured = working_tree_changed_lines(root);
+    assert!(
+        measured >= 50,
+        "untracked-file lines must count toward the size measure, got {measured}"
+    );
+}
+
+#[test]
+fn working_tree_changed_lines_combines_tracked_and_untracked() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    std::fs::write(root.join("seed.txt"), "seed\nedit-a\nedit-b\n").unwrap();
+    std::fs::write(root.join("extra.txt"), "u1\nu2\nu3\nu4\n").unwrap();
+
+    assert_eq!(working_tree_changed_lines(root), 6);
+}
+
+#[test]
+fn working_tree_changed_lines_excludes_gitignored_files() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    std::fs::write(root.join(".gitignore"), "build/\n*.log\n").unwrap();
+    run_git(root, &["add", ".gitignore"]);
+    run_git(root, &["commit", "-q", "-m", "add gitignore"]);
+
+    let big: String = (0..500).map(|i| format!("artifact {i}\n")).collect();
+    std::fs::create_dir_all(root.join("build")).unwrap();
+    std::fs::write(root.join("build/out.txt"), &big).unwrap();
+    std::fs::write(root.join("debug.log"), &big).unwrap();
+
+    assert_eq!(
+        working_tree_changed_lines(root),
+        0,
+        "ignored files must not inflate the writer-guard size measure"
+    );
+}
+
+#[test]
+fn working_tree_changed_lines_zero_for_non_git_dir() {
+    let temp = tempfile::tempdir().unwrap();
+    assert_eq!(working_tree_changed_lines(temp.path()), 0);
+}

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
@@ -316,6 +316,47 @@ fn large_diff_warning_changed_paths_preserves_boundary_whitespace_in_untracked_p
 }
 
 #[test]
+fn large_diff_warning_changed_paths_treats_tracked_pathspec_magic_as_literal() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    let magic_path = ":(glob)large.rs";
+    std::fs::write(root.join(magic_path), "seed\n").unwrap();
+    run_git_literal_pathspecs(root, &["add", "--", magic_path]);
+    run_git(root, &["commit", "-q", "-m", "add magic path"]);
+
+    let token_threshold = 10;
+    let long_line = "x".repeat(tracked_diff_byte_limit(token_threshold) * 4);
+    std::fs::write(root.join(magic_path), format!("seed\n{long_line}\n")).unwrap();
+
+    let changes = collect_uncommitted_changes_for_changed_paths_with_token_threshold(
+        root,
+        &[magic_path.to_string()],
+        token_threshold,
+    )
+    .expect("filtered tracked path with pathspec magic should count");
+
+    assert_eq!(changes.file_count, 1);
+    assert_eq!(changes.files, vec![magic_path.to_string()]);
+    assert_eq!(changes.insertions, 1);
+    assert_eq!(changes.deletions, 0);
+    assert_eq!(changes.approx_diff_tokens, token_threshold + 1);
+
+    let warning = large_diff_warning_report(
+        &changes,
+        &RunLargeDiffWarningConfig {
+            enabled: true,
+            changed_files: 100,
+            changed_lines: 100,
+            approx_diff_tokens: token_threshold,
+            mode: RunLargeDiffWarningMode::Warn,
+        },
+    )
+    .expect("large literal tracked path should trip token threshold");
+
+    assert_eq!(warning.approx_diff_tokens, token_threshold + 1);
+}
+
+#[test]
 fn effective_writer_must_commit_respects_cli_and_config_precedence() {
     assert!(!effective_writer_must_commit(false, None));
 
@@ -368,6 +409,22 @@ fn run_git(root: &Path, args: &[&str]) {
         .arg("-C")
         .arg(root)
         .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_git_literal_pathspecs(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .env("GIT_LITERAL_PATHSPECS", "1")
         .output()
         .expect("git command should execute");
     assert!(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -133,6 +133,9 @@ pub(crate) fn render_wait_result_summary(
     if let Some(changes) = result.uncommitted_changes.as_ref() {
         lines.push(crate::run_cmd::format_uncommitted_warning(changes));
     }
+    if let Some(warning) = result.large_diff_warning.as_ref() {
+        lines.push(crate::run_cmd::format_large_diff_warning_block(warning));
+    }
 
     for warning in &result.warnings {
         lines.push(format!("Warning: {warning}"));
@@ -214,6 +217,7 @@ fn render_wait_result_json(
         "review_verdict": read_review_verdict_label(session_dir, result),
         "failover": format_failover_chain_label(session_dir, result),
         "kill_hint": result.kill_hint.as_deref(),
+        "large_diff_warning": result.large_diff_warning.as_ref(),
         "warnings": result.warnings,
         "summary": crate::session_summary_text::human_session_summary(session_dir, &result.summary)
             .and_then(|text| compact_wait_summary_text(&text)),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -209,6 +209,7 @@ fn compact_summary_labels_fix_loop_noop_from_review_meta() {
         warnings: vec!["fix loop did not engage: head_unchanged_worktree_clean".to_string()],
         raw_process_exit_code: None,
         uncommitted_changes: None,
+        large_diff_warning: None,
         manager_fields: Default::default(),
     };
 
@@ -335,9 +336,11 @@ fn compact_summary_includes_writer_uncommitted_warning() {
             file_count: 7,
             insertions: 240,
             deletions: 12,
+            approx_diff_tokens: 1_024,
             files: vec!["src/lib.rs".to_string()],
             truncated: 6,
         }),
+        large_diff_warning: None,
         manager_fields: Default::default(),
     };
 
@@ -346,6 +349,41 @@ fn compact_summary_includes_writer_uncommitted_warning() {
     assert!(summary.contains(
         "⚠ writer session ended with 7 uncommitted files (+240/-12) — work NOT committed"
     ));
+    assert!(
+        !summary.contains("CSA:LARGE_DIFF_WARNING"),
+        "small/unspecified large-diff warning must stay absent"
+    );
+}
+
+#[test]
+fn compact_summary_includes_large_diff_warning_block() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let now = Utc::now();
+    let warning = csa_session::LargeDiffWarningReport {
+        changed_files: 9,
+        changed_lines: 1_420,
+        approx_diff_tokens: 18_000,
+    };
+    let result = csa_session::SessionResult {
+        post_exec_gate: None,
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "done".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        events_count: 0,
+        artifacts: Vec::new(),
+        large_diff_warning: Some(warning.clone()),
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITLARGEDIFF", &result);
+
+    assert!(summary.contains(&crate::run_cmd::format_large_diff_warning_block(&warning)));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/untracked_size.rs
+++ b/crates/cli-sub-agent/src/untracked_size.rs
@@ -52,11 +52,13 @@ pub(crate) const MAX_UNTRACKED_FILES: usize = 1_000;
 /// counted). `notes` is empty when every counted total is exact; otherwise it
 /// carries human-readable markers stating which totals are a lower bound
 /// (capped, binary/large, or truncated), so a reader is never misled into
-/// treating an estimate as exact.
+/// treating an estimate as exact. `lower_bound` is the structured equivalent of
+/// those notes for callers that need a boolean gate instead of report text.
 pub(crate) struct UntrackedDiffSize {
     pub(crate) files: usize,
     pub(crate) lines: usize,
     pub(crate) bytes: u64,
+    pub(crate) lower_bound: bool,
     pub(crate) notes: Vec<String>,
 }
 
@@ -86,6 +88,7 @@ fn untracked_diff_size_with_filter(
         files: 0,
         lines: 0,
         bytes: 0,
+        lower_bound: false,
         notes: Vec::new(),
     };
     let mut capped_files = 0usize;
@@ -120,17 +123,20 @@ fn untracked_diff_size_with_filter(
     }
 
     if uncounted_files > 0 {
+        out.lower_bound = true;
         out.notes.push(format!(
             "{uncounted_files} untracked file(s) not line-counted (binary or > {} MiB); changed-line total is a lower bound",
             MAX_LINE_SCAN_BYTES >> 20
         ));
     }
     if capped_files > 0 {
+        out.lower_bound = true;
         out.notes.push(format!(
             "{capped_files} untracked file(s) line-counted up to {MAX_LINES_PER_FILE} lines (capped); changed-line total is a lower bound"
         ));
     }
     if listing.truncated {
+        out.lower_bound = true;
         out.notes.push(format!(
             "untracked scan truncated: sized the first {MAX_UNTRACKED_FILES} untracked files (the working tree has more, not enumerated); totals are a lower bound"
         ));

--- a/crates/cli-sub-agent/src/untracked_size.rs
+++ b/crates/cli-sub-agent/src/untracked_size.rs
@@ -17,6 +17,7 @@
 //! number of files scanned is itself capped. Any single unreadable/race-deleted
 //! file is tolerated (skipped), never fatal.
 
+use std::collections::BTreeSet;
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -64,6 +65,21 @@ pub(crate) struct UntrackedDiffSize {
 /// result when `project_root` is not a git worktree or has no untracked files
 /// (git failure is fail-open, never fatal).
 pub(crate) fn untracked_diff_size(project_root: &Path) -> UntrackedDiffSize {
+    untracked_diff_size_with_filter(project_root, None)
+}
+
+/// Size only untracked files whose repo-relative path appears in `path_filter`.
+pub(crate) fn untracked_diff_size_for_paths(
+    project_root: &Path,
+    path_filter: &BTreeSet<String>,
+) -> UntrackedDiffSize {
+    untracked_diff_size_with_filter(project_root, Some(path_filter))
+}
+
+fn untracked_diff_size_with_filter(
+    project_root: &Path,
+    path_filter: Option<&BTreeSet<String>>,
+) -> UntrackedDiffSize {
     let listing = list_untracked(project_root);
 
     let mut out = UntrackedDiffSize {
@@ -76,6 +92,11 @@ pub(crate) fn untracked_diff_size(project_root: &Path) -> UntrackedDiffSize {
     let mut uncounted_files = 0usize; // large + binary: sized but not line-counted
 
     for path in &listing.paths {
+        if let Some(filter) = path_filter
+            && !untracked_path_matches_filter(project_root, path, filter)
+        {
+            continue;
+        }
         match classify_untracked_file(path) {
             FileClass::Text {
                 lines,
@@ -117,31 +138,14 @@ pub(crate) fn untracked_diff_size(project_root: &Path) -> UntrackedDiffSize {
     out
 }
 
-/// Count newline-delimited lines in `path` with bounded memory and IO, for the
-/// review-aware writer guard (#1842), whose size measure only needs a single
-/// running total (trivial vs substantial), not the richer per-file
-/// classification the review report needs.
-///
-/// Only regular files are opened: `path` comes from an untracked-worktree
-/// enumeration that can legitimately surface symlinks, FIFOs, sockets, or device
-/// nodes, and opening those could follow a link or block indefinitely. Streams
-/// through a fixed buffer counting `\n`, bounded by [`MAX_LINE_SCAN_BYTES`]; a
-/// final line lacking a trailing newline still counts. Fail-open: a non-regular
-/// path or any IO error (including a missing/race-deleted file) yields `0` so a
-/// transient failure cannot abort the guard.
-pub(crate) fn count_file_lines(path: &Path) -> usize {
-    if regular_file_meta(path).is_none() {
-        return 0;
-    }
-    let Ok(file) = std::fs::File::open(path) else {
-        return 0;
-    };
-    // `usize::MAX` line cap: the guard never wants a per-file line ceiling, only
-    // the byte ceiling, preserving the pre-extraction behavior exactly (a huge
-    // file still contributes its first 1 MiB of lines = substantial work).
-    scan_file_bounded(file, usize::MAX)
-        .map(|scan| scan.lines)
-        .unwrap_or(0)
+fn untracked_path_matches_filter(
+    project_root: &Path,
+    path: &Path,
+    path_filter: &BTreeSet<String>,
+) -> bool {
+    let rel_path = path.strip_prefix(project_root).unwrap_or(path);
+    let rel = rel_path.to_string_lossy();
+    path_filter.contains(rel.as_ref())
 }
 
 /// A bounded enumeration of untracked, non-ignored working-tree paths.

--- a/crates/cli-sub-agent/src/untracked_size.rs
+++ b/crates/cli-sub-agent/src/untracked_size.rs
@@ -82,7 +82,10 @@ fn untracked_diff_size_with_filter(
     project_root: &Path,
     path_filter: Option<&BTreeSet<String>>,
 ) -> UntrackedDiffSize {
-    let listing = list_untracked(project_root);
+    let listing = match path_filter {
+        Some(filter) => list_filtered_untracked(project_root, filter),
+        None => list_untracked(project_root),
+    };
 
     let mut out = UntrackedDiffSize {
         files: 0,
@@ -95,11 +98,6 @@ fn untracked_diff_size_with_filter(
     let mut uncounted_files = 0usize; // large + binary: sized but not line-counted
 
     for path in &listing.paths {
-        if let Some(filter) = path_filter
-            && !untracked_path_matches_filter(project_root, path, filter)
-        {
-            continue;
-        }
         match classify_untracked_file(path) {
             FileClass::Text {
                 lines,
@@ -144,14 +142,55 @@ fn untracked_diff_size_with_filter(
     out
 }
 
-fn untracked_path_matches_filter(
+fn list_filtered_untracked(
     project_root: &Path,
-    path: &Path,
     path_filter: &BTreeSet<String>,
-) -> bool {
-    let rel_path = path.strip_prefix(project_root).unwrap_or(path);
-    let rel = rel_path.to_string_lossy();
-    path_filter.contains(rel.as_ref())
+) -> UntrackedListing {
+    let mut rels = BTreeSet::new();
+    for rel in path_filter {
+        if rel.is_empty() || rel.contains('\0') {
+            continue;
+        }
+        for candidate in list_untracked_for_path(project_root, rel) {
+            if path_filter.contains(candidate.as_str()) {
+                rels.insert(candidate);
+            }
+        }
+    }
+
+    UntrackedListing {
+        paths: rels.into_iter().map(|rel| project_root.join(rel)).collect(),
+        truncated: false,
+    }
+}
+
+fn list_untracked_for_path(project_root: &Path, rel_path: &str) -> Vec<String> {
+    let Ok(mut child) = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["ls-files", "--others", "--exclude-standard", "-z", "--"])
+        .arg(rel_path)
+        .env("GIT_LITERAL_PATHSPECS", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return Vec::new();
+    };
+    let Some(stdout) = child.stdout.take() else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Vec::new();
+    };
+
+    // A literal file path can yield only itself; a directory path may yield
+    // descendants, but `list_filtered_untracked` keeps only exact path matches.
+    // Reading one entry preserves the noisy-worktree bound for directory input.
+    let (rels, _) = read_nul_delimited_capped(std::io::BufReader::new(stdout), 1);
+    let _ = child.kill();
+    let _ = child.wait();
+    rels
 }
 
 /// A bounded enumeration of untracked, non-ignored working-tree paths.

--- a/crates/cli-sub-agent/src/untracked_size.rs
+++ b/crates/cli-sub-agent/src/untracked_size.rs
@@ -18,6 +18,7 @@
 //! file is tolerated (skipped), never fatal.
 
 use std::collections::BTreeSet;
+use std::ffi::OsStr;
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -45,6 +46,11 @@ const READ_BUF_BYTES: usize = 16 * 1024; // 16 KiB
 /// the scan stops and the report is marked truncated, so an untracked set with
 /// an arbitrarily large number of files can never spin an unbounded loop.
 pub(crate) const MAX_UNTRACKED_FILES: usize = 1_000;
+
+/// Maximum total bytes of literal pathspec arguments passed to a filtered
+/// `git ls-files` call. This keeps filtered sizing below OS argument-vector
+/// limits even when the changed-path set contains unusually long names.
+const MAX_FILTERED_PATHSPEC_BYTES: usize = 128 * 1024;
 
 /// Aggregate size contribution of the untracked working-tree files, ready to be
 /// merged into a [`csa_session::ReviewDiffSize`]. `bytes` is the on-disk size of
@@ -146,51 +152,105 @@ fn list_filtered_untracked(
     project_root: &Path,
     path_filter: &BTreeSet<String>,
 ) -> UntrackedListing {
-    let mut rels = BTreeSet::new();
-    for rel in path_filter {
-        if rel.is_empty() || rel.contains('\0') {
-            continue;
-        }
-        for candidate in list_untracked_for_path(project_root, rel) {
-            if path_filter.contains(candidate.as_str()) {
-                rels.insert(candidate);
-            }
-        }
-    }
-
-    UntrackedListing {
-        paths: rels.into_iter().map(|rel| project_root.join(rel)).collect(),
-        truncated: false,
-    }
+    list_filtered_untracked_with_git(project_root, path_filter, OsStr::new("git"))
 }
 
-fn list_untracked_for_path(project_root: &Path, rel_path: &str) -> Vec<String> {
-    let Ok(mut child) = Command::new("git")
+fn list_filtered_untracked_with_git(
+    project_root: &Path,
+    path_filter: &BTreeSet<String>,
+    git_program: &OsStr,
+) -> UntrackedListing {
+    let selection = filtered_pathspecs(project_root, path_filter);
+    if selection.pathspecs.is_empty() {
+        return UntrackedListing {
+            paths: Vec::new(),
+            truncated: selection.truncated,
+        };
+    }
+
+    let Ok(mut child) = Command::new(git_program)
         .arg("-C")
         .arg(project_root)
         .args(["ls-files", "--others", "--exclude-standard", "-z", "--"])
-        .arg(rel_path)
+        .args(selection.pathspecs.iter().copied())
         .env("GIT_LITERAL_PATHSPECS", "1")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
     else {
-        return Vec::new();
+        return UntrackedListing {
+            paths: Vec::new(),
+            truncated: selection.truncated,
+        };
     };
     let Some(stdout) = child.stdout.take() else {
         let _ = child.kill();
         let _ = child.wait();
-        return Vec::new();
+        return UntrackedListing {
+            paths: Vec::new(),
+            truncated: selection.truncated,
+        };
     };
 
-    // A literal file path can yield only itself; a directory path may yield
-    // descendants, but `list_filtered_untracked` keeps only exact path matches.
-    // Reading one entry preserves the noisy-worktree bound for directory input.
-    let (rels, _) = read_nul_delimited_capped(std::io::BufReader::new(stdout), 1);
+    let (candidates, output_truncated) =
+        read_nul_delimited_capped(std::io::BufReader::new(stdout), MAX_UNTRACKED_FILES);
     let _ = child.kill();
     let _ = child.wait();
-    rels
+
+    let mut rels = BTreeSet::new();
+    for candidate in candidates {
+        if path_filter.contains(candidate.as_str()) {
+            rels.insert(candidate);
+        }
+    }
+    UntrackedListing {
+        paths: rels.into_iter().map(|rel| project_root.join(rel)).collect(),
+        truncated: selection.truncated || output_truncated,
+    }
+}
+
+struct FilteredPathspecs<'a> {
+    pathspecs: Vec<&'a str>,
+    truncated: bool,
+}
+
+fn filtered_pathspecs<'a>(
+    project_root: &Path,
+    path_filter: &'a BTreeSet<String>,
+) -> FilteredPathspecs<'a> {
+    let mut pathspecs = Vec::new();
+    let mut pathspec_bytes = 0usize;
+    for (inspected, rel) in path_filter.iter().enumerate() {
+        if inspected == MAX_UNTRACKED_FILES {
+            return FilteredPathspecs {
+                pathspecs,
+                truncated: true,
+            };
+        }
+        if rel.is_empty() || rel.contains('\0') || is_directory_entry(project_root, rel) {
+            continue;
+        }
+        let next_bytes = pathspec_bytes.saturating_add(rel.len());
+        if next_bytes > MAX_FILTERED_PATHSPEC_BYTES {
+            return FilteredPathspecs {
+                pathspecs,
+                truncated: true,
+            };
+        }
+        pathspecs.push(rel.as_str());
+        pathspec_bytes = next_bytes;
+    }
+    FilteredPathspecs {
+        pathspecs,
+        truncated: false,
+    }
+}
+
+fn is_directory_entry(project_root: &Path, rel_path: &str) -> bool {
+    std::fs::symlink_metadata(project_root.join(rel_path))
+        .ok()
+        .is_some_and(|meta| meta.file_type().is_dir())
 }
 
 /// A bounded enumeration of untracked, non-ignored working-tree paths.

--- a/crates/cli-sub-agent/src/untracked_size_tests.rs
+++ b/crates/cli-sub-agent/src/untracked_size_tests.rs
@@ -215,6 +215,40 @@ fn untracked_diff_size_for_paths_counts_only_matching_files() {
 }
 
 #[test]
+fn untracked_diff_size_for_paths_checks_filtered_paths_after_global_cap() {
+    let temp = init_repo();
+    let root = temp.path();
+    for i in 0..=MAX_UNTRACKED_FILES {
+        std::fs::write(root.join(format!("aa-preexisting-{i:04}.txt")), "x\n").unwrap();
+    }
+    std::fs::write(
+        root.join("zz-large.txt"),
+        vec![b'x'; (MAX_LINE_SCAN_BYTES + 1) as usize],
+    )
+    .unwrap();
+    let filter = std::collections::BTreeSet::from(["zz-large.txt".to_string()]);
+
+    let size = untracked_diff_size_for_paths(root, &filter);
+
+    assert_eq!(size.files, 1);
+    assert_eq!(size.lines, 0, "large files are sized but not line-counted");
+    assert_eq!(size.bytes, MAX_LINE_SCAN_BYTES + 1);
+    assert!(size.lower_bound);
+    assert!(
+        size.notes
+            .iter()
+            .any(|note| note.contains("not line-counted")),
+        "large file should add a lower-bound note, got {:?}",
+        size.notes
+    );
+    assert!(
+        !size.notes.iter().any(|note| note.contains("truncated")),
+        "filtered path sizing must not inherit the global untracked cap note, got {:?}",
+        size.notes
+    );
+}
+
+#[test]
 fn untracked_diff_size_excludes_gitignored_files() {
     let temp = init_repo();
     let root = temp.path();

--- a/crates/cli-sub-agent/src/untracked_size_tests.rs
+++ b/crates/cli-sub-agent/src/untracked_size_tests.rs
@@ -35,6 +35,42 @@ fn init_repo() -> tempfile::TempDir {
     temp
 }
 
+#[cfg(unix)]
+fn make_pathspec_echo_git(root: &Path) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fake_git = root.join("git");
+    std::fs::write(
+        &fake_git,
+        r#"#!/bin/sh
+set -eu
+dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+count_file="$dir/git-count"
+if [ -f "$count_file" ]; then
+    count=$(cat "$count_file")
+else
+    count=0
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+after_separator=0
+for arg in "$@"; do
+    if [ "$after_separator" -eq 1 ]; then
+        printf '%s\000' "$arg"
+    fi
+    if [ "$arg" = "--" ]; then
+        after_separator=1
+    fi
+done
+"#,
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&fake_git).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&fake_git, perms).unwrap();
+    fake_git
+}
+
 #[test]
 fn classify_counts_exact_small_text_file() {
     let temp = tempfile::tempdir().unwrap();
@@ -245,6 +281,53 @@ fn untracked_diff_size_for_paths_checks_filtered_paths_after_global_cap() {
         !size.notes.iter().any(|note| note.contains("truncated")),
         "filtered path sizing must not inherit the global untracked cap note, got {:?}",
         size.notes
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn filtered_untracked_listing_batches_many_pathspecs_once() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("repo");
+    std::fs::create_dir(&root).unwrap();
+    let fake_git = make_pathspec_echo_git(temp.path());
+    let filter = (0..64)
+        .map(|i| format!("new-{i:04}.rs"))
+        .collect::<BTreeSet<_>>();
+
+    let listing = list_filtered_untracked_with_git(&root, &filter, fake_git.as_os_str());
+
+    assert_eq!(listing.paths.len(), filter.len());
+    assert!(!listing.truncated);
+    let count = std::fs::read_to_string(temp.path().join("git-count")).unwrap();
+    assert_eq!(
+        count, "1",
+        "filtered sizing must batch pathspecs into one git call"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn filtered_untracked_listing_caps_many_pathspecs_before_git() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("repo");
+    std::fs::create_dir(&root).unwrap();
+    let fake_git = make_pathspec_echo_git(temp.path());
+    let filter = (0..(MAX_UNTRACKED_FILES + 25))
+        .map(|i| format!("new-{i:04}.rs"))
+        .collect::<BTreeSet<_>>();
+
+    let listing = list_filtered_untracked_with_git(&root, &filter, fake_git.as_os_str());
+
+    assert_eq!(listing.paths.len(), MAX_UNTRACKED_FILES);
+    assert!(
+        listing.truncated,
+        "oversized filtered path sets must be marked lower-bound/truncated"
+    );
+    let count = std::fs::read_to_string(temp.path().join("git-count")).unwrap();
+    assert_eq!(
+        count, "1",
+        "filtered sizing must not spawn once per changed path"
     );
 }
 

--- a/crates/cli-sub-agent/src/untracked_size_tests.rs
+++ b/crates/cli-sub-agent/src/untracked_size_tests.rs
@@ -179,25 +179,6 @@ fn classify_skips_fifo_without_blocking() {
 }
 
 #[test]
-fn count_file_lines_matches_exact_partial_and_missing() {
-    let temp = tempfile::tempdir().unwrap();
-
-    let with_nl = temp.path().join("with_nl.txt");
-    std::fs::write(&with_nl, "x\ny\nz\n").unwrap();
-    assert_eq!(count_file_lines(&with_nl), 3);
-
-    let no_nl = temp.path().join("no_nl.txt");
-    std::fs::write(&no_nl, "x\ny\nz").unwrap();
-    assert_eq!(count_file_lines(&no_nl), 3);
-
-    let empty = temp.path().join("empty.txt");
-    std::fs::write(&empty, "").unwrap();
-    assert_eq!(count_file_lines(&empty), 0);
-
-    assert_eq!(count_file_lines(&temp.path().join("missing.txt")), 0);
-}
-
-#[test]
 fn untracked_diff_size_counts_exact_small_files() {
     let temp = init_repo();
     let root = temp.path();
@@ -214,6 +195,22 @@ fn untracked_diff_size_counts_exact_small_files() {
         "exact small files need no estimated/capped note, got {:?}",
         size.notes
     );
+}
+
+#[test]
+fn untracked_diff_size_for_paths_counts_only_matching_files() {
+    let temp = init_repo();
+    let root = temp.path();
+    std::fs::write(root.join("a.txt"), "1\n2\n3\n").unwrap();
+    std::fs::write(root.join("b.txt"), "4\n5\n").unwrap();
+    let filter = std::collections::BTreeSet::from(["b.txt".to_string()]);
+
+    let size = untracked_diff_size_for_paths(root, &filter);
+
+    assert_eq!(size.files, 1);
+    assert_eq!(size.lines, 2);
+    assert_eq!(size.bytes, 4);
+    assert!(size.notes.is_empty());
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/untracked_size_tests.rs
+++ b/crates/cli-sub-agent/src/untracked_size_tests.rs
@@ -190,6 +190,7 @@ fn untracked_diff_size_counts_exact_small_files() {
     assert_eq!(size.files, 2);
     assert_eq!(size.lines, 5);
     assert_eq!(size.bytes, 6 + 4);
+    assert!(!size.lower_bound);
     assert!(
         size.notes.is_empty(),
         "exact small files need no estimated/capped note, got {:?}",
@@ -248,6 +249,7 @@ fn untracked_diff_size_marks_large_and_binary_without_inflating_lines() {
 
     assert_eq!(size.files, 3, "all three regular files are sized");
     assert_eq!(size.lines, 2, "only the exact text file contributes lines");
+    assert!(size.lower_bound);
     assert_eq!(
         size.notes.len(),
         1,

--- a/crates/csa-config/src/config_session.rs
+++ b/crates/csa-config/src/config_session.rs
@@ -48,8 +48,72 @@ impl PostExecGateConfig {
     }
 }
 
+pub const DEFAULT_RUN_LARGE_DIFF_WARNING_CHANGED_FILES: usize = 5;
+pub const DEFAULT_RUN_LARGE_DIFF_WARNING_CHANGED_LINES: u64 = 500;
+pub const DEFAULT_RUN_LARGE_DIFF_WARNING_APPROX_TOKENS: usize = 8_000;
+
+const fn default_run_large_diff_warning_enabled() -> bool {
+    true
+}
+
+const fn default_run_large_diff_warning_changed_files() -> usize {
+    DEFAULT_RUN_LARGE_DIFF_WARNING_CHANGED_FILES
+}
+
+const fn default_run_large_diff_warning_changed_lines() -> u64 {
+    DEFAULT_RUN_LARGE_DIFF_WARNING_CHANGED_LINES
+}
+
+const fn default_run_large_diff_warning_approx_tokens() -> usize {
+    DEFAULT_RUN_LARGE_DIFF_WARNING_APPROX_TOKENS
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RunLargeDiffWarningMode {
+    #[default]
+    Warn,
+}
+
+/// Caller-visible warning policy for writer sessions that leave a large diff.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunLargeDiffWarningConfig {
+    #[serde(default = "default_run_large_diff_warning_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_run_large_diff_warning_changed_files")]
+    pub changed_files: usize,
+    #[serde(default = "default_run_large_diff_warning_changed_lines")]
+    pub changed_lines: u64,
+    #[serde(default = "default_run_large_diff_warning_approx_tokens")]
+    pub approx_diff_tokens: usize,
+    #[serde(default)]
+    pub mode: RunLargeDiffWarningMode,
+}
+
+impl Default for RunLargeDiffWarningConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_run_large_diff_warning_enabled(),
+            changed_files: default_run_large_diff_warning_changed_files(),
+            changed_lines: default_run_large_diff_warning_changed_lines(),
+            approx_diff_tokens: default_run_large_diff_warning_approx_tokens(),
+            mode: RunLargeDiffWarningMode::Warn,
+        }
+    }
+}
+
+impl RunLargeDiffWarningConfig {
+    pub fn is_default(&self) -> bool {
+        self.enabled == default_run_large_diff_warning_enabled()
+            && self.changed_files == default_run_large_diff_warning_changed_files()
+            && self.changed_lines == default_run_large_diff_warning_changed_lines()
+            && self.approx_diff_tokens == default_run_large_diff_warning_approx_tokens()
+            && self.mode == RunLargeDiffWarningMode::Warn
+    }
+}
+
 /// Run-command behavior (`[run]` in config).
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RunConfig {
     /// Allow `csa run` to work on protected base branches.
     ///
@@ -62,6 +126,8 @@ pub struct RunConfig {
     pub writer_must_commit: bool,
     #[serde(default)]
     pub post_exec_gate: PostExecGateConfig,
+    #[serde(default)]
+    pub large_diff_warning: RunLargeDiffWarningConfig,
 }
 
 impl RunConfig {
@@ -69,6 +135,7 @@ impl RunConfig {
         !self.allow_base_branch_working
             && !self.writer_must_commit
             && self.post_exec_gate.is_default()
+            && self.large_diff_warning.is_default()
     }
 }
 
@@ -494,6 +561,10 @@ impl VcsConfig {
             && self.snapshot_trigger == SnapshotTrigger::PostRun
     }
 }
+
+#[cfg(test)]
+#[path = "config_tests_run_large_diff.rs"]
+mod run_large_diff_tests;
 
 #[cfg(test)]
 mod vcs_config_tests {

--- a/crates/csa-config/src/config_tests_run_large_diff.rs
+++ b/crates/csa-config/src/config_tests_run_large_diff.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+#[test]
+fn test_run_config_large_diff_warning_defaults() {
+    let cfg = RunConfig::default();
+
+    assert!(cfg.large_diff_warning.enabled);
+    assert_eq!(cfg.large_diff_warning.changed_files, 5);
+    assert_eq!(cfg.large_diff_warning.changed_lines, 500);
+    assert_eq!(cfg.large_diff_warning.approx_diff_tokens, 8_000);
+    assert_eq!(cfg.large_diff_warning.mode, RunLargeDiffWarningMode::Warn);
+    assert!(cfg.large_diff_warning.is_default());
+}
+
+#[test]
+fn test_run_config_deserializes_large_diff_warning() {
+    let toml_str = r#"
+[large_diff_warning]
+enabled = true
+changed_files = 3
+changed_lines = 200
+approx_diff_tokens = 4000
+mode = "warn"
+"#;
+    let cfg: RunConfig = toml::from_str(toml_str).unwrap();
+
+    assert!(cfg.large_diff_warning.enabled);
+    assert_eq!(cfg.large_diff_warning.changed_files, 3);
+    assert_eq!(cfg.large_diff_warning.changed_lines, 200);
+    assert_eq!(cfg.large_diff_warning.approx_diff_tokens, 4_000);
+    assert_eq!(cfg.large_diff_warning.mode, RunLargeDiffWarningMode::Warn);
+}
+
+#[test]
+fn test_run_config_is_default_reflects_large_diff_warning() {
+    let cfg = RunConfig {
+        large_diff_warning: RunLargeDiffWarningConfig {
+            changed_files: 10,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    assert!(!cfg.is_default());
+}

--- a/crates/csa-config/src/global_caller_hints_tests.rs
+++ b/crates/csa-config/src/global_caller_hints_tests.rs
@@ -16,10 +16,12 @@ fn test_caller_hints_defaults_parse_when_section_omitted() {
     );
     assert_eq!(DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC, 7_200);
     assert_eq!(DEFAULT_CODEX_SESSION_WAIT_MCP_INTERNAL_TIMEOUT_SEC, 6_900);
-    assert!(
-        DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC
-            > DEFAULT_CODEX_SESSION_WAIT_MCP_INTERNAL_TIMEOUT_SEC
-    );
+    const {
+        assert!(
+            DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC
+                > DEFAULT_CODEX_SESSION_WAIT_MCP_INTERNAL_TIMEOUT_SEC
+        );
+    }
 }
 
 #[test]

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -131,6 +131,12 @@ long_poll_seconds = 240
 # overrides it.
 # [run]
 # writer_must_commit = false
+# [run.large_diff_warning]
+# enabled = true
+# changed_files = 5
+# changed_lines = 500
+# approx_diff_tokens = 8000
+# mode = "warn"
 # [run.post_exec_gate]
 # enabled = true
 # command = "just pre-commit"

--- a/crates/csa-config/src/lib.rs
+++ b/crates/csa-config/src/lib.rs
@@ -37,6 +37,7 @@ pub use config::{
     TierStrategy, ToolConfig, ToolFilesystemSandboxConfig, ToolResourceProfile, ToolRestrictions,
     VcsConfig,
 };
+pub use config_session::{RunLargeDiffWarningConfig, RunLargeDiffWarningMode};
 pub type MergedConfig = ProjectConfig;
 pub use config_filesystem_sandbox::FilesystemSandboxConfig;
 pub use config_resources::ResourcesConfig;

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -79,7 +79,10 @@ pub use post_exec_gate_report::{
 };
 pub use process_tree_memory::{SessionTreeMemorySampler, session_tree_rss_mb};
 pub use redact::{redact_event, redact_text_content};
-pub use result::{SessionArtifact, SessionManagerFields, SessionResult, UncommittedChanges};
+pub use result::{
+    LargeDiffWarningReport, SessionArtifact, SessionManagerFields, SessionResult,
+    UncommittedChanges,
+};
 pub use review_artifact::{
     Finding, FindingsFile, REVIEW_VERDICT_SCHEMA_VERSION, ReviewArtifact, ReviewDiffSize,
     ReviewFinding, ReviewFindingFileRange, ReviewVerdictArtifact, Severity, SeveritySummary,

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -12,7 +12,7 @@ pub const RESULT_TOML_PATH_CONTRACT_ENV: &str = "CSA_RESULT_TOML_PATH_CONTRACT";
 pub const CONTRACT_RESULT_ARTIFACT_PATH: &str = "output/result.toml";
 pub const LEGACY_USER_RESULT_ARTIFACT_PATH: &str = "output/user-result.toml";
 const LEGACY_KILL_REASON_KEY: &str = "kill_reason";
-const RUNTIME_RESULT_KEYS: [&str; 17] = [
+const RUNTIME_RESULT_KEYS: [&str; 22] = [
     "status",
     "exit_code",
     "summary",
@@ -27,6 +27,11 @@ const RUNTIME_RESULT_KEYS: [&str; 17] = [
     "fallback_chain",
     "peak_memory_mb",
     "post_exec_gate",
+    "gate_timeout",
+    "warnings",
+    "raw_process_exit_code",
+    "uncommitted_changes",
+    "large_diff_warning",
     "kill_hint",
     LEGACY_KILL_REASON_KEY,
     "last_item",
@@ -411,9 +416,13 @@ fn value_matches_runtime_schema(key: &str, value: &toml::Value) -> bool {
         "status" | "summary" | "tool" | "started_at" | "completed_at" | "kill_hint"
         | "last_item" => value.is_str(),
         LEGACY_KILL_REASON_KEY => value.is_str(),
-        "exit_code" | "events_count" => value.is_integer(),
+        "exit_code" | "events_count" | "peak_memory_mb" | "raw_process_exit_code" => {
+            value.is_integer()
+        }
+        "gate_timeout" => value.is_bool(),
+        "warnings" => value.is_array(),
         "artifacts" => artifacts_value_matches_runtime_schema(value),
-        "post_exec_gate" => value.is_table(),
+        "post_exec_gate" | "uncommitted_changes" | "large_diff_warning" => value.is_table(),
         _ => false,
     }
 }

--- a/crates/csa-session/src/manager_result_spillover.rs
+++ b/crates/csa-session/src/manager_result_spillover.rs
@@ -339,6 +339,7 @@ mod tests {
             warnings: Vec::new(),
             raw_process_exit_code: None,
             uncommitted_changes: None,
+            large_diff_warning: None,
             manager_fields: crate::result::SessionManagerFields {
                 report: Some(
                     toml::toml! {

--- a/crates/csa-session/src/manager_tests_audit.rs
+++ b/crates/csa-session/src/manager_tests_audit.rs
@@ -23,6 +23,7 @@ fn test_save_result_persists_manager_fields_sidecar() {
         warnings: Vec::new(),
         raw_process_exit_code: None,
         uncommitted_changes: None,
+        large_diff_warning: None,
         manager_fields: crate::result::SessionManagerFields {
             artifacts: Some(
                 toml::toml! {

--- a/crates/csa-session/src/manager_tests_result_view.rs
+++ b/crates/csa-session/src/manager_tests_result_view.rs
@@ -431,6 +431,7 @@ fn test_save_result_with_empty_manager_fields_preserves_existing_sidecar() {
         warnings: Vec::new(),
         raw_process_exit_code: None,
         uncommitted_changes: None,
+        large_diff_warning: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {
@@ -511,6 +512,7 @@ fn test_clear_manager_sidecar_removes_existing_sidecar() {
         warnings: Vec::new(),
         raw_process_exit_code: None,
         uncommitted_changes: None,
+        large_diff_warning: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {

--- a/crates/csa-session/src/manager_tests_sidecar_preservation.rs
+++ b/crates/csa-session/src/manager_tests_sidecar_preservation.rs
@@ -79,6 +79,7 @@ fn sidecar_write_failure_leaves_envelope_unchanged() {
         warnings: Vec::new(),
         raw_process_exit_code: None,
         uncommitted_changes: None,
+        large_diff_warning: None,
         manager_fields: crate::result::SessionManagerFields {
             artifacts: Some(
                 toml::toml! {
@@ -111,6 +112,7 @@ fn sidecar_write_failure_leaves_envelope_unchanged() {
         warnings: Vec::new(),
         raw_process_exit_code: None,
         uncommitted_changes: None,
+        large_diff_warning: None,
         manager_fields: crate::result::SessionManagerFields {
             artifacts: Some(
                 toml::toml! {
@@ -172,6 +174,7 @@ fn sidecar_clear_failure_or_crash_leaves_envelope_consistent() {
         warnings: Vec::new(),
         raw_process_exit_code: None,
         uncommitted_changes: None,
+        large_diff_warning: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {
@@ -247,6 +250,7 @@ fn sidecar_clear_happy_path_publishes_envelope_then_unlinks() {
         warnings: Vec::new(),
         raw_process_exit_code: None,
         uncommitted_changes: None,
+        large_diff_warning: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {

--- a/crates/csa-session/src/manager_tests_tail.rs
+++ b/crates/csa-session/src/manager_tests_tail.rs
@@ -490,6 +490,26 @@ fn test_save_result_clears_stale_optional_runtime_fields() {
         "last_item".to_string(),
         toml::Value::String("old work".to_string()),
     );
+    table.insert(
+        "uncommitted_changes".to_string(),
+        toml::toml! {
+            file_count = 7
+            insertions = 240
+            deletions = 12
+            approx_diff_tokens = 1024
+            files = ["src/lib.rs"]
+        }
+        .into(),
+    );
+    table.insert(
+        "large_diff_warning".to_string(),
+        toml::toml! {
+            changed_files = 7
+            changed_lines = 252
+            approx_diff_tokens = 1024
+        }
+        .into(),
+    );
     std::fs::write(&result_path, toml::to_string_pretty(&persisted).unwrap()).unwrap();
 
     save_result_in(
@@ -505,6 +525,8 @@ fn test_save_result_clears_stale_optional_runtime_fields() {
     assert!(!persisted.contains("artifacts"));
     assert!(!persisted.contains("kill_hint"));
     assert!(!persisted.contains("last_item"));
+    assert!(!persisted.contains("uncommitted_changes"));
+    assert!(!persisted.contains("large_diff_warning"));
 
     let loaded = load_result_in(td.path(), &state.meta_session_id)
         .unwrap()
@@ -513,6 +535,8 @@ fn test_save_result_clears_stale_optional_runtime_fields() {
     assert!(loaded.artifacts.is_empty());
     assert!(loaded.kill_hint.is_none());
     assert!(loaded.last_item.is_none());
+    assert!(loaded.uncommitted_changes.is_none());
+    assert!(loaded.large_diff_warning.is_none());
 }
 
 #[test]

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -165,11 +165,28 @@ pub struct UncommittedChanges {
     pub insertions: u64,
     /// Best-effort deleted line count from `git diff --numstat HEAD`.
     pub deletions: u64,
+    /// Approximate token count of the changed diff payload.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub approx_diff_tokens: usize,
     /// First changed paths, capped to keep `result.toml` compact.
     pub files: Vec<String>,
     /// Number of paths omitted from `files` due to the cap.
     #[serde(default, skip_serializing_if = "is_zero_usize")]
     pub truncated: usize,
+}
+
+impl UncommittedChanges {
+    pub fn changed_lines(&self) -> u64 {
+        self.insertions.saturating_add(self.deletions)
+    }
+}
+
+/// Caller-visible warning emitted when a writer session leaves a large changed surface.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LargeDiffWarningReport {
+    pub changed_files: usize,
+    pub changed_lines: u64,
+    pub approx_diff_tokens: usize,
 }
 
 /// Structured result of a session execution.
@@ -241,6 +258,10 @@ pub struct SessionResult {
     /// committing. Omitted for clean sessions and read-only session kinds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uncommitted_changes: Option<UncommittedChanges>,
+    /// Structured large-diff warning data derived from `uncommitted_changes`.
+    /// Omitted when the dirty surface stays below the configured warning thresholds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub large_diff_warning: Option<LargeDiffWarningReport>,
     /// Structured detail of a failed post-exec verification gate (#1726).
     /// Present ONLY when the gate (e.g. `just pre-commit`) failed, so an SA
     /// orchestrator can diagnose the failing step/test from `result.toml`
@@ -386,8 +407,14 @@ mod tests {
                 file_count: 7,
                 insertions: 240,
                 deletions: 12,
+                approx_diff_tokens: 1_024,
                 files: vec!["src/lib.rs".to_string()],
                 truncated: 6,
+            }),
+            large_diff_warning: Some(LargeDiffWarningReport {
+                changed_files: 7,
+                changed_lines: 252,
+                approx_diff_tokens: 1_024,
             }),
             manager_fields: Default::default(),
         };
@@ -402,7 +429,15 @@ mod tests {
         assert_eq!(changes.file_count, 7);
         assert_eq!(changes.insertions, 240);
         assert_eq!(changes.deletions, 12);
+        assert_eq!(changes.changed_lines(), 252);
+        assert_eq!(changes.approx_diff_tokens, 1_024);
         assert_eq!(changes.truncated, 6);
+        let warning = loaded
+            .large_diff_warning
+            .expect("large_diff_warning should roundtrip");
+        assert_eq!(warning.changed_files, 7);
+        assert_eq!(warning.changed_lines, 252);
+        assert_eq!(warning.approx_diff_tokens, 1_024);
     }
 
     #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.976"
-weave = "0.1.976"
+csa = "0.1.977"
+weave = "0.1.977"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
Auto-created by dev2merge pipeline.