### PR TITLE
fix(session): make resume result contract unambiguous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.987"
+version = "0.1.988"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.987"
+version = "0.1.988"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -31,7 +31,7 @@ mod prompt_cache;
 pub(crate) mod changed_paths;
 
 #[path = "pipeline_result_contract.rs"]
-mod result_contract;
+pub(crate) mod result_contract;
 
 #[path = "pipeline_design_context.rs"]
 pub(crate) mod design_context;

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -297,14 +297,12 @@ pub(crate) async fn process_execution_result(
         }
         EffectiveOutcome::ExitCodeAuthoritative => {}
     }
-    // No-op exit gate: detect sa-mode sessions that reported success but
-    // produced zero useful work (single turn, no tool calls, very short
-    // elapsed time).  Rewrite status to failure so orchestrators retry.
+    // No-op gate: fail short successful SA-mode runs with no tool calls/output.
     let elapsed_secs = (execution_end_time - ctx.execution_start_time).num_seconds();
     if ctx.sa_mode
         && ctx.task_type.is_none_or(|t| t == "run")
         && result.exit_code == 0
-        && !result_sidecar::status_is_success(&ctx.session_dir)
+        && !result_sidecar::status_is_success(&ctx.session_dir, session.turn_count)
         && session.turn_count <= 1
         && !ctx.has_tool_calls
         && !has_meaningful_reasoning_output
@@ -362,7 +360,7 @@ pub(crate) async fn process_execution_result(
     }
     if result.exit_code == 0
         && ctx.task_type == Some("run")
-        && !result_sidecar::status_is_success(&ctx.session_dir)
+        && !result_sidecar::status_is_success(&ctx.session_dir, session.turn_count)
         && session.turn_count <= 1
         && !ctx.has_tool_calls
         && !has_meaningful_reasoning_output
@@ -404,6 +402,11 @@ pub(crate) async fn process_execution_result(
         result,
     );
     audit::maybe_record_repo_write_audit(&ctx, session, &mut session_result);
+    result_sidecar::ensure_turn_scoped_manager_artifact(
+        &ctx.session_dir,
+        session.turn_count,
+        &mut session_result,
+    );
     if let Err(e) = crate::session_kill_diagnostics::save_result_with_signal_diagnostic(
         ctx.project_root,
         session,

--- a/crates/cli-sub-agent/src/pipeline_post_exec_fallback.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_fallback.rs
@@ -56,7 +56,7 @@ pub(crate) fn collect_fallback_result_artifacts(
     match csa_session::list_artifacts(project_root, session_id) {
         Ok(artifact_names) => artifact_names
             .into_iter()
-            .map(|name| SessionArtifact::new(format!("output/{name}")))
+            .map(|name| csa_session::observed_session_artifact(format!("output/{name}")))
             .collect(),
         Err(err) => {
             warn!(
@@ -239,4 +239,98 @@ pub(super) fn read_output_log_tail(session_dir: &Path, max_lines: usize) -> Opti
     }
 
     Some(tail.into_iter().rev().collect::<Vec<_>>().join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_session_sandbox::ScopedSessionSandbox;
+    use anyhow::Result;
+    use std::fs;
+
+    #[test]
+    fn collect_fallback_result_artifacts_marks_manager_results_display_only() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let _sandbox = ScopedSessionSandbox::new_blocking(&temp);
+        let project_root = temp.path().join("project");
+        fs::create_dir_all(&project_root)?;
+        let session = csa_session::create_session(
+            &project_root,
+            Some("fallback artifact ownership"),
+            None,
+            Some("codex"),
+        )?;
+        let session_dir = csa_session::get_session_dir(&project_root, &session.meta_session_id)?;
+        let turn_artifact = csa_session::turn_contract_result_artifact_path(1);
+        let turn_path = session_dir.join(&turn_artifact);
+        fs::create_dir_all(turn_path.parent().expect("turn parent"))?;
+        fs::write(&turn_path, "[report]\nwhat_was_done = \"prior turn\"\n")?;
+        fs::create_dir_all(session_dir.join("output"))?;
+        fs::write(session_dir.join("output").join("acp-events.jsonl"), "{}\n")?;
+
+        let artifacts = collect_fallback_result_artifacts(&project_root, &session.meta_session_id);
+
+        assert!(
+            artifacts
+                .iter()
+                .any(|artifact| artifact.path == turn_artifact && artifact.display_only),
+            "recursively discovered turn result sidecars must be display-only"
+        );
+        assert!(
+            artifacts.iter().any(|artifact| {
+                artifact.path == "output/acp-events.jsonl" && !artifact.display_only
+            }),
+            "ordinary fallback artifacts remain owned artifacts"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn post_exec_fallback_does_not_overlay_historical_turn_sidecar() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let _sandbox = ScopedSessionSandbox::new_blocking(&temp);
+        let project_root = temp.path().join("project");
+        fs::create_dir_all(&project_root)?;
+        let mut session = csa_session::create_session(
+            &project_root,
+            Some("fallback stale turn sidecar"),
+            None,
+            Some("codex"),
+        )?;
+        let session_dir = csa_session::get_session_dir(&project_root, &session.meta_session_id)?;
+        let stale_artifact = csa_session::turn_contract_result_artifact_path(1);
+        let stale_path = session_dir.join(&stale_artifact);
+        fs::create_dir_all(stale_path.parent().expect("stale turn parent"))?;
+        fs::write(
+            &stale_path,
+            r#"
+[report]
+what_was_done = "stale turn one manager report"
+"#,
+        )?;
+
+        ensure_terminal_result_on_post_exec_error(
+            &project_root,
+            &mut session,
+            "codex",
+            chrono::Utc::now(),
+            &anyhow::anyhow!("child exited before current result"),
+        );
+
+        let loaded = csa_session::load_result(&project_root, &session.meta_session_id)?
+            .expect("fallback result should be saved");
+        assert_eq!(loaded.status, "failure");
+        assert!(
+            loaded.manager_fields.as_sidecar().is_none(),
+            "fallback result must not overlay stale manager fields from a historical turn"
+        );
+        assert!(
+            loaded
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.path == stale_artifact && artifact.display_only),
+            "historical turn sidecar remains visible as a display-only diagnostic"
+        );
+        Ok(())
+    }
 }

--- a/crates/cli-sub-agent/src/pipeline_post_exec_result_sidecar.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_result_sidecar.rs
@@ -1,9 +1,70 @@
-use std::fs;
-use std::path::Path;
+use std::{fs, path::Path};
 
-pub(super) fn status_is_success(session_dir: &Path) -> bool {
-    let path = session_dir.join(csa_session::CONTRACT_RESULT_ARTIFACT_PATH);
-    let Ok(contents) = fs::read_to_string(path) else {
+pub(super) fn ensure_turn_scoped_manager_artifact(
+    session_dir: &Path,
+    completed_turn_count: u32,
+    result: &mut csa_session::SessionResult,
+) {
+    if let Some(artifact_path) = current_result_artifact_marker(session_dir)
+        && (result.manager_fields.as_sidecar().is_some()
+            || session_dir.join(&artifact_path).is_file())
+    {
+        ensure_owned_manager_result_artifact(result, artifact_path);
+        return;
+    }
+
+    if result.manager_fields.as_sidecar().is_none()
+        || result.artifacts.iter().any(|artifact| {
+            !artifact.display_only && csa_session::is_manager_result_artifact_path(&artifact.path)
+        })
+    {
+        return;
+    }
+
+    ensure_owned_manager_result_artifact(
+        result,
+        csa_session::turn_contract_result_artifact_path(completed_turn_count),
+    );
+}
+
+fn current_result_artifact_marker(session_dir: &Path) -> Option<String> {
+    let marker_path =
+        crate::pipeline::result_contract::current_result_artifact_marker_path(session_dir);
+    let contents = fs::read_to_string(marker_path).ok()?;
+    let marker: toml::Value = toml::from_str(&contents).ok()?;
+    let artifact_path = marker.get("artifact_path")?.as_str()?.to_string();
+    csa_session::is_manager_result_artifact_path(&artifact_path).then_some(artifact_path)
+}
+
+fn ensure_owned_manager_result_artifact(
+    result: &mut csa_session::SessionResult,
+    artifact_path: String,
+) {
+    result.artifacts.retain(|artifact| {
+        artifact.path != artifact_path
+            && (artifact.display_only
+                || !csa_session::is_manager_result_artifact_path(&artifact.path))
+    });
+    result
+        .artifacts
+        .push(csa_session::SessionArtifact::new(artifact_path));
+    result
+        .artifacts
+        .sort_by(|left, right| left.path.cmp(&right.path));
+}
+
+pub(super) fn status_is_success(session_dir: &Path, completed_turn_count: u32) -> bool {
+    let turn_scoped_path =
+        csa_session::turn_contract_result_path(session_dir, completed_turn_count);
+    if path_status_is_success(&turn_scoped_path) {
+        return true;
+    }
+
+    path_status_is_success(&csa_session::contract_result_path(session_dir))
+}
+
+fn path_status_is_success(path: &Path) -> bool {
+    let Ok(contents) = std::fs::read_to_string(path) else {
         return false;
     };
     let Ok(toml::Value::Table(table)) = toml::from_str::<toml::Value>(&contents) else {
@@ -21,3 +82,7 @@ pub(super) fn status_is_success(session_dir: &Path) -> bool {
         .and_then(|value| value.as_str())
         .is_some_and(|status| status.eq_ignore_ascii_case("success"))
 }
+
+#[cfg(test)]
+#[path = "pipeline_post_exec_result_sidecar_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/pipeline_post_exec_result_sidecar_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_result_sidecar_tests.rs
@@ -1,0 +1,133 @@
+use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_session::{SessionResult, create_session, get_session_dir, load_result, save_result};
+use std::fs;
+
+#[test]
+fn current_marker_upgrades_observed_turn_sidecar_to_owned_manager_artifact() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new_blocking(&tmp);
+    let project_root = tmp.path();
+    let session =
+        create_session(project_root, Some("test"), None, Some("codex")).expect("create session");
+    let session_dir = get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let current_artifact = csa_session::turn_contract_result_artifact_path(1);
+    let historical_artifact = csa_session::turn_contract_result_artifact_path(2);
+    let post_stream_artifact = csa_session::turn_contract_result_artifact_path(3);
+    let current_path = session_dir.join(&current_artifact);
+    let historical_path = session_dir.join(&historical_artifact);
+
+    fs::create_dir_all(current_path.parent().expect("current parent"))
+        .expect("create current parent");
+    fs::write(
+        &current_path,
+        r#"
+[report]
+what_was_done = "current marker-owned report"
+"#,
+    )
+    .expect("write current sidecar");
+    fs::create_dir_all(historical_path.parent().expect("historical parent"))
+        .expect("create historical parent");
+    fs::write(
+        &historical_path,
+        r#"
+[report]
+what_was_done = "historical diagnostic report"
+"#,
+    )
+    .expect("write historical sidecar");
+    fs::write(
+        crate::pipeline::result_contract::current_result_artifact_marker_path(&session_dir),
+        format!("artifact_path = \"{current_artifact}\"\n"),
+    )
+    .expect("write current marker");
+
+    let now = chrono::Utc::now();
+    let mut result = SessionResult {
+        post_exec_gate: None,
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "runtime envelope".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: Vec::new(),
+        ..Default::default()
+    };
+
+    crate::session_observability::enrich_result_from_session_dir(
+        project_root,
+        &session.meta_session_id,
+        &session_dir,
+        &mut result,
+    )
+    .expect("refresh artifacts");
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == current_artifact && artifact.display_only),
+        "recursive artifact refresh should first observe the current sidecar as display-only"
+    );
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == historical_artifact && artifact.display_only),
+        "historical manager sidecars should remain display-only diagnostics"
+    );
+    result.artifacts.push(csa_session::SessionArtifact::new(
+        post_stream_artifact.clone(),
+    ));
+
+    ensure_turn_scoped_manager_artifact(&session_dir, 3, &mut result);
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == current_artifact && !artifact.display_only),
+        "current marker path should be upgraded to an owned manager artifact"
+    );
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == historical_artifact && artifact.display_only),
+        "unproven historical sidecar must stay display-only"
+    );
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .all(|artifact| artifact.path != post_stream_artifact),
+        "marker-owned sidecar must be the only owned manager result artifact"
+    );
+
+    save_result(project_root, &session.meta_session_id, &result).expect("save result");
+    let loaded = load_result(project_root, &session.meta_session_id)
+        .expect("load result")
+        .expect("result should exist");
+    assert_eq!(
+        loaded
+            .manager_fields
+            .report
+            .as_ref()
+            .and_then(|value| value.get("what_was_done")),
+        Some(&toml::Value::String(
+            "current marker-owned report".to_string()
+        )),
+        "load_result should overlay the marker-owned current sidecar"
+    );
+    assert!(
+        loaded
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == historical_artifact && artifact.display_only),
+        "historical sidecar remains visible but diagnostics-only after save/load"
+    );
+}

--- a/crates/cli-sub-agent/src/pipeline_result_contract.rs
+++ b/crates/cli-sub-agent/src/pipeline_result_contract.rs
@@ -2,9 +2,10 @@
 //!
 //! When a prompt contains the contract marker `csa_result_toml_path_contract=1`,
 //! the session output must contain the absolute path to a valid `result.toml`
-//! artifact inside the session directory. Accepted paths are the runtime
-//! session root (`result.toml`), the canonical output-sidecar
-//! (`output/result.toml`), or the legacy sidecar (`output/user-result.toml`).
+//! artifact inside the session directory. Accepted paths are the current
+//! turn-scoped sidecar (`output/turns/turn-N/result.toml`), the runtime session
+//! root (`result.toml`), the legacy canonical sidecar (`output/result.toml`), or
+//! the legacy user sidecar (`output/user-result.toml`).
 //! If the contract is violated the execution result is coerced to failure.
 
 use std::path::Path;
@@ -13,11 +14,13 @@ use tracing::warn;
 use csa_process::ExecutionResult;
 
 pub(crate) const RESULT_TOML_PATH_CONTRACT_MARKER: &str = "csa_result_toml_path_contract=1";
+pub(crate) const CURRENT_RESULT_ARTIFACT_FILE: &str = "current-result-artifact.toml";
 
 pub(crate) fn enforce_result_toml_path_contract(
     prompt: &str,
     _effective_prompt: &str,
     session_dir: &Path,
+    completed_turn_count: u32,
     result_file_cleared: bool,
     result: &mut ExecutionResult,
 ) {
@@ -27,10 +30,13 @@ pub(crate) fn enforce_result_toml_path_contract(
 
     if !result_file_cleared {
         let expected_path = session_dir.join("result.toml");
+        let expected_turn_path =
+            csa_session::next_turn_contract_result_path(session_dir, completed_turn_count);
         let legacy_output_path = csa_session::legacy_user_result_path(session_dir);
         let reason = format!(
-            "contract violation: failed to clear pre-existing result artifacts '{}', '{}', and '{}' before execution; refusing to trust stale files",
+            "contract violation: failed to prepare result artifacts before execution (stale-file cleanup or parent mkdir): '{}', '{}', '{}', '{}'",
             expected_path.display(),
+            expected_turn_path.display(),
             csa_session::contract_result_path(session_dir).display(),
             legacy_output_path.display()
         );
@@ -52,9 +58,12 @@ pub(crate) fn enforce_result_toml_path_contract(
 
     let path_candidate = contract_result_toml_path_candidate(result);
     let expected_path = session_dir.join("result.toml");
+    let expected_turn_path =
+        csa_session::next_turn_contract_result_path(session_dir, completed_turn_count);
     let expected_contract_output_path = csa_session::contract_result_path(session_dir);
     let expected_user_result_path = csa_session::legacy_user_result_path(session_dir);
-    if path_matches_expected_contract_result(path_candidate, &expected_path)
+    if path_matches_expected_contract_result(path_candidate, &expected_turn_path)
+        || path_matches_expected_contract_result(path_candidate, &expected_path)
         || path_matches_expected_contract_result(path_candidate, &expected_contract_output_path)
         || path_matches_expected_contract_result(path_candidate, &expected_user_result_path)
     {
@@ -67,15 +76,34 @@ pub(crate) fn enforce_result_toml_path_contract(
     // emits a more specific diagnostic than the generic TOML-validity fallback
     // below so post-mortem readers can distinguish "trusted because status was
     // success" from "trusted because TOML parsed".
-    if result_artifact_status_is_success(&expected_contract_output_path) {
+    if result_artifact_status_is_success(&expected_turn_path) {
         let warning = format!(
             "contract warning: output/summary path mismatch; accepted artifact with [result] status=\"success\" at '{}'",
+            expected_turn_path.display()
+        );
+        warn!(
+            summary = %result.summary,
+            artifact = %expected_turn_path.display(),
+            "Session output path did not match contract; accepting verified turn-scoped result.toml whose [result] status is success"
+        );
+        if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
+            result.stderr_output.push('\n');
+        }
+        result.stderr_output.push_str(&warning);
+        result.stderr_output.push('\n');
+        rewrite_contract_output_last_line(result, &expected_turn_path);
+        return;
+    }
+
+    if result_artifact_status_is_success(&expected_contract_output_path) {
+        let warning = format!(
+            "contract warning: output/summary path mismatch; accepted legacy artifact with [result] status=\"success\" at '{}'",
             expected_contract_output_path.display()
         );
         warn!(
             summary = %result.summary,
             artifact = %expected_contract_output_path.display(),
-            "Session output path did not match contract; accepting verified output/result.toml whose [result] status is success"
+            "Session output path did not match contract; accepting verified legacy output/result.toml whose [result] status is success"
         );
         if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
             result.stderr_output.push('\n');
@@ -86,15 +114,34 @@ pub(crate) fn enforce_result_toml_path_contract(
         return;
     }
 
-    if sidecar_result_fallback_is_valid(&expected_contract_output_path) {
+    if sidecar_result_fallback_is_valid(&expected_turn_path) {
         let warning = format!(
             "contract warning: output/summary path mismatch; accepted fallback artifact '{}'",
+            expected_turn_path.display()
+        );
+        warn!(
+            summary = %result.summary,
+            fallback = %expected_turn_path.display(),
+            "Session output path did not match contract; accepting verified turn-scoped result.toml fallback"
+        );
+        if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
+            result.stderr_output.push('\n');
+        }
+        result.stderr_output.push_str(&warning);
+        result.stderr_output.push('\n');
+        rewrite_contract_output_last_line(result, &expected_turn_path);
+        return;
+    }
+
+    if sidecar_result_fallback_is_valid(&expected_contract_output_path) {
+        let warning = format!(
+            "contract warning: output/summary path mismatch; accepted legacy fallback artifact '{}'",
             expected_contract_output_path.display()
         );
         warn!(
             summary = %result.summary,
             fallback = %expected_contract_output_path.display(),
-            "Session output path did not match contract; accepting verified output/result.toml fallback"
+            "Session output path did not match contract; accepting verified legacy output/result.toml fallback"
         );
         if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
             result.stderr_output.push('\n');
@@ -149,14 +196,16 @@ pub(crate) fn enforce_result_toml_path_contract(
 
     let reason = if path_candidate.is_empty() {
         format!(
-            "contract violation: expected existing absolute result path '{}', '{}', or '{}' in output/summary, but output and summary were empty",
+            "contract violation: expected existing absolute result path '{}', '{}', '{}', or '{}' in output/summary, but output and summary were empty",
+            expected_turn_path.display(),
             expected_path.display(),
             expected_contract_output_path.display(),
             expected_user_result_path.display()
         )
     } else {
         format!(
-            "contract violation: expected existing absolute result path '{}', '{}', or '{}' in output/summary, got '{path_candidate}'",
+            "contract violation: expected existing absolute result path '{}', '{}', '{}', or '{}' in output/summary, got '{path_candidate}'",
+            expected_turn_path.display(),
             expected_path.display(),
             expected_contract_output_path.display(),
             expected_user_result_path.display()
@@ -466,18 +515,98 @@ pub(super) fn clear_expected_result_toml(path: &Path) -> bool {
     }
 }
 
-pub(super) fn clear_expected_result_artifacts_for_prompt(prompt: &str, session_dir: &Path) -> bool {
+fn ensure_expected_result_parent_dir(path: &Path) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    if let Err(err) = std::fs::create_dir_all(parent) {
+        warn!(
+            path = %path.display(),
+            parent = %parent.display(),
+            error = %err,
+            "Failed to create result.toml parent directory before execution"
+        );
+        return false;
+    }
+    true
+}
+
+pub(super) fn clear_expected_result_artifacts_for_prompt(
+    prompt: &str,
+    session_dir: &Path,
+    completed_turn_count: u32,
+) -> bool {
     let session_result_path = session_dir.join("result.toml");
     let session_cleared = clear_expected_result_toml(&session_result_path);
     if !prompt_requires_result_toml_path(prompt) {
+        clear_current_result_artifact_marker(session_dir);
         return session_cleared;
     }
 
+    let turn_output_path =
+        csa_session::next_turn_contract_result_path(session_dir, completed_turn_count);
+    let turn_output_parent_ready = ensure_expected_result_parent_dir(&turn_output_path);
     let contract_output_path = csa_session::contract_result_path(session_dir);
     let legacy_output_path = csa_session::legacy_user_result_path(session_dir);
+    let turn_output_cleared = clear_expected_result_toml(&turn_output_path);
     let contract_output_cleared = clear_expected_result_toml(&contract_output_path);
     let legacy_output_cleared = clear_expected_result_toml(&legacy_output_path);
-    session_cleared && contract_output_cleared && legacy_output_cleared
+    let prepared = session_cleared
+        && turn_output_parent_ready
+        && turn_output_cleared
+        && contract_output_cleared
+        && legacy_output_cleared;
+    if prepared {
+        persist_current_result_artifact_marker(session_dir, completed_turn_count);
+    } else {
+        clear_current_result_artifact_marker(session_dir);
+    }
+    prepared
+}
+
+pub(crate) fn current_result_artifact_marker_path(session_dir: &Path) -> std::path::PathBuf {
+    session_dir.join(CURRENT_RESULT_ARTIFACT_FILE)
+}
+
+fn persist_current_result_artifact_marker(session_dir: &Path, completed_turn_count: u32) {
+    let artifact_path = csa_session::next_turn_contract_result_artifact_path(completed_turn_count);
+    let mut table = toml::Table::new();
+    table.insert(
+        "artifact_path".to_string(),
+        toml::Value::String(artifact_path),
+    );
+    let marker_path = current_result_artifact_marker_path(session_dir);
+    let contents = match toml::to_string_pretty(&table) {
+        Ok(contents) => contents,
+        Err(err) => {
+            warn!(
+                path = %marker_path.display(),
+                error = %err,
+                "Failed to serialize current result artifact marker"
+            );
+            return;
+        }
+    };
+    if let Err(err) = std::fs::write(&marker_path, contents) {
+        warn!(
+            path = %marker_path.display(),
+            error = %err,
+            "Failed to persist current result artifact marker"
+        );
+    }
+}
+
+fn clear_current_result_artifact_marker(session_dir: &Path) {
+    let marker_path = current_result_artifact_marker_path(session_dir);
+    match std::fs::remove_file(&marker_path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => warn!(
+            path = %marker_path.display(),
+            error = %err,
+            "Failed to remove stale current result artifact marker"
+        ),
+    }
 }
 
 fn normalize_contract_path_candidate(path: &str) -> &str {

--- a/crates/cli-sub-agent/src/pipeline_session_exec_bootstrap.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_bootstrap.rs
@@ -148,6 +148,29 @@ pub(super) async fn bootstrap_session(
         }
     }
 
+    if session_arg.is_some()
+        && let Some(wrapper_session_id) = startup_env.session_id()
+        && std::env::var("CSA_DAEMON_SESSION_ID").ok().as_deref() == Some(wrapper_session_id)
+        && wrapper_session_id != session.meta_session_id
+    {
+        csa_session::write_resume_target(
+            project_root,
+            wrapper_session_id,
+            &session.meta_session_id,
+        )
+        .with_context(|| {
+            format!(
+                "failed to persist resume wrapper alias {wrapper_session_id} -> {}",
+                session.meta_session_id
+            )
+        })?;
+        info!(
+            wrapper_session = %wrapper_session_id,
+            target_session = %session.meta_session_id,
+            "Persisted resume wrapper target"
+        );
+    }
+
     Ok(SessionBootstrap {
         session,
         resolved_provider_session_id,

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -89,6 +89,7 @@ pub(super) async fn complete_session_execution(
         input.prompt,
         &input.effective_prompt,
         input.session_dir,
+        session.turn_count,
         result_file_cleared,
         &mut result,
     );

--- a/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
@@ -206,8 +206,11 @@ async fn prepare_session_runtime_inner(
     let tool_state =
         ensure_tool_state_initialized(session, input.executor, input.resolved_provider_session_id)
             .await?;
-    let result_file_cleared =
-        clear_expected_result_artifacts_for_prompt(input.prompt, input.session_dir);
+    let result_file_cleared = clear_expected_result_artifacts_for_prompt(
+        input.prompt,
+        input.session_dir,
+        session.turn_count,
+    );
     let execution_start_time = chrono::Utc::now();
     let sa_mode =
         std::env::var_os(crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV)

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -697,7 +697,7 @@ fn enforce_result_toml_contract_now(
     session_dir: &std::path::Path,
     result: &mut ExecutionResult,
 ) {
-    enforce_result_toml_path_contract(prompt, effective_prompt, session_dir, true, result);
+    enforce_result_toml_path_contract(prompt, effective_prompt, session_dir, 0, true, result);
 }
 
 #[path = "pipeline_tests_contract.rs"]

--- a/crates/cli-sub-agent/src/pipeline_tests_contract.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_contract.rs
@@ -354,21 +354,82 @@ fn clear_expected_result_tomls_removes_all_stale_result_artifacts() {
     let output_dir = temp.path().join("output");
     fs::create_dir_all(&output_dir).unwrap();
     let session_result = temp.path().join("result.toml");
+    let turn_result = csa_session::next_turn_contract_result_path(temp.path(), 0);
     let output_result = output_dir.join("result.toml");
     let legacy_output_result = output_dir.join("user-result.toml");
     fs::write(&session_result, "status = \"stale\"\n").unwrap();
+    fs::create_dir_all(turn_result.parent().unwrap()).unwrap();
+    fs::write(&turn_result, "status = \"stale\"\n").unwrap();
     fs::write(&output_result, "status = \"stale\"\n").unwrap();
     fs::write(&legacy_output_result, "status = \"stale\"\n").unwrap();
 
     assert!(
         crate::pipeline::result_contract::clear_expected_result_artifacts_for_prompt(
             crate::pipeline::result_contract::RESULT_TOML_PATH_CONTRACT_MARKER,
-            temp.path()
+            temp.path(),
+            0
         )
     );
     assert!(!session_result.exists());
+    assert!(!turn_result.exists());
     assert!(!output_result.exists());
     assert!(!legacy_output_result.exists());
+}
+
+#[test]
+fn clear_expected_result_artifacts_records_current_turn_result_marker() {
+    let temp = tempfile::tempdir().unwrap();
+
+    assert!(
+        crate::pipeline::result_contract::clear_expected_result_artifacts_for_prompt(
+            crate::pipeline::result_contract::RESULT_TOML_PATH_CONTRACT_MARKER,
+            temp.path(),
+            2
+        )
+    );
+
+    let marker_path =
+        crate::pipeline::result_contract::current_result_artifact_marker_path(temp.path());
+    let marker = std::fs::read_to_string(marker_path).expect("read current result marker");
+    assert!(
+        marker.contains("output/turns/turn-000003/result.toml"),
+        "marker must preserve the pre-run expected current turn artifact"
+    );
+}
+
+#[test]
+fn clear_expected_result_artifacts_creates_turn_result_parent_before_execution() {
+    let temp = tempfile::tempdir().unwrap();
+    let turn_result = csa_session::next_turn_contract_result_path(temp.path(), 0);
+    let turn_result_text = turn_result.display().to_string();
+    assert!(
+        turn_result_text.ends_with("output/turns/turn-000001/result.toml"),
+        "test must cover the nested turn-scoped result path, got: {turn_result_text}"
+    );
+    let turn_parent = turn_result.parent().expect("turn result has parent");
+    assert!(
+        !turn_parent.exists(),
+        "test setup should start before CSA creates the turn result parent"
+    );
+
+    assert!(
+        crate::pipeline::result_contract::clear_expected_result_artifacts_for_prompt(
+            crate::pipeline::result_contract::RESULT_TOML_PATH_CONTRACT_MARKER,
+            temp.path(),
+            0
+        )
+    );
+
+    assert!(
+        turn_parent.is_dir(),
+        "pre-run result-contract setup must create the child-writable parent directory"
+    );
+    fs::write(&turn_result, "status = \"success\"\nsummary = \"done\"\n")
+        .expect("child can write directly to CSA_RESULT_TOML_PATH_CONTRACT");
+    assert!(
+        turn_result.is_file(),
+        "direct write to injected result contract path should succeed"
+    );
 }
 
 #[test]
@@ -379,14 +440,22 @@ fn clear_expected_result_artifacts_for_plain_prompt_preserves_sidecars() {
     let session_result = temp.path().join("result.toml");
     let output_result = output_dir.join("result.toml");
     let legacy_output_result = output_dir.join("user-result.toml");
+    let marker_path =
+        crate::pipeline::result_contract::current_result_artifact_marker_path(temp.path());
     fs::write(&session_result, "status = \"stale\"\n").unwrap();
     fs::write(&output_result, "status = \"preserve\"\n").unwrap();
     fs::write(&legacy_output_result, "status = \"preserve\"\n").unwrap();
+    fs::write(
+        &marker_path,
+        "artifact_path = \"output/turns/turn-000001/result.toml\"\n",
+    )
+    .unwrap();
 
     assert!(
         crate::pipeline::result_contract::clear_expected_result_artifacts_for_prompt(
             "plain follow-up without contract marker",
-            temp.path()
+            temp.path(),
+            0
         )
     );
     assert!(
@@ -400,6 +469,10 @@ fn clear_expected_result_artifacts_for_plain_prompt_preserves_sidecars() {
     assert!(
         legacy_output_result.exists(),
         "legacy sidecar must survive non-contract follow-up turns"
+    );
+    assert!(
+        !marker_path.exists(),
+        "plain prompts must clear stale current-turn markers"
     );
 }
 

--- a/crates/cli-sub-agent/src/pipeline_tests_tail.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_tail.rs
@@ -142,13 +142,8 @@ fn result_toml_path_contract_fails_closed_when_preclear_failed() {
         ..Default::default()
     };
 
-    enforce_result_toml_path_contract(
-        "CSA_RESULT_TOML_PATH_CONTRACT=1",
-        "",
-        temp.path(),
-        false,
-        &mut result,
-    );
+    let env = "CSA_RESULT_TOML_PATH_CONTRACT=1";
+    enforce_result_toml_path_contract(env, "", temp.path(), 0, false, &mut result);
 
     assert_eq!(result.exit_code, 1);
     assert!(

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -35,6 +35,8 @@ pub(crate) use completion::{
     seed_daemon_session_env,
 };
 #[cfg(test)]
+pub(crate) use wait::parse_output_result_artifact_for_test;
+#[cfg(test)]
 pub(crate) use wait::render_wait_result_summary;
 #[cfg(test)]
 pub(crate) use wait::resolve_wait_completion_status_and_exit;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
@@ -500,6 +500,51 @@ mod tests {
     }
 
     #[test]
+    fn daemon_completion_result_marks_historical_turn_sidecar_display_only() -> Result<()> {
+        let tmp = tempdir()?;
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let state_home = tmp.path().join("xdg-state");
+        std::fs::create_dir_all(&state_home)?;
+        let _home_guard = ScopedEnvVarRestore::set("HOME", tmp.path());
+        let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+        let project = tmp.path();
+
+        let session = create_session(
+            project,
+            Some("daemon historical sidecar"),
+            None,
+            Some("codex"),
+        )?;
+        let session_id = session.meta_session_id;
+        let session_dir = get_session_dir(project, &session_id)?;
+        let stale_artifact = csa_session::turn_contract_result_artifact_path(1);
+        let stale_path = session_dir.join(&stale_artifact);
+        std::fs::create_dir_all(stale_path.parent().expect("stale turn parent"))?;
+        std::fs::write(
+            &stale_path,
+            "[report]\nwhat_was_done = \"stale daemon turn report\"\n",
+        )?;
+        let session = load_session(project, &session_id)?;
+        let packet = DaemonCompletionPacket::from_exit_code(0);
+
+        let result =
+            daemon_completion_result(project, &session_dir, &session, &packet, chrono::Utc::now());
+
+        assert!(
+            result.manager_fields.as_sidecar().is_none(),
+            "daemon-completion synthetic result must not own stale manager fields"
+        );
+        assert!(
+            result
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.path == stale_artifact && artifact.display_only),
+            "historical turn sidecar remains visible as display-only diagnostics"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn daemon_completion_result_explicitly_reports_no_tool_launch_metadata() -> Result<()> {
         let tmp = tempdir()?;
         let _env_lock = TEST_ENV_LOCK.blocking_lock();

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -25,6 +25,10 @@ pub(crate) use completion::SESSION_WAIT_MEMORY_WARN_EXIT_CODE;
 pub(crate) use completion::resolve_wait_completion_status_and_exit;
 pub(crate) use lock::try_acquire_session_wait_lock;
 pub(crate) use next_step::synthesized_wait_next_step;
+#[cfg(test)]
+pub(crate) use result_loader::expected_in_flight_turn_result_artifact_path_for_test;
+#[cfg(test)]
+pub(crate) use result_loader::parse_output_result_artifact_for_test;
 use result_loader::{
     load_completed_daemon_result_with_fallback, refresh_result_for_wait,
     suppress_pending_tier_failover_result,

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -94,23 +94,42 @@ pub(crate) fn handle_session_wait_with_emitters(
     let resolved = resolve_session_prefix_with_global_fallback(&project_root, &session)?;
     // For cross-project sessions, derive session_dir from the resolved sessions_dir
     let session_dir = resolved.sessions_dir.join(&resolved.session_id);
-    let _wait_lock = match try_acquire_session_wait_lock(&session_dir)? {
-        Some(lock) => lock,
-        None => {
-            eprintln!(
-                "ERROR: another csa session wait is already running for session {} (lock held). The existing wait will notify you on completion. Do NOT re-issue.",
-                resolved.session_id
-            );
-            return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
-        }
-    };
-
     // Use the foreign project root for cross-project sessions, local otherwise.
     let effective_root = resolved
         .foreign_project_root
         .as_deref()
         .unwrap_or(&project_root);
     let is_cross_project = resolved.foreign_project_root.is_some();
+    let resume_target = csa_session::resolve_resume_target_from_dir(effective_root, &session_dir)?;
+    let result_session_id = resume_target
+        .as_ref()
+        .map(|target| target.session_id.as_str())
+        .unwrap_or(&resolved.session_id);
+    let result_session_dir = resume_target
+        .as_ref()
+        .map(|target| target.session_dir.clone())
+        .unwrap_or_else(|| session_dir.clone());
+    let follows_resume_target = resume_target.is_some();
+    let observed_session_dir = if follows_resume_target {
+        &result_session_dir
+    } else {
+        &session_dir
+    };
+    let lock_session_dir = if follows_resume_target {
+        &result_session_dir
+    } else {
+        &session_dir
+    };
+    let _wait_lock = match try_acquire_session_wait_lock(lock_session_dir)? {
+        Some(lock) => lock,
+        None => {
+            eprintln!(
+                "ERROR: another csa session wait is already running for session {} (lock held). The existing wait will notify you on completion. Do NOT re-issue.",
+                result_session_id
+            );
+            return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
+        }
+    };
 
     let start = std::time::Instant::now();
     let memory_warn_mb = wait_options
@@ -125,17 +144,14 @@ pub(crate) fn handle_session_wait_with_emitters(
     // and no progress for an extended period.
     if let Err(stale_err) = super::check_session_stale_before_wait(
         effective_root,
-        &resolved.session_id,
-        &session_dir,
+        result_session_id,
+        observed_session_dir,
         wait_options.behavior,
     ) {
-        eprintln!(
-            "Session {} appears stale: {}",
-            resolved.session_id, stale_err
-        );
+        eprintln!("Session {} appears stale: {}", result_session_id, stale_err);
         eprintln!(
             "Run `csa session result --session {}` for diagnostics.",
-            resolved.session_id
+            result_session_id
         );
         return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
     }
@@ -143,17 +159,17 @@ pub(crate) fn handle_session_wait_with_emitters(
     loop {
         if let Some(completion) = load_daemon_completion_packet(&session_dir)?
             && (completion.is_legacy_complete_marker()
-                || !session_has_terminal_process(&session_dir))
+                || !session_has_terminal_process(observed_session_dir))
         {
             let refreshed_result = refresh_result_for_wait(
                 effective_root,
-                &resolved.session_id,
-                &session_dir,
+                result_session_id,
+                &result_session_dir,
                 is_cross_project,
             );
             if let Err(err) = &refreshed_result {
                 tracing::debug!(
-                    session_id = %resolved.session_id,
+                    session_id = %result_session_id,
                     error = %err,
                     "Failed to refresh result after daemon completion packet"
                 );
@@ -170,30 +186,30 @@ pub(crate) fn handle_session_wait_with_emitters(
             if refreshed_result_available {
                 crate::session_cmds::retire_if_dead_with_result(
                     effective_root,
-                    &resolved.session_id,
+                    result_session_id,
                     "session wait",
                 )?;
             } else {
-                loaded_result =
-                    finalize_daemon_completion_if_present(&session_dir)?.and_then(|result| {
+                loaded_result = finalize_daemon_completion_if_present(&result_session_dir)?
+                    .and_then(|result| {
                         suppress_pending_tier_failover_result(
-                            &resolved.session_id,
-                            &session_dir,
+                            result_session_id,
+                            &result_session_dir,
                             result,
                         )
                     });
                 if loaded_result.is_none() {
                     let reconciled = (emitters.reconcile_dead_active_session)(
                         effective_root,
-                        &resolved.session_id,
+                        result_session_id,
                         "session wait",
                     )?;
                     synthetic = reconciled.synthetic;
                     if reconciled.result_became_available {
                         loaded_result = load_completed_daemon_result_with_fallback(
                             effective_root,
-                            &resolved.session_id,
-                            &session_dir,
+                            result_session_id,
+                            &result_session_dir,
                             is_cross_project,
                         )?;
                     }
@@ -201,12 +217,12 @@ pub(crate) fn handle_session_wait_with_emitters(
             }
             if let Some(result) = loaded_result {
                 let streamed_output = (emitters.emit_terminal_output)(
-                    &session_dir,
-                    &resolved.session_id,
+                    &result_session_dir,
+                    result_session_id,
                     Some(&result),
                     wait_options.output_mode,
                 )?;
-                (emitters.emit_next_step)(&session_dir)?;
+                (emitters.emit_next_step)(&result_session_dir)?;
                 #[rustfmt::skip]
                 let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(completion.status.as_str(), completion.exit_code, synthetic, Some(&result));
                 emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
@@ -220,9 +236,11 @@ pub(crate) fn handle_session_wait_with_emitters(
                 return Ok(exit_code);
             }
 
-            if csa_process::ToolLiveness::is_alive(&session_dir) {
+            if session_has_terminal_process(observed_session_dir)
+                || csa_process::ToolLiveness::is_alive(observed_session_dir)
+            {
                 tracing::debug!(
-                    session_id = %resolved.session_id,
+                    session_id = %result_session_id,
                     completion_status = %completion.status,
                     completion_exit_code = completion.exit_code,
                     "Daemon completion packet exists but no authoritative result is available yet; continuing wait"
@@ -240,21 +258,21 @@ pub(crate) fn handle_session_wait_with_emitters(
             }
         }
 
-        if !session_has_terminal_process(&session_dir)
+        if !session_has_terminal_process(observed_session_dir)
             && let Some(result) = load_completed_daemon_result_with_fallback(
                 effective_root,
-                &resolved.session_id,
-                &session_dir,
+                result_session_id,
+                &result_session_dir,
                 is_cross_project,
             )?
         {
             let streamed_output = (emitters.emit_terminal_output)(
-                &session_dir,
-                &resolved.session_id,
+                &result_session_dir,
+                result_session_id,
                 Some(&result),
                 wait_options.output_mode,
             )?;
-            (emitters.emit_next_step)(&session_dir)?;
+            (emitters.emit_next_step)(&result_session_dir)?;
             #[rustfmt::skip]
             let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, false, Some(&result));
             emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
@@ -271,24 +289,24 @@ pub(crate) fn handle_session_wait_with_emitters(
         // Synthesize terminal result for dead Active sessions.
         let reconciled = (emitters.reconcile_dead_active_session)(
             effective_root,
-            &resolved.session_id,
+            result_session_id,
             "session wait",
         )?;
         if reconciled.result_became_available
             && let Some(result) = load_completed_daemon_result_with_fallback(
                 effective_root,
-                &resolved.session_id,
-                &session_dir,
+                result_session_id,
+                &result_session_dir,
                 is_cross_project,
             )?
         {
             let streamed_output = (emitters.emit_terminal_output)(
-                &session_dir,
-                &resolved.session_id,
+                &result_session_dir,
+                result_session_id,
                 Some(&result),
                 wait_options.output_mode,
             )?;
-            (emitters.emit_next_step)(&session_dir)?;
+            (emitters.emit_next_step)(&result_session_dir)?;
             #[rustfmt::skip]
             let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, reconciled.synthetic, Some(&result));
             emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
@@ -308,20 +326,20 @@ pub(crate) fn handle_session_wait_with_emitters(
             return Ok(exit_code);
         }
 
-        if !session_has_terminal_process(&session_dir) {
+        if !session_has_terminal_process(observed_session_dir) {
             if let Some(result) = load_completed_daemon_result_with_fallback(
                 effective_root,
-                &resolved.session_id,
-                &session_dir,
+                result_session_id,
+                &result_session_dir,
                 is_cross_project,
             )? {
                 let streamed_output = (emitters.emit_terminal_output)(
-                    &session_dir,
-                    &resolved.session_id,
+                    &result_session_dir,
+                    result_session_id,
                     Some(&result),
                     wait_options.output_mode,
                 )?;
-                (emitters.emit_next_step)(&session_dir)?;
+                (emitters.emit_next_step)(&result_session_dir)?;
                 #[rustfmt::skip]
                 let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, false, Some(&result));
                 emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
@@ -334,10 +352,10 @@ pub(crate) fn handle_session_wait_with_emitters(
                 );
                 return Ok(exit_code);
             }
-            if csa_process::ToolLiveness::is_alive(&session_dir) {
+            if csa_process::ToolLiveness::is_alive(observed_session_dir) {
                 // PID detection missed but filesystem liveness signals say alive;
                 // continue polling so the timeout (exit 124) fires instead of exit 1.
-                tracing::debug!(session_id = %resolved.session_id, "alive; no terminal PID");
+                tracing::debug!(session_id = %result_session_id, "alive; no terminal PID");
             } else {
                 eprintln!(
                     "Session {} has no live daemon process and no terminal result packet.",
@@ -354,11 +372,11 @@ pub(crate) fn handle_session_wait_with_emitters(
         if let (Some(limit_mb), Some(sample_at)) = (memory_warn_mb, next_memory_sample_at)
             && std::time::Instant::now() >= sample_at
         {
-            match (emitters.sample_session_tree_rss_mb)(effective_root, &resolved.session_id) {
+            match (emitters.sample_session_tree_rss_mb)(effective_root, result_session_id) {
                 Ok(actual_rss_mb) => {
                     if actual_rss_mb > limit_mb {
                         (emitters.emit_memory_warn_marker)(
-                            &resolved.session_id,
+                            result_session_id,
                             actual_rss_mb,
                             limit_mb,
                         );
@@ -371,7 +389,7 @@ pub(crate) fn handle_session_wait_with_emitters(
                 }
                 Err(err) => {
                     tracing::debug!(
-                        session_id = %resolved.session_id,
+                        session_id = %result_session_id,
                         error = %err,
                         "Session wait memory sampler failed; will retry"
                     );
@@ -390,8 +408,8 @@ pub(crate) fn handle_session_wait_with_emitters(
                 .as_ref()
                 .map(|path| crate::daemon_caller_hints::format_cd_arg(Path::new(path)))
                 .unwrap_or_default();
-            let session_alive = session_has_terminal_process(&session_dir)
-                || csa_process::ToolLiveness::is_alive(&session_dir);
+            let session_alive = session_has_terminal_process(observed_session_dir)
+                || csa_process::ToolLiveness::is_alive(observed_session_dir);
             if session_alive {
                 let wait_cmd = format!(
                     "csa session wait --session {}{}",

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_result.rs
@@ -1,7 +1,8 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
 
 use super::super::session_has_terminal_process;
 
@@ -103,25 +104,243 @@ fn load_output_result_fallback(
     session_id: &str,
     session_dir: &Path,
 ) -> Result<Option<csa_session::SessionResult>> {
-    let output_result_path = session_dir
-        .join("output")
-        .join(csa_session::result::RESULT_FILE_NAME);
-    if !output_result_path.is_file() {
+    let Some(output_result_artifact_path) =
+        expected_in_flight_turn_result_artifact_path(session_dir)
+            .or_else(|| current_legacy_result_artifact_path(session_dir))
+    else {
         return Ok(None);
-    }
+    };
+    let output_result_path = session_dir.join(output_result_artifact_path);
 
     tracing::debug!(
         path = %output_result_path.display(),
-        "Found output/result.toml as fallback completion signal"
+        "Found manager result artifact as fallback completion signal"
     );
 
     let contents = fs::read_to_string(&output_result_path)?;
-    let result: csa_session::SessionResult = toml::from_str(&contents)?;
+    let result = parse_output_result_artifact(&contents).with_context(|| {
+        format!(
+            "Failed to parse manager result artifact fallback: {}",
+            output_result_path.display()
+        )
+    })?;
     Ok(suppress_pending_tier_failover_result(
         session_id,
         session_dir,
         result,
     ))
+}
+
+fn parse_output_result_artifact(contents: &str) -> Result<csa_session::SessionResult> {
+    match toml::from_str::<csa_session::SessionResult>(contents) {
+        Ok(result) => Ok(result),
+        Err(flat_schema_error) => parse_nested_manager_result_artifact(contents)
+            .with_context(|| {
+                format!(
+                    "artifact is neither a flat SessionResult nor a canonical nested [result] manager sidecar: {flat_schema_error}"
+                )
+            }),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn parse_output_result_artifact_for_test(
+    contents: &str,
+) -> Result<csa_session::SessionResult> {
+    parse_output_result_artifact(contents)
+}
+
+fn parse_nested_manager_result_artifact(contents: &str) -> Result<csa_session::SessionResult> {
+    let value: toml::Value =
+        toml::from_str(contents).context("manager result artifact is not valid TOML")?;
+    let Some(table) = value.as_table() else {
+        bail!("manager result artifact must be a TOML table");
+    };
+    let Some(result_table) = table.get("result").and_then(toml::Value::as_table) else {
+        bail!("manager result artifact must contain a [result] table");
+    };
+    let status = required_nonempty_string(result_table, "status")?;
+    let summary = optional_string(result_table, "summary")?
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("manager result sidecar reported status={status}"));
+    let exit_code =
+        optional_i32(result_table, "exit_code")?.unwrap_or_else(|| status_exit_code(status));
+    let tool = nested_tool_name(table).unwrap_or("unknown").to_string();
+    let now = Utc::now();
+
+    Ok(csa_session::SessionResult {
+        post_exec_gate: None,
+        status: status.to_string(),
+        exit_code,
+        summary,
+        tool,
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        manager_fields: csa_session::SessionManagerFields::from_sidecar(&value),
+        ..Default::default()
+    })
+}
+
+fn required_nonempty_string<'a>(table: &'a toml::Table, key: &str) -> Result<&'a str> {
+    let Some(value) = table.get(key) else {
+        bail!("manager [result].{key} is required");
+    };
+    let Some(text) = value.as_str() else {
+        bail!("manager [result].{key} must be a string");
+    };
+    let text = text.trim();
+    if text.is_empty() {
+        bail!("manager [result].{key} must not be empty");
+    }
+    Ok(text)
+}
+
+fn optional_string<'a>(table: &'a toml::Table, key: &str) -> Result<Option<&'a str>> {
+    let Some(value) = table.get(key) else {
+        return Ok(None);
+    };
+    let Some(text) = value.as_str() else {
+        bail!("manager [result].{key} must be a string when present");
+    };
+    Ok(Some(text))
+}
+
+fn optional_i32(table: &toml::Table, key: &str) -> Result<Option<i32>> {
+    let Some(value) = table.get(key) else {
+        return Ok(None);
+    };
+    let Some(exit_code) = value.as_integer() else {
+        bail!("manager [result].{key} must be an integer when present");
+    };
+    let exit_code = i32::try_from(exit_code)
+        .with_context(|| format!("manager [result].{key} is out of i32 range"))?;
+    Ok(Some(exit_code))
+}
+
+fn nested_tool_name(table: &toml::Table) -> Option<&str> {
+    table
+        .get("tool")
+        .and_then(toml::Value::as_table)
+        .and_then(|tool| tool.get("name"))
+        .and_then(toml::Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+}
+
+fn status_exit_code(status: &str) -> i32 {
+    if status.eq_ignore_ascii_case("success") {
+        0
+    } else {
+        1
+    }
+}
+
+fn expected_in_flight_turn_result_artifact_path(session_dir: &Path) -> Option<String> {
+    let explicit_artifact_path = explicit_contract_result_artifact_path(session_dir);
+    let marker_artifact_path = persisted_current_result_artifact_path(session_dir);
+    let state_artifact_path = state_derived_next_turn_result_artifact_path(session_dir);
+
+    if let Some(artifact_path) = explicit_artifact_path
+        && (marker_artifact_path.as_deref() == Some(artifact_path.as_str())
+            || state_artifact_path.as_deref() == Some(artifact_path.as_str()))
+    {
+        return Some(artifact_path);
+    }
+    if let Some(artifact_path) = marker_artifact_path {
+        return Some(artifact_path);
+    }
+
+    state_artifact_path
+}
+
+#[cfg(test)]
+pub(crate) fn expected_in_flight_turn_result_artifact_path_for_test(
+    session_dir: &Path,
+) -> Option<String> {
+    expected_in_flight_turn_result_artifact_path(session_dir)
+}
+
+fn state_derived_next_turn_result_artifact_path(session_dir: &Path) -> Option<String> {
+    let state_path = session_dir.join("state.toml");
+    let contents = fs::read_to_string(state_path).ok()?;
+    let table: toml::Table = toml::from_str(&contents).ok()?;
+    let completed_turn_count = table
+        .get("turn_count")?
+        .as_integer()
+        .and_then(|value| u32::try_from(value).ok())?;
+
+    csa_session::existing_next_turn_contract_result_artifact_path(session_dir, completed_turn_count)
+}
+
+fn explicit_contract_result_artifact_path(session_dir: &Path) -> Option<String> {
+    let contract_path = std::env::var_os(csa_session::RESULT_TOML_PATH_CONTRACT_ENV)?;
+    valid_existing_manager_artifact_path(session_dir, PathBuf::from(contract_path))
+}
+
+fn persisted_current_result_artifact_path(session_dir: &Path) -> Option<String> {
+    let artifact_path = persisted_current_result_artifact_candidate(session_dir)?;
+    session_dir
+        .join(&artifact_path)
+        .is_file()
+        .then_some(artifact_path)
+}
+
+fn persisted_current_result_artifact_candidate(session_dir: &Path) -> Option<String> {
+    let marker_path =
+        crate::pipeline::result_contract::current_result_artifact_marker_path(session_dir);
+    let contents = fs::read_to_string(marker_path).ok()?;
+    let table: toml::Table = toml::from_str(&contents).ok()?;
+    let artifact_path = table.get("artifact_path")?.as_str()?;
+    valid_manager_artifact_path(session_dir, PathBuf::from(artifact_path))
+}
+
+fn valid_existing_manager_artifact_path(
+    session_dir: &Path,
+    candidate_path: PathBuf,
+) -> Option<String> {
+    let artifact_path = valid_manager_artifact_path(session_dir, candidate_path)?;
+    session_dir
+        .join(&artifact_path)
+        .is_file()
+        .then_some(artifact_path)
+}
+
+fn valid_manager_artifact_path(session_dir: &Path, candidate_path: PathBuf) -> Option<String> {
+    let artifact_path = if candidate_path.is_absolute() {
+        candidate_path.strip_prefix(session_dir).ok()?.to_path_buf()
+    } else {
+        candidate_path
+    };
+    if artifact_path
+        .components()
+        .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return None;
+    }
+    let artifact_path = artifact_path.to_string_lossy().replace('\\', "/");
+    if !csa_session::is_manager_result_artifact_path(&artifact_path) {
+        return None;
+    }
+    Some(artifact_path)
+}
+
+fn current_legacy_result_artifact_path(session_dir: &Path) -> Option<String> {
+    let current_artifact = persisted_current_result_artifact_candidate(session_dir)?;
+    if current_artifact == csa_session::CONTRACT_RESULT_ARTIFACT_PATH
+        || session_dir.join(&current_artifact).is_file()
+    {
+        return None;
+    }
+
+    session_dir
+        .join(csa_session::CONTRACT_RESULT_ARTIFACT_PATH)
+        .is_file()
+        .then(|| csa_session::CONTRACT_RESULT_ARTIFACT_PATH.to_string())
 }
 
 pub(super) fn load_completed_daemon_result_with_fallback(

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -87,6 +87,56 @@ fn tail_backdate_tree(path: &std::path::Path, seconds_ago: u64) {
     tail_set_file_mtime_seconds_ago(path, seconds_ago);
 }
 
+#[cfg(unix)]
+#[test]
+fn ensure_terminal_result_for_dead_active_session_marks_historical_turn_sidecar_display_only() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("reconcile historical sidecar"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    let stale_artifact = csa_session::turn_contract_result_artifact_path(1);
+    let stale_path = session_dir.join(&stale_artifact);
+    fs::create_dir_all(stale_path.parent().expect("stale turn parent")).unwrap();
+    fs::write(
+        &stale_path,
+        "[report]\nwhat_was_done = \"stale reconcile turn report\"\n",
+    )
+    .unwrap();
+    tail_backdate_tree(&session_dir, 120);
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session wait")
+            .unwrap();
+
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::SynthesizedFailure
+    );
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("result should be synthesized");
+    assert!(
+        result.manager_fields.as_sidecar().is_none(),
+        "dead-session synthetic result must not overlay stale manager fields"
+    );
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == stale_artifact && artifact.display_only),
+        "historical turn sidecar remains visible as display-only diagnostics"
+    );
+}
+
 #[test]
 fn ensure_terminal_result_for_dead_active_session_writes_unpushed_commit_sidecar() {
     let td = tempdir().expect("tempdir");

--- a/crates/cli-sub-agent/src/session_cmds_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result.rs
@@ -4,7 +4,6 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 use csa_session::SessionResultView;
-use csa_session::TokenUsage;
 use csa_session::state::ReviewSessionMeta;
 
 use crate::session_cmds::{
@@ -13,8 +12,14 @@ use crate::session_cmds::{
 
 #[path = "session_cmds_result_artifacts.rs"]
 mod artifacts;
+#[path = "session_cmds_result_display.rs"]
+mod display;
 #[path = "session_cmds_result_tool_output.rs"]
 mod tool_output;
+
+use display::{
+    display_result_json, display_result_text, display_structured_output, load_total_token_usage,
+};
 
 #[derive(Debug, Clone)]
 struct TranscriptSummary {
@@ -90,8 +95,8 @@ pub(crate) fn handle_session_result(
 ) -> Result<()> {
     let project_root = crate::pipeline::determine_project_root(cd.as_deref())?;
     let resolved = resolve_session_prefix_with_global_fallback(&project_root, &session)?;
-    let resolved_id = resolved.session_id;
-    let session_dir = resolved.sessions_dir.join(&resolved_id);
+    let mut resolved_id = resolved.session_id;
+    let mut session_dir = resolved.sessions_dir.join(&resolved_id);
 
     // Use the foreign project root for cross-project sessions, local otherwise.
     let effective_root = resolved
@@ -99,6 +104,12 @@ pub(crate) fn handle_session_result(
         .as_deref()
         .unwrap_or(&project_root);
     let is_cross_project = resolved.foreign_project_root.is_some();
+
+    let resume_target = csa_session::resolve_resume_target_from_dir(effective_root, &session_dir)?;
+    if let Some(target) = resume_target {
+        resolved_id = target.session_id;
+        session_dir = target.session_dir;
+    }
 
     let daemon_completion_result =
         match crate::session_cmds_daemon::finalize_daemon_completion_if_present(&session_dir) {
@@ -255,150 +266,6 @@ pub(crate) fn handle_session_result(
     Ok(())
 }
 
-fn display_result_json(
-    result: &SessionResultView,
-    transcript_summary: Option<&TranscriptSummary>,
-    review_meta: Option<&ReviewSessionMeta>,
-    token_usage: Option<&TokenUsage>,
-) -> Result<()> {
-    let payload = build_result_json_payload(result, transcript_summary, review_meta, token_usage)?;
-    println!("{}", serde_json::to_string_pretty(&payload)?);
-    Ok(())
-}
-
-fn display_result_text(
-    session_id: &str,
-    session_dir: &Path,
-    result: &SessionResultView,
-    transcript_summary: Option<&TranscriptSummary>,
-    review_meta: Option<&ReviewSessionMeta>,
-    token_usage: Option<&TokenUsage>,
-) {
-    let envelope = &result.envelope;
-    println!("Session: {session_id}");
-    println!("Status:  {}", envelope.status);
-    println!("Exit:    {}", envelope.exit_code);
-    println!("Tool:    {}", envelope.tool);
-    println!("Started: {}", envelope.started_at);
-    println!("Ended:   {}", envelope.completed_at);
-    // Match `csa session wait`: prefer `output/summary.md` and suppress raw JSON
-    // event envelopes (e.g. codex `turn.completed`) rather than printing machine
-    // JSON as the human Summary line (#161 / #1682).
-    if let Some(summary) =
-        crate::session_summary_text::human_session_summary(session_dir, &envelope.summary)
-    {
-        // #1852: enrich a bare failing verdict (e.g. "FAIL") with the
-        // highest-severity finding's grade + title so the one-line Summary
-        // explains why the review failed, not merely that it did.
-        let summary = crate::session_summary_text::enrich_review_summary(session_dir, &summary);
-        println!("Summary: {summary}");
-    }
-    if !envelope.artifacts.is_empty() {
-        println!("Artifacts:");
-        for a in &envelope.artifacts {
-            println!("  - {a}");
-        }
-    }
-    display_sidecar("Manager Sidecar", result.manager_sidecar.as_ref());
-    display_sidecar("Legacy Sidecar", result.legacy_sidecar.as_ref());
-    if let Some(meta) = review_meta {
-        println!("Review Iterations: {}", meta.review_iterations);
-    }
-    if let Some(usage) = token_usage {
-        print_token_usage(usage);
-    }
-    if let Some(summary) = transcript_summary {
-        println!("Transcript:");
-        println!("  Events: {}", summary.event_count);
-        println!("  Size:   {} bytes", summary.size_bytes);
-        println!(
-            "  First:  {}",
-            summary.first_timestamp.as_deref().unwrap_or("-")
-        );
-        println!(
-            "  Last:   {}",
-            summary.last_timestamp.as_deref().unwrap_or("-")
-        );
-    }
-}
-
-/// Load total_token_usage from a session's state.toml on disk.
-///
-/// Returns None on any parse/read failure or when the field is absent.
-/// Reading directly avoids the project-root coupling of `load_session`,
-/// which lets cross-project sessions render their token totals too.
-fn load_total_token_usage(session_dir: &Path) -> Option<TokenUsage> {
-    let state_path = session_dir.join("state.toml");
-    let content = fs::read_to_string(&state_path).ok()?;
-    let value: toml::Value = toml::from_str(&content).ok()?;
-    let usage_table = value.get("total_token_usage")?;
-    usage_table.clone().try_into::<TokenUsage>().ok()
-}
-
-fn print_token_usage(usage: &TokenUsage) {
-    for line in render_token_usage_lines(usage) {
-        println!("{line}");
-    }
-}
-
-fn render_token_usage_lines(usage: &TokenUsage) -> Vec<String> {
-    let any_field = usage.input_tokens.is_some()
-        || usage.output_tokens.is_some()
-        || usage.total_tokens.is_some()
-        || usage.estimated_cost_usd.is_some()
-        || usage.cache_read_input_tokens.is_some();
-    if !any_field {
-        return Vec::new();
-    }
-
-    let mut lines = vec!["Tokens:".to_string()];
-    if let Some(v) = usage.input_tokens {
-        lines.push(format!("  Input:  {} tokens", format_thousands(v)));
-    }
-    if let Some(v) = usage.output_tokens {
-        lines.push(format!("  Output: {} tokens", format_thousands(v)));
-    }
-    if let Some(v) = display_total_tokens(usage) {
-        lines.push(format!("  Total:  {} tokens", format_thousands(v)));
-    }
-    if let Some(v) = usage.cache_read_input_tokens {
-        if let Some(ratio) = usage.cache_hit_ratio() {
-            lines.push(format!(
-                "  Cache read: {} tokens ({:.0}% hit rate)",
-                format_thousands(v),
-                ratio * 100.0
-            ));
-        } else {
-            lines.push(format!("  Cache read: {} tokens", format_thousands(v)));
-        }
-    }
-    if let Some(cost) = usage.estimated_cost_usd {
-        lines.push(format!("  Cost:   ${cost:.4}"));
-    }
-    lines
-}
-
-fn display_total_tokens(usage: &TokenUsage) -> Option<u64> {
-    match (usage.input_tokens, usage.output_tokens) {
-        (Some(input), Some(output)) => input.checked_add(output),
-        _ => usage.total_tokens,
-    }
-}
-
-fn format_thousands(n: u64) -> String {
-    let s = n.to_string();
-    let bytes = s.as_bytes();
-    let len = bytes.len();
-    let mut out = String::with_capacity(len + len / 3);
-    for (idx, byte) in bytes.iter().enumerate() {
-        if idx > 0 && (len - idx).is_multiple_of(3) {
-            out.push(',');
-        }
-        out.push(*byte as char);
-    }
-    out
-}
-
 fn load_review_meta(session_dir: &Path) -> Result<Option<ReviewSessionMeta>> {
     let review_meta_path = session_dir.join("review_meta.json");
     if !review_meta_path.is_file() {
@@ -410,286 +277,15 @@ fn load_review_meta(session_dir: &Path) -> Result<Option<ReviewSessionMeta>> {
     Ok(Some(review_meta))
 }
 
-fn build_result_json_payload(
-    result: &SessionResultView,
-    transcript_summary: Option<&TranscriptSummary>,
-    review_meta: Option<&ReviewSessionMeta>,
-    token_usage: Option<&TokenUsage>,
-) -> Result<serde_json::Value> {
-    let mut payload = serde_json::to_value(&result.envelope)?;
-    if let Some(sidecar) = result
-        .manager_sidecar
-        .as_ref()
-        .and_then(redact_result_sidecar_for_json)
-    {
-        payload["manager_sidecar"] = serde_json::to_value(sidecar)?;
-    }
-    if let Some(sidecar) = result
-        .legacy_sidecar
-        .as_ref()
-        .and_then(redact_result_sidecar_for_json)
-    {
-        payload["legacy_sidecar"] = serde_json::to_value(sidecar)?;
-    }
-    if let Some(summary) = transcript_summary {
-        payload["transcript_summary"] = serde_json::json!({
-            "event_count": summary.event_count,
-            "size_bytes": summary.size_bytes,
-            "first_timestamp": summary.first_timestamp,
-            "last_timestamp": summary.last_timestamp,
-        });
-    }
-    if let Some(meta) = review_meta {
-        payload["review_meta"] = serde_json::to_value(meta)?;
-    }
-    if let Some(usage) = token_usage {
-        let usage = normalized_token_usage_for_output(usage);
-        let mut value = serde_json::to_value(&usage)?;
-        if let Some(ratio) = usage.cache_hit_ratio() {
-            value["cache_hit_ratio"] = serde_json::json!(ratio);
-        }
-        payload["total_token_usage"] = value;
-    }
-    Ok(payload)
-}
-
-fn normalized_token_usage_for_output(usage: &TokenUsage) -> TokenUsage {
-    let mut normalized = usage.clone();
-    normalized.total_tokens = display_total_tokens(usage);
-    normalized
-}
-
-fn display_sidecar(label: &str, sidecar: Option<&toml::Value>) {
-    if let Some(rendered) = sidecar.and_then(render_result_sidecar_for_text) {
-        println!("{label}:");
-        print_rendered_sidecar(&rendered, 2);
-    }
-}
-
-fn render_result_sidecar_for_text(sidecar: &toml::Value) -> Option<String> {
-    match csa_session::render_redacted_result_sidecar(sidecar) {
-        Ok(rendered) if rendered.trim().is_empty() => None,
-        Ok(rendered) => Some(rendered),
-        Err(err) => Some(format!("<failed to render TOML sidecar: {err}>")),
-    }
-}
-
-fn redact_result_sidecar_for_json(sidecar: &toml::Value) -> Option<toml::Value> {
-    match csa_session::redact_result_sidecar_value(sidecar) {
-        Ok(toml::Value::Table(table)) if table.is_empty() => None,
-        Ok(value) => Some(value),
-        Err(_) => Some(toml::Value::String(
-            "<failed to render TOML sidecar>".to_string(),
-        )),
-    }
-}
-
-fn print_rendered_sidecar(rendered: &str, indent: usize) {
-    let padding = " ".repeat(indent);
-    for line in rendered.lines() {
-        println!("{padding}{line}");
-    }
-}
-
-const FALLBACK_LINES: usize = 20;
-
-/// Display structured output sections based on the requested mode.
-fn display_structured_output(
-    session_dir: &Path,
-    session_id: &str,
-    opts: &StructuredOutputOpts,
-    json: bool,
-) -> Result<()> {
-    if opts.summary {
-        return display_summary_section(session_dir, session_id, json);
-    }
-
-    if let Some(ref section_id) = opts.section {
-        return display_single_section(session_dir, session_id, section_id, json);
-    }
-
-    if opts.full {
-        return display_all_sections(session_dir, session_id, json);
-    }
-
-    Ok(())
-}
-
-/// Show only the summary section, with fallback to first N lines of output.log.
-pub(crate) fn display_summary_section(
-    session_dir: &Path,
-    session_id: &str,
-    json: bool,
-) -> Result<()> {
-    // Try reading "summary" section first
-    let (section_id, content) = match csa_session::read_section(session_dir, "summary")? {
-        Some(content) => ("summary", content),
-        None => {
-            // If there's a "full" section, use that as fallback
-            match csa_session::read_section(session_dir, "full")? {
-                Some(content) => ("full", content),
-                None => {
-                    // Final fallback: first N lines of output.log
-                    return display_summary_fallback(session_dir, session_id, json);
-                }
-            }
-        }
-    };
-
-    if json {
-        let payload = serde_json::json!({
-            "section": section_id,
-            "content": content,
-            "tokens": csa_session::estimate_tokens(&content),
-        });
-        println!("{}", serde_json::to_string_pretty(&payload)?);
-    } else {
-        let is_full_fallback = section_id == "full";
-        if is_full_fallback {
-            print_truncated_content(&content, FALLBACK_LINES);
-        } else {
-            println!("{content}");
-        }
-    }
-    Ok(())
-}
-
-fn display_summary_fallback(session_dir: &Path, session_id: &str, json: bool) -> Result<()> {
-    let output_log = session_dir.join("output.log");
-    if output_log.is_file() {
-        let content = fs::read_to_string(&output_log)?;
-        if !content.is_empty() {
-            if json {
-                let payload = serde_json::json!({
-                    "section": "summary",
-                    "source": "output.log",
-                    "content": content.lines().take(FALLBACK_LINES).collect::<Vec<_>>().join("\n"),
-                    "truncated": content.lines().count() > FALLBACK_LINES,
-                });
-                println!("{}", serde_json::to_string_pretty(&payload)?);
-            } else {
-                print_truncated_content(&content, FALLBACK_LINES);
-            }
-            return Ok(());
-        }
-    }
-    eprintln!("No output found for session '{session_id}'");
-    Ok(())
-}
-
-fn print_truncated_content(content: &str, max_lines: usize) {
-    let lines: Vec<&str> = content.lines().take(max_lines).collect();
-    println!("{}", lines.join("\n"));
-    if content.lines().count() > max_lines {
-        eprintln!(
-            "... ({} more lines, use --full to see all)",
-            content.lines().count() - max_lines
-        );
-    }
-}
-
-/// Show a single section by ID.
-pub(crate) fn display_single_section(
-    session_dir: &Path,
-    session_id: &str,
-    section_id: &str,
-    json: bool,
-) -> Result<()> {
-    match csa_session::read_section(session_dir, section_id)? {
-        Some(content) => {
-            if json {
-                let payload = serde_json::json!({
-                    "section": section_id,
-                    "content": content,
-                    "tokens": csa_session::estimate_tokens(&content),
-                });
-                println!("{}", serde_json::to_string_pretty(&payload)?);
-            } else {
-                println!("{content}");
-            }
-        }
-        None => {
-            // Check if index exists to give a better error
-            match csa_session::load_output_index(session_dir)? {
-                Some(index) => {
-                    let available: Vec<&str> =
-                        index.sections.iter().map(|s| s.id.as_str()).collect();
-                    anyhow::bail!(
-                        "Section '{}' not found in session '{}'. Available sections: {}",
-                        section_id,
-                        session_id,
-                        available.join(", ")
-                    );
-                }
-                None => {
-                    anyhow::bail!(
-                        "No structured output for session '{session_id}'. Run without --section to see raw result."
-                    );
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Show all sections in index order.
-pub(crate) fn display_all_sections(session_dir: &Path, session_id: &str, json: bool) -> Result<()> {
-    let sections = csa_session::read_all_sections(session_dir)?;
-    if sections.is_empty() {
-        // Fallback: show full output.log
-        let output_log = session_dir.join("output.log");
-        if output_log.is_file() {
-            let content = fs::read_to_string(&output_log)?;
-            if !content.is_empty() {
-                if json {
-                    let payload = serde_json::json!({
-                        "sections": [{
-                            "section": "full",
-                            "content": content,
-                            "tokens": csa_session::estimate_tokens(&content),
-                        }]
-                    });
-                    println!("{}", serde_json::to_string_pretty(&payload)?);
-                } else {
-                    print!("{content}");
-                }
-                return Ok(());
-            }
-        }
-        eprintln!("No output found for session '{session_id}'");
-        return Ok(());
-    }
-
-    if json {
-        let json_sections: Vec<serde_json::Value> = sections
-            .iter()
-            .map(|(section, content)| {
-                serde_json::json!({
-                    "section": section.id,
-                    "title": section.title,
-                    "content": content,
-                    "tokens": section.token_estimate,
-                })
-            })
-            .collect();
-        let payload = serde_json::json!({ "sections": json_sections });
-        println!("{}", serde_json::to_string_pretty(&payload)?);
-    } else {
-        for (i, (section, content)) in sections.iter().enumerate() {
-            if i > 0 {
-                println!();
-            }
-            println!("=== {} ({}) ===", section.title, section.id);
-            println!("{content}");
-        }
-    }
-    Ok(())
-}
-
 pub(crate) use crate::session_cmds_result_measure::handle_session_measure;
 #[cfg(test)]
 pub(crate) use crate::session_cmds_result_measure::{compute_token_measurement, format_number};
 pub(crate) use artifacts::handle_session_artifacts;
+#[cfg(test)]
+use display::{
+    build_result_json_payload, display_all_sections, display_single_section,
+    display_summary_section, render_result_sidecar_for_text, render_token_usage_lines,
+};
 pub(crate) use tool_output::handle_session_tool_output;
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/session_cmds_result_display.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_display.rs
@@ -1,0 +1,406 @@
+use anyhow::Result;
+use csa_session::state::ReviewSessionMeta;
+use csa_session::{SessionResultView, TokenUsage};
+use std::fs;
+use std::path::Path;
+
+use super::{StructuredOutputOpts, TranscriptSummary};
+
+pub(super) fn display_result_json(
+    result: &SessionResultView,
+    transcript_summary: Option<&TranscriptSummary>,
+    review_meta: Option<&ReviewSessionMeta>,
+    token_usage: Option<&TokenUsage>,
+) -> Result<()> {
+    let payload = build_result_json_payload(result, transcript_summary, review_meta, token_usage)?;
+    println!("{}", serde_json::to_string_pretty(&payload)?);
+    Ok(())
+}
+
+pub(super) fn display_result_text(
+    session_id: &str,
+    session_dir: &Path,
+    result: &SessionResultView,
+    transcript_summary: Option<&TranscriptSummary>,
+    review_meta: Option<&ReviewSessionMeta>,
+    token_usage: Option<&TokenUsage>,
+) {
+    let envelope = &result.envelope;
+    println!("Session: {session_id}");
+    println!("Status:  {}", envelope.status);
+    println!("Exit:    {}", envelope.exit_code);
+    println!("Tool:    {}", envelope.tool);
+    println!("Started: {}", envelope.started_at);
+    println!("Ended:   {}", envelope.completed_at);
+    if let Some(summary) =
+        crate::session_summary_text::human_session_summary(session_dir, &envelope.summary)
+    {
+        let summary = crate::session_summary_text::enrich_review_summary(session_dir, &summary);
+        println!("Summary: {summary}");
+    }
+    if !envelope.artifacts.is_empty() {
+        println!("Artifacts:");
+        for a in &envelope.artifacts {
+            println!("  - {a}");
+        }
+    }
+    display_sidecar("Manager Sidecar", result.manager_sidecar.as_ref());
+    display_sidecar("Legacy Sidecar", result.legacy_sidecar.as_ref());
+    if let Some(meta) = review_meta {
+        println!("Review Iterations: {}", meta.review_iterations);
+    }
+    if let Some(usage) = token_usage {
+        print_token_usage(usage);
+    }
+    if let Some(summary) = transcript_summary {
+        println!("Transcript:");
+        println!("  Events: {}", summary.event_count);
+        println!("  Size:   {} bytes", summary.size_bytes);
+        println!(
+            "  First:  {}",
+            summary.first_timestamp.as_deref().unwrap_or("-")
+        );
+        println!(
+            "  Last:   {}",
+            summary.last_timestamp.as_deref().unwrap_or("-")
+        );
+    }
+}
+
+/// Load total_token_usage from a session's state.toml on disk.
+///
+/// Returns None on any parse/read failure or when the field is absent.
+/// Reading directly avoids the project-root coupling of `load_session`,
+/// which lets cross-project sessions render their token totals too.
+pub(super) fn load_total_token_usage(session_dir: &Path) -> Option<TokenUsage> {
+    let state_path = session_dir.join("state.toml");
+    let content = fs::read_to_string(&state_path).ok()?;
+    let value: toml::Value = toml::from_str(&content).ok()?;
+    let usage_table = value.get("total_token_usage")?;
+    usage_table.clone().try_into::<TokenUsage>().ok()
+}
+
+fn print_token_usage(usage: &TokenUsage) {
+    for line in render_token_usage_lines(usage) {
+        println!("{line}");
+    }
+}
+
+pub(super) fn render_token_usage_lines(usage: &TokenUsage) -> Vec<String> {
+    let any_field = usage.input_tokens.is_some()
+        || usage.output_tokens.is_some()
+        || usage.total_tokens.is_some()
+        || usage.estimated_cost_usd.is_some()
+        || usage.cache_read_input_tokens.is_some();
+    if !any_field {
+        return Vec::new();
+    }
+
+    let mut lines = vec!["Tokens:".to_string()];
+    if let Some(v) = usage.input_tokens {
+        lines.push(format!("  Input:  {} tokens", format_thousands(v)));
+    }
+    if let Some(v) = usage.output_tokens {
+        lines.push(format!("  Output: {} tokens", format_thousands(v)));
+    }
+    if let Some(v) = display_total_tokens(usage) {
+        lines.push(format!("  Total:  {} tokens", format_thousands(v)));
+    }
+    if let Some(v) = usage.cache_read_input_tokens {
+        if let Some(ratio) = usage.cache_hit_ratio() {
+            lines.push(format!(
+                "  Cache read: {} tokens ({:.0}% hit rate)",
+                format_thousands(v),
+                ratio * 100.0
+            ));
+        } else {
+            lines.push(format!("  Cache read: {} tokens", format_thousands(v)));
+        }
+    }
+    if let Some(cost) = usage.estimated_cost_usd {
+        lines.push(format!("  Cost:   ${cost:.4}"));
+    }
+    lines
+}
+
+fn display_total_tokens(usage: &TokenUsage) -> Option<u64> {
+    match (usage.input_tokens, usage.output_tokens) {
+        (Some(input), Some(output)) => input.checked_add(output),
+        _ => usage.total_tokens,
+    }
+}
+
+fn format_thousands(n: u64) -> String {
+    let s = n.to_string();
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let mut out = String::with_capacity(len + len / 3);
+    for (idx, byte) in bytes.iter().enumerate() {
+        if idx > 0 && (len - idx).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(*byte as char);
+    }
+    out
+}
+
+pub(super) fn build_result_json_payload(
+    result: &SessionResultView,
+    transcript_summary: Option<&TranscriptSummary>,
+    review_meta: Option<&ReviewSessionMeta>,
+    token_usage: Option<&TokenUsage>,
+) -> Result<serde_json::Value> {
+    let mut payload = serde_json::to_value(&result.envelope)?;
+    if let Some(sidecar) = result
+        .manager_sidecar
+        .as_ref()
+        .and_then(redact_result_sidecar_for_json)
+    {
+        payload["manager_sidecar"] = serde_json::to_value(sidecar)?;
+    }
+    if let Some(sidecar) = result
+        .legacy_sidecar
+        .as_ref()
+        .and_then(redact_result_sidecar_for_json)
+    {
+        payload["legacy_sidecar"] = serde_json::to_value(sidecar)?;
+    }
+    if let Some(summary) = transcript_summary {
+        payload["transcript_summary"] = serde_json::json!({
+            "event_count": summary.event_count,
+            "size_bytes": summary.size_bytes,
+            "first_timestamp": summary.first_timestamp,
+            "last_timestamp": summary.last_timestamp,
+        });
+    }
+    if let Some(meta) = review_meta {
+        payload["review_meta"] = serde_json::to_value(meta)?;
+    }
+    if let Some(usage) = token_usage {
+        let usage = normalized_token_usage_for_output(usage);
+        let mut value = serde_json::to_value(&usage)?;
+        if let Some(ratio) = usage.cache_hit_ratio() {
+            value["cache_hit_ratio"] = serde_json::json!(ratio);
+        }
+        payload["total_token_usage"] = value;
+    }
+    Ok(payload)
+}
+
+fn normalized_token_usage_for_output(usage: &TokenUsage) -> TokenUsage {
+    let mut normalized = usage.clone();
+    normalized.total_tokens = display_total_tokens(usage);
+    normalized
+}
+
+fn display_sidecar(label: &str, sidecar: Option<&toml::Value>) {
+    if let Some(rendered) = sidecar.and_then(render_result_sidecar_for_text) {
+        println!("{label}:");
+        print_rendered_sidecar(&rendered, 2);
+    }
+}
+
+pub(super) fn render_result_sidecar_for_text(sidecar: &toml::Value) -> Option<String> {
+    match csa_session::render_redacted_result_sidecar(sidecar) {
+        Ok(rendered) if rendered.trim().is_empty() => None,
+        Ok(rendered) => Some(rendered),
+        Err(err) => Some(format!("<failed to render TOML sidecar: {err}>")),
+    }
+}
+
+fn redact_result_sidecar_for_json(sidecar: &toml::Value) -> Option<toml::Value> {
+    match csa_session::redact_result_sidecar_value(sidecar) {
+        Ok(toml::Value::Table(table)) if table.is_empty() => None,
+        Ok(value) => Some(value),
+        Err(_) => Some(toml::Value::String(
+            "<failed to render TOML sidecar>".to_string(),
+        )),
+    }
+}
+
+fn print_rendered_sidecar(rendered: &str, indent: usize) {
+    let padding = " ".repeat(indent);
+    for line in rendered.lines() {
+        println!("{padding}{line}");
+    }
+}
+
+const FALLBACK_LINES: usize = 20;
+
+/// Display structured output sections based on the requested mode.
+pub(super) fn display_structured_output(
+    session_dir: &Path,
+    session_id: &str,
+    opts: &StructuredOutputOpts,
+    json: bool,
+) -> Result<()> {
+    if opts.summary {
+        return display_summary_section(session_dir, session_id, json);
+    }
+
+    if let Some(ref section_id) = opts.section {
+        return display_single_section(session_dir, session_id, section_id, json);
+    }
+
+    if opts.full {
+        return display_all_sections(session_dir, session_id, json);
+    }
+
+    Ok(())
+}
+
+/// Show only the summary section, with fallback to first N lines of output.log.
+pub(super) fn display_summary_section(
+    session_dir: &Path,
+    session_id: &str,
+    json: bool,
+) -> Result<()> {
+    let (section_id, content) = match csa_session::read_section(session_dir, "summary")? {
+        Some(content) => ("summary", content),
+        None => match csa_session::read_section(session_dir, "full")? {
+            Some(content) => ("full", content),
+            None => return display_summary_fallback(session_dir, session_id, json),
+        },
+    };
+
+    if json {
+        let payload = serde_json::json!({
+            "section": section_id,
+            "content": content,
+            "tokens": csa_session::estimate_tokens(&content),
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else if section_id == "full" {
+        print_truncated_content(&content, FALLBACK_LINES);
+    } else {
+        println!("{content}");
+    }
+    Ok(())
+}
+
+fn display_summary_fallback(session_dir: &Path, session_id: &str, json: bool) -> Result<()> {
+    let output_log = session_dir.join("output.log");
+    if output_log.is_file() {
+        let content = fs::read_to_string(&output_log)?;
+        if !content.is_empty() {
+            if json {
+                let payload = serde_json::json!({
+                    "section": "summary",
+                    "source": "output.log",
+                    "content": content.lines().take(FALLBACK_LINES).collect::<Vec<_>>().join("\n"),
+                    "truncated": content.lines().count() > FALLBACK_LINES,
+                });
+                println!("{}", serde_json::to_string_pretty(&payload)?);
+            } else {
+                print_truncated_content(&content, FALLBACK_LINES);
+            }
+            return Ok(());
+        }
+    }
+    eprintln!("No output found for session '{session_id}'");
+    Ok(())
+}
+
+fn print_truncated_content(content: &str, max_lines: usize) {
+    let lines: Vec<&str> = content.lines().take(max_lines).collect();
+    println!("{}", lines.join("\n"));
+    if content.lines().count() > max_lines {
+        eprintln!(
+            "... ({} more lines, use --full to see all)",
+            content.lines().count() - max_lines
+        );
+    }
+}
+
+/// Show a single section by ID.
+pub(super) fn display_single_section(
+    session_dir: &Path,
+    session_id: &str,
+    section_id: &str,
+    json: bool,
+) -> Result<()> {
+    match csa_session::read_section(session_dir, section_id)? {
+        Some(content) => {
+            if json {
+                let payload = serde_json::json!({
+                    "section": section_id,
+                    "content": content,
+                    "tokens": csa_session::estimate_tokens(&content),
+                });
+                println!("{}", serde_json::to_string_pretty(&payload)?);
+            } else {
+                println!("{content}");
+            }
+        }
+        None => match csa_session::load_output_index(session_dir)? {
+            Some(index) => {
+                let available: Vec<&str> = index.sections.iter().map(|s| s.id.as_str()).collect();
+                anyhow::bail!(
+                    "Section '{}' not found in session '{}'. Available sections: {}",
+                    section_id,
+                    session_id,
+                    available.join(", ")
+                );
+            }
+            None => {
+                anyhow::bail!(
+                    "No structured output for session '{session_id}'. Run without --section to see raw result."
+                );
+            }
+        },
+    }
+    Ok(())
+}
+
+/// Show all sections in index order.
+pub(super) fn display_all_sections(session_dir: &Path, session_id: &str, json: bool) -> Result<()> {
+    let sections = csa_session::read_all_sections(session_dir)?;
+    if sections.is_empty() {
+        let output_log = session_dir.join("output.log");
+        if output_log.is_file() {
+            let content = fs::read_to_string(&output_log)?;
+            if !content.is_empty() {
+                if json {
+                    let payload = serde_json::json!({
+                        "sections": [{
+                            "section": "full",
+                            "content": content,
+                            "tokens": csa_session::estimate_tokens(&content),
+                        }]
+                    });
+                    println!("{}", serde_json::to_string_pretty(&payload)?);
+                } else {
+                    print!("{content}");
+                }
+                return Ok(());
+            }
+        }
+        eprintln!("No output found for session '{session_id}'");
+        return Ok(());
+    }
+
+    if json {
+        let json_sections: Vec<serde_json::Value> = sections
+            .iter()
+            .map(|(section, content)| {
+                serde_json::json!({
+                    "section": section.id,
+                    "title": section.title,
+                    "content": content,
+                    "tokens": section.token_estimate,
+                })
+            })
+            .collect();
+        let payload = serde_json::json!({ "sections": json_sections });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        for (i, (section, content)) in sections.iter().enumerate() {
+            if i > 0 {
+                println!();
+            }
+            println!("=== {} ({}) ===", section.title, section.id);
+            println!("{content}");
+        }
+    }
+    Ok(())
+}

--- a/crates/cli-sub-agent/src/session_cmds_result_resume_wrapper_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_resume_wrapper_tests.rs
@@ -1,0 +1,133 @@
+use super::*;
+
+fn make_result(status: &str, exit_code: i32) -> SessionResult {
+    let now = chrono::Utc::now();
+    SessionResult {
+        status: status.to_string(),
+        exit_code,
+        summary: status.to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        ..Default::default()
+    }
+}
+
+fn move_session_to_legacy_root(project: &std::path::Path, session_id: &str) -> std::path::PathBuf {
+    let primary_root = csa_session::get_session_root(project).unwrap();
+    let primary_session_dir = primary_root.join("sessions").join(session_id);
+    let primary_state_dir = csa_config::paths::state_dir_write().unwrap();
+    let legacy_state_dir = csa_config::paths::legacy_state_dir().unwrap();
+    let relative_root = primary_root.strip_prefix(&primary_state_dir).unwrap();
+    let legacy_root = legacy_state_dir.join(relative_root);
+    let legacy_sessions_dir = legacy_root.join("sessions");
+    std::fs::create_dir_all(&legacy_sessions_dir).unwrap();
+    let legacy_session_dir = legacy_sessions_dir.join(session_id);
+    std::fs::rename(&primary_session_dir, &legacy_session_dir).unwrap();
+    legacy_session_dir
+}
+
+#[cfg(unix)]
+#[test]
+fn handle_session_result_on_resume_wrapper_uses_worker_result() {
+    let tmp = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = tmp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", tmp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = tmp.path();
+
+    let worker = create_session(project, Some("worker-result"), None, Some("codex")).unwrap();
+    let wrapper = create_session(project, Some("wrapper-result"), None, None).unwrap();
+    let worker_id = worker.meta_session_id;
+    let wrapper_id = wrapper.meta_session_id;
+    let wrapper_dir = get_session_dir(project, &wrapper_id).unwrap();
+    csa_session::write_resume_target(project, &wrapper_id, &worker_id).unwrap();
+    std::fs::write(
+        wrapper_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .unwrap();
+    csa_session::save_result(
+        project,
+        &worker_id,
+        &SessionResult {
+            summary: "worker completed".to_string(),
+            ..make_result("success", 0)
+        },
+    )
+    .unwrap();
+
+    handle_session_result(
+        wrapper_id.clone(),
+        false,
+        Some(project.to_string_lossy().into_owned()),
+        StructuredOutputOpts::default(),
+    )
+    .unwrap();
+
+    assert!(
+        load_result(project, &wrapper_id).unwrap().is_none(),
+        "session result on a wrapper must not synthesize wrapper result.toml"
+    );
+    let result = load_result(project, &worker_id)
+        .unwrap()
+        .expect("worker result should be authoritative");
+    assert_eq!(result.summary, "worker completed");
+}
+
+#[cfg(unix)]
+#[test]
+fn handle_session_result_on_resume_wrapper_follows_worker_in_legacy_root() {
+    let tmp = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = tmp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", tmp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = tmp.path();
+
+    let worker =
+        create_session(project, Some("worker-result-legacy"), None, Some("codex")).unwrap();
+    let wrapper = create_session(project, Some("wrapper-result"), None, None).unwrap();
+    let worker_id = worker.meta_session_id;
+    let wrapper_id = wrapper.meta_session_id;
+    let wrapper_dir = get_session_dir(project, &wrapper_id).unwrap();
+    let worker_dir = move_session_to_legacy_root(project, &worker_id);
+    assert!(worker_dir.join("state.toml").is_file());
+
+    csa_session::write_resume_target(project, &wrapper_id, &worker_id)
+        .expect("resume wrapper alias should accept a legacy-root target");
+    std::fs::write(
+        wrapper_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .unwrap();
+    csa_session::save_result(
+        project,
+        &worker_id,
+        &SessionResult {
+            summary: "legacy worker completed".to_string(),
+            ..make_result("success", 0)
+        },
+    )
+    .unwrap();
+
+    handle_session_result(
+        wrapper_id.clone(),
+        false,
+        Some(project.to_string_lossy().into_owned()),
+        StructuredOutputOpts::default(),
+    )
+    .unwrap();
+
+    assert!(
+        load_result(project, &wrapper_id).unwrap().is_none(),
+        "session result on a cross-root wrapper must not synthesize wrapper result.toml"
+    );
+    let result = load_result(project, &worker_id)
+        .unwrap()
+        .expect("legacy-root worker result should be authoritative");
+    assert_eq!(result.summary, "legacy worker completed");
+}

--- a/crates/cli-sub-agent/src/session_cmds_result_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tests.rs
@@ -38,6 +38,8 @@ impl Drop for EnvVarGuard {
 mod daemon_completion;
 #[path = "session_cmds_result_tests_2016.rs"]
 mod issue_2016;
+#[path = "session_cmds_result_resume_wrapper_tests.rs"]
+mod resume_wrapper;
 
 // ── display_structured_output tests ───────────────────────────────
 

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -822,18 +822,14 @@ fn session_logs_cli_events_defaults_to_false() {
     }
 }
 
-// ── print_content_with_tail tests ─────────────────────────────────
-
 #[test]
 fn print_content_with_tail_no_panic_on_empty() {
-    // Should not panic on empty content
     print_content_with_tail("", None);
     print_content_with_tail("", Some(5));
 }
 
 #[test]
 fn print_content_with_tail_no_panic_on_large_tail() {
-    // Tail larger than line count should not panic
     print_content_with_tail("line1\nline2\n", Some(100));
 }
 
@@ -865,3 +861,7 @@ mod tail_tests_wait_liveness;
 mod tail_tests_wait_lock;
 #[path = "session_cmds_tests_tail_wait_regression.rs"]
 mod tail_tests_wait_regression;
+#[path = "session_cmds_tests_tail_wait_2105.rs"]
+mod w;
+#[path = "session_cmds_tests_tail_wait_resume_wrapper.rs"]
+mod wait_resume;

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait.rs
@@ -299,19 +299,14 @@ fn handle_session_wait_maps_output_result_timeout_to_terminal_failure() {
     .expect("create session");
     let session_id = session.meta_session_id;
     let session_dir = get_session_dir(project, &session_id).expect("session dir");
-    let output_dir = session_dir.join("output");
-    std::fs::create_dir_all(&output_dir).expect("create output dir");
+    let output_result_path = csa_session::turn_contract_result_path(&session_dir, 1);
+    std::fs::create_dir_all(output_result_path.parent().expect("parent")).expect("mkdir");
     let output_result = SessionResult {
-        summary: "tool execution timed out".to_string(),
+        summary: "timeout".to_string(),
         ..make_result("timeout", 124)
     };
-    let output_result_toml =
-        toml::to_string_pretty(&output_result).expect("serialize output result");
-    std::fs::write(
-        output_dir.join(csa_session::result::RESULT_FILE_NAME),
-        output_result_toml,
-    )
-    .expect("write output result");
+    let output_result_toml = toml::to_string_pretty(&output_result).expect("serialize");
+    std::fs::write(&output_result_path, output_result_toml).expect("write");
 
     let mut emitted_completion: Option<(String, String, i32, bool)> = None;
     let exit_code = handle_session_wait_with_hooks(

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2105.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2105.rs
@@ -1,0 +1,602 @@
+use super::*;
+use crate::session_cmds_daemon::{
+    WaitBehavior, WaitLoopTiming, WaitReconciliationOutcome, handle_session_wait_with_hooks,
+};
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+use tempfile::tempdir;
+
+#[test]
+fn handle_session_wait_uses_persisted_current_turn_artifact_after_multi_turn_state_save() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = ScopedEnvVarRestore::set("HOME", td.path());
+    let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+    let _contract_guard = ScopedEnvVarRestore::unset(csa_session::RESULT_TOML_PATH_CONTRACT_ENV);
+    let project = td.path();
+
+    let mut session = create_session(
+        project,
+        Some("wait-current-turn-marker-after-multiturn-save"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id.clone();
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let current_turn_artifact = csa_session::turn_contract_result_artifact_path(1);
+    let current_turn_path = session_dir.join(&current_turn_artifact);
+    std::fs::create_dir_all(current_turn_path.parent().expect("turn result parent"))
+        .expect("create turn result dir");
+    let current_turn_result = SessionResult {
+        summary: "current invocation result from pre-run turn path".to_string(),
+        ..make_result("success", 0)
+    };
+    let current_turn_result_toml =
+        toml::to_string_pretty(&current_turn_result).expect("serialize current turn result");
+    std::fs::write(&current_turn_path, current_turn_result_toml)
+        .expect("write current turn result");
+    let marker_contents = format!("artifact_path = \"{current_turn_artifact}\"\n");
+    std::fs::write(
+        crate::pipeline::result_contract::current_result_artifact_marker_path(&session_dir),
+        marker_contents,
+    )
+    .expect("write current result artifact marker");
+    session.turn_count = 3;
+    save_session(&session).expect("save post-run multi-turn count");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write daemon completion");
+    assert!(
+        !csa_session::turn_contract_result_path(&session_dir, 4).exists(),
+        "test setup requires saved turn_count + 1 to miss the current artifact"
+    );
+    assert!(
+        !session_dir
+            .join(csa_session::result::RESULT_FILE_NAME)
+            .exists(),
+        "test setup requires missing root result.toml"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should detect persisted current turn artifact fallback");
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id, "success".to_string(), 0, false))
+    );
+}
+
+#[test]
+fn handle_session_wait_accepts_nested_manager_sidecar_current_turn_fallback() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = ScopedEnvVarRestore::set("HOME", td.path());
+    let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+    let _contract_guard = ScopedEnvVarRestore::unset(csa_session::RESULT_TOML_PATH_CONTRACT_ENV);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-nested-manager-sidecar-current-turn"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id.clone();
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let current_turn_artifact = csa_session::turn_contract_result_artifact_path(1);
+    let current_turn_path = session_dir.join(&current_turn_artifact);
+    std::fs::create_dir_all(current_turn_path.parent().expect("turn result parent"))
+        .expect("create turn result dir");
+    let nested_result_toml = r#"[result]
+status = "success"
+summary = "nested manager sidecar completed"
+
+[report]
+what_was_done = "exercised wait fallback nested schema"
+
+[tool]
+name = "codex"
+"#;
+    std::fs::write(&current_turn_path, nested_result_toml).expect("write nested turn result");
+    let parsed =
+        crate::session_cmds_daemon::parse_output_result_artifact_for_test(nested_result_toml)
+            .expect("nested manager sidecar parser should derive a wait result");
+    assert_eq!(parsed.status, "success");
+    assert_eq!(parsed.exit_code, 0);
+    assert_eq!(parsed.summary, "nested manager sidecar completed");
+    assert_eq!(parsed.tool, "codex");
+
+    let marker_contents = format!("artifact_path = \"{current_turn_artifact}\"\n");
+    std::fs::write(
+        crate::pipeline::result_contract::current_result_artifact_marker_path(&session_dir),
+        marker_contents,
+    )
+    .expect("write current result artifact marker");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write daemon completion");
+    assert!(
+        !session_dir
+            .join(csa_session::result::RESULT_FILE_NAME)
+            .exists(),
+        "test setup requires missing root result.toml"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should recover nested current turn manager sidecar fallback");
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id, "success".to_string(), 0, false))
+    );
+}
+
+#[test]
+fn handle_session_wait_rejects_malformed_nested_manager_sidecar_current_turn_fallback() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = ScopedEnvVarRestore::set("HOME", td.path());
+    let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+    let _contract_guard = ScopedEnvVarRestore::unset(csa_session::RESULT_TOML_PATH_CONTRACT_ENV);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-malformed-nested-manager-sidecar-current-turn"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id.clone();
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let current_turn_artifact = csa_session::turn_contract_result_artifact_path(1);
+    let current_turn_path = session_dir.join(&current_turn_artifact);
+    std::fs::create_dir_all(current_turn_path.parent().expect("turn result parent"))
+        .expect("create turn result dir");
+    let malformed_nested_result_toml = r#"[result]
+status = 1
+summary = "non-string status must not become success"
+"#;
+    std::fs::write(&current_turn_path, malformed_nested_result_toml)
+        .expect("write malformed nested turn result");
+    let marker_contents = format!("artifact_path = \"{current_turn_artifact}\"\n");
+    std::fs::write(
+        crate::pipeline::result_contract::current_result_artifact_marker_path(&session_dir),
+        marker_contents,
+    )
+    .expect("write current result artifact marker");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write daemon completion");
+    assert!(
+        !session_dir
+            .join(csa_session::result::RESULT_FILE_NAME)
+            .exists(),
+        "test setup requires missing root result.toml"
+    );
+
+    let mut emitted_completion = false;
+    let err = handle_session_wait_with_hooks(
+        session_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |_sid: &str, _status: &str, _exit_code, _synthetic, _mirror_to_stdout| {
+            emitted_completion = true;
+        },
+    )
+    .expect_err("malformed nested manager sidecar must fail closed");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("Failed to parse manager result artifact fallback")
+            || message.contains("manager [result].status must be a string"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        !emitted_completion,
+        "malformed nested manager sidecar must not emit terminal success"
+    );
+}
+
+#[test]
+fn handle_session_wait_uses_legacy_output_result_when_current_marker_artifact_missing() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = ScopedEnvVarRestore::set("HOME", td.path());
+    let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+    let _contract_guard = ScopedEnvVarRestore::unset(csa_session::RESULT_TOML_PATH_CONTRACT_ENV);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-legacy-output-result-current-marker"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id.clone();
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let current_turn_artifact = csa_session::turn_contract_result_artifact_path(1);
+    let marker_contents = format!("artifact_path = \"{current_turn_artifact}\"\n");
+    std::fs::write(
+        crate::pipeline::result_contract::current_result_artifact_marker_path(&session_dir),
+        marker_contents,
+    )
+    .expect("write current result artifact marker");
+    let legacy_output_result_path = session_dir.join(csa_session::CONTRACT_RESULT_ARTIFACT_PATH);
+    std::fs::create_dir_all(
+        legacy_output_result_path
+            .parent()
+            .expect("legacy result parent"),
+    )
+    .expect("create legacy result parent");
+    let legacy_output_result = SessionResult {
+        summary: "current invocation wrote legacy manager result".to_string(),
+        ..make_result("success", 0)
+    };
+    std::fs::write(
+        &legacy_output_result_path,
+        toml::to_string_pretty(&legacy_output_result).expect("serialize legacy result"),
+    )
+    .expect("write legacy output result");
+    assert!(
+        !session_dir.join(&current_turn_artifact).exists(),
+        "test setup requires missing marker-selected current turn artifact"
+    );
+    assert!(
+        !session_dir
+            .join(csa_session::result::RESULT_FILE_NAME)
+            .exists(),
+        "test setup requires missing root result.toml"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should recover current legacy output/result.toml fallback");
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id, "success".to_string(), 0, false))
+    );
+}
+
+#[test]
+fn handle_session_wait_rejects_stale_legacy_output_result_without_current_marker() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = ScopedEnvVarRestore::set("HOME", td.path());
+    let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+    let _contract_guard = ScopedEnvVarRestore::unset(csa_session::RESULT_TOML_PATH_CONTRACT_ENV);
+    let project = td.path();
+
+    let mut session = create_session(
+        project,
+        Some("wait-stale-legacy-output-result"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id.clone();
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let legacy_output_result_path = session_dir.join(csa_session::CONTRACT_RESULT_ARTIFACT_PATH);
+    std::fs::create_dir_all(
+        legacy_output_result_path
+            .parent()
+            .expect("legacy result parent"),
+    )
+    .expect("create legacy result parent");
+    let stale_legacy_result = SessionResult {
+        summary: "stale legacy manager result from an earlier turn".to_string(),
+        ..make_result("success", 0)
+    };
+    std::fs::write(
+        &legacy_output_result_path,
+        toml::to_string_pretty(&stale_legacy_result).expect("serialize stale legacy result"),
+    )
+    .expect("write stale legacy output result");
+    session.turn_count = 1;
+    save_session(&session).expect("save state after earlier turn");
+    assert!(
+        !crate::pipeline::result_contract::current_result_artifact_marker_path(&session_dir)
+            .exists(),
+        "test setup requires no current-turn marker"
+    );
+    assert!(
+        !csa_session::turn_contract_result_path(&session_dir, 2).exists(),
+        "test setup requires missing next-turn artifact"
+    );
+    assert!(
+        !session_dir
+            .join(csa_session::result::RESULT_FILE_NAME)
+            .exists(),
+        "test setup requires missing root result.toml"
+    );
+
+    let mut emitted_completion = false;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |_sid: &str, _status: &str, _exit_code, _synthetic, _mirror_to_stdout| {
+            emitted_completion = true;
+        },
+    )
+    .expect("wait should reject stale legacy output/result.toml fallback");
+
+    assert_eq!(exit_code, 1);
+    assert!(
+        !emitted_completion,
+        "stale legacy output/result.toml must not emit terminal completion"
+    );
+}
+
+#[test]
+fn handle_session_wait_rejects_stale_inherited_contract_env_prior_turn_sidecar() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = ScopedEnvVarRestore::set("HOME", td.path());
+    let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let mut session = create_session(
+        project,
+        Some("wait-stale-inherited-contract-env"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id.clone();
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let prior_turn_artifact = csa_session::turn_contract_result_artifact_path(1);
+    let prior_turn_path = session_dir.join(&prior_turn_artifact);
+    std::fs::create_dir_all(prior_turn_path.parent().expect("turn result parent"))
+        .expect("create prior turn result dir");
+    let stale_prior_result = SessionResult {
+        summary: "stale prior turn result must not be emitted".to_string(),
+        ..make_result("success", 0)
+    };
+    std::fs::write(
+        &prior_turn_path,
+        toml::to_string_pretty(&stale_prior_result).expect("serialize stale prior result"),
+    )
+    .expect("write stale prior turn result");
+    session.turn_count = 1;
+    save_session(&session).expect("save state after turn one");
+    let _contract_guard =
+        ScopedEnvVarRestore::set(csa_session::RESULT_TOML_PATH_CONTRACT_ENV, &prior_turn_path);
+
+    assert!(
+        !crate::pipeline::result_contract::current_result_artifact_marker_path(&session_dir)
+            .exists(),
+        "test setup requires no current-result marker"
+    );
+    assert!(
+        !csa_session::turn_contract_result_path(&session_dir, 2).exists(),
+        "test setup requires missing next-turn artifact"
+    );
+    assert!(
+        !session_dir
+            .join(csa_session::result::RESULT_FILE_NAME)
+            .exists(),
+        "test setup requires missing root result.toml"
+    );
+    assert_eq!(
+        crate::session_cmds_daemon::expected_in_flight_turn_result_artifact_path_for_test(
+            &session_dir
+        ),
+        None,
+        "stale inherited env path must not select the prior turn sidecar"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(10),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should ignore stale inherited contract env sidecar");
+
+    assert_eq!(exit_code, 1);
+    assert_eq!(
+        emitted_completion, None,
+        "stale prior summary must not be emitted as terminal completion"
+    );
+}
+
+#[test]
+fn handle_session_wait_accepts_inherited_contract_env_matching_state_next_turn_sidecar() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = ScopedEnvVarRestore::set("HOME", td.path());
+    let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let mut session = create_session(
+        project,
+        Some("wait-current-inherited-contract-env"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id.clone();
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    session.turn_count = 1;
+    save_session(&session).expect("save state after turn one");
+    let next_turn_artifact = csa_session::turn_contract_result_artifact_path(2);
+    let next_turn_path = session_dir.join(&next_turn_artifact);
+    std::fs::create_dir_all(next_turn_path.parent().expect("turn result parent"))
+        .expect("create next turn result dir");
+    let current_result = SessionResult {
+        summary: "state-derived current turn result".to_string(),
+        ..make_result("success", 0)
+    };
+    std::fs::write(
+        &next_turn_path,
+        toml::to_string_pretty(&current_result).expect("serialize current result"),
+    )
+    .expect("write state-derived current result");
+    let _contract_guard =
+        ScopedEnvVarRestore::set(csa_session::RESULT_TOML_PATH_CONTRACT_ENV, &next_turn_path);
+
+    assert!(
+        !crate::pipeline::result_contract::current_result_artifact_marker_path(&session_dir)
+            .exists(),
+        "test setup uses state-derived current path, not marker"
+    );
+    assert!(
+        !session_dir
+            .join(csa_session::result::RESULT_FILE_NAME)
+            .exists(),
+        "test setup requires missing root result.toml"
+    );
+    assert_eq!(
+        crate::session_cmds_daemon::expected_in_flight_turn_result_artifact_path_for_test(
+            &session_dir
+        ),
+        Some(next_turn_artifact),
+        "current inherited env path should be accepted when it matches state-derived next turn"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(10),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should accept current inherited contract env sidecar");
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id, "success".to_string(), 0, false))
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
@@ -124,6 +124,140 @@ fn handle_session_wait_completes_terminal_result_with_stale_daemon_pid() {
     );
 }
 
+#[test]
+fn handle_session_wait_detects_turn_scoped_output_result_fallback() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-turn-scoped-result-fallback"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let turn_result_path = csa_session::turn_contract_result_path(&session_dir, 1);
+    std::fs::create_dir_all(turn_result_path.parent().expect("turn result parent"))
+        .expect("create turn result dir");
+    let turn_result = SessionResult {
+        summary: "turn-scoped result fallback".to_string(),
+        ..make_result("success", 0)
+    };
+    let turn_result_toml =
+        toml::to_string_pretty(&turn_result).expect("serialize turn-scoped result");
+    std::fs::write(&turn_result_path, turn_result_toml).expect("write turn-scoped result");
+    assert!(
+        !session_dir
+            .join(csa_session::result::RESULT_FILE_NAME)
+            .exists(),
+        "test setup requires missing root result.toml"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should detect turn-scoped result fallback");
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id, "success".to_string(), 0, false))
+    );
+}
+
+#[test]
+fn handle_session_wait_does_not_reuse_prior_turn_output_result_fallback() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let mut session = create_session(
+        project,
+        Some("wait-does-not-reuse-prior-turn-result"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    session.turn_count = 1;
+    save_session(&session).expect("save completed turn count");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let prior_turn_result_path = csa_session::turn_contract_result_path(&session_dir, 1);
+    std::fs::create_dir_all(prior_turn_result_path.parent().expect("turn result parent"))
+        .expect("create prior turn result dir");
+    let prior_turn_result = SessionResult {
+        summary: "prior turn result must not be reused".to_string(),
+        ..make_result("success", 0)
+    };
+    let prior_turn_result_toml =
+        toml::to_string_pretty(&prior_turn_result).expect("serialize prior turn result");
+    std::fs::write(&prior_turn_result_path, prior_turn_result_toml)
+        .expect("write prior turn result");
+    assert!(
+        !csa_session::turn_contract_result_path(&session_dir, 2).exists(),
+        "test setup requires missing expected turn 2 result"
+    );
+    assert!(
+        !session_dir
+            .join(csa_session::result::RESULT_FILE_NAME)
+            .exists(),
+        "test setup requires missing root result.toml"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let _exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should not treat prior turn output as current completion");
+
+    assert_eq!(
+        emitted_completion, None,
+        "wait must not emit a success completion from turn 1 while waiting for turn 2"
+    );
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn handle_session_wait_ignores_intermediate_success_result_while_daemon_pid_alive() {

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs
@@ -1,0 +1,425 @@
+use super::*;
+use crate::session_cmds_daemon::{
+    SESSION_WAIT_MEMORY_WARN_EXIT_CODE, WaitBehavior, WaitLoopTiming, WaitReconciliationOutcome,
+    handle_session_wait_with_hooks, handle_session_wait_with_hooks_and_sampler,
+    try_acquire_session_wait_lock,
+};
+
+fn move_session_to_legacy_root(project: &std::path::Path, session_id: &str) -> std::path::PathBuf {
+    let primary_root = csa_session::get_session_root(project).unwrap();
+    let primary_session_dir = primary_root.join("sessions").join(session_id);
+    let primary_state_dir = csa_config::paths::state_dir_write().unwrap();
+    let legacy_state_dir = csa_config::paths::legacy_state_dir().unwrap();
+    let relative_root = primary_root.strip_prefix(&primary_state_dir).unwrap();
+    let legacy_root = legacy_state_dir.join(relative_root);
+    let legacy_sessions_dir = legacy_root.join("sessions");
+    std::fs::create_dir_all(&legacy_sessions_dir).unwrap();
+    let legacy_session_dir = legacy_sessions_dir.join(session_id);
+    std::fs::rename(&primary_session_dir, &legacy_session_dir).unwrap();
+    legacy_session_dir
+}
+
+fn set_tree_file_mtimes_seconds_ago(path: &std::path::Path, seconds_ago: u64) {
+    let stale_time = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(seconds_ago))
+        .unwrap();
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).unwrap().flatten() {
+            let path = entry.path();
+            let file_type = entry.file_type().unwrap();
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if file_type.is_file() {
+                let file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+                file.set_times(std::fs::FileTimes::new().set_modified(stale_time))
+                    .unwrap();
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn handle_session_wait_on_resume_wrapper_uses_worker_result() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let worker = create_session(project, Some("worker"), None, Some("codex")).unwrap();
+    let wrapper = create_session(project, Some("wrapper"), None, None).unwrap();
+    let worker_id = worker.meta_session_id;
+    let wrapper_id = wrapper.meta_session_id;
+    let wrapper_dir = get_session_dir(project, &wrapper_id).unwrap();
+    csa_session::write_resume_target(project, &wrapper_id, &worker_id).unwrap();
+    std::fs::write(
+        wrapper_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .unwrap();
+    save_result(project, &worker_id, &make_result("success", 0)).unwrap();
+
+    let exit_code = handle_session_wait(
+        wrapper_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(exit_code, 0);
+    assert!(
+        load_result(project, &wrapper_id).unwrap().is_none(),
+        "waiting on a resume wrapper must not synthesize or clobber wrapper result.toml"
+    );
+    let worker_result = load_result(project, &worker_id)
+        .unwrap()
+        .expect("worker result should remain authoritative");
+    assert_eq!(worker_result.status, "success");
+    assert_eq!(worker_result.exit_code, 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn handle_session_wait_on_resume_wrapper_continues_while_worker_target_alive_without_result() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let worker =
+        create_session(project, Some("worker-live-no-result"), None, Some("codex")).unwrap();
+    let wrapper =
+        create_session(project, Some("wrapper-completed-live-target"), None, None).unwrap();
+    let worker_id = worker.meta_session_id;
+    let wrapper_id = wrapper.meta_session_id;
+    let worker_dir = get_session_dir(project, &worker_id).unwrap();
+    let wrapper_dir = get_session_dir(project, &wrapper_id).unwrap();
+    csa_session::write_resume_target(project, &wrapper_id, &worker_id).unwrap();
+    std::fs::write(
+        wrapper_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .unwrap();
+    set_tree_file_mtimes_seconds_ago(&wrapper_dir, 120);
+    std::fs::write(
+        worker_dir.join("stderr.log"),
+        "worker target still producing diagnostics\n",
+    )
+    .unwrap();
+    assert!(
+        csa_process::ToolLiveness::is_alive(&worker_dir),
+        "test setup requires worker target liveness"
+    );
+    assert!(
+        !csa_process::ToolLiveness::is_alive(&wrapper_dir),
+        "test setup requires wrapper-only liveness to be dead"
+    );
+    assert!(
+        load_result(project, &worker_id).unwrap().is_none(),
+        "worker target result must be absent"
+    );
+
+    let mut reconciled_session_id: Option<String> = None;
+    let mut emitted_completion = false;
+    let exit_code = handle_session_wait_with_hooks(
+        wrapper_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, current_session_id, trigger| {
+            assert_eq!(trigger, "session wait");
+            reconciled_session_id = Some(current_session_id.to_string());
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |_sid: &str, _status: &str, _exit_code, _synthetic, _mirror_to_stdout| {
+            emitted_completion = true;
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        exit_code, 0,
+        "live worker target should keep wrapper wait in the nonterminal KV-warm path"
+    );
+    assert_eq!(reconciled_session_id, Some(worker_id.clone()));
+    assert!(
+        !emitted_completion,
+        "worker liveness without a result must not emit terminal completion"
+    );
+    assert!(
+        load_result(project, &wrapper_id).unwrap().is_none(),
+        "wrapper wait must not synthesize wrapper result.toml"
+    );
+    assert!(
+        load_result(project, &worker_id).unwrap().is_none(),
+        "worker result must remain absent while target is only live"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn handle_session_wait_on_resume_wrapper_memory_warn_samples_worker_target() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let worker = create_session(
+        project,
+        Some("worker-memory-warn-target"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let wrapper = create_session(project, Some("wrapper-memory-warn"), None, None).unwrap();
+    let worker_id = worker.meta_session_id;
+    let wrapper_id = wrapper.meta_session_id;
+    let worker_dir = get_session_dir(project, &worker_id).unwrap();
+    let wrapper_dir = get_session_dir(project, &wrapper_id).unwrap();
+    csa_session::write_resume_target(project, &wrapper_id, &worker_id).unwrap();
+    std::fs::write(
+        worker_dir.join("stderr.log"),
+        "worker target still producing diagnostics\n",
+    )
+    .unwrap();
+    set_tree_file_mtimes_seconds_ago(&wrapper_dir, 120);
+    assert!(
+        csa_process::ToolLiveness::is_alive(&worker_dir),
+        "test setup requires worker target liveness"
+    );
+    assert!(
+        !csa_process::ToolLiveness::is_alive(&wrapper_dir),
+        "test setup requires wrapper-only liveness to be dead"
+    );
+
+    let mut sampled_session_id: Option<String> = None;
+    let mut emitted_marker: Option<(String, u64, u64)> = None;
+    let exit_code = handle_session_wait_with_hooks_and_sampler(
+        wrapper_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 5,
+            memory_warn_mb: Some(64),
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::ZERO,
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |_sid: &str, _status: &str, _exit_code, _synthetic, _mirror_to_stdout| {
+            panic!("memory warn must not emit terminal completion");
+        },
+        |_project_root, session_id| {
+            sampled_session_id = Some(session_id.to_string());
+            Ok(65)
+        },
+        |session_id, rss_mb, limit_mb| {
+            emitted_marker = Some((session_id.to_string(), rss_mb, limit_mb));
+        },
+    )
+    .unwrap();
+
+    assert_eq!(exit_code, SESSION_WAIT_MEMORY_WARN_EXIT_CODE);
+    assert_eq!(sampled_session_id, Some(worker_id.clone()));
+    assert_eq!(emitted_marker, Some((worker_id, 65, 64)));
+}
+
+#[cfg(unix)]
+#[test]
+fn handle_session_wait_on_resume_wrapper_reconciles_worker_after_wrapper_completion() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let worker = create_session(project, Some("worker-no-result"), None, Some("codex")).unwrap();
+    let wrapper = create_session(project, Some("wrapper-completed"), None, None).unwrap();
+    let worker_id = worker.meta_session_id;
+    let wrapper_id = wrapper.meta_session_id;
+    let wrapper_dir = get_session_dir(project, &wrapper_id).unwrap();
+    csa_session::write_resume_target(project, &wrapper_id, &worker_id).unwrap();
+    std::fs::write(
+        wrapper_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .unwrap();
+    assert!(
+        load_result(project, &worker_id).unwrap().is_none(),
+        "test setup requires missing worker result.toml"
+    );
+
+    let mut reconciled_session_id: Option<String> = None;
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        wrapper_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, current_session_id, trigger| {
+            assert_eq!(trigger, "session wait");
+            reconciled_session_id = Some(current_session_id.to_string());
+            assert_eq!(
+                current_session_id, worker_id,
+                "resume wrapper wait must reconcile the worker target"
+            );
+            save_result(project, current_session_id, &make_result("success", 0))?;
+            Ok(WaitReconciliationOutcome {
+                result_became_available: true,
+                synthetic: false,
+            })
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .unwrap();
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(reconciled_session_id, Some(worker_id.clone()));
+    assert_eq!(
+        emitted_completion,
+        Some((wrapper_id.clone(), "success".to_string(), 0, false))
+    );
+    assert!(
+        load_result(project, &wrapper_id).unwrap().is_none(),
+        "wrapper completion must not synthesize wrapper result.toml"
+    );
+    assert!(
+        load_result(project, &worker_id).unwrap().is_some(),
+        "worker result should become authoritative"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn handle_session_wait_on_resume_wrapper_follows_worker_in_legacy_root() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let worker = create_session(project, Some("worker-legacy"), None, Some("codex")).unwrap();
+    let wrapper = create_session(project, Some("wrapper-legacy"), None, None).unwrap();
+    let worker_id = worker.meta_session_id;
+    let wrapper_id = wrapper.meta_session_id;
+    let wrapper_dir = get_session_dir(project, &wrapper_id).unwrap();
+    let worker_dir = move_session_to_legacy_root(project, &worker_id);
+    csa_session::write_resume_target(project, &wrapper_id, &worker_id)
+        .expect("resume wrapper alias should accept a legacy-root target");
+    std::fs::write(
+        wrapper_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .unwrap();
+    save_result(project, &worker_id, &make_result("success", 0)).unwrap();
+
+    let exit_code = handle_session_wait(
+        wrapper_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        1,
+    )
+    .unwrap();
+
+    assert_eq!(exit_code, 0);
+    assert!(
+        load_result(project, &wrapper_id).unwrap().is_none(),
+        "waiting on a cross-root resume wrapper must not synthesize wrapper result.toml"
+    );
+    assert!(
+        worker_dir.join("result.toml").is_file(),
+        "worker result should stay in the legacy-root session directory"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn handle_session_wait_on_resume_wrapper_uses_target_wait_lock() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let worker = create_session(project, Some("worker-lock"), None, Some("codex")).unwrap();
+    let wrapper = create_session(project, Some("wrapper-lock"), None, None).unwrap();
+    let worker_id = worker.meta_session_id;
+    let wrapper_id = wrapper.meta_session_id;
+    let wrapper_dir = get_session_dir(project, &wrapper_id).unwrap();
+    let worker_dir = move_session_to_legacy_root(project, &worker_id);
+    csa_session::write_resume_target(project, &wrapper_id, &worker_id)
+        .expect("resume wrapper alias should accept a legacy-root target");
+    std::fs::write(
+        wrapper_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .unwrap();
+    save_result(project, &worker_id, &make_result("success", 0)).unwrap();
+    let _worker_wait_lock = try_acquire_session_wait_lock(&worker_dir)
+        .expect("pre-acquire worker wait lock")
+        .expect("worker wait lock should be acquired");
+
+    let mut reconcile_called = false;
+    let exit_code = handle_session_wait_with_hooks(
+        wrapper_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            reconcile_called = true;
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |_sid: &str, _status: &str, _exit_code, _synthetic, _mirror_to_stdout| {},
+    )
+    .unwrap();
+
+    assert_eq!(exit_code, 1);
+    assert!(
+        !reconcile_called,
+        "duplicate target wait lock must short-circuit"
+    );
+    assert!(
+        !wrapper_dir.join(".wait.lock").exists(),
+        "wrapper-id wait should not acquire an independent wrapper lock"
+    );
+}

--- a/crates/cli-sub-agent/src/session_observability.rs
+++ b/crates/cli-sub-agent/src/session_observability.rs
@@ -521,7 +521,7 @@ fn merge_artifacts(artifacts: &mut Vec<SessionArtifact>, artifact_names: Vec<Str
     for name in artifact_names {
         let path = format!("output/{name}");
         if seen.insert(path.clone()) {
-            artifacts.push(SessionArtifact::new(path));
+            artifacts.push(csa_session::observed_session_artifact(path));
             changed = true;
         }
     }
@@ -674,6 +674,10 @@ fn is_cjk(ch: char) -> bool {
 fn truncate_summary(line: &str) -> String {
     line.chars().take(SUMMARY_MAX_CHARS).collect()
 }
+
+#[cfg(test)]
+#[path = "session_observability_result_artifact_tests.rs"]
+mod result_artifact_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/cli-sub-agent/src/session_observability_result_artifact_tests.rs
+++ b/crates/cli-sub-agent/src/session_observability_result_artifact_tests.rs
@@ -1,0 +1,116 @@
+use super::*;
+
+fn runtime_result(summary: &str, artifact_path: &str) -> SessionResult {
+    let now = chrono::Utc::now();
+    SessionResult {
+        post_exec_gate: None,
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: summary.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: vec![SessionArtifact::new(artifact_path)],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn refresh_and_repair_result_does_not_overwrite_in_flight_turn_sidecar() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let _state_guard =
+        crate::test_env_lock::ScopedTestEnvVar::set("XDG_STATE_HOME", temp.path().join("state"));
+    let project_root = temp.path().join("project");
+    fs::create_dir_all(&project_root).expect("create project");
+    let session = csa_session::create_session(
+        &project_root,
+        Some("refresh sidecar ownership regression"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session.meta_session_id).expect("session dir");
+    let turn_one_artifact = csa_session::turn_contract_result_artifact_path(1);
+    let turn_two_artifact = csa_session::turn_contract_result_artifact_path(2);
+    let turn_one_path = session_dir.join(&turn_one_artifact);
+    let turn_two_path = session_dir.join(&turn_two_artifact);
+
+    fs::create_dir_all(turn_one_path.parent().expect("turn one parent"))
+        .expect("create turn one parent");
+    fs::write(
+        &turn_one_path,
+        r#"
+[report]
+what_was_done = "completed turn one report"
+"#,
+    )
+    .expect("write turn one sidecar");
+    csa_session::save_result(
+        &project_root,
+        &session.meta_session_id,
+        &runtime_result("completed turn one", &turn_one_artifact),
+    )
+    .expect("save completed turn one envelope");
+
+    fs::create_dir_all(turn_two_path.parent().expect("turn two parent"))
+        .expect("create turn two parent");
+    fs::write(
+        &turn_two_path,
+        r#"
+[report]
+what_was_done = "in-flight turn two report"
+"#,
+    )
+    .expect("write in-flight turn two sidecar");
+    let turn_two_before = fs::read_to_string(&turn_two_path).expect("read turn two before");
+
+    let refreshed = refresh_and_repair_result(&project_root, &session.meta_session_id)
+        .expect("refresh result")
+        .expect("result should exist");
+
+    assert_eq!(
+        fs::read_to_string(&turn_two_path).expect("read turn two after"),
+        turn_two_before,
+        "observation refresh must not overwrite an in-flight turn result sidecar"
+    );
+    assert!(
+        fs::read_to_string(&turn_one_path)
+            .expect("read turn one after")
+            .contains("completed turn one report"),
+        "owned turn one sidecar should remain the manager report source"
+    );
+    assert!(
+        refreshed
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == turn_one_artifact && !artifact.display_only),
+        "completed turn one sidecar remains the owned manager artifact"
+    );
+    assert!(
+        refreshed
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == turn_two_artifact && artifact.display_only),
+        "in-flight turn two sidecar remains visible but display-only"
+    );
+
+    let loaded = csa_session::load_result(&project_root, &session.meta_session_id)
+        .expect("load result")
+        .expect("result should exist");
+    assert_eq!(
+        loaded
+            .manager_fields
+            .report
+            .as_ref()
+            .and_then(|value| value.get("what_was_done")),
+        Some(&toml::Value::String(
+            "completed turn one report".to_string()
+        )),
+        "subsequent loads must ignore display-only in-flight sidecars for manager overlay"
+    );
+}

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -487,7 +487,7 @@ impl Executor {
                 cmd.env("CSA_SESSION_DIR", dir.to_string_lossy().into_owned());
                 cmd.env(
                     csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
-                    csa_session::contract_result_path(&dir)
+                    csa_session::next_turn_contract_result_path(&dir, session.turn_count)
                         .to_string_lossy()
                         .into_owned(),
                 );

--- a/crates/csa-executor/src/executor_build_cmd_tests.rs
+++ b/crates/csa-executor/src/executor_build_cmd_tests.rs
@@ -113,8 +113,8 @@ fn test_build_command_sets_csa_session_dir() {
         .expect("CSA_RESULT_TOML_PATH_CONTRACT should have a value");
     let result_contract_path = result_contract_path.to_string_lossy();
     assert!(
-        result_contract_path.ends_with("/output/result.toml"),
-        "contract path should target the session output/result.toml artifact, got: {result_contract_path}"
+        result_contract_path.ends_with("/output/turns/turn-000001/result.toml"),
+        "bad result path: {result_contract_path}"
     );
     assert!(
         result_contract_path.contains("01HTEST000000000000000000"),
@@ -277,8 +277,8 @@ fn test_build_command_reserved_session_paths_override_extra_env() {
         .expect("CSA_RESULT_TOML_PATH_CONTRACT should have a value")
         .to_string_lossy();
     assert!(
-        result_contract_path.ends_with("/output/result.toml"),
-        "reserved result contract path should override extra_env, got: {result_contract_path}"
+        result_contract_path.ends_with("/output/turns/turn-000001/result.toml"),
+        "bad result path: {result_contract_path}"
     );
     assert!(
         result_contract_path.contains("01HTEST000000000000000000"),

--- a/crates/csa-executor/src/transport_cli.rs
+++ b/crates/csa-executor/src/transport_cli.rs
@@ -463,7 +463,7 @@ fn inject_cli_session_env(cmd: &mut Command, session: &MetaSessionState) {
         );
         cmd.env(
             csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
-            csa_session::contract_result_path(&session_dir)
+            csa_session::next_turn_contract_result_path(&session_dir, session.turn_count)
                 .to_string_lossy()
                 .into_owned(),
         );

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -243,7 +243,7 @@ impl AcpTransport {
             );
             env.insert(
                 csa_session::RESULT_TOML_PATH_CONTRACT_ENV.to_string(),
-                csa_session::contract_result_path(&dir)
+                csa_session::next_turn_contract_result_path(&dir, session.turn_count)
                     .to_string_lossy()
                     .into_owned(),
             );
@@ -612,7 +612,7 @@ mod tests {
             .get(csa_session::RESULT_TOML_PATH_CONTRACT_ENV)
             .expect("CSA_RESULT_TOML_PATH_CONTRACT should be present");
         assert!(
-            result_contract_path.ends_with("/output/result.toml"),
+            result_contract_path.ends_with("/output/turns/turn-000001/result.toml"),
             "result contract path should be recomputed after merge, got: {result_contract_path}"
         );
         assert!(

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -346,8 +346,8 @@ fn test_acp_build_env_includes_csa_session_dir() {
         .get("CSA_RESULT_TOML_PATH_CONTRACT")
         .expect("CSA_RESULT_TOML_PATH_CONTRACT should be present in env");
     assert!(
-        result_contract_path.ends_with("/output/result.toml"),
-        "contract path should point to output/result.toml, got: {result_contract_path}"
+        result_contract_path.ends_with("/output/turns/turn-000001/result.toml"),
+        "bad result path: {result_contract_path}"
     );
     assert!(
         result_contract_path.contains("01HTEST000000000000000000"),
@@ -419,7 +419,7 @@ fn test_acp_build_env_reserved_session_paths_override_extra_env() {
         .get("CSA_RESULT_TOML_PATH_CONTRACT")
         .expect("CSA_RESULT_TOML_PATH_CONTRACT should be present");
     assert!(
-        result_contract_path.ends_with("/output/result.toml"),
+        result_contract_path.ends_with("/output/turns/turn-000001/result.toml"),
         "reserved result contract path should override extra_env, got: {result_contract_path}"
     );
     assert!(

--- a/crates/csa-executor/src/transport_tmux.rs
+++ b/crates/csa-executor/src/transport_tmux.rs
@@ -1,13 +1,10 @@
 //! TmuxTransport — runs Claude Code inside a detached tmux session.
-//!
 //! ## Why tmux?
-//!
 //! Anthropic's interactive billing pool (unlimited) applies to terminal-based
 //! Claude Code sessions. The tmux transport wraps Claude in a real interactive
 //! terminal session so CSA usage is billed there rather than against Agent SDK
 //! credits (June 2026 cap). This is an **Experimental** transport — billing
 //! classification may change.
-//!
 //! ## Lifecycle
 //!
 //! 1. Snapshot existing `.jsonl` files in `~/.claude/projects/<escaped-path>/`
@@ -18,10 +15,9 @@
 //!    through tmux
 //! 5. Discover new JSONL: diff snapshot to find newly created `.jsonl` file
 //! 6. Tail JSONL until `type=system subtype=turn_duration` marker
-//! 7. Read output: prefer `output/result.toml` (if child wrote it), fall back to JSONL text
+//! 7. Read output: prefer expected turn `result.toml`; fall back to JSONL text
 //! 8. Symlink Claude JSONL → `<session_dir>/output/claude-conversation.jsonl` for audit
 //! 9. Kill tmux session on Drop (`TmuxCleanupGuard`)
-//!
 //! ## Limitations
 //!
 //! - Incompatible with bwrap/landlock filesystem sandbox (tmux spawns outside
@@ -279,30 +275,19 @@ async fn deliver_prompt(session_name: &str, prompt: &str, prompt_file_path: &Pat
 
 // ── Result contract ──────────────────────────────────────────────────────────
 
-/// Read the `output/result.toml` contract artifact if the child agent wrote one.
-/// Checks both top-level `summary` (canonical CSA `SessionResult` schema) and
-/// nested `[result].summary` for robustness. Returns `None` when the file is
-/// absent or contains neither variant so callers fall back to JSONL text.
-fn try_read_contract_result(session_dir: &Path) -> Option<String> {
-    let path = csa_session::contract_result_path(session_dir);
+/// Read the expected `result.toml`; return `None` so callers can use JSONL fallback.
+fn try_read_contract_result(session_dir: &Path, artifact: Option<&str>) -> Option<String> {
+    let path = artifact
+        .map(|artifact| session_dir.join(artifact))
+        .unwrap_or_else(|| csa_session::contract_result_path(session_dir));
     let contents = fs::read_to_string(&path).ok()?;
     let table: toml::Table = toml::from_str(&contents).ok()?;
-    let summary = table
-        .get("summary")
-        .and_then(|v| v.as_str())
-        .or_else(|| {
-            table
-                .get("result")
-                .and_then(|v| v.as_table())
-                .and_then(|t| t.get("summary"))
-                .and_then(|v| v.as_str())
-        })
-        .map(String::from)?;
-    tracing::debug!(
-        path = %path.display(),
-        summary_len = summary.len(),
-        "tmux transport: read result.toml contract output"
-    );
+    let nested = table
+        .get("result")
+        .and_then(|v| v.as_table())
+        .and_then(|t| t.get("summary"));
+    let summary = table.get("summary").or(nested)?.as_str()?.to_string();
+    tracing::debug!(path = %path.display(), "tmux transport: read result.toml");
     Some(summary)
 }
 
@@ -495,11 +480,12 @@ impl TmuxTransport {
             _ => (None, None),
         };
 
-        let (merged_env, session_dir) = {
+        let (merged_env, session_dir, expected_result_artifact_path) = {
             let mut env = extra_env.cloned().unwrap_or_default();
             csa_core::env::scrub_subtree_contract_env_map(&mut env);
             csa_core::env::strip_git_push_authorization_keys(&mut env);
             let mut dir = None;
+            let mut expected_artifact_path = None;
             if let Some(session) = session {
                 env.insert("CSA_SESSION_ID".into(), session.meta_session_id.clone());
                 env.insert(
@@ -522,12 +508,17 @@ impl TmuxTransport {
                         "CSA_SESSION_DIR".into(),
                         session_dir_path.to_string_lossy().into_owned(),
                     );
+                    let artifact =
+                        csa_session::next_turn_contract_result_artifact_path(session.turn_count);
+                    let result_path = session_dir_path
+                        .join(&artifact)
+                        .to_string_lossy()
+                        .into_owned();
                     env.insert(
                         csa_session::RESULT_TOML_PATH_CONTRACT_ENV.into(),
-                        csa_session::contract_result_path(&session_dir_path)
-                            .to_string_lossy()
-                            .into_owned(),
+                        result_path,
                     );
+                    expected_artifact_path = Some(artifact);
                     dir = Some(session_dir_path);
                 }
                 if let Some(parent) = session.genealogy.parent_session_id.as_deref()
@@ -554,7 +545,7 @@ impl TmuxTransport {
                     "true".to_string(),
                 );
             }
-            (env, dir)
+            (env, dir, expected_artifact_path)
         };
 
         Self::spawn_tmux(
@@ -606,13 +597,10 @@ impl TmuxTransport {
             "tmux transport: turn complete"
         );
 
-        // Prefer result.toml written by the child agent (if session_dir is set
-        // and the prompt instructed Claude to write there). Fall back to JSONL
-        // text extraction when result.toml is absent.
-        let output_text = match &session_dir {
-            Some(dir) => try_read_contract_result(dir).unwrap_or(jsonl_fallback_text),
-            None => jsonl_fallback_text,
-        };
+        let output_text = session_dir
+            .as_deref()
+            .and_then(|dir| try_read_contract_result(dir, expected_result_artifact_path.as_deref()))
+            .unwrap_or(jsonl_fallback_text);
 
         // Symlink Claude's JSONL into the CSA session output dir so xurl/recall
         // can locate the conversation log by CSA session ID.

--- a/crates/csa-executor/src/transport_tmux_tests.rs
+++ b/crates/csa-executor/src/transport_tmux_tests.rs
@@ -441,7 +441,7 @@ fn read_contract_result_returns_summary_when_present() {
     )
     .unwrap();
 
-    let result = try_read_contract_result(tmp.path());
+    let result = try_read_contract_result(tmp.path(), None);
     assert_eq!(result, Some("The task is done.".to_string()));
 }
 
@@ -456,14 +456,58 @@ fn read_contract_result_reads_nested_result_summary() {
     )
     .unwrap();
 
-    let result = try_read_contract_result(tmp.path());
+    let result = try_read_contract_result(tmp.path(), None);
     assert_eq!(result, Some("Nested result.".to_string()));
+}
+
+#[test]
+fn read_contract_result_reads_expected_turn_scoped_summary() {
+    let tmp = TempDir::new().unwrap();
+    let legacy_output = tmp.path().join("output");
+    fs::create_dir_all(&legacy_output).unwrap();
+    fs::write(
+        legacy_output.join("result.toml"),
+        "status = \"success\"\nsummary = \"Legacy result.\"\nexit_code = 0\n",
+    )
+    .unwrap();
+    let turn_output = tmp.path().join("output/turns/turn-000002");
+    fs::create_dir_all(&turn_output).unwrap();
+    fs::write(
+        turn_output.join("result.toml"),
+        "status = \"success\"\nsummary = \"Latest turn result.\"\nexit_code = 0\n",
+    )
+    .unwrap();
+
+    let result = try_read_contract_result(
+        tmp.path(),
+        Some(csa_session::turn_contract_result_artifact_path(2).as_str()),
+    );
+    assert_eq!(result, Some("Latest turn result.".to_string()));
+}
+
+#[test]
+fn read_contract_result_does_not_reuse_prior_turn_when_expected_turn_missing() {
+    let tmp = TempDir::new().unwrap();
+    let prior_turn_output = tmp.path().join("output/turns/turn-000001");
+    fs::create_dir_all(&prior_turn_output).unwrap();
+    fs::write(
+        prior_turn_output.join("result.toml"),
+        "status = \"success\"\nsummary = \"Prior turn result.\"\nexit_code = 0\n",
+    )
+    .unwrap();
+
+    let result = try_read_contract_result(
+        tmp.path(),
+        Some(csa_session::turn_contract_result_artifact_path(2).as_str()),
+    );
+
+    assert_eq!(result, None);
 }
 
 #[test]
 fn read_contract_result_returns_none_when_missing() {
     let tmp = TempDir::new().unwrap();
-    assert!(try_read_contract_result(tmp.path()).is_none());
+    assert!(try_read_contract_result(tmp.path(), None).is_none());
 }
 
 #[test]
@@ -473,7 +517,7 @@ fn read_contract_result_returns_none_when_no_summary_field() {
     fs::create_dir_all(&output).unwrap();
     fs::write(output.join("result.toml"), "status = \"success\"\n").unwrap();
 
-    assert!(try_read_contract_result(tmp.path()).is_none());
+    assert!(try_read_contract_result(tmp.path(), None).is_none());
 }
 
 // ── create_jsonl_audit_symlink ──────────────────────────────────────────

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -97,15 +97,23 @@ pub use manager::{
     RepoWriteAudit, SaveOptions, SignalResultMetadata, clear_manager_sidecar, complete_session,
     compute_repo_write_audit, contract_result_path, create_session, create_session_fresh,
     create_session_with_daemon_env, decode_session_created_at, delete_session,
-    delete_session_from_root, detect_git_head, find_sessions, get_session_dir,
-    get_session_dir_global, get_session_root, legacy_user_result_path,
-    list_all_project_session_roots, list_all_sessions, list_all_sessions_all_projects,
-    list_artifacts, list_sessions, list_sessions_from_root, list_sessions_from_root_readonly,
-    list_sessions_readonly, load_metadata, load_result, load_result_view, load_session,
-    load_session_global_exact, redact_result_sidecar_value, render_redacted_result_sidecar,
+    delete_session_from_root, detect_git_head, existing_next_turn_contract_result_artifact_path,
+    existing_turn_contract_result_artifact_path, find_sessions, get_session_dir,
+    get_session_dir_global, get_session_root, is_manager_result_artifact_path,
+    latest_manager_result_artifact_path, legacy_user_result_path, list_all_project_session_roots,
+    list_all_sessions, list_all_sessions_all_projects, list_artifacts, list_sessions,
+    list_sessions_from_root, list_sessions_from_root_readonly, list_sessions_readonly,
+    load_metadata, load_result, load_result_view, load_session, load_session_global_exact,
+    next_turn_contract_result_artifact_path, next_turn_contract_result_path,
+    observed_session_artifact, redact_result_sidecar_value, render_redacted_result_sidecar,
     resolve_fork_source, resolve_resume_session, save_result, save_result_with_options,
-    save_result_with_signal_metadata, save_session, save_session_in, update_last_accessed,
+    save_result_with_signal_metadata, save_session, save_session_in,
+    turn_contract_result_artifact_path, turn_contract_result_path, update_last_accessed,
     validate_tool_access, write_audit_warning_artifact,
+};
+pub use manager::{
+    RESUME_TARGET_FILE_NAME, ResumeTargetResolution, read_resume_target_from_dir,
+    resolve_resume_target_from_dir, write_resume_target,
 };
 
 pub use manager::ResumeSessionResolution;

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -24,6 +24,8 @@ mod manager_paths;
 mod manager_recovery;
 #[path = "manager_result.rs"]
 mod manager_result;
+#[path = "manager_resume_alias.rs"]
+mod manager_resume_alias;
 #[path = "manager_vcs.rs"]
 mod manager_vcs;
 
@@ -44,14 +46,22 @@ use manager_paths::{legacy_session_root, normalize_project_path};
 pub use manager_result::{
     CONTRACT_RESULT_ARTIFACT_PATH, LEGACY_USER_RESULT_ARTIFACT_PATH, RESULT_TOML_PATH_CONTRACT_ENV,
     SaveOptions, SessionResultView, SignalResultMetadata, clear_manager_sidecar,
-    contract_result_path, legacy_user_result_path, list_artifacts, load_result, load_result_view,
-    redact_result_sidecar_value, render_redacted_result_sidecar, save_result,
-    save_result_with_options, save_result_with_signal_metadata,
+    contract_result_path, existing_next_turn_contract_result_artifact_path,
+    existing_turn_contract_result_artifact_path, is_manager_result_artifact_path,
+    latest_manager_result_artifact_path, legacy_user_result_path, list_artifacts, load_result,
+    load_result_view, next_turn_contract_result_artifact_path, next_turn_contract_result_path,
+    observed_session_artifact, redact_result_sidecar_value, render_redacted_result_sidecar,
+    save_result, save_result_with_options, save_result_with_signal_metadata,
+    turn_contract_result_artifact_path, turn_contract_result_path,
 };
 #[cfg(test)]
 pub(crate) use manager_result::{
     list_artifacts_in, load_result_in, load_result_view_in, save_result_in,
     save_result_with_signal_metadata_in,
+};
+pub use manager_resume_alias::{
+    RESUME_TARGET_FILE_NAME, ResumeTargetResolution, read_resume_target_from_dir,
+    resolve_resume_target_from_dir, write_resume_target,
 };
 pub use manager_vcs::detect_git_head;
 use manager_vcs::{detect_change_id, detect_current_branch, detect_git_status_porcelain};
@@ -634,3 +644,6 @@ pub(crate) fn complete_session_in(
 #[cfg(test)]
 #[path = "manager_tests.rs"]
 mod tests;
+#[cfg(test)]
+#[path = "manager_tests_turn_results.rs"]
+mod turn_result_tests;

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, bail};
 use serde::Serialize;
 use std::fs;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 const TRANSCRIPT_FILE_NAME: &str = "acp-events.jsonl";
 const USER_RESULT_FILE_NAME: &str = "user-result.toml";
@@ -37,8 +37,22 @@ const RUNTIME_RESULT_KEYS: [&str; 22] = [
     "last_item",
 ];
 
+#[path = "manager_result_artifacts.rs"]
+mod manager_result_artifacts;
 #[path = "manager_result_spillover.rs"]
 mod manager_result_spillover;
+
+use manager_result_artifacts::{
+    collect_output_artifacts, referenced_manager_sidecar_artifact, remove_manager_result_artifacts,
+    select_manager_sidecar_artifact_path,
+};
+pub use manager_result_artifacts::{
+    contract_result_path, existing_next_turn_contract_result_artifact_path,
+    existing_turn_contract_result_artifact_path, is_manager_result_artifact_path,
+    latest_manager_result_artifact_path, legacy_user_result_path,
+    next_turn_contract_result_artifact_path, next_turn_contract_result_path,
+    observed_session_artifact, turn_contract_result_artifact_path, turn_contract_result_path,
+};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SaveOptions {
@@ -178,8 +192,15 @@ fn save_result_in_with_threshold(
 
     let mut persisted_result = result.clone();
     let requested_manager_sidecar = persisted_result.manager_fields.as_sidecar();
-    let preserve_existing_manager_sidecar = requested_manager_sidecar.is_some()
-        || (!options.clear_stale_manager_sidecar && manager_sidecar_exists(&session_dir));
+    let has_requested_manager_sidecar = requested_manager_sidecar.is_some();
+    let has_referenced_manager_sidecar =
+        referenced_manager_sidecar_artifact(&persisted_result).is_some();
+    let manager_sidecar_artifact_path =
+        select_manager_sidecar_artifact_path(&persisted_result, has_requested_manager_sidecar);
+    let preserve_existing_manager_sidecar = has_requested_manager_sidecar
+        || (!options.clear_stale_manager_sidecar
+            && has_referenced_manager_sidecar
+            && manager_sidecar_exists(&session_dir, &manager_sidecar_artifact_path));
     if has_custom_schema {
         let Some(contents) = existing_contents.as_deref() else {
             bail!("Expected existing result content when custom schema was detected");
@@ -190,6 +211,7 @@ fn save_result_in_with_threshold(
         &session_dir,
         &mut persisted_result,
         preserve_existing_manager_sidecar,
+        &manager_sidecar_artifact_path,
     )?;
     let manager_sidecar = if let Some(sidecar) = requested_manager_sidecar {
         Some(
@@ -204,23 +226,25 @@ fn save_result_in_with_threshold(
         manager_result_spillover::load_existing_manager_sidecar_for_publish(
             &session_dir,
             &mut persisted_result,
+            &manager_sidecar_artifact_path,
             spill_threshold_bytes,
         )?
     } else {
         None
     };
     if manager_sidecar.is_none() && preserve_existing_manager_sidecar {
-        ensure_result_artifact(&mut persisted_result, CONTRACT_RESULT_ARTIFACT_PATH);
+        ensure_result_artifact(&mut persisted_result, &manager_sidecar_artifact_path);
     } else {
-        remove_result_artifact(&mut persisted_result, CONTRACT_RESULT_ARTIFACT_PATH);
+        remove_manager_result_artifacts(&mut persisted_result);
     }
     let clear_manager_sidecar_after_publish =
         manager_sidecar.is_none() && options.clear_stale_manager_sidecar;
     if let Some(sidecar) = manager_sidecar.as_ref() {
         // Publish the sidecar before the envelope so the authoritative
         // envelope never points at a sidecar path that failed to write.
-        write_result_sidecar(&session_dir, CONTRACT_RESULT_ARTIFACT_PATH, sidecar)?;
-        ensure_result_artifact(&mut persisted_result, CONTRACT_RESULT_ARTIFACT_PATH);
+        write_result_sidecar(&session_dir, &manager_sidecar_artifact_path, sidecar)?;
+        remove_manager_result_artifacts(&mut persisted_result);
+        ensure_result_artifact(&mut persisted_result, &manager_sidecar_artifact_path);
     }
 
     let runtime_table = session_result_to_table(&persisted_result)?;
@@ -237,12 +261,12 @@ fn save_result_in_with_threshold(
         // Mirror round-7's write-path atomicity: on clear, publish the
         // envelope first so it never points at a sidecar that was deleted
         // before the new envelope became durable.
-        if let Err(err) = clear_manager_sidecar(&session_dir) {
+        if let Err(err) = clear_manager_sidecar_at(&session_dir, &manager_sidecar_artifact_path) {
             // NOTE: stale sidecar on disk is harmless. load_result_in gates the overlay
-            // on envelope.artifacts containing CONTRACT_RESULT_ARTIFACT_PATH (#956 Option A),
+            // on envelope.artifacts containing the selected manager sidecar path (#956 Option A),
             // so even if the unlink fails, the stale sidecar will be ignored on reload.
             tracing::warn!(
-                path = %contract_result_path(&session_dir).display(),
+                path = %session_dir.join(&manager_sidecar_artifact_path).display(),
                 error = %err,
                 "Failed to remove manager sidecar after envelope publication"
             );
@@ -251,12 +275,18 @@ fn save_result_in_with_threshold(
     Ok(())
 }
 
-fn manager_sidecar_exists(session_dir: &Path) -> bool {
-    session_dir.join(CONTRACT_RESULT_ARTIFACT_PATH).exists()
+fn manager_sidecar_exists(session_dir: &Path, artifact_path: &str) -> bool {
+    session_dir.join(artifact_path).exists()
 }
 
 pub fn clear_manager_sidecar(session_dir: &Path) -> Result<()> {
-    let manager_sidecar_path = session_dir.join(CONTRACT_RESULT_ARTIFACT_PATH);
+    let artifact_path = latest_manager_result_artifact_path(session_dir)
+        .unwrap_or_else(|| CONTRACT_RESULT_ARTIFACT_PATH.to_string());
+    clear_manager_sidecar_at(session_dir, &artifact_path)
+}
+
+fn clear_manager_sidecar_at(session_dir: &Path, artifact_path: &str) -> Result<()> {
+    let manager_sidecar_path = session_dir.join(artifact_path);
     if !manager_sidecar_path.exists() {
         return Ok(());
     }
@@ -300,21 +330,15 @@ fn preserve_user_result_snapshot(session_dir: &Path, contents: &str) -> Result<(
     })
 }
 
-pub fn contract_result_path(session_dir: &Path) -> PathBuf {
-    session_dir.join(CONTRACT_RESULT_ARTIFACT_PATH)
-}
-
-pub fn legacy_user_result_path(session_dir: &Path) -> PathBuf {
-    session_dir.join(LEGACY_USER_RESULT_ARTIFACT_PATH)
-}
-
 fn retain_sidecar_result_artifacts_if_present(
     session_dir: &Path,
     result: &mut SessionResult,
     retain_contract_sidecar: bool,
+    manager_sidecar_artifact_path: &str,
 ) -> Result<()> {
+    remove_manager_result_artifacts(result);
     if retain_contract_sidecar {
-        retain_result_artifact_if_present(session_dir, result, CONTRACT_RESULT_ARTIFACT_PATH)?;
+        retain_result_artifact_if_present(session_dir, result, manager_sidecar_artifact_path)?;
     }
     retain_result_artifact_if_present(session_dir, result, LEGACY_USER_RESULT_ARTIFACT_PATH)?;
     Ok(())
@@ -348,12 +372,6 @@ fn ensure_result_artifact(result: &mut SessionResult, artifact_path: &str) {
         return;
     }
     result.artifacts.push(SessionArtifact::new(artifact_path));
-}
-
-fn remove_result_artifact(result: &mut SessionResult, artifact_path: &str) {
-    result
-        .artifacts
-        .retain(|artifact| artifact.path != artifact_path);
 }
 
 fn write_result_sidecar(
@@ -447,6 +465,7 @@ fn artifacts_value_matches_runtime_schema(value: &toml::Value) -> bool {
                 "line_count" | "size_bytes" => {
                     value.as_integer().map(|num| num >= 0).unwrap_or(false)
                 }
+                "display_only" => value.is_bool(),
                 _ => false,
             })
         }
@@ -523,7 +542,6 @@ pub(crate) fn load_result_in(base_dir: &Path, session_id: &str) -> Result<Option
     validate_session_id(session_id)?;
     let session_dir = super::get_session_dir_in(base_dir, session_id);
     let result_path = session_dir.join(RESULT_FILE_NAME);
-    let manager_sidecar_path = session_dir.join(CONTRACT_RESULT_ARTIFACT_PATH);
     if !result_path.exists() {
         return Ok(None);
     }
@@ -531,14 +549,14 @@ pub(crate) fn load_result_in(base_dir: &Path, session_id: &str) -> Result<Option
         .with_context(|| format!("Failed to read result: {}", result_path.display()))?;
     let mut result: SessionResult = toml::from_str(&contents)
         .with_context(|| format!("Failed to parse result: {}", result_path.display()))?;
-    let envelope_references_manager_sidecar = result
-        .artifacts
-        .iter()
-        .any(|artifact| artifact.path == CONTRACT_RESULT_ARTIFACT_PATH);
-    if envelope_references_manager_sidecar {
+    let manager_sidecar_artifact = referenced_manager_sidecar_artifact(&result);
+    let manager_sidecar_path = manager_sidecar_artifact
+        .map(|artifact| session_dir.join(artifact))
+        .unwrap_or_else(|| session_dir.join(CONTRACT_RESULT_ARTIFACT_PATH));
+    if let Some(manager_sidecar_artifact) = manager_sidecar_artifact {
         let manager_sidecar = load_optional_result_sidecar(
             &session_dir,
-            CONTRACT_RESULT_ARTIFACT_PATH,
+            manager_sidecar_artifact,
         )
         .unwrap_or_else(|error| {
             tracing::warn!(
@@ -564,15 +582,12 @@ pub(crate) fn load_result_view_in(
         return Ok(None);
     };
     let session_dir = super::get_session_dir_in(base_dir, session_id);
-    let manager_sidecar = if envelope
-        .artifacts
-        .iter()
-        .any(|artifact| artifact.path == CONTRACT_RESULT_ARTIFACT_PATH)
-    {
-        load_optional_result_sidecar(&session_dir, CONTRACT_RESULT_ARTIFACT_PATH)?
-    } else {
-        None
-    };
+    let manager_sidecar =
+        if let Some(manager_sidecar_artifact) = referenced_manager_sidecar_artifact(&envelope) {
+            load_optional_result_sidecar(&session_dir, manager_sidecar_artifact)?
+        } else {
+            None
+        };
     Ok(Some(SessionResultView {
         envelope,
         manager_sidecar,
@@ -622,12 +637,7 @@ pub(crate) fn list_artifacts_in(base_dir: &Path, session_id: &str) -> Result<Vec
         return Ok(Vec::new());
     }
     let mut artifacts = Vec::new();
-    for entry in fs::read_dir(&output_dir)? {
-        let entry = entry?;
-        if entry.file_type()?.is_file() {
-            artifacts.push(entry.file_name().to_string_lossy().to_string());
-        }
-    }
+    collect_output_artifacts(&output_dir, &output_dir, &mut artifacts)?;
     let transcript_path = output_dir.join(TRANSCRIPT_FILE_NAME);
     if transcript_path.is_file() && !artifacts.iter().any(|name| name == TRANSCRIPT_FILE_NAME) {
         artifacts.push(TRANSCRIPT_FILE_NAME.to_string());

--- a/crates/csa-session/src/manager_result_artifacts.rs
+++ b/crates/csa-session/src/manager_result_artifacts.rs
@@ -1,0 +1,191 @@
+use crate::result::{RESULT_FILE_NAME, SessionArtifact, SessionResult};
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::{CONTRACT_RESULT_ARTIFACT_PATH, LEGACY_USER_RESULT_ARTIFACT_PATH};
+
+const TURN_CONTRACT_RESULT_PREFIX: &str = "output/turns/turn-";
+const TURN_CONTRACT_RESULT_SUFFIX: &str = "/result.toml";
+
+pub fn contract_result_path(session_dir: &Path) -> PathBuf {
+    session_dir.join(CONTRACT_RESULT_ARTIFACT_PATH)
+}
+
+pub fn legacy_user_result_path(session_dir: &Path) -> PathBuf {
+    session_dir.join(LEGACY_USER_RESULT_ARTIFACT_PATH)
+}
+
+pub fn turn_contract_result_artifact_path(turn_number: u32) -> String {
+    let turn_number = turn_number.max(1);
+    format!("output/turns/turn-{turn_number:06}/result.toml")
+}
+
+pub fn turn_contract_result_path(session_dir: &Path, turn_number: u32) -> PathBuf {
+    session_dir.join(turn_contract_result_artifact_path(turn_number))
+}
+
+pub fn next_turn_contract_result_artifact_path(completed_turn_count: u32) -> String {
+    turn_contract_result_artifact_path(completed_turn_count.saturating_add(1))
+}
+
+pub fn next_turn_contract_result_path(session_dir: &Path, completed_turn_count: u32) -> PathBuf {
+    session_dir.join(next_turn_contract_result_artifact_path(
+        completed_turn_count,
+    ))
+}
+
+pub fn existing_turn_contract_result_artifact_path(
+    session_dir: &Path,
+    turn_number: u32,
+) -> Option<String> {
+    let artifact_path = turn_contract_result_artifact_path(turn_number);
+    session_dir
+        .join(&artifact_path)
+        .is_file()
+        .then_some(artifact_path)
+}
+
+pub fn existing_next_turn_contract_result_artifact_path(
+    session_dir: &Path,
+    completed_turn_count: u32,
+) -> Option<String> {
+    existing_turn_contract_result_artifact_path(session_dir, completed_turn_count.saturating_add(1))
+}
+
+pub fn is_manager_result_artifact_path(artifact_path: &str) -> bool {
+    artifact_path == CONTRACT_RESULT_ARTIFACT_PATH
+        || parse_turn_contract_result_artifact_path(artifact_path).is_some()
+}
+
+/// Convert an observed session artifact path into an ownership-safe artifact.
+///
+/// Manager result artifacts discovered by directory scans are diagnostics only:
+/// callers must prove current-turn ownership before such paths can drive
+/// manager sidecar overlay or write-target selection.
+pub fn observed_session_artifact(artifact_path: impl Into<String>) -> SessionArtifact {
+    let artifact_path = artifact_path.into();
+    if is_manager_result_artifact_path(&artifact_path) {
+        SessionArtifact::display_only(artifact_path)
+    } else {
+        SessionArtifact::new(artifact_path)
+    }
+}
+
+pub fn latest_manager_result_artifact_path(session_dir: &Path) -> Option<String> {
+    latest_turn_contract_result_artifact_path(session_dir).or_else(|| {
+        session_dir
+            .join(CONTRACT_RESULT_ARTIFACT_PATH)
+            .is_file()
+            .then(|| CONTRACT_RESULT_ARTIFACT_PATH.to_string())
+    })
+}
+
+pub(super) fn remove_manager_result_artifacts(result: &mut SessionResult) {
+    result.artifacts.retain(|artifact| {
+        artifact.display_only || !is_manager_result_artifact_path(&artifact.path)
+    });
+}
+
+pub(super) fn select_manager_sidecar_artifact_path(
+    result: &SessionResult,
+    has_requested_manager_sidecar: bool,
+) -> String {
+    result
+        .artifacts
+        .iter()
+        .filter(|artifact| !artifact.display_only)
+        .filter_map(|artifact| parse_turn_contract_result_artifact_path(&artifact.path))
+        .max()
+        .map(turn_contract_result_artifact_path)
+        .or_else(|| {
+            result
+                .artifacts
+                .iter()
+                .filter(|artifact| !artifact.display_only)
+                .any(|artifact| artifact.path == CONTRACT_RESULT_ARTIFACT_PATH)
+                .then(|| CONTRACT_RESULT_ARTIFACT_PATH.to_string())
+        })
+        .or_else(|| {
+            if has_requested_manager_sidecar {
+                Some(CONTRACT_RESULT_ARTIFACT_PATH.to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| CONTRACT_RESULT_ARTIFACT_PATH.to_string())
+}
+
+pub(super) fn referenced_manager_sidecar_artifact(result: &SessionResult) -> Option<&str> {
+    result
+        .artifacts
+        .iter()
+        .filter(|artifact| !artifact.display_only)
+        .filter_map(|artifact| {
+            parse_turn_contract_result_artifact_path(&artifact.path)
+                .map(|turn| (turn, artifact.path.as_str()))
+        })
+        .max_by_key(|(turn, _)| *turn)
+        .map(|(_, path)| path)
+        .or_else(|| {
+            result
+                .artifacts
+                .iter()
+                .filter(|artifact| !artifact.display_only)
+                .any(|artifact| artifact.path == CONTRACT_RESULT_ARTIFACT_PATH)
+                .then_some(CONTRACT_RESULT_ARTIFACT_PATH)
+        })
+}
+
+pub(super) fn collect_output_artifacts(
+    output_dir: &Path,
+    current_dir: &Path,
+    artifacts: &mut Vec<String>,
+) -> Result<()> {
+    for entry in fs::read_dir(current_dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_dir() {
+            collect_output_artifacts(output_dir, &path, artifacts)?;
+        } else if file_type.is_file() {
+            let relative = path.strip_prefix(output_dir).with_context(|| {
+                format!(
+                    "Failed to relativize artifact {} against {}",
+                    path.display(),
+                    output_dir.display()
+                )
+            })?;
+            artifacts.push(relative.to_string_lossy().replace('\\', "/"));
+        }
+    }
+    Ok(())
+}
+
+fn latest_turn_contract_result_artifact_path(session_dir: &Path) -> Option<String> {
+    let entries = fs::read_dir(session_dir.join("output").join("turns")).ok()?;
+    entries
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            if !entry.file_type().ok()?.is_dir() {
+                return None;
+            }
+            let name = entry.file_name();
+            let name = name.to_str()?;
+            let turn_number = name.strip_prefix("turn-")?.parse::<u32>().ok()?;
+            entry
+                .path()
+                .join(RESULT_FILE_NAME)
+                .is_file()
+                .then_some(turn_number)
+        })
+        .max()
+        .map(turn_contract_result_artifact_path)
+}
+
+fn parse_turn_contract_result_artifact_path(artifact_path: &str) -> Option<u32> {
+    let turn = artifact_path
+        .strip_prefix(TURN_CONTRACT_RESULT_PREFIX)?
+        .strip_suffix(TURN_CONTRACT_RESULT_SUFFIX)?;
+    turn.parse::<u32>().ok().filter(|turn| *turn > 0)
+}

--- a/crates/csa-session/src/manager_result_spillover.rs
+++ b/crates/csa-session/src/manager_result_spillover.rs
@@ -23,10 +23,11 @@ pub(super) fn resolve_report_spill_threshold_bytes(project_path: &Path) -> u64 {
 pub(super) fn load_existing_manager_sidecar_for_publish(
     session_dir: &Path,
     result: &mut SessionResult,
+    manager_sidecar_artifact_path: &str,
     spill_threshold_bytes: u64,
 ) -> Result<Option<toml::Value>> {
-    let sidecar_path = session_dir.join(CONTRACT_RESULT_ARTIFACT_PATH);
-    match load_optional_result_sidecar(session_dir, CONTRACT_RESULT_ARTIFACT_PATH) {
+    let sidecar_path = session_dir.join(manager_sidecar_artifact_path);
+    match load_optional_result_sidecar(session_dir, manager_sidecar_artifact_path) {
         Ok(Some(sidecar)) => Ok(Some(prepare_manager_sidecar_for_publish(
             session_dir,
             result,
@@ -257,6 +258,7 @@ fn upsert_session_artifact(
     }
     result.artifacts.push(SessionArtifact {
         path: artifact_path.to_string(),
+        display_only: false,
         line_count: None,
         size_bytes,
     });
@@ -478,7 +480,10 @@ mod tests {
             started_at: now,
             completed_at: now,
             events_count: 1,
-            artifacts: vec![SessionArtifact::new("output/acp-events.jsonl")],
+            artifacts: vec![
+                SessionArtifact::new("output/acp-events.jsonl"),
+                SessionArtifact::new(CONTRACT_RESULT_ARTIFACT_PATH),
+            ],
             ..Default::default()
         };
         save_result_in_with_threshold(

--- a/crates/csa-session/src/manager_resume_alias.rs
+++ b/crates/csa-session/src/manager_resume_alias.rs
@@ -1,0 +1,125 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::validate::validate_session_id;
+
+pub const RESUME_TARGET_FILE_NAME: &str = "resume-target.toml";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ResumeTarget {
+    kind: String,
+    target_session_id: String,
+    created_at: DateTime<Utc>,
+}
+
+/// Resolved resume-wrapper target identity and on-disk session directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResumeTargetResolution {
+    /// CSA meta session ID of the worker session that the wrapper follows.
+    pub session_id: String,
+    /// Directory that contains the worker session's `state.toml`.
+    pub session_dir: PathBuf,
+}
+
+pub fn write_resume_target(
+    project_path: &Path,
+    wrapper_session_id: &str,
+    target_session_id: &str,
+) -> Result<()> {
+    validate_session_id(wrapper_session_id)?;
+    validate_session_id(target_session_id)?;
+    if wrapper_session_id == target_session_id {
+        return Ok(());
+    }
+
+    let base_dir = super::resolve_write_base_dir(project_path, wrapper_session_id)?;
+    let wrapper_dir = super::get_session_dir_in(&base_dir, wrapper_session_id);
+    resolve_existing_resume_target(project_path, target_session_id)?;
+
+    let target = ResumeTarget {
+        kind: "resume-wrapper".to_string(),
+        target_session_id: target_session_id.to_string(),
+        created_at: Utc::now(),
+    };
+    let contents = toml::to_string_pretty(&target).context("failed to serialize resume target")?;
+    write_file_atomically(&wrapper_dir.join(RESUME_TARGET_FILE_NAME), &contents)
+}
+
+pub fn read_resume_target_from_dir(session_dir: &Path) -> Result<Option<String>> {
+    let path = session_dir.join(RESUME_TARGET_FILE_NAME);
+    if !path.exists() {
+        return Ok(None);
+    }
+    if !path.is_file() {
+        bail!("resume target path is not a file: {}", path.display());
+    }
+
+    let contents = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read resume target: {}", path.display()))?;
+    let target: ResumeTarget = toml::from_str(&contents)
+        .with_context(|| format!("failed to parse resume target: {}", path.display()))?;
+    if target.kind != "resume-wrapper" {
+        bail!("unsupported resume target kind '{}'", target.kind);
+    }
+    validate_session_id(&target.target_session_id)?;
+    Ok(Some(target.target_session_id))
+}
+
+/// Resolve a wrapper's resume target through all supported project session roots.
+///
+/// The alias file stores only the target session ID. This function re-resolves
+/// that ID instead of assuming the wrapper and worker live in the same root, so
+/// legacy/global same-project session roots remain valid.
+pub fn resolve_resume_target_from_dir(
+    project_path: &Path,
+    wrapper_session_dir: &Path,
+) -> Result<Option<ResumeTargetResolution>> {
+    let Some(target_session_id) = read_resume_target_from_dir(wrapper_session_dir)? else {
+        return Ok(None);
+    };
+    let session_dir = resolve_existing_resume_target(project_path, &target_session_id)
+        .with_context(|| {
+            format!(
+                "failed to resolve resume target session '{target_session_id}' from {}",
+                wrapper_session_dir.display()
+            )
+        })?;
+    Ok(Some(ResumeTargetResolution {
+        session_id: target_session_id,
+        session_dir,
+    }))
+}
+
+fn resolve_existing_resume_target(project_path: &Path, target_session_id: &str) -> Result<PathBuf> {
+    let target_dir = super::get_session_dir(project_path, target_session_id)?;
+    if target_dir.join(super::STATE_FILE_NAME).is_file() {
+        return Ok(target_dir);
+    }
+    bail!("resume target session '{target_session_id}' not found in supported session roots");
+}
+
+fn write_file_atomically(path: &Path, contents: &str) -> Result<()> {
+    let Some(parent_dir) = path.parent() else {
+        bail!("path has no parent for atomic write: {}", path.display());
+    };
+    fs::create_dir_all(parent_dir)
+        .with_context(|| format!("failed to create parent dir: {}", parent_dir.display()))?;
+    let mut temp_file = tempfile::NamedTempFile::new_in(parent_dir)
+        .with_context(|| format!("failed to create temp file in {}", parent_dir.display()))?;
+    temp_file
+        .write_all(contents.as_bytes())
+        .with_context(|| format!("failed to write temp file for {}", path.display()))?;
+    temp_file
+        .flush()
+        .with_context(|| format!("failed to flush temp file for {}", path.display()))?;
+    temp_file
+        .persist(path)
+        .map_err(|err| err.error)
+        .with_context(|| format!("failed to atomically replace {}", path.display()))?;
+    Ok(())
+}

--- a/crates/csa-session/src/manager_tests.rs
+++ b/crates/csa-session/src/manager_tests.rs
@@ -361,4 +361,5 @@ include!("manager_tests_tail.rs");
 include!("manager_tests_tail_2.rs");
 include!("manager_tests_audit.rs");
 include!("manager_tests_sidecar_preservation.rs");
+include!("manager_tests_result_schema.rs");
 include!("manager_tests_result_view.rs");

--- a/crates/csa-session/src/manager_tests_result_schema.rs
+++ b/crates/csa-session/src/manager_tests_result_schema.rs
@@ -1,0 +1,127 @@
+fn result_schema_runtime_result(
+    summary: &str,
+    artifacts: Vec<crate::result::SessionArtifact>,
+) -> crate::result::SessionResult {
+    let now = chrono::Utc::now();
+    crate::result::SessionResult {
+        post_exec_gate: None,
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: summary.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_display_only_artifact_runtime_schema_does_not_create_user_result_snapshot() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    let result_path = session_dir.join(crate::result::RESULT_FILE_NAME);
+    let display_artifact = manager_result::turn_contract_result_artifact_path(1);
+
+    let first_result = result_schema_runtime_result(
+        "display-only artifact",
+        vec![crate::result::SessionArtifact::display_only(
+            display_artifact.clone(),
+        )],
+    );
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &first_result,
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+
+    let after_first_raw = std::fs::read_to_string(&result_path).unwrap();
+    assert!(
+        after_first_raw.contains("display_only = true"),
+        "first save must serialize display_only as a runtime artifact field: {after_first_raw}"
+    );
+
+    let second_result = result_schema_runtime_result(
+        "second clean save",
+        vec![crate::result::SessionArtifact::display_only(
+            display_artifact.clone(),
+        )],
+    );
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &second_result,
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+
+    assert!(
+        !session_dir
+            .join(manager_result::LEGACY_USER_RESULT_ARTIFACT_PATH)
+            .exists(),
+        "a runtime artifact with boolean display_only must not be snapshotted as a custom user result"
+    );
+    let loaded = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .unwrap();
+    assert!(
+        loaded
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == display_artifact && artifact.display_only),
+        "runtime result must still round-trip the display-only artifact"
+    );
+}
+
+#[test]
+fn test_display_only_artifact_runtime_schema_rejects_non_bool_value() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    let result_path = session_dir.join(crate::result::RESULT_FILE_NAME);
+    let display_artifact = manager_result::turn_contract_result_artifact_path(1);
+
+    let first_result = result_schema_runtime_result(
+        "display-only artifact",
+        vec![crate::result::SessionArtifact::display_only(display_artifact)],
+    );
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &first_result,
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+
+    let invalid_runtime_schema = std::fs::read_to_string(&result_path)
+        .unwrap()
+        .replace("display_only = true", "display_only = \"true\"");
+    std::fs::write(&result_path, invalid_runtime_schema).unwrap();
+
+    let second_result = result_schema_runtime_result("second clean save", vec![]);
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &second_result,
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+
+    let snapshot_path = session_dir.join(manager_result::LEGACY_USER_RESULT_ARTIFACT_PATH);
+    assert!(
+        snapshot_path.exists(),
+        "a non-bool display_only artifact field must still be treated as custom schema"
+    );
+    let snapshot = std::fs::read_to_string(snapshot_path).unwrap();
+    assert!(
+        snapshot.contains("display_only = \"true\""),
+        "custom-schema snapshot must preserve the invalid display_only value: {snapshot}"
+    );
+}

--- a/crates/csa-session/src/manager_tests_result_view.rs
+++ b/crates/csa-session/src/manager_tests_result_view.rs
@@ -63,7 +63,10 @@ fn test_load_result_view_ignores_orphaned_manager_sidecar() {
         started_at: now,
         completed_at: now,
         events_count: 1,
-        artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
+        artifacts: vec![
+            crate::result::SessionArtifact::new("output/acp-events.jsonl"),
+            crate::result::SessionArtifact::new(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
+        ],
         ..Default::default()
     };
     save_result_in(
@@ -119,7 +122,10 @@ fn test_load_result_merges_manager_sidecar_sections_into_runtime_result() {
         started_at: now,
         completed_at: now,
         events_count: 1,
-        artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
+        artifacts: vec![
+            crate::result::SessionArtifact::new("output/acp-events.jsonl"),
+            crate::result::SessionArtifact::new(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
+        ],
         ..Default::default()
     };
     std::fs::write(
@@ -237,7 +243,10 @@ fn test_manager_sidecar_roundtrip_preserves_full_sa_schema() {
         started_at: now,
         completed_at: now,
         events_count: 1,
-        artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
+        artifacts: vec![
+            crate::result::SessionArtifact::new("output/acp-events.jsonl"),
+            crate::result::SessionArtifact::new(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
+        ],
         ..Default::default()
     };
     let input_sidecar = toml::Value::Table(toml::toml! {
@@ -456,11 +465,11 @@ fn test_save_result_with_empty_manager_fields_preserves_existing_sidecar() {
             .exists()
     );
 
-    let clean_result = crate::result::SessionResult {
-        fallback_chain: None,
-        manager_fields: Default::default(),
-        ..populated_result.clone()
-    };
+    let mut clean_result = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .expect("first result should exist");
+    clean_result.fallback_chain = None;
+    clean_result.manager_fields = Default::default();
     save_result_in(
         td.path(),
         &state.meta_session_id,
@@ -503,7 +512,10 @@ fn test_clear_manager_sidecar_removes_existing_sidecar() {
         started_at: now,
         completed_at: now,
         events_count: 1,
-        artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
+        artifacts: vec![
+            crate::result::SessionArtifact::new("output/acp-events.jsonl"),
+            crate::result::SessionArtifact::new(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
+        ],
         peak_memory_mb: None,
         kill_hint: None,
         last_item: None,
@@ -563,7 +575,10 @@ fn test_load_result_with_malformed_manager_sidecar_is_non_fatal() {
         started_at: now,
         completed_at: now,
         events_count: 1,
-        artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
+        artifacts: vec![
+            crate::result::SessionArtifact::new("output/acp-events.jsonl"),
+            crate::result::SessionArtifact::new(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
+        ],
         ..Default::default()
     };
     std::fs::write(

--- a/crates/csa-session/src/manager_tests_sidecar_preservation.rs
+++ b/crates/csa-session/src/manager_tests_sidecar_preservation.rs
@@ -1,5 +1,5 @@
 #[test]
-fn test_save_result_preserves_existing_contract_result_artifact_when_output_result_exists() {
+fn test_save_result_preserves_existing_contract_result_artifact_when_envelope_references_it() {
     let td = tempdir().unwrap();
     let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
     let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
@@ -20,7 +20,10 @@ fn test_save_result_preserves_existing_contract_result_artifact_when_output_resu
         started_at: now,
         completed_at: now,
         events_count: 1,
-        artifacts: vec![crate::result::SessionArtifact::new("output/acp-events.jsonl")],
+        artifacts: vec![
+            crate::result::SessionArtifact::new("output/acp-events.jsonl"),
+            crate::result::SessionArtifact::new(manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
+        ],
         ..Default::default()
     };
     save_result_in(

--- a/crates/csa-session/src/manager_tests_turn_results.rs
+++ b/crates/csa-session/src/manager_tests_turn_results.rs
@@ -1,0 +1,449 @@
+use super::*;
+use tempfile::tempdir;
+
+fn runtime_result(summary: &str, artifact_path: &str) -> crate::result::SessionResult {
+    let now = chrono::Utc::now();
+    crate::result::SessionResult {
+        post_exec_gate: None,
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: summary.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: vec![crate::result::SessionArtifact::new(artifact_path)],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_turn_scoped_manager_sidecars_do_not_clobber_prior_resume_reports() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    let turn_one_artifact = manager_result::turn_contract_result_artifact_path(1);
+    let turn_two_artifact = manager_result::turn_contract_result_artifact_path(2);
+    let turn_one_path = session_dir.join(&turn_one_artifact);
+    let turn_two_path = session_dir.join(&turn_two_artifact);
+
+    std::fs::create_dir_all(turn_one_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &turn_one_path,
+        r#"
+[report]
+what_was_done = "turn one report"
+
+[artifacts]
+repo_write_audit = "turn-one"
+"#,
+    )
+    .unwrap();
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &runtime_result("runtime turn one", &turn_one_artifact),
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+    let turn_one_contents = std::fs::read_to_string(&turn_one_path).unwrap();
+    assert!(turn_one_contents.contains("turn one report"));
+
+    std::fs::create_dir_all(turn_two_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &turn_two_path,
+        r#"
+[report]
+what_was_done = "turn two report"
+
+[artifacts]
+repo_write_audit = "turn-two"
+"#,
+    )
+    .unwrap();
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &runtime_result("runtime turn two", &turn_two_artifact),
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(&turn_one_path).unwrap(),
+        turn_one_contents,
+        "saving turn two must not overwrite turn one's manager report"
+    );
+    assert!(
+        std::fs::read_to_string(&turn_two_path)
+            .unwrap()
+            .contains("turn two report")
+    );
+
+    let persisted = std::fs::read_to_string(session_dir.join(crate::result::RESULT_FILE_NAME))
+        .expect("runtime result should exist");
+    assert!(persisted.contains("status = \"success\""));
+    assert!(persisted.contains("summary = \"runtime turn two\""));
+    assert!(persisted.contains(&turn_two_artifact));
+    assert!(
+        !persisted.contains(&turn_one_artifact),
+        "runtime envelope should reference only the current manager sidecar"
+    );
+
+    let loaded = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        loaded
+            .manager_fields
+            .report
+            .as_ref()
+            .and_then(|value| value.get("what_was_done")),
+        Some(&toml::Value::String("turn two report".to_string()))
+    );
+}
+
+#[test]
+fn test_turn_scoped_sidecar_preservation_ignores_stale_legacy_sidecar() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    let legacy_path = manager_result::contract_result_path(&session_dir);
+    let turn_artifact = manager_result::turn_contract_result_artifact_path(2);
+    let turn_path = session_dir.join(&turn_artifact);
+
+    std::fs::create_dir_all(legacy_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &legacy_path,
+        r#"
+[report]
+what_was_done = "stale legacy report"
+
+[artifacts]
+repo_write_audit = "legacy-stale"
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(turn_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &turn_path,
+        r#"
+[report]
+what_was_done = "current turn report"
+
+[artifacts]
+repo_write_audit = "turn-current"
+"#,
+    )
+    .unwrap();
+
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &runtime_result("runtime turn two", &turn_artifact),
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+
+    let turn_contents = std::fs::read_to_string(&turn_path).unwrap();
+    assert!(
+        turn_contents.contains("current turn report"),
+        "selected turn sidecar must remain the preserved manager report"
+    );
+    assert!(
+        turn_contents.contains("turn-current"),
+        "selected turn sidecar artifacts must remain current turn fields"
+    );
+    assert!(
+        !turn_contents.contains("stale legacy report"),
+        "stale legacy sidecar must not be republished into the selected turn path"
+    );
+    assert!(
+        !turn_contents.contains("legacy-stale"),
+        "stale legacy artifact fields must not replace current turn fields"
+    );
+    assert!(
+        std::fs::read_to_string(&legacy_path)
+            .unwrap()
+            .contains("stale legacy report"),
+        "legacy sidecar may coexist but must not drive turn preservation"
+    );
+
+    let loaded = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        loaded
+            .manager_fields
+            .report
+            .as_ref()
+            .and_then(|value| value.get("what_was_done")),
+        Some(&toml::Value::String("current turn report".to_string()))
+    );
+    assert!(
+        loaded
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == turn_artifact)
+    );
+    assert!(
+        loaded
+            .artifacts
+            .iter()
+            .all(|artifact| artifact.path != manager_result::CONTRACT_RESULT_ARTIFACT_PATH),
+        "runtime envelope should advertise the selected turn sidecar, not legacy output/result.toml"
+    );
+}
+
+#[test]
+fn test_new_manager_sidecar_without_explicit_turn_artifact_preserves_prior_turn_report() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    let prior_turn_artifact = manager_result::turn_contract_result_artifact_path(1);
+    let prior_turn_path = session_dir.join(&prior_turn_artifact);
+
+    std::fs::create_dir_all(prior_turn_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &prior_turn_path,
+        r#"
+[report]
+what_was_done = "prior turn report"
+"#,
+    )
+    .unwrap();
+    let prior_turn_contents = std::fs::read_to_string(&prior_turn_path).unwrap();
+    let now = chrono::Utc::now();
+    let result = crate::result::SessionResult {
+        post_exec_gate: None,
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "runtime summary".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: vec![],
+        manager_fields: crate::result::SessionManagerFields {
+            report: Some(toml::toml! { what_was_done = "legacy fallback report" }.into()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &result,
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(&prior_turn_path).unwrap(),
+        prior_turn_contents,
+        "a save without an explicit turn artifact must not overwrite a prior turn report"
+    );
+    assert!(
+        std::fs::read_to_string(manager_result::contract_result_path(&session_dir))
+            .unwrap()
+            .contains("legacy fallback report"),
+        "legacy sidecar should receive manager fields when no turn artifact is explicit"
+    );
+
+    let loaded = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .unwrap();
+    assert!(
+        loaded
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == manager_result::CONTRACT_RESULT_ARTIFACT_PATH)
+    );
+}
+
+#[test]
+fn test_expected_turn_artifact_helper_does_not_return_prior_turn_result() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    let turn_one_path = manager_result::turn_contract_result_path(&session_dir, 1);
+
+    std::fs::create_dir_all(turn_one_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &turn_one_path,
+        "status = \"success\"\nsummary = \"turn one\"\n",
+    )
+    .unwrap();
+
+    assert_eq!(
+        manager_result::existing_next_turn_contract_result_artifact_path(&session_dir, 0),
+        Some(manager_result::turn_contract_result_artifact_path(1))
+    );
+    assert_eq!(
+        manager_result::existing_next_turn_contract_result_artifact_path(&session_dir, 1),
+        None,
+        "turn 1 must not satisfy the expected turn 2 artifact lookup"
+    );
+}
+
+#[test]
+fn test_save_result_without_explicit_sidecar_does_not_attach_prior_turn_artifact() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    let prior_turn_artifact = manager_result::turn_contract_result_artifact_path(1);
+    let prior_turn_path = session_dir.join(&prior_turn_artifact);
+
+    std::fs::create_dir_all(prior_turn_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &prior_turn_path,
+        r#"
+[report]
+what_was_done = "prior turn report"
+"#,
+    )
+    .unwrap();
+
+    let now = chrono::Utc::now();
+    let result = crate::result::SessionResult {
+        post_exec_gate: None,
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "turn two failed before writing sidecar".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: vec![],
+        ..Default::default()
+    };
+
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &result,
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+
+    let persisted = std::fs::read_to_string(session_dir.join(crate::result::RESULT_FILE_NAME))
+        .expect("runtime result should exist");
+    assert!(
+        !persisted.contains(&prior_turn_artifact),
+        "a new envelope without an explicit sidecar must not advertise a prior turn artifact"
+    );
+
+    let loaded = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .unwrap();
+    assert!(
+        loaded.manager_fields.as_sidecar().is_none(),
+        "prior turn manager fields must not be rehydrated into the new root result"
+    );
+}
+
+#[test]
+fn test_display_only_turn_result_artifact_is_visible_but_not_selected_as_manager_sidecar() {
+    let td = tempdir().unwrap();
+    let state = create_session_in(td.path(), td.path(), None, None, Some("codex")).unwrap();
+    let session_dir = get_session_dir_in(td.path(), &state.meta_session_id);
+    let owned_artifact = manager_result::turn_contract_result_artifact_path(1);
+    let discovered_artifact = manager_result::turn_contract_result_artifact_path(2);
+    let owned_path = session_dir.join(&owned_artifact);
+    let discovered_path = session_dir.join(&discovered_artifact);
+
+    std::fs::create_dir_all(owned_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &owned_path,
+        r#"
+[report]
+what_was_done = "owned turn one report"
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(discovered_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &discovered_path,
+        r#"
+[report]
+what_was_done = "in-flight turn two report"
+"#,
+    )
+    .unwrap();
+    let discovered_before = std::fs::read_to_string(&discovered_path).unwrap();
+
+    let mut result = runtime_result("runtime turn one", &owned_artifact);
+    result
+        .artifacts
+        .push(crate::result::SessionArtifact::display_only(
+            discovered_artifact.clone(),
+        ));
+    save_result_in(
+        td.path(),
+        &state.meta_session_id,
+        &result,
+        crate::SaveOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(&discovered_path).unwrap(),
+        discovered_before,
+        "display-only turn result artifact must not be rewritten as a manager sidecar"
+    );
+
+    let loaded = load_result_in(td.path(), &state.meta_session_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        loaded
+            .manager_fields
+            .report
+            .as_ref()
+            .and_then(|value| value.get("what_was_done")),
+        Some(&toml::Value::String("owned turn one report".to_string())),
+        "manager overlay must come from the owned turn sidecar, not the display-only artifact"
+    );
+    assert!(
+        loaded
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == discovered_artifact && artifact.display_only),
+        "display-only turn artifact must remain visible in the envelope"
+    );
+}
+
+#[test]
+fn test_observed_session_artifact_marks_manager_results_display_only() {
+    let legacy = observed_session_artifact(CONTRACT_RESULT_ARTIFACT_PATH);
+    assert_eq!(legacy.path, CONTRACT_RESULT_ARTIFACT_PATH);
+    assert!(
+        legacy.display_only,
+        "observed legacy manager result artifacts are diagnostics-only"
+    );
+
+    let turn_artifact = turn_contract_result_artifact_path(7);
+    let observed_turn = observed_session_artifact(turn_artifact.clone());
+    assert_eq!(observed_turn.path, turn_artifact);
+    assert!(
+        observed_turn.display_only,
+        "observed turn-scoped manager result artifacts are diagnostics-only"
+    );
+
+    let observed_log = observed_session_artifact("output/acp-events.jsonl");
+    assert_eq!(observed_log.path, "output/acp-events.jsonl");
+    assert!(
+        !observed_log.display_only,
+        "ordinary observed artifacts remain owned artifacts"
+    );
+}

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -12,6 +12,12 @@ pub const RESULT_FILE_NAME: &str = "result.toml";
 pub struct SessionArtifact {
     /// Artifact path relative to session dir (e.g., "output/acp-events.jsonl")
     pub path: String,
+    /// True when the artifact was discovered for display/diagnostics only.
+    ///
+    /// Display-only manager result artifacts must not drive manager sidecar
+    /// overlay or write-target selection.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub display_only: bool,
     /// Optional number of lines (used by transcript JSONL artifacts).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line_count: Option<u64>,
@@ -24,6 +30,16 @@ impl SessionArtifact {
     pub fn new(path: impl Into<String>) -> Self {
         Self {
             path: path.into(),
+            display_only: false,
+            line_count: None,
+            size_bytes: None,
+        }
+    }
+
+    pub fn display_only(path: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            display_only: true,
             line_count: None,
             size_bytes: None,
         }
@@ -32,6 +48,7 @@ impl SessionArtifact {
     pub fn with_stats(path: impl Into<String>, line_count: u64, size_bytes: u64) -> Self {
         Self {
             path: path.into(),
+            display_only: false,
             line_count: Some(line_count),
             size_bytes: Some(size_bytes),
         }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -163,7 +163,8 @@ csa session clean --days <N> [--dry-run] [--tool <TOOLS>] [--cd <DIR>]
 
 ### `csa session result`
 
-Show the last execution result.
+Show the last execution result. If the supplied ID is a resume wrapper returned
+by `csa run --session`, the command follows the wrapper to the worker result.
 
 ```bash
 csa session result --session <ID> [--json] [--cd <DIR>]
@@ -185,7 +186,9 @@ csa session is-alive --session <ID> [--cd <DIR>]
 
 ### `csa session artifacts`
 
-List artifacts in a session's output directory.
+List artifacts in a session's output directory, including resumed-turn manager
+reports under `turns/turn-000001/result.toml`, `turns/turn-000002/result.toml`,
+and later turn directories.
 
 ```bash
 csa session artifacts --session <ID> [--cd <DIR>]

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -44,6 +44,7 @@ garbage collection.
   |   |   +-- locks/              # Tool-level flock files
   |   |   +-- transcript.jsonl    # ACP event transcript
   |   |   +-- output/             # Execution artifacts
+  |   |   |   +-- turns/turn-000001/result.toml  # Turn-scoped manager report
   |   +-- 01JH4QWERT9876.../
   |   |   +-- state.toml
   |   |   +-- ...
@@ -69,6 +70,16 @@ Resume by ID, prefix, or the most recent session:
 csa run --sa-mode false --session 01JH4Q "continue implementation"
 csa run --sa-mode false --last "continue the most recent session"
 ```
+
+When a resumed daemon turn returns a wrapper ID, CSA records the worker target
+under the wrapper session. `csa session wait` and `csa session result` accept
+that returned ID and follow it to the actual worker result.
+
+Each resumed turn writes manager-facing reports to a turn-scoped artifact path:
+`output/turns/turn-000001/result.toml`, `output/turns/turn-000002/result.toml`,
+and so on. The root `result.toml` remains the runtime envelope for the latest
+turn and references the current turn-scoped report; earlier turn reports are not
+overwritten.
 
 ### 3. List
 


### PR DESCRIPTION
## Summary
- Make resumed `--session` turn identity and result ownership explicit across runtime envelopes, manager sidecars, resume wrappers, wait/result paths, and observation artifacts.
- Preserve root runtime `result.toml` while moving resumed turn reports to turn-scoped manager sidecars under `output/turns/turn-N/result.toml`.
- Add guarded fallback, display-only/owned artifact separation, cross-root resume-wrapper alias support, and regressions for stale prior-turn/legacy/env sidecar reuse.

## Validation
- Parent hook-enabled amend on final HEAD `ddbb6cb5` passed branch-protection and quality-gates.
- `cargo clippy --workspace --all-features -- -D warnings` passed in parent hooks.
- Fresh pinned Codex full-diff review passed: `01KTZXPJTCMT5NH3DYG3MXXXB8`.

Closes #2105
