### PR TITLE
fix(plan): preserve mktd bash fence literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.978"
+version = "0.1.979"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.978"
+version = "0.1.979"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -387,15 +387,40 @@ pub(super) fn is_stale_session_error(error: &anyhow::Error) -> bool {
 }
 
 pub(super) fn extract_bash_code_block(prompt: &str) -> Option<&str> {
-    let start_patterns = ["```bash\n", "```sh\n", "```\n"];
-    for pattern in &start_patterns {
-        if let Some(start_idx) = prompt.find(pattern) {
-            let code_start = start_idx + pattern.len();
-            if let Some(end_idx) = prompt[code_start..].find("```") {
-                let code = &prompt[code_start..code_start + end_idx];
+    let mut search_start = 0;
+    while let Some(fence_offset) = prompt[search_start..].find("```") {
+        let fence_start = search_start + fence_offset;
+        let line_start = prompt[..fence_start]
+            .rfind('\n')
+            .map_or(0, |index| index + 1);
+        if !prompt[line_start..fence_start]
+            .chars()
+            .all(char::is_whitespace)
+        {
+            search_start = fence_start + "```".len();
+            continue;
+        }
+
+        let open_line_end_offset = prompt[fence_start..].find('\n')?;
+        let open_line_end = fence_start + open_line_end_offset;
+        let language = prompt[fence_start + "```".len()..open_line_end].trim();
+        if !matches!(language, "" | "bash" | "sh") {
+            search_start = open_line_end + 1;
+            continue;
+        }
+
+        let code_start = open_line_end + 1;
+        let mut line_start = code_start;
+        for line in prompt[code_start..].split_inclusive('\n') {
+            let line_end = line_start + line.len();
+            if line.trim_end_matches('\n').trim() == "```" {
+                let code = &prompt[code_start..line_start];
                 return Some(code.trim());
             }
+            line_start = line_end;
         }
+
+        return None;
     }
     None
 }

--- a/crates/cli-sub-agent/src/plan_cmd_exec_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec_tests.rs
@@ -69,6 +69,29 @@ fn reduce_bash_env_for_spawn_keeps_referenced_step_runtime_vars() {
 }
 
 #[test]
+fn extract_bash_code_block_ignores_markdown_fence_literals_inside_script() {
+    let prompt = r#"Run this:
+```bash
+set -euo pipefail
+EPIC_PLAN=$(printf '%s\n' "${FINAL_TODO}" | sed -n '/^```epic-plan.toml$/,/^```$/p' | sed '1d;$d')
+printf '%s\n' "${EPIC_PLAN}"
+```
+Afterward text.
+"#;
+
+    let script = extract_bash_code_block(prompt).expect("bash block should parse");
+
+    assert!(
+        script.contains("epic-plan.toml"),
+        "script should preserve the sed expression containing markdown fences"
+    );
+    assert!(
+        script.contains(r#"printf '%s\n' "${EPIC_PLAN}""#),
+        "script must not be truncated at the fence literal"
+    );
+}
+
+#[test]
 fn clean_step_output_extracts_codex_json_event_stream_text() {
     let output = [
             r#"{"type":"thread.started","thread_id":"thread_1"}"#,

--- a/crates/cli-sub-agent/src/plan_cmd_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure.rs
@@ -7,6 +7,9 @@ use csa_session::SessionArtifact;
 
 use super::StepResult;
 
+#[path = "plan_cmd_failure_detail.rs"]
+mod failure_detail;
+
 const PR_BOT_WORKFLOW_NAME: &str = "pr-bot";
 const WEAVE_LOCK: &str = "weave.lock";
 const CSA_PLAN_STATE_PREFIX: &str = ".csa/state/plan/";
@@ -70,6 +73,9 @@ impl PlanFailureReport {
                 "; failed_step={} exit_code={}",
                 step.step_id, step.exit_code
             ));
+            if let Some(detail) = step.actionable_failure_detail() {
+                line.push_str(&format!(" detail={detail}"));
+            }
         }
         line
     }
@@ -84,6 +90,9 @@ impl PlanFailureReport {
                 "Failed step: {} ({}) exited {}",
                 step.step_id, step.title, step.exit_code
             ));
+            if let Some(detail) = step.actionable_failure_detail() {
+                lines.push(format!("Failure detail: {detail}"));
+            }
         }
         if let Some(recovery) = &self.recovery {
             lines.push(format!("Recovery status: {}", recovery.status.as_str()));
@@ -133,6 +142,19 @@ impl PlanFailureReport {
         }
 
         details
+    }
+}
+
+impl FailedPlanStep {
+    fn actionable_failure_detail(&self) -> Option<String> {
+        self.stderr_excerpt
+            .as_deref()
+            .and_then(failure_detail::select_actionable_failure_line)
+            .or_else(|| {
+                self.error
+                    .as_deref()
+                    .and_then(failure_detail::select_actionable_failure_line)
+            })
     }
 }
 

--- a/crates/cli-sub-agent/src/plan_cmd_failure_detail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_detail.rs
@@ -1,0 +1,52 @@
+pub(super) fn select_actionable_failure_line(text: &str) -> Option<String> {
+    let lines: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !is_low_signal_failure_line(line))
+        .collect();
+    lines
+        .iter()
+        .rev()
+        .find(|line| is_high_signal_failure_line(line))
+        .or_else(|| lines.last())
+        .map(|line| truncate_failure_detail(line))
+}
+
+fn is_low_signal_failure_line(line: &str) -> bool {
+    line.starts_with("✓ PASS")
+        || line.starts_with("- SKIP")
+        || line.starts_with("✗ FAIL")
+        || line.starts_with("Status:")
+        || line.starts_with("Summary:")
+        || line.starts_with("Failed step:")
+        || line.starts_with("Artifacts:")
+        || line.starts_with("Passed:")
+        || line.starts_with("Total:")
+        || line.starts_with("Duration:")
+        || line.starts_with("Exit code ")
+        || (line.starts_with("Error: ") && line.contains(" step(s) failed"))
+        || line.starts_with("stderr (last ")
+        || line == "```text"
+        || line == "```"
+}
+
+fn is_high_signal_failure_line(line: &str) -> bool {
+    let normalized = line.to_ascii_lowercase();
+    line.starts_with("ERROR:")
+        || line.starts_with("Error:")
+        || normalized.contains("unexpected eof")
+        || normalized.contains("quota")
+        || normalized.contains("timeout")
+        || normalized.contains("failed")
+}
+
+fn truncate_failure_detail(line: &str) -> String {
+    const MAX_FAILURE_DETAIL_CHARS: usize = 240;
+    let mut chars = line.chars();
+    let truncated: String = chars.by_ref().take(MAX_FAILURE_DETAIL_CHARS).collect();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}

--- a/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
@@ -107,6 +107,51 @@ fn persisted_failure_output_redacts_step_secrets() {
 }
 
 #[test]
+fn failure_summary_surfaces_actionable_step_stderr() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let workflow_path = temp.path().join("workflow.toml");
+    let results = vec![StepResult {
+        step_id: 7,
+        title: "Plan with mktd".to_string(),
+        exit_code: 1,
+        duration_secs: 0.0,
+        skipped: false,
+        error: Some("Exit code 1".to_string()),
+        output: None,
+        session_id: None,
+        command: Some("csa plan run patterns/mktd/workflow.toml".to_string()),
+        stderr: Some(
+            [
+                "✓ PASS   Step 7 - Phase 2 — DRAFT TODO",
+                "✗ FAIL   Step 13 - Save TODO (0.02s) — Exit code 2",
+                "ERROR: TODO artifact has an open task without a mechanically-verifiable DONE WHEN: clause.",
+                "Error: 1 step(s) failed (1 execution, 0 unsupported-skip)",
+            ]
+            .join("\n"),
+        ),
+    }];
+    let report = PlanFailureReport::from_results(
+        "dev2merge",
+        &workflow_path,
+        "1 step(s) failed".to_string(),
+        &results,
+        None,
+    );
+
+    let summary_line = report.summary_line("patterns/dev2merge/workflow.toml");
+    let summary_section = report.render_summary_section();
+
+    assert!(
+        summary_line.contains("detail=ERROR: TODO artifact has an open task"),
+        "result summary should include actionable stderr detail: {summary_line}"
+    );
+    assert!(
+        summary_section.contains("Failure detail: ERROR: TODO artifact has an open task"),
+        "structured summary section should include actionable stderr detail: {summary_section}"
+    );
+}
+
+#[test]
 fn recovery_ignores_untracked_plan_journal_after_snapshot() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let project_root = temp.path().join("repo");

--- a/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use weave::compiler::plan_from_toml;
 
+use crate::plan_cmd::extract_bash_code_block;
+
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
 }
@@ -277,8 +279,15 @@ fn mktd_save_step_uses_session_output_artifacts_and_persist() {
         .iter()
         .find(|step| step.id == 13)
         .expect("missing mktd save step");
+    let extracted_save_script =
+        extract_bash_code_block(&save_step.prompt).expect("mktd save step must have bash block");
     let pattern = std::fs::read_to_string(workspace_root().join("patterns/mktd/PATTERN.md"))
         .expect("read mktd pattern");
+
+    assert!(
+        extracted_save_script.contains(r#"csa todo persist -t "${TODO_TS}""#),
+        "mktd Save TODO bash extraction must not stop at markdown fence literals in sed expressions"
+    );
 
     for (name, content) in [
         ("PATTERN.md", pattern.as_str()),

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.978"
-weave = "0.1.978"
+csa = "0.1.979"
+weave = "0.1.979"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Preserve bash code fence literals while rendering mktd/dev2merge plan templates
- Prevent dev2merge Step 7 mktd planning from failing opaquely on repo-managed skill issues

## Verification
- CSA implementation session 01KTW64VYZNY9ZJ7K99210PKM2
- CSA review PASS session 01KTW7FJJ98DCJNPSJ44AW1F86

Closes #2082