### PR TITLE
test(run): make codex quota fixture hermetic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.983"
+version = "0.1.984"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.983"
+version = "0.1.984"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_attempt_codex_quota_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_codex_quota_tests.rs
@@ -364,6 +364,7 @@ fn codex_model_scoped_quota_uses_globally_configured_openai_compat_fallback() {
 
 #[test]
 fn explicit_tool_in_tier_codex_quota_skips_globally_configured_openai_compat() {
+    let _assume = assume_tools_available();
     let _base = crate::test_env_lock::ScopedEnvVarRestore::unset("OPENAI_COMPAT_BASE_URL");
     let _key = crate::test_env_lock::ScopedEnvVarRestore::unset("OPENAI_COMPAT_API_KEY");
     let _model = crate::test_env_lock::ScopedEnvVarRestore::unset("OPENAI_COMPAT_MODEL");

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.983"
-weave = "0.1.983"
+csa = "0.1.984"
+weave = "0.1.984"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Makes the codex quota regression fixture hermetic so it no longer depends on whether `codex` is installed on the CI runner.
- Fixes the red `main` introduced when PR #2133 was merged despite failing PR checks.
- Bumps the workspace version to `0.1.984` so the follow-up PR satisfies the version gate.
- Leaves production fallback behavior unchanged; the behavior fix is test-fixture-only.

## Verification
- Hook-running commit `73f85f04` passed local `branch-protection` and `quality-gates`.
- CSA full-diff review PASS/CLEAN: `01KTXRTFD9WDHF3D1J5DC832WN`.
- CSA recovery session `01KTXP7N5BRAE57QQX8RMWR5ED` reported the focused failing test, adjacent #2112 regression tests, `just find-monolith-files`, `cargo fmt -- --check`, `git diff --check`, and `just pre-commit-fast` all passed.

Closes #2136
