### PR TITLE
fix(mktsk): document Hermes task adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.977"
+version = "0.1.978"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.977"
+version = "0.1.978"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/mktsk/PATTERN.md
+++ b/patterns/mktsk/PATTERN.md
@@ -11,6 +11,22 @@ version = "0.3.0"
 Execute TODO plans or open GitHub issues as deterministic serial checklists.
 Strict order: implement -> verify -> review -> commit -> next.
 
+**Task tool adapter:** mktsk is run by the main agent/orchestrator, which must
+translate task-list operations to the current host:
+
+| Host | Create task | Update task | List/resume |
+|------|-------------|-------------|-------------|
+| Claude Code | `TaskCreate` | `TaskUpdate` | `TaskGet` / `TaskList` |
+| Hermes | `todo` tool | `todo` tool | `todo` tool |
+| Codex | `update_plan` | `update_plan` | current plan state |
+
+The step text uses Claude Code names as canonical operation names. Hermes uses
+its `todo` tool as the `TaskCreate` / `TaskUpdate` / `TaskList` equivalent, and
+Codex/Hermes must adapt to host task-list tools rather than assuming
+Claude-only tool names. mktsk bookkeeping itself must not be delegated to CSA
+subprocesses; implementation work for individual registered items may still be
+delegated by executor tag.
+
 ## Step 1: Resolve Input
 
 Choose exactly one mode:
@@ -62,9 +78,18 @@ Output the normalized numbered task list before registration.
 
 ## Step 2: Register Tasks
 
-TODO.md is a read-only planning artifact. Progress tracking uses TaskCreate/TaskUpdate.
+TODO.md is a read-only planning artifact. Progress tracking uses the host
+task-list adapter.
 
-Register each parsed TODO item or issue candidate via TaskCreate.
+Task adapter mapping:
+- Claude Code: `TaskCreate` creates, `TaskUpdate` updates, `TaskGet` /
+  `TaskList` resume.
+- Hermes: use the `todo` tool as the `TaskCreate` / `TaskUpdate` /
+  `TaskList` equivalent.
+- Codex: use `update_plan` for task registration and status updates.
+
+Register each parsed TODO item or issue candidate via TaskCreate or the host
+equivalent.
 
 Each TODO task MUST include:
 - stable item id
@@ -81,7 +106,8 @@ Each issue task MUST include:
   dependency links, and a mechanically verifiable `DONE WHEN`
 - enough context to start work without rereading the full issue body
 
-Do NOT modify TODO.md checkboxes — task progress is tracked via TaskUpdate status.
+Do NOT modify TODO.md checkboxes — task progress is tracked via TaskUpdate or
+the host equivalent.
 
 **MANDATORY publish-phase task decomposition** (when Step 6 applies):
 The publish pipeline MUST be registered as **separate, individually tracked tasks**:
@@ -96,13 +122,16 @@ dedicated task for it, agents consistently skip it after PR creation.
 ## Step 3: Execute Tasks Serially
 
 Execute tasks strictly in order. Do not parallelize implementation work.
+mktsk bookkeeping stays in the main agent/orchestrator. Do not delegate
+task-list registration, status updates, or resume state to a CSA subprocess.
 
 Before each task: use TaskUpdate to set status to `in_progress`.
+Use the host equivalent when TaskUpdate is not available.
 
 Treat each task as an atomic transaction:
 1. Execute exactly one item.
 2. Run verification/review.
-3. Use TaskUpdate to set status to `completed`.
+3. Use TaskUpdate or the host equivalent to set status to `completed`.
 4. Persist checkpoint before next item.
 
 Dispatch policy by executor tag:
@@ -117,13 +146,14 @@ Dispatch policy by executor tag:
 Checkpoint policy (mandatory):
 - Use `.csa/state/mktsk/checkpoint.json` as progress checkpoint.
 - Write latest completed item id after each completed item.
-- On interruption, resume from TaskList status and checkpoint state.
+- On interruption, resume from TaskList or host task-list status and checkpoint
+  state.
 
 After each item:
 1. Run quality gates (`just fmt`, `just clippy`, `just test`).
 2. Run `csa review --diff`.
 3. Apply fixes if review reports blocking issues.
-4. Use TaskUpdate to mark the task as `completed`.
+4. Use TaskUpdate or the host equivalent to mark the task as `completed`.
 
 ## Step 4: Compact Context (Conditional)
 
@@ -145,7 +175,7 @@ just test
 git status --short
 ```
 
-Ensure all registered TaskCreate entries from the selected mode are completed.
+Ensure all registered task-list entries from the selected mode are completed.
 
 ## Step 6: Publish Transaction
 

--- a/patterns/mktsk/skills/mktsk/SKILL.md
+++ b/patterns/mktsk/skills/mktsk/SKILL.md
@@ -14,14 +14,51 @@ triggers:
 
 # mktsk: Make Task -- Plan-to-Execution Bridge
 
-## MANDATORY: Main Agent Execution
+## MANDATORY: Main Agent / Orchestrator Execution
 
-**mktsk MUST be executed by the main agent (Claude Code).**
-Do NOT delegate to `csa plan run --pattern mktsk` or `csa run --skill mktsk`.
+**mktsk MUST be executed by the main agent/orchestrator.**
+Do NOT delegate mktsk bookkeeping to `csa plan run --pattern mktsk` or
+`csa run --skill mktsk`.
 
-**Why**: mktsk requires Claude Code tools (TaskCreate, TaskUpdate, TaskGet, TaskList)
-for progress tracking across auto-compaction. CSA subprocesses cannot use these tools,
-making task persistence impossible.
+**Why**: mktsk owns progress tracking across auto-compaction. CSA subprocesses
+cannot update the caller's task list, so delegating mktsk bookkeeping makes
+task persistence impossible. Implementation work for individual registered
+items may still be delegated when the pattern's executor policy says so.
+
+## Task Tool Adapter
+
+Use the host agent's native task-list tool. The pattern uses Claude Code tool
+names as operation names; adapt them instead of assuming Claude-only tools:
+
+| Host | Create task | Update task | List/resume |
+|------|-------------|-------------|-------------|
+| Claude Code | `TaskCreate` | `TaskUpdate` | `TaskGet` / `TaskList` |
+| Hermes | `todo` tool | `todo` tool | `todo` tool |
+| Codex | `update_plan` | `update_plan` | current plan state |
+
+Hermes agents exposed through `~/.hermes/skills` must use the `todo` tool as
+the `TaskCreate` / `TaskUpdate` / `TaskList` equivalent. Codex and Hermes must
+translate task operations to their host tools rather than inventing or invoking
+Claude-only tool names.
+
+If the current host has no durable task-list equivalent, stop and ask the user
+which tracking tool to use before executing mktsk.
+
+## Hermes Exposure
+
+Keep the source of truth in this repository:
+
+```text
+patterns/mktsk/skills/mktsk
+```
+
+Expose it to Hermes with a symlink from the Hermes skill directory:
+
+```text
+~/.hermes/skills/software-development/mktsk -> patterns/mktsk/skills/mktsk
+```
+
+Do not copy or maintain a separate `~/.hermes` version of this skill.
 
 ## Execution Protocol
 
@@ -30,8 +67,8 @@ step by step. You are executing directly — every step runs in your context.
 
 Modes:
 - Default: parse a TODO plan from `path=...`, `timestamp=...`, or the latest mktd output.
-- `--from-issues`: read open GitHub issues and register one ordered TaskCreate
-  task per issue.
+- `--from-issues`: read open GitHub issues and register one ordered task-list
+  entry per issue.
 
 For `csa` commands within pattern steps (e.g., `csa review --diff`), add
 `--sa-mode true` when operating under SA mode.
@@ -45,7 +82,7 @@ This is the while-waiting checklist. When you background a `csa session wait` vi
 2. For deferred MEDIUM findings from prior rounds, queue issue-template drafts locally and batch filing later when the review cluster is clear.
 3. Read the next sprint task or issue to preload context for the next non-conflicting step.
 4. Check existing issues for possible duplicate-of candidates for findings already queued.
-5. Clean up stale TaskCreate or TaskUpdate entries.
+5. Clean up stale task-list entries.
 
 **Do NOT**:
 - Start new `csa run` or `csa review` sessions that could race on git branch or checkout state with the waiting one (single-checkout sequential rule, AGENTS.md 028).
@@ -62,7 +99,7 @@ If there is no useful parallel work available, return control and wait for the n
 | `/mktsk` | Execute the most recent TODO plan for the current branch |
 | `/mktsk path=./plans/feature.md` | Execute tasks from a specific plan file |
 | `/mktsk timestamp=01JK...` | Execute tasks from a csa todo by timestamp |
-| `/mktsk --from-issues` | Create an ordered TaskCreate backlog from all open issues |
+| `/mktsk --from-issues` | Create an ordered task-list backlog from all open issues |
 
 ## Integration
 
@@ -74,7 +111,7 @@ If there is no useful parallel work available, return control and wait for the n
 ## Done Criteria
 
 1. All TODO items executed and verified via `DONE WHEN` conditions.
-2. All tasks marked complete via TaskUpdate.
+2. All tasks marked complete through the host task-list adapter.
 3. Branch pushed to remote.
 4. PR created (or reused).
 5. **pr-bot completed** — this is a SEPARATE gate from PR creation. NEVER mark

--- a/patterns/mktsk/workflow.toml
+++ b/patterns/mktsk/workflow.toml
@@ -48,7 +48,15 @@ on_fail = "abort"
 id = 2
 title = "Register Tasks"
 prompt = """
-Register each parsed TODO item or issue candidate via TaskCreate.
+TODO.md is a read-only planning artifact. Progress tracking uses the host
+task-list adapter.
+
+Task adapter mapping:
+- Claude Code: TaskCreate creates, TaskUpdate updates, TaskGet/TaskList resume.
+- Hermes: use the todo tool as the TaskCreate/TaskUpdate/TaskList equivalent.
+- Codex: use update_plan for task registration and status updates.
+
+Register each parsed TODO item or issue candidate via TaskCreate or the host equivalent.
 
 Each TODO task must include:
 - stable item id
@@ -63,7 +71,7 @@ Each issue task must include:
 - description with the issue URL or #<number>, key constraint summary, dependency links, and DONE WHEN
 - enough context to start work without rereading the full issue body
 
-Do NOT modify TODO.md checkboxes — task progress is tracked via TaskUpdate.
+Do NOT modify TODO.md checkboxes — task progress is tracked via TaskUpdate or the host equivalent.
 
 MANDATORY publish-phase task decomposition (when publish is not skipped):
 The publish pipeline MUST be registered as SEPARATE tasks:
@@ -82,10 +90,12 @@ id = 3
 title = "Execute Checklist Serially"
 prompt = """
 Execute the normalized tasks strictly in order.
+mktsk bookkeeping stays in the main agent/orchestrator. Do not delegate task-list
+registration, status updates, or resume state to a CSA subprocess.
 Treat each task as an atomic transaction:
 1) execute exactly one item
 2) run quality gates/review
-3) persist completion via TaskUpdate immediately
+3) persist completion via TaskUpdate or the host equivalent immediately
 4) write progress checkpoint before moving to next item
 
 Dispatch by executor tag:
@@ -101,14 +111,14 @@ Dispatch by executor tag:
 Checkpoint policy (mandatory):
 - Use `.csa/state/mktsk/checkpoint.json` as progress checkpoint.
 - Update checkpoint after each completed item with latest completed item id.
-- If interrupted, resume from TaskList status and checkpoint state.
+- If interrupted, resume from TaskList or host task-list status and checkpoint state.
 
 After each item:
 1) just fmt
 2) just clippy
 3) just test
 4) SID=$(csa review --diff) && csa session wait --session "$SID"
-5) mark the TaskCreate entry as completed via TaskUpdate
+5) mark the task-list entry as completed via TaskUpdate or the host equivalent
 
 ## Execution Tasks
 ${STEP_2_OUTPUT}"""

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.977"
-weave = "0.1.977"
+csa = "0.1.978"
+weave = "0.1.978"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- make the repo-managed mktsk skill agent-neutral instead of Claude-Code-only
- document Hermes todo-tool adaptation for TaskCreate/TaskUpdate semantics
- document Hermes symlink exposure for repo-managed skills

## Verification
- csa review PASS: 01KTW5ER454MZXWQRGBBMAMEQD

Closes #2081