### PR TITLE
fix(ci): re-export session wait test helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.988"
+version = "0.1.989"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.988"
+version = "0.1.989"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -35,6 +35,8 @@ pub(crate) use completion::{
     seed_daemon_session_env,
 };
 #[cfg(test)]
+pub(crate) use wait::expected_in_flight_turn_result_artifact_path_for_test;
+#[cfg(test)]
 pub(crate) use wait::parse_output_result_artifact_for_test;
 #[cfg(test)]
 pub(crate) use wait::render_wait_result_summary;


### PR DESCRIPTION
## Summary
- Re-export the `expected_in_flight_turn_result_artifact_path_for_test` helper from the top-level `session_cmds_daemon` test namespace so the #2105 tail/wait regression tests compile in CI.
- Bump the workspace patch version to `0.1.989` for this follow-up branch.

## Context
PR #2171 was merged while PR checks were red. This follow-up carries the smallest staged repair onto a new branch from the red main merge commit.

Refs #2172
Supersedes closed #2105

## Verification
- Parent hook-enabled commit: PASS
- `csa review --check-verdict --sa-mode true --range origin/main...HEAD`: PASS via `01KTZZQS5MF5516DWMZ9S06389`
