### PR TITLE
feat(session): add peek and stats observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.986"
+version = "0.1.987"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.986"
+version = "0.1.987"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_session.rs
+++ b/crates/cli-sub-agent/src/cli_session.rs
@@ -134,6 +134,48 @@ pub enum SessionCommands {
         cd: Option<String>,
     },
 
+    /// Show bounded liveness and recent operation state for a session
+    Peek {
+        /// Session ID or prefix (positional alternative to --session)
+        #[arg(conflicts_with = "session")]
+        session_id: Option<String>,
+
+        /// Session ID or prefix
+        #[arg(short, long)]
+        session: Option<String>,
+
+        /// Number of recent operations to show
+        #[arg(short = 'n', default_value_t = 5)]
+        operations: usize,
+
+        /// Working directory
+        #[arg(long)]
+        cd: Option<String>,
+    },
+
+    /// Roll up session time, liveness gaps, token usage, and optional costs
+    Stats {
+        /// Include sessions accessed since this duration ago (e.g. "1h", "30m", "2d")
+        #[arg(long)]
+        since: String,
+
+        /// Include per-issue rollups
+        #[arg(long)]
+        by_issue: bool,
+
+        /// Include per-tool rollups
+        #[arg(long)]
+        by_tool: bool,
+
+        /// Include conservative cost rollups from recorded estimates only
+        #[arg(long)]
+        cost: bool,
+
+        /// Working directory
+        #[arg(long)]
+        cd: Option<String>,
+    },
+
     /// Show the last execution result for a session
     Result {
         /// Session ID or prefix (positional alternative to --session)

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -54,6 +54,10 @@ pub(crate) use logs::{
     display_acp_events, display_daemon_spool_logs, display_log_files, print_content_with_tail,
 };
 
+#[path = "session_cmds_observe.rs"]
+mod observe;
+pub(crate) use observe::{handle_session_peek, handle_session_stats};
+
 /// Parse a human-friendly duration string (e.g., "1h", "30m", "2d") into
 /// a `chrono::Duration`. Supports `s` (seconds), `m` (minutes), `h` (hours),
 /// and `d` (days).

--- a/crates/cli-sub-agent/src/session_cmds_observe.rs
+++ b/crates/cli-sub-agent/src/session_cmds_observe.rs
@@ -1,0 +1,646 @@
+//! Token-bounded, transport-agnostic session observability.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use csa_core::types::OutputFormat;
+use csa_session::{MetaSessionState, SessionPhase, SessionResult};
+use serde::Serialize;
+
+use crate::stdout_write::{write_stdout, write_stdout_line};
+
+#[path = "session_cmds_observe_render.rs"]
+mod render;
+
+use self::render::{render_peek_text, render_stats_text};
+
+const DEFAULT_PEEK_OPERATIONS: usize = 5;
+const UNKNOWN_GROUP: &str = "unknown";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PeekState {
+    Working,
+    Idle,
+    Dead,
+}
+
+impl std::fmt::Display for PeekState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Working => write!(f, "working"),
+            Self::Idle => write!(f, "idle"),
+            Self::Dead => write!(f, "dead"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct SessionOperation {
+    pub timestamp: DateTime<Utc>,
+    pub age_secs: u64,
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct SessionPeekReport {
+    pub session_id: String,
+    pub state: PeekState,
+    pub idle_secs: u64,
+    pub elapsed_secs: u64,
+    pub idle_timeout_secs: u64,
+    pub created_at: DateTime<Utc>,
+    pub last_accessed: DateTime<Utc>,
+    pub phase: SessionPhase,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_exit_code: Option<i32>,
+    pub session_dir: PathBuf,
+    pub operations: Vec<SessionOperation>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct TokenRollup {
+    pub uncached_input_tokens: u64,
+    pub cached_input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+    pub sessions_with_tokens: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CostSource {
+    RecordedSessionEstimates,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct CostRollup {
+    pub estimated_usd: Option<f64>,
+    pub source: CostSource,
+    pub sessions_with_recorded_cost: usize,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+pub(crate) struct SessionStatsBucket {
+    pub session_count: usize,
+    pub wall_clock_span_secs: u64,
+    pub idle_gap_secs: u64,
+    pub stuck_gap_secs: u64,
+    pub stuck_session_count: usize,
+    pub tokens: TokenRollup,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost: Option<CostRollup>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct SessionStatsGroup {
+    pub key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issue_source: Option<String>,
+    #[serde(flatten)]
+    pub bucket: SessionStatsBucket,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct SessionStatsReport {
+    pub generated_at: DateTime<Utc>,
+    pub since: String,
+    pub since_secs: i64,
+    pub cutoff: DateTime<Utc>,
+    #[serde(flatten)]
+    pub total: SessionStatsBucket,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub by_issue: Vec<SessionStatsGroup>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub by_tool: Vec<SessionStatsGroup>,
+}
+
+#[derive(Debug, Clone)]
+struct SessionStatsRecord {
+    session: MetaSessionState,
+    state: PeekState,
+    idle_secs: u64,
+    stuck_gap_secs: u64,
+    end_at: DateTime<Utc>,
+    issue_key: String,
+    issue_source: IssueSource,
+    tool_key: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IssueSource {
+    Explicit,
+    Heuristic,
+    Unknown,
+}
+
+impl IssueSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit",
+            Self::Heuristic => "heuristic",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+pub(crate) fn handle_session_peek(
+    session: String,
+    operations: Option<usize>,
+    cd: Option<String>,
+    format: OutputFormat,
+) -> Result<()> {
+    let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
+    let resolved = super::resolve_session_prefix_with_global_fallback(&project_root, &session)?;
+    let session_dir = resolved.sessions_dir.join(&resolved.session_id);
+    let effective_root = resolved
+        .foreign_project_root
+        .as_deref()
+        .unwrap_or(&project_root);
+    let idle_timeout_secs = resolve_idle_timeout_secs(effective_root)?;
+
+    let report = build_peek_report(
+        &resolved.session_id,
+        &session_dir,
+        effective_root,
+        operations.unwrap_or(DEFAULT_PEEK_OPERATIONS),
+        idle_timeout_secs,
+        Utc::now(),
+    )?;
+
+    match format {
+        OutputFormat::Json => write_stdout_line(&serde_json::to_string_pretty(&report)?)?,
+        OutputFormat::Text => write_stdout(&render_peek_text(&report))?,
+    }
+    Ok(())
+}
+
+pub(crate) fn handle_session_stats(
+    since: String,
+    by_issue: bool,
+    by_tool: bool,
+    include_cost: bool,
+    cd: Option<String>,
+    format: OutputFormat,
+) -> Result<()> {
+    let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
+    let duration = super::parse_duration_filter(&since)?;
+    let now = Utc::now();
+    let report = build_stats_report(
+        &project_root,
+        since,
+        duration,
+        by_issue,
+        by_tool,
+        include_cost,
+        now,
+    )?;
+
+    match format {
+        OutputFormat::Json => write_stdout_line(&serde_json::to_string_pretty(&report)?)?,
+        OutputFormat::Text => write_stdout(&render_stats_text(&report))?,
+    }
+    Ok(())
+}
+
+fn resolve_idle_timeout_secs(project_root: &Path) -> Result<u64> {
+    let config = csa_config::ProjectConfig::load(project_root)?;
+    Ok(crate::pipeline::resolve_idle_timeout_seconds(
+        config.as_ref(),
+        None,
+    ))
+}
+
+fn build_peek_report(
+    session_id: &str,
+    session_dir: &Path,
+    project_root: &Path,
+    operation_limit: usize,
+    idle_timeout_secs: u64,
+    now: DateTime<Utc>,
+) -> Result<SessionPeekReport> {
+    let mut session = load_session_from_dir(session_dir)
+        .with_context(|| format!("failed to load session state for {session_id}"))?;
+    let state = classify_session_liveness(session_dir);
+    if state == PeekState::Dead && matches!(session.phase, SessionPhase::Active) {
+        match super::ensure_terminal_result_for_dead_active_session(
+            project_root,
+            session_id,
+            "session peek",
+        ) {
+            Ok(reconciliation) if reconciliation.result_became_available() => {
+                session = load_session_from_dir(session_dir).with_context(|| {
+                    format!(
+                        "failed to reload session state for {session_id} after dead-session reconciliation"
+                    )
+                })?;
+            }
+            Ok(_) => {}
+            Err(err) => {
+                tracing::warn!(session_id, error = %err, "Failed to reconcile dead Active session in session peek");
+            }
+        }
+    }
+
+    let result = load_result_from_dir(session_dir)?;
+    let created_at = super::list::session_created_at(&session);
+    let elapsed_secs = nonnegative_secs(now - created_at);
+    let idle_secs = nonnegative_secs(now - session.last_accessed);
+    let operations = collect_operations(&session, result.as_ref(), now, operation_limit);
+
+    Ok(SessionPeekReport {
+        session_id: session_id.to_string(),
+        state,
+        idle_secs,
+        elapsed_secs,
+        idle_timeout_secs,
+        created_at,
+        last_accessed: session.last_accessed,
+        phase: session.phase,
+        result_status: result.as_ref().map(|result| result.status.clone()),
+        result_exit_code: result.as_ref().map(|result| result.exit_code),
+        session_dir: session_dir.to_path_buf(),
+        operations,
+    })
+}
+
+fn build_stats_report(
+    project_root: &Path,
+    since: String,
+    duration: Duration,
+    by_issue: bool,
+    by_tool: bool,
+    include_cost: bool,
+    now: DateTime<Utc>,
+) -> Result<SessionStatsReport> {
+    let cutoff = now - duration;
+    let idle_timeout_secs = resolve_idle_timeout_secs(project_root)?;
+    let mut sessions = csa_session::list_sessions_readonly(project_root, None)?;
+    sessions.retain(|session| session.last_accessed >= cutoff);
+
+    let mut records = Vec::with_capacity(sessions.len());
+    for session in sessions {
+        let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id)?;
+        let result = load_result_from_dir(&session_dir)?;
+        let state = classify_session_liveness(&session_dir);
+        let idle_secs = if matches!(session.phase, SessionPhase::Active) {
+            nonnegative_secs(now - session.last_accessed)
+        } else {
+            0
+        };
+        let stuck_gap_secs = idle_secs.saturating_sub(idle_timeout_secs);
+        let end_at = if matches!(session.phase, SessionPhase::Active)
+            && matches!(state, PeekState::Working | PeekState::Idle)
+        {
+            now
+        } else {
+            session
+                .last_accessed
+                .max(super::list::session_created_at(&session))
+        };
+        let (issue_key, issue_source) = issue_key_for_session(&session);
+        let tool_key = tool_key_for_session(&session, result.as_ref());
+
+        records.push(SessionStatsRecord {
+            session,
+            state,
+            idle_secs,
+            stuck_gap_secs,
+            end_at,
+            issue_key,
+            issue_source,
+            tool_key,
+        });
+    }
+
+    let total = build_bucket(&records, include_cost);
+    let by_issue_groups = if by_issue {
+        build_groups(&records, include_cost, |record| {
+            (
+                record.issue_key.clone(),
+                Some(record.issue_source.as_str().to_string()),
+            )
+        })
+    } else {
+        Vec::new()
+    };
+    let by_tool_groups = if by_tool {
+        build_groups(&records, include_cost, |record| {
+            (record.tool_key.clone(), None)
+        })
+    } else {
+        Vec::new()
+    };
+
+    Ok(SessionStatsReport {
+        generated_at: now,
+        since,
+        since_secs: duration.num_seconds(),
+        cutoff,
+        total,
+        by_issue: by_issue_groups,
+        by_tool: by_tool_groups,
+    })
+}
+
+fn load_session_from_dir(session_dir: &Path) -> Result<MetaSessionState> {
+    let state_path = session_dir.join("state.toml");
+    let content = std::fs::read_to_string(&state_path)
+        .with_context(|| format!("failed to read {}", state_path.display()))?;
+    toml::from_str(&content).with_context(|| format!("failed to parse {}", state_path.display()))
+}
+
+fn load_result_from_dir(session_dir: &Path) -> Result<Option<SessionResult>> {
+    let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
+    if !result_path.is_file() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(&result_path)
+        .with_context(|| format!("failed to read {}", result_path.display()))?;
+    let result = toml::from_str(&content)
+        .with_context(|| format!("failed to parse {}", result_path.display()))?;
+    Ok(Some(result))
+}
+
+fn classify_session_liveness(session_dir: &Path) -> PeekState {
+    if csa_process::ToolLiveness::is_working(session_dir) {
+        PeekState::Working
+    } else if csa_process::ToolLiveness::is_alive_read_only(session_dir) {
+        PeekState::Idle
+    } else {
+        PeekState::Dead
+    }
+}
+
+fn collect_operations(
+    session: &MetaSessionState,
+    result: Option<&SessionResult>,
+    now: DateTime<Utc>,
+    limit: usize,
+) -> Vec<SessionOperation> {
+    let mut operations = Vec::new();
+
+    for (tool, state) in &session.tools {
+        operations.push(SessionOperation {
+            timestamp: state.updated_at,
+            age_secs: nonnegative_secs(now - state.updated_at),
+            kind: "tool".to_string(),
+            tool: Some(tool.clone()),
+            exit_code: Some(state.last_exit_code),
+            summary: state.last_action_summary.clone(),
+        });
+    }
+
+    if let Some(result) = result {
+        operations.push(SessionOperation {
+            timestamp: result.completed_at,
+            age_secs: nonnegative_secs(now - result.completed_at),
+            kind: "result".to_string(),
+            tool: Some(result.tool.clone()),
+            exit_code: Some(result.exit_code),
+            summary: result.summary.clone(),
+        });
+    }
+
+    operations.push(SessionOperation {
+        timestamp: session.last_accessed,
+        age_secs: nonnegative_secs(now - session.last_accessed),
+        kind: "session_state".to_string(),
+        tool: None,
+        exit_code: None,
+        summary: format!("phase={}", session.phase),
+    });
+
+    operations.sort_by_key(|operation| std::cmp::Reverse(operation.timestamp));
+    operations.truncate(limit);
+    operations
+}
+
+fn build_bucket(records: &[SessionStatsRecord], include_cost: bool) -> SessionStatsBucket {
+    let session_count = records.len();
+    let wall_clock_span_secs = wall_clock_span_secs(records);
+    let idle_gap_secs = records.iter().map(|record| record.idle_secs).sum::<u64>();
+    let stuck_gap_secs = records
+        .iter()
+        .map(|record| record.stuck_gap_secs)
+        .sum::<u64>();
+    let stuck_session_count = records
+        .iter()
+        .filter(|record| {
+            record.stuck_gap_secs > 0
+                || (record.state == PeekState::Dead
+                    && matches!(record.session.phase, SessionPhase::Active))
+        })
+        .count();
+    let tokens = rollup_tokens(records.iter().map(|record| &record.session));
+    let cost = include_cost.then(|| rollup_cost(records.iter().map(|record| &record.session)));
+
+    SessionStatsBucket {
+        session_count,
+        wall_clock_span_secs,
+        idle_gap_secs,
+        stuck_gap_secs,
+        stuck_session_count,
+        tokens,
+        cost,
+    }
+}
+
+fn build_groups<F>(
+    records: &[SessionStatsRecord],
+    include_cost: bool,
+    key_fn: F,
+) -> Vec<SessionStatsGroup>
+where
+    F: Fn(&SessionStatsRecord) -> (String, Option<String>),
+{
+    let mut grouped: BTreeMap<String, (Option<String>, Vec<SessionStatsRecord>)> = BTreeMap::new();
+    for record in records {
+        let (key, issue_source) = key_fn(record);
+        let entry = grouped.entry(key).or_insert_with(|| (None, Vec::new()));
+        entry.0 = preferred_issue_source(entry.0.take(), issue_source);
+        entry.1.push(record.clone());
+    }
+
+    grouped
+        .into_iter()
+        .map(|(key, (issue_source, records))| SessionStatsGroup {
+            key,
+            issue_source,
+            bucket: build_bucket(&records, include_cost),
+        })
+        .collect()
+}
+
+fn preferred_issue_source(current: Option<String>, candidate: Option<String>) -> Option<String> {
+    match (current.as_deref(), candidate.as_deref()) {
+        (Some("explicit"), _) | (_, Some("explicit")) => Some("explicit".to_string()),
+        (Some("heuristic"), _) | (_, Some("heuristic")) => Some("heuristic".to_string()),
+        (Some("unknown"), _) | (_, Some("unknown")) => Some("unknown".to_string()),
+        _ => None,
+    }
+}
+
+fn wall_clock_span_secs(records: &[SessionStatsRecord]) -> u64 {
+    let Some(first) = records.first() else {
+        return 0;
+    };
+    let mut start = super::list::session_created_at(&first.session);
+    let mut end = first.end_at;
+
+    for record in &records[1..] {
+        start = start.min(super::list::session_created_at(&record.session));
+        end = end.max(record.end_at);
+    }
+
+    nonnegative_secs(end - start)
+}
+
+fn rollup_tokens<'a>(sessions: impl Iterator<Item = &'a MetaSessionState>) -> TokenRollup {
+    let mut rollup = TokenRollup::default();
+    for session in sessions {
+        let Some(usage) = session.total_token_usage.as_ref() else {
+            continue;
+        };
+        let input = usage.input_tokens.unwrap_or(0);
+        let cached = usage.cache_read_input_tokens.unwrap_or(0).min(input);
+        let uncached = input.saturating_sub(cached);
+        let output = usage.output_tokens.unwrap_or(0);
+        let total = usage
+            .total_tokens
+            .unwrap_or_else(|| input.saturating_add(output));
+
+        rollup.uncached_input_tokens = rollup.uncached_input_tokens.saturating_add(uncached);
+        rollup.cached_input_tokens = rollup.cached_input_tokens.saturating_add(cached);
+        rollup.output_tokens = rollup.output_tokens.saturating_add(output);
+        rollup.total_tokens = rollup.total_tokens.saturating_add(total);
+        rollup.sessions_with_tokens += 1;
+    }
+    rollup
+}
+
+fn rollup_cost<'a>(sessions: impl Iterator<Item = &'a MetaSessionState>) -> CostRollup {
+    let mut total = 0.0;
+    let mut sessions_with_recorded_cost = 0;
+
+    for session in sessions {
+        let Some(cost) = session
+            .total_token_usage
+            .as_ref()
+            .and_then(|usage| usage.estimated_cost_usd)
+        else {
+            continue;
+        };
+        if cost > 0.0 {
+            total += cost;
+            sessions_with_recorded_cost += 1;
+        }
+    }
+
+    if sessions_with_recorded_cost == 0 {
+        CostRollup {
+            estimated_usd: None,
+            source: CostSource::Unknown,
+            sessions_with_recorded_cost,
+        }
+    } else {
+        CostRollup {
+            estimated_usd: Some(total),
+            source: CostSource::RecordedSessionEstimates,
+            sessions_with_recorded_cost,
+        }
+    }
+}
+
+fn issue_key_for_session(session: &MetaSessionState) -> (String, IssueSource) {
+    for text in [
+        session.spec_id.as_deref(),
+        session.description.as_deref(),
+        session.task_context.task_type.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if let Some(issue) = extract_issue_with_marker(text) {
+            return (issue, IssueSource::Explicit);
+        }
+    }
+
+    if let Some(branch) = session.branch.as_deref()
+        && let Some(issue) = extract_issue_heuristic(branch)
+    {
+        return (issue, IssueSource::Heuristic);
+    }
+
+    (UNKNOWN_GROUP.to_string(), IssueSource::Unknown)
+}
+
+fn extract_issue_with_marker(text: &str) -> Option<String> {
+    let lower = text.to_ascii_lowercase();
+    for marker in ["issue #", "issue-", "issue/", "gh #", "github #"] {
+        if let Some(pos) = lower.find(marker) {
+            let raw = &text[pos + marker.len()..];
+            if let Some(issue) = leading_issue_number(raw) {
+                return Some(format!("#{issue}"));
+            }
+        }
+    }
+    None
+}
+
+fn extract_issue_heuristic(text: &str) -> Option<String> {
+    for part in text.split(|c: char| !c.is_ascii_alphanumeric() && c != '#') {
+        let candidate = part.strip_prefix('#').unwrap_or(part);
+        if (3..=7).contains(&candidate.len()) && candidate.chars().all(|c| c.is_ascii_digit()) {
+            return Some(format!("#{candidate}"));
+        }
+    }
+    None
+}
+
+fn leading_issue_number(raw: &str) -> Option<String> {
+    let digits: String = raw
+        .chars()
+        .skip_while(|c| c.is_whitespace())
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    (!digits.is_empty()).then_some(digits)
+}
+
+fn tool_key_for_session(session: &MetaSessionState, result: Option<&SessionResult>) -> String {
+    if let Some(tool) = result
+        .map(|result| result.tool.as_str())
+        .filter(|tool| !tool.trim().is_empty())
+    {
+        return tool.to_string();
+    }
+
+    match session.tools.len() {
+        0 => UNKNOWN_GROUP.to_string(),
+        1 => session
+            .tools
+            .keys()
+            .next()
+            .cloned()
+            .unwrap_or_else(|| UNKNOWN_GROUP.to_string()),
+        _ => "multiple".to_string(),
+    }
+}
+
+fn nonnegative_secs(duration: Duration) -> u64 {
+    duration.num_seconds().max(0) as u64
+}
+
+#[cfg(test)]
+#[path = "session_cmds_observe_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/session_cmds_observe_render.rs
+++ b/crates/cli-sub-agent/src/session_cmds_observe_render.rs
@@ -1,0 +1,132 @@
+use super::{SessionPeekReport, SessionStatsBucket, SessionStatsGroup, SessionStatsReport};
+
+pub(super) fn render_peek_text(report: &SessionPeekReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("Session: {}\n", report.session_id));
+    out.push_str(&format!("State: {}\n", report.state));
+    out.push_str(&format!(
+        "Idle: {} / timeout {}\n",
+        format_secs(report.idle_secs),
+        format_secs(report.idle_timeout_secs)
+    ));
+    out.push_str(&format!("Elapsed: {}\n", format_secs(report.elapsed_secs)));
+    out.push_str(&format!("Last accessed: {}\n", report.last_accessed));
+    if let Some(status) = &report.result_status {
+        out.push_str(&format!(
+            "Result: {} exit={}\n",
+            status,
+            report.result_exit_code.unwrap_or_default()
+        ));
+    }
+    out.push_str("Operations:\n");
+    if report.operations.is_empty() {
+        out.push_str("  -\n");
+    } else {
+        for op in &report.operations {
+            let tool = op
+                .tool
+                .as_deref()
+                .map(|tool| format!(" tool={tool}"))
+                .unwrap_or_default();
+            let exit = op
+                .exit_code
+                .map(|code| format!(" exit={code}"))
+                .unwrap_or_default();
+            out.push_str(&format!(
+                "  {} ({} ago) {}{}{}: {}\n",
+                op.timestamp,
+                format_secs(op.age_secs),
+                op.kind,
+                tool,
+                exit,
+                op.summary
+            ));
+        }
+    }
+    out
+}
+
+pub(super) fn render_stats_text(report: &SessionStatsReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "Sessions since {}: {}\n",
+        report.since, report.total.session_count
+    ));
+    out.push_str(&format!(
+        "Wall-clock span: {}\n",
+        format_secs(report.total.wall_clock_span_secs)
+    ));
+    append_bucket_detail(&mut out, &report.total);
+
+    if !report.by_issue.is_empty() {
+        out.push_str("By issue:\n");
+        for group in &report.by_issue {
+            append_group_line(&mut out, group);
+        }
+    }
+
+    if !report.by_tool.is_empty() {
+        out.push_str("By tool:\n");
+        for group in &report.by_tool {
+            append_group_line(&mut out, group);
+        }
+    }
+
+    out
+}
+
+fn append_bucket_detail(out: &mut String, bucket: &SessionStatsBucket) {
+    out.push_str(&format!(
+        "Idle gaps: {} total, {} stuck across {} session(s)\n",
+        format_secs(bucket.idle_gap_secs),
+        format_secs(bucket.stuck_gap_secs),
+        bucket.stuck_session_count
+    ));
+    out.push_str(&format!(
+        "Tokens: uncached_input={} cached_input={} output={} total={}\n",
+        bucket.tokens.uncached_input_tokens,
+        bucket.tokens.cached_input_tokens,
+        bucket.tokens.output_tokens,
+        bucket.tokens.total_tokens
+    ));
+    if let Some(cost) = &bucket.cost {
+        match cost.estimated_usd {
+            Some(value) => out.push_str(&format!(
+                "Cost: ${value:.4} ({:?}, {} session(s))\n",
+                cost.source, cost.sessions_with_recorded_cost
+            )),
+            None => out.push_str(
+                "Cost: unknown (no authoritative pricing table or recorded positive estimate)\n",
+            ),
+        }
+    }
+}
+
+fn append_group_line(out: &mut String, group: &SessionStatsGroup) {
+    out.push_str(&format!(
+        "  {}: sessions={} wall={} idle={} stuck={} tokens={}\n",
+        group.key,
+        group.bucket.session_count,
+        format_secs(group.bucket.wall_clock_span_secs),
+        format_secs(group.bucket.idle_gap_secs),
+        format_secs(group.bucket.stuck_gap_secs),
+        group.bucket.tokens.total_tokens
+    ));
+}
+
+fn format_secs(secs: u64) -> String {
+    let days = secs / 86_400;
+    let hours = (secs % 86_400) / 3_600;
+    let minutes = (secs % 3_600) / 60;
+    let seconds = secs % 60;
+
+    if days > 0 {
+        format!("{days}d{hours}h")
+    } else if hours > 0 {
+        format!("{hours}h{minutes}m")
+    } else if minutes > 0 {
+        format!("{minutes}m{seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}

--- a/crates/cli-sub-agent/src/session_cmds_observe_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_observe_tests.rs
@@ -1,0 +1,357 @@
+use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_session::{
+    TaskContext, TokenUsage, ToolState, create_session, get_session_dir, save_result, save_session,
+};
+use tempfile::tempdir;
+
+fn make_result(tool: &str, status: &str, exit_code: i32, at: DateTime<Utc>) -> SessionResult {
+    SessionResult {
+        status: status.to_string(),
+        exit_code,
+        summary: "completed work".to_string(),
+        tool: tool.to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: at - Duration::seconds(30),
+        completed_at: at,
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    }
+}
+
+#[cfg(unix)]
+fn set_file_mtime_seconds_ago(path: &std::path::Path, seconds_ago: u64) {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before unix epoch");
+    let target = now.saturating_sub(std::time::Duration::from_secs(seconds_ago));
+    let tv_sec = target.as_secs() as libc::time_t;
+    let tv_nsec = target.subsec_nanos() as libc::c_long;
+    let times = [
+        libc::timespec { tv_sec, tv_nsec },
+        libc::timespec { tv_sec, tv_nsec },
+    ];
+    let c_path = CString::new(path.as_os_str().as_bytes()).expect("path contains NUL");
+    // SAFETY: path is NUL-terminated and timespec array lives for the syscall.
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+    assert_eq!(rc, 0, "utimensat failed for {}", path.display());
+}
+
+#[cfg(unix)]
+fn backdate_tree(path: &std::path::Path, seconds_ago: u64) {
+    if path.is_dir() {
+        for entry in std::fs::read_dir(path).expect("read_dir") {
+            let entry = entry.expect("dir entry");
+            backdate_tree(&entry.path(), seconds_ago);
+        }
+    }
+    set_file_mtime_seconds_ago(path, seconds_ago);
+}
+
+#[test]
+fn peek_report_classifies_recent_session_as_idle_and_limits_operations() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let now = Utc::now();
+    let mut session = create_session(&project, Some("issue #2106 peek"), None, Some("codex"))
+        .expect("create session");
+    session.created_at = now - Duration::minutes(5);
+    session.last_accessed = now - Duration::seconds(20);
+    session.tools.insert(
+        "codex".to_string(),
+        ToolState {
+            provider_session_id: None,
+            last_action_summary: "edited session stats".to_string(),
+            last_exit_code: 0,
+            updated_at: now - Duration::seconds(10),
+            tool_version: None,
+            token_usage: None,
+        },
+    );
+    save_session(&session).unwrap();
+    let session_dir = get_session_dir(&project, &session.meta_session_id).unwrap();
+    save_result(
+        &project,
+        &session.meta_session_id,
+        &make_result("codex", "success", 0, now - Duration::seconds(5)),
+    )
+    .unwrap();
+
+    let report = build_peek_report(
+        &session.meta_session_id,
+        &session_dir,
+        &project,
+        2,
+        250,
+        now,
+    )
+    .unwrap();
+
+    assert_eq!(report.state, PeekState::Idle);
+    assert_eq!(report.idle_secs, 20);
+    assert_eq!(report.elapsed_secs, 300);
+    assert_eq!(report.operations.len(), 2);
+    assert_eq!(report.operations[0].kind, "result");
+    assert_eq!(report.operations[1].kind, "tool");
+
+    let json = serde_json::to_value(&report).unwrap();
+    assert_eq!(json["state"], "idle");
+    assert_eq!(json["idle_secs"], 20);
+
+    let text = render_peek_text(&report);
+    assert!(text.contains("State: idle"));
+    assert!(text.contains("Operations:"));
+}
+
+#[cfg(unix)]
+#[test]
+fn peek_report_classifies_old_session_without_liveness_as_dead() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let now = Utc::now();
+    let mut session = create_session(&project, Some("dead peek"), None, Some("codex")).unwrap();
+    session.created_at = now - Duration::hours(2);
+    session.last_accessed = now - Duration::hours(1);
+    save_session(&session).unwrap();
+    let session_dir = get_session_dir(&project, &session.meta_session_id).unwrap();
+    backdate_tree(&session_dir, 3_600);
+
+    let report = build_peek_report(
+        &session.meta_session_id,
+        &session_dir,
+        &project,
+        5,
+        250,
+        now,
+    )
+    .unwrap();
+
+    assert_eq!(report.state, PeekState::Dead);
+    assert_eq!(report.phase, SessionPhase::Retired);
+    assert!(report.operations.iter().any(|operation| {
+        operation.kind == "session_state" && operation.summary == "phase=retired"
+    }));
+    assert!(!report.operations.iter().any(|operation| {
+        operation.kind == "session_state" && operation.summary == "phase=active"
+    }));
+    let result = csa_session::load_result(&project, &session.meta_session_id)
+        .unwrap()
+        .expect("dead Active session should be reconciled");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+}
+
+#[test]
+fn stats_report_filters_since_and_groups_by_issue_and_tool() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let now = Utc::now();
+
+    let mut first = create_session(
+        &project,
+        Some("Implement GitHub issue #2106"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    first.branch = Some("fix/2106-session-observability".to_string());
+    first.created_at = now - Duration::minutes(20);
+    first.last_accessed = now - Duration::minutes(10);
+    first.task_context = TaskContext {
+        task_type: Some("implement".to_string()),
+        tier_name: Some("tier-4-critical".to_string()),
+    };
+    first.total_token_usage = Some(TokenUsage {
+        input_tokens: Some(1_000),
+        cache_read_input_tokens: Some(250),
+        output_tokens: Some(400),
+        total_tokens: Some(1_400),
+        estimated_cost_usd: None,
+    });
+    save_session(&first).unwrap();
+    save_result(
+        &project,
+        &first.meta_session_id,
+        &make_result("codex", "success", 0, now - Duration::minutes(10)),
+    )
+    .unwrap();
+
+    let mut second = create_session(
+        &project,
+        Some("review issue #2106"),
+        None,
+        Some("gemini-cli"),
+    )
+    .unwrap();
+    second.created_at = now - Duration::minutes(8);
+    second.last_accessed = now - Duration::minutes(4);
+    second.total_token_usage = Some(TokenUsage {
+        input_tokens: Some(500),
+        cache_read_input_tokens: None,
+        output_tokens: Some(100),
+        total_tokens: None,
+        estimated_cost_usd: Some(0.125),
+    });
+    save_session(&second).unwrap();
+    save_result(
+        &project,
+        &second.meta_session_id,
+        &make_result("gemini-cli", "success", 0, now - Duration::minutes(4)),
+    )
+    .unwrap();
+
+    let mut old = create_session(&project, Some("issue #9999 old"), None, Some("codex")).unwrap();
+    old.created_at = now - Duration::days(2);
+    old.last_accessed = now - Duration::days(2);
+    save_session(&old).unwrap();
+
+    let report = build_stats_report(
+        &project,
+        "30m".to_string(),
+        Duration::minutes(30),
+        true,
+        true,
+        true,
+        now,
+    )
+    .unwrap();
+
+    assert_eq!(report.total.session_count, 2);
+    assert_eq!(report.total.tokens.uncached_input_tokens, 1_250);
+    assert_eq!(report.total.tokens.cached_input_tokens, 250);
+    assert_eq!(report.total.tokens.output_tokens, 500);
+    assert_eq!(report.total.tokens.total_tokens, 2_000);
+    assert_eq!(
+        report.total.cost.as_ref().unwrap().estimated_usd,
+        Some(0.125)
+    );
+    assert_eq!(report.by_issue.len(), 1);
+    assert_eq!(report.by_issue[0].key, "#2106");
+    assert_eq!(report.by_issue[0].issue_source.as_deref(), Some("explicit"));
+    assert_eq!(report.by_tool.len(), 2);
+    assert!(report.by_tool.iter().any(|group| group.key == "codex"));
+    assert!(report.by_tool.iter().any(|group| group.key == "gemini-cli"));
+
+    let json = serde_json::to_value(&report).unwrap();
+    assert_eq!(json["session_count"], 2);
+    assert_eq!(json["by_issue"][0]["key"], "#2106");
+
+    let text = render_stats_text(&report);
+    assert!(text.contains("Sessions since 30m: 2"));
+    assert!(text.contains("By issue:"));
+    assert!(text.contains("By tool:"));
+}
+
+#[test]
+fn stats_cost_is_unknown_without_positive_recorded_estimate() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let now = Utc::now();
+
+    let mut session = create_session(&project, Some("fix/2106"), None, Some("codex")).unwrap();
+    session.created_at = now - Duration::minutes(2);
+    session.last_accessed = now - Duration::minutes(1);
+    session.total_token_usage = Some(TokenUsage {
+        input_tokens: Some(100),
+        output_tokens: Some(50),
+        total_tokens: Some(150),
+        estimated_cost_usd: Some(0.0),
+        cache_read_input_tokens: None,
+    });
+    save_session(&session).unwrap();
+
+    let report = build_stats_report(
+        &project,
+        "10m".to_string(),
+        Duration::minutes(10),
+        false,
+        false,
+        true,
+        now,
+    )
+    .unwrap();
+
+    let cost = report.total.cost.as_ref().expect("cost requested");
+    assert_eq!(cost.estimated_usd, None);
+    assert_eq!(cost.source, CostSource::Unknown);
+}
+
+#[test]
+fn issue_link_uses_branch_number_only_as_heuristic_fallback() {
+    let mut session = MetaSessionState {
+        description: Some("general implementation".to_string()),
+        branch: Some("fix/2106-session-observability".to_string()),
+        ..Default::default()
+    };
+    let (key, source) = issue_key_for_session(&session);
+    assert_eq!(key, "#2106");
+    assert_eq!(source, IssueSource::Heuristic);
+
+    session.description = Some("GitHub issue #1762 stats".to_string());
+    let (key, source) = issue_key_for_session(&session);
+    assert_eq!(key, "#1762");
+    assert_eq!(source, IssueSource::Explicit);
+}
+
+#[cfg(unix)]
+#[test]
+fn peek_preserves_fail_closed_daemon_completion_without_result() {
+    let tmp = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let now = Utc::now();
+    let mut session = create_session(
+        &project,
+        Some("result-success-completion-without-result"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    session.last_accessed = now - Duration::minutes(30);
+    save_session(&session).unwrap();
+    let session_dir = get_session_dir(&project, &session.meta_session_id).unwrap();
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .unwrap();
+    backdate_tree(&session_dir, 1_800);
+
+    let report = build_peek_report(
+        &session.meta_session_id,
+        &session_dir,
+        &project,
+        5,
+        250,
+        now,
+    )
+    .unwrap();
+
+    assert_eq!(report.state, PeekState::Dead);
+    let result = csa_session::load_result(&project, &session.meta_session_id)
+        .unwrap()
+        .expect("session peek should synthesize fail-closed result");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.raw_process_exit_code, Some(0));
+    assert!(
+        result
+            .summary
+            .contains("treating daemon completion as failure")
+    );
+}

--- a/crates/cli-sub-agent/src/session_dispatch.rs
+++ b/crates/cli-sub-agent/src/session_dispatch.rs
@@ -98,6 +98,24 @@ pub(crate) fn dispatch(
             let _ = std::io::stderr().flush();
             std::process::exit(if alive { 0 } else { 1 });
         }
+        SessionCommands::Peek {
+            session_id,
+            session,
+            operations,
+            cd,
+        } => {
+            let sid = resolve_session_id(session_id, session)?;
+            session_cmds::handle_session_peek(sid, Some(operations), cd, output_format)?;
+        }
+        SessionCommands::Stats {
+            since,
+            by_issue,
+            by_tool,
+            cost,
+            cd,
+        } => {
+            session_cmds::handle_session_stats(since, by_issue, by_tool, cost, cd, output_format)?;
+        }
         SessionCommands::Result {
             session_id,
             session,


### PR DESCRIPTION
## Summary
- Add `csa session peek` for bounded per-session liveness/phase/result/operator observability in text and JSON formats.
- Add `csa session stats` for token-bounded session rollups by issue/tool with uncached/cached/output token splits and conservative cost reporting.
- Preserve #2107 fail-closed daemon-completion behavior and fix the review-found stale `peek` phase path after dead-active reconciliation.
- Split observe text rendering into a small render module to satisfy the monolith gate.

## Verification
- CSA implementation session `01KTYHJY0HT` reported focused observe tests, #2107 regression, fmt, diff checks, monolith, and pre-commit-fast passing.
- Review-fix salvage `01KTYNAB0ZZ` verified stale peek phase regression and observe tests.
- Monolith salvage `01KTYQ0FMCM` verified observe tests, fmt, diff checks, monolith, and pre-commit-fast passing.
- Hook-running amend passed branch-protection and quality-gates.
- Full-diff review `01KTYSJX8D0HX9TPV6S4V0PZG1` PASS/CLEAN for `main...HEAD` at `29f66339fce`.

Closes #2106
