### PR TITLE
test(run): make no-tiers force test hermetic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.981"
+version = "0.1.982"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.981"
+version = "0.1.982"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_helpers_tier_force_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_force_tests.rs
@@ -519,18 +519,20 @@ fn resolve_tool_and_model_force_ignore_tier_skipped_when_no_tiers_configured() {
         filesystem_sandbox: Default::default(),
     };
 
-    // When no tiers are configured, validation should be skipped
+    // Use an explicit tool so the test only exercises the no-tiers force-ignore
+    // validation path, not host-dependent auto-selection of installed tools.
     let result = super::resolve_tool_and_model(super::RoutingRequest {
+        tool: Some(ToolName::Codex),
         config: Some(&cfg),
         force_ignore_tier_setting: true, // force_ignore_tier_setting = true
         ..super::RoutingRequest::new(std::path::Path::new("/tmp"))
     });
-    // Should succeed because no tiers are configured, so validation is skipped
-    assert!(
-        result.is_ok(),
-        "No tiers configured should skip validation: {:?}",
-        result
-    );
+    let (tool, model_spec, model) =
+        result.expect("no tiers configured should skip force-ignore complete-spec validation");
+
+    assert_eq!(tool, ToolName::Codex);
+    assert_eq!(model_spec, None);
+    assert_eq!(model, None);
 }
 
 #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.981"
-weave = "0.1.981"
+csa = "0.1.982"
+weave = "0.1.982"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Make the no-tiers force-ignore-tier test hermetic by explicitly selecting a test tool path instead of relying on host-installed CSA tools.
- Keep runtime availability filtering intact.
- Bump workspace/weave version to `0.1.982`.

## Verification
- `quality-gates` passed during hook-running commit
- CSA full-diff review PASS/CLEAN: `01KTX4B1DCEAYAHAA6NTTTEPJP`

Closes #2118
