### PR TITLE
fix(session): fail closed on daemon completion without result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.985"
+version = "0.1.986"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.985"
+version = "0.1.986"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
@@ -12,6 +12,7 @@ const DAEMON_SESSION_DIR_ENV: &str = "CSA_DAEMON_SESSION_DIR";
 const DAEMON_PROJECT_ROOT_ENV: &str = "CSA_DAEMON_PROJECT_ROOT";
 const DAEMON_COMPLETION_FILE: &str = "daemon-completion.toml";
 const LEGACY_COMPLETE_FILE: &str = ".complete";
+const MISSING_RESULT_TERMINATION_REASON: &str = "daemon_completion_missing_result";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct DaemonCompletionPacket {
@@ -209,8 +210,19 @@ pub(crate) fn daemon_completion_result(
                 .map(|m| m.tool)
         })
         .unwrap_or_else(|| "unknown".to_string());
+    let tool_note = if tool_name == "unknown" {
+        "; no tool launch metadata was recorded"
+    } else {
+        ""
+    };
+    let effective = daemon_completion_effective_outcome(packet);
+    let missing_result_note = if effective.forced_missing_result_failure {
+        "; treating daemon completion as failure because result.toml was missing"
+    } else {
+        ""
+    };
     let summary_prefix = format!(
-        "daemon completion recorded status={} exit_code={}{} before result.toml was written; committed or staged work may be salvageable on the session branch",
+        "daemon completion recorded status={} exit_code={}{} before result.toml was written{missing_result_note}{tool_note}; committed or staged work may be salvageable on the session branch",
         packet.status,
         packet.exit_code,
         packet
@@ -222,8 +234,8 @@ pub(crate) fn daemon_completion_result(
 
     SessionResult {
         post_exec_gate: None,
-        status: packet.status.clone(),
-        exit_code: packet.exit_code,
+        status: effective.status,
+        exit_code: effective.exit_code,
         summary: crate::pipeline_post_exec::build_fallback_result_summary(
             session_dir,
             &summary_prefix,
@@ -239,7 +251,35 @@ pub(crate) fn daemon_completion_result(
             project_root,
             &session.meta_session_id,
         ),
+        raw_process_exit_code: effective.raw_process_exit_code,
         ..Default::default()
+    }
+}
+
+struct DaemonCompletionEffectiveOutcome {
+    status: String,
+    exit_code: i32,
+    raw_process_exit_code: Option<i32>,
+    forced_missing_result_failure: bool,
+}
+
+fn daemon_completion_effective_outcome(
+    packet: &DaemonCompletionPacket,
+) -> DaemonCompletionEffectiveOutcome {
+    if packet.status == "success" || packet.exit_code == 0 {
+        return DaemonCompletionEffectiveOutcome {
+            status: "failure".to_string(),
+            exit_code: 1,
+            raw_process_exit_code: (packet.exit_code != 1).then_some(packet.exit_code),
+            forced_missing_result_failure: true,
+        };
+    }
+
+    DaemonCompletionEffectiveOutcome {
+        status: packet.status.clone(),
+        exit_code: packet.exit_code,
+        raw_process_exit_code: None,
+        forced_missing_result_failure: false,
     }
 }
 
@@ -257,7 +297,7 @@ pub(crate) fn retire_session_from_daemon_completion(
         packet.reason.as_deref().map_or_else(
             || {
                 if packet.exit_code == 0 {
-                    "completed".to_string()
+                    MISSING_RESULT_TERMINATION_REASON.to_string()
                 } else {
                     "daemon_completion".to_string()
                 }
@@ -418,6 +458,74 @@ mod tests {
         let result = load_result(project, &session_id)?.expect("existing result should remain");
         assert_eq!(result.status, "success");
         assert_eq!(result.exit_code, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn daemon_completion_result_fails_closed_when_packet_claims_success() -> Result<()> {
+        let tmp = tempdir()?;
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let state_home = tmp.path().join("xdg-state");
+        std::fs::create_dir_all(&state_home)?;
+        let _home_guard = ScopedEnvVarRestore::set("HOME", tmp.path());
+        let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+        let project = tmp.path();
+
+        let session = create_session(
+            project,
+            Some("daemon-success-before-result"),
+            None,
+            Some("codex"),
+        )?;
+        let session_id = session.meta_session_id;
+        let session_dir = get_session_dir(project, &session_id)?;
+        let session = load_session(project, &session_id)?;
+        let packet = DaemonCompletionPacket::from_exit_code(0);
+
+        let result =
+            daemon_completion_result(project, &session_dir, &session, &packet, chrono::Utc::now());
+
+        assert_eq!(result.status, "failure");
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.raw_process_exit_code, Some(0));
+        assert_eq!(result.tool, "codex");
+        assert!(
+            result
+                .summary
+                .contains("treating daemon completion as failure"),
+            "summary should explain fail-closed conversion: {}",
+            result.summary
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn daemon_completion_result_explicitly_reports_no_tool_launch_metadata() -> Result<()> {
+        let tmp = tempdir()?;
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let state_home = tmp.path().join("xdg-state");
+        std::fs::create_dir_all(&state_home)?;
+        let _home_guard = ScopedEnvVarRestore::set("HOME", tmp.path());
+        let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+        let project = tmp.path();
+
+        let session = create_session(project, Some("daemon-no-tool-before-result"), None, None)?;
+        let session_id = session.meta_session_id;
+        let session_dir = get_session_dir(project, &session_id)?;
+        let session = load_session(project, &session_id)?;
+        let packet = DaemonCompletionPacket::from_exit_code(0);
+
+        let result =
+            daemon_completion_result(project, &session_dir, &session, &packet, chrono::Utc::now());
+
+        assert_eq!(result.tool, "unknown");
+        assert!(
+            result
+                .summary
+                .contains("no tool launch metadata was recorded"),
+            "summary should make unknown tool explicit: {}",
+            result.summary
+        );
         Ok(())
     }
 }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_diagnostics_tests.rs
@@ -273,8 +273,9 @@ fn daemon_completion_result_survives_state_save_failure() {
     let result = load_result(project, &session_id)
         .unwrap()
         .expect("daemon completion result must remain recoverable");
-    assert_eq!(result.status, "success");
-    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.raw_process_exit_code, Some(0));
     assert!(
         result.summary.contains("daemon completion recorded"),
         "unexpected daemon completion summary: {}",

--- a/crates/cli-sub-agent/src/session_cmds_result_daemon_completion_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_daemon_completion_tests.rs
@@ -1,0 +1,58 @@
+use super::*;
+
+#[cfg(unix)]
+#[test]
+fn handle_session_result_fails_closed_on_success_completion_without_result() {
+    let tmp = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = tmp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", tmp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = tmp.path();
+
+    let session = create_session(
+        project,
+        Some("result-success-completion-without-result"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    backdate_tree(&session_dir, 120);
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .unwrap();
+
+    handle_session_result(
+        session_id.clone(),
+        false,
+        Some(project.to_string_lossy().into_owned()),
+        StructuredOutputOpts::default(),
+    )
+    .unwrap();
+
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("session result should synthesize fail-closed result");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.raw_process_exit_code, Some(0));
+    assert!(
+        result
+            .summary
+            .contains("treating daemon completion as failure"),
+        "summary should explain fail-closed conversion: {}",
+        result.summary
+    );
+
+    let persisted = csa_session::load_session(project, &session_id).unwrap();
+    assert_eq!(persisted.phase, csa_session::SessionPhase::Retired);
+    assert_eq!(
+        persisted.termination_reason.as_deref(),
+        Some("daemon_completion_missing_result")
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_result_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tests.rs
@@ -34,6 +34,8 @@ impl Drop for EnvVarGuard {
     }
 }
 
+#[path = "session_cmds_result_daemon_completion_tests.rs"]
+mod daemon_completion;
 #[path = "session_cmds_result_tests_2016.rs"]
 mod issue_2016;
 

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
@@ -3,6 +3,9 @@ use crate::session_cmds::resolve_session_prefix_with_global_fallback;
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 
+#[path = "session_cmds_tests_tail_daemon_completion.rs"]
+mod daemon_completion;
+
 #[cfg(unix)]
 fn wait_for_spawned_daemon_visibility(
     session_dir: &std::path::Path,

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_daemon_completion.rs
@@ -1,0 +1,44 @@
+use super::super::*;
+
+#[cfg(unix)]
+#[test]
+fn handle_session_wait_fails_closed_on_success_completion_without_result() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-success-completion-without-result"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    backdate_tree(&session_dir, 120);
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .unwrap();
+
+    let exit_code = handle_session_wait(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(exit_code, 1);
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("wait should synthesize fail-closed result");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.raw_process_exit_code, Some(0));
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.985"
-weave = "0.1.985"
+csa = "0.1.986"
+weave = "0.1.986"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Fail closed when daemon completion/legacy marker reports success before a complete `result.toml` exists.
- Preserve raw process exit details while emitting structured missing-result diagnostics and retirement metadata.
- Add focused regression coverage for session result/wait daemon-completion behavior without relaxing monolith ratchets.

## Verification
- Hook-running commit passed `branch-protection` and `quality-gates`.
- CSA implementation verification: focused daemon/session tests, fix-finding tests, explicit tool/tier tests, fmt, diff checks, monolith, pre-commit-fast.
- CSA monolith salvage verification: focused tests, fmt, diff checks, `just find-monolith-files`, `just pre-commit-fast`.
- Full-diff review: `01KTYFX36NW3NX1DM3TV5QM6KQ` PASS/CLEAN for `52e310a7059`.

Closes #2107
