### PR TITLE
test(run): configure failover tool availability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.980"
+version = "0.1.981"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.980"
+version = "0.1.981"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_attempt_fallback_chain_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_fallback_chain_tests.rs
@@ -9,13 +9,15 @@ use csa_process::ExecutionResult;
 use std::path::Path;
 
 use super::{
-    assert_no_rate_limit, assert_retry_to, make_failover_config, make_named_failover_config,
+    assert_no_rate_limit, assert_retry_to, assume_failover_tools_available, make_failover_config,
+    make_named_failover_config,
 };
 
 // --- fallback_chain population tests (#1346) ---
 
 #[test]
 fn evaluate_error_rate_limit_failover_populates_fallback_chain_on_transient_retry_chain() {
+    let _assume = assume_failover_tools_available();
     let config = make_failover_config(&[
         "gemini-cli/google/gemini-2.5-pro/high",
         "codex/openai/o4-mini/high",
@@ -69,6 +71,7 @@ fn evaluate_error_rate_limit_failover_populates_fallback_chain_on_transient_retr
 fn evaluate_error_rate_limit_failover_continues_past_permanent_gemini_quota() {
     // #1629: gemini-cli permanent quota (via retry chain exhaustion with
     // QUOTA_EXHAUSTED tail) MUST fail over to codex (different provider).
+    let _assume = assume_failover_tools_available();
     let config = make_failover_config(&[
         "gemini-cli/google/gemini-2.5-pro/high",
         "codex/openai/o4-mini/high",
@@ -171,6 +174,7 @@ fn evaluate_rate_limit_failover_gemini_quota_skips_antigravity_picks_codex() {
     // Both gemini-cli and antigravity-cli share Google's quota pool, so once
     // gemini-cli is marked permanently exhausted, antigravity-cli MUST be
     // skipped and codex (OpenAI) selected.
+    let _assume = assume_failover_tools_available();
     let config = make_failover_config(&[
         "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
         "antigravity-cli/google/gemini-3.1-pro/high",
@@ -223,6 +227,7 @@ fn evaluate_rate_limit_failover_chained_google_pool_exhaustion_continues_past() 
     // with quota_exhausted=true in fallback_chain. Now antigravity-cli (same
     // Google pool) also hits quota. The decision must skip antigravity-cli
     // (same provider) and pick codex.
+    let _assume = assume_failover_tools_available();
     let config = make_failover_config(&[
         "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
         "antigravity-cli/google/gemini-3.1-pro/high",

--- a/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
@@ -10,6 +10,7 @@ use crate::run_cmd_post::{
     evaluate_error_rate_limit_failover, evaluate_rate_limit_failover,
 };
 use crate::run_cmd_tool_selection::resolve_tool_by_strategy;
+use crate::test_env_lock::ScopedTestEnvVar;
 use crate::test_session_sandbox::ScopedSessionSandbox;
 use anyhow::anyhow;
 use chrono::Utc;
@@ -67,6 +68,10 @@ fn make_named_failover_config(tier_name: &str, models: &[&str]) -> ProjectConfig
         vcs: Default::default(),
         filesystem_sandbox: Default::default(),
     }
+}
+
+fn assume_failover_tools_available() -> ScopedTestEnvVar {
+    ScopedTestEnvVar::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1")
 }
 
 fn assert_retry_to(action: RateLimitAction, expected_tool: &str, expected_spec: &str) {
@@ -228,6 +233,7 @@ fn build_failover_context_addendum_maps_claude_provider() {
 
 #[test]
 fn evaluate_error_rate_limit_failover_retries_on_acp_crash_retry_exhaustion() {
+    let _assume = assume_failover_tools_available();
     let config = make_failover_config(&[
         "claude-code/anthropic/claude-sonnet/high",
         "codex/openai/o4-mini/high",
@@ -264,6 +270,7 @@ fn evaluate_error_rate_limit_failover_retries_on_acp_crash_retry_exhaustion() {
 
 #[test]
 fn evaluate_error_rate_limit_failover_retries_on_gemini_retry_chain_exhaustion() {
+    let _assume = assume_failover_tools_available();
     let config = make_failover_config(&[
         "gemini-cli/google/gemini-2.5-pro/high",
         "codex/openai/o4-mini/high",
@@ -300,6 +307,7 @@ fn evaluate_error_rate_limit_failover_retries_on_gemini_retry_chain_exhaustion()
 
 #[test]
 fn issue_1730_evaluate_error_rate_limit_failover_retries_on_gemini_legacy_initial_stall() {
+    let _assume = assume_failover_tools_available();
     let config = make_failover_config(&[
         "gemini-cli/google/gemini-2.5-pro/high",
         "codex/openai/o4-mini/high",
@@ -350,6 +358,7 @@ fn full_anyhow_chain_preserves_quota_markers_and_fails_over_to_next_provider() {
     // #1629: permanent quota exhaustion on gemini-cli (Google pool) MUST NOT
     // short-circuit failover; cross-provider alternatives (codex/OpenAI) still
     // count, and the gemini-cli quota attempt is recorded in fallback_chain.
+    let _assume = assume_failover_tools_available();
     let config = make_failover_config(&[
         "gemini-cli/google/gemini-2.5-pro/high",
         "codex/openai/o4-mini/high",
@@ -508,6 +517,7 @@ fn evaluate_rate_limit_failover_continues_past_permanent_quota_to_next_provider(
     // #1629: gemini-cli (Google pool) RESOURCE_EXHAUSTED MUST fail over to
     // codex (OpenAI pool) instead of stopping the chain. Same-provider tools
     // would be skipped; cross-provider alternatives proceed.
+    let _assume = assume_failover_tools_available();
     let config = make_failover_config(&[
         "gemini-cli/google/gemini-2.5-pro/high",
         "codex/openai/o4-mini/high",
@@ -567,6 +577,7 @@ fn evaluate_rate_limit_failover_continues_past_permanent_quota_to_next_provider(
 
 #[test]
 fn explicit_tool_in_tier_crash_triggers_failover() {
+    let _assume = assume_failover_tools_available();
     let config = make_named_failover_config(
         "tier-3-complex",
         &[

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.980"
-weave = "0.1.980"
+csa = "0.1.981"
+weave = "0.1.981"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Make failover strategy tests explicitly mark test fallback tools available instead of relying on host-installed binaries.
- Keep the #2086 runtime availability filtering behavior intact.
- Bump workspace/weave version to 0.1.981 for the feature branch gate.

## Review
- CSA full-diff review PASS: `01KTX10P2Y05YXAMQP02D37E5H`

## Test Plan
- `just pre-commit-fast`
- hook-running `git commit` quality gates
- CSA review `--check-verdict` PASS/CLEAN for `main...HEAD`

Closes #2113
