### PR TITLE
fix(session): stabilize wait result CI regressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.989"
+version = "0.1.990"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.989"
+version = "0.1.990"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_result_contract.rs
+++ b/crates/cli-sub-agent/src/pipeline_result_contract.rs
@@ -34,7 +34,7 @@ pub(crate) fn enforce_result_toml_path_contract(
             csa_session::next_turn_contract_result_path(session_dir, completed_turn_count);
         let legacy_output_path = csa_session::legacy_user_result_path(session_dir);
         let reason = format!(
-            "contract violation: failed to prepare result artifacts before execution (stale-file cleanup or parent mkdir): '{}', '{}', '{}', '{}'",
+            "contract violation: failed to clear pre-existing result artifacts before execution (or create current-turn result parent): '{}', '{}', '{}', '{}'",
             expected_path.display(),
             expected_turn_path.display(),
             csa_session::contract_result_path(session_dir).display(),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -190,6 +190,14 @@ pub(crate) fn handle_session_wait_with_emitters(
                     "session wait",
                 )?;
             } else {
+                loaded_result = load_completed_daemon_result_with_fallback(
+                    effective_root,
+                    result_session_id,
+                    &result_session_dir,
+                    is_cross_project,
+                )?;
+            }
+            if loaded_result.is_none() {
                 loaded_result = finalize_daemon_completion_if_present(&result_session_dir)?
                     .and_then(|result| {
                         suppress_pending_tier_failover_result(

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2105.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2105.rs
@@ -5,6 +5,14 @@ use crate::session_cmds_daemon::{
 use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use tempfile::tempdir;
 
+#[cfg(unix)]
+fn backdate_dead_wait_fixture(session_dir: &std::path::Path) {
+    super::backdate_tree(
+        session_dir,
+        csa_process::DEFAULT_LIVENESS_DEAD_SECS.saturating_add(1),
+    );
+}
+
 #[test]
 fn handle_session_wait_uses_persisted_current_turn_artifact_after_multi_turn_state_save() {
     let td = tempdir().expect("tempdir");
@@ -394,6 +402,8 @@ fn handle_session_wait_rejects_stale_legacy_output_result_without_current_marker
             .exists(),
         "test setup requires missing root result.toml"
     );
+    #[cfg(unix)]
+    backdate_dead_wait_fixture(&session_dir);
 
     let mut emitted_completion = false;
     let exit_code = handle_session_wait_with_hooks(
@@ -475,6 +485,8 @@ fn handle_session_wait_rejects_stale_inherited_contract_env_prior_turn_sidecar()
             .exists(),
         "test setup requires missing root result.toml"
     );
+    #[cfg(unix)]
+    backdate_dead_wait_fixture(&session_dir);
     assert_eq!(
         crate::session_cmds_daemon::expected_in_flight_turn_result_artifact_path_for_test(
             &session_dir

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -290,7 +290,7 @@ fn find_session_pid(session_dir: &Path) -> Option<u32> {
 fn is_reconciler_artifact(path: &Path) -> bool {
     matches!(
         path.file_name().and_then(|n| n.to_str()),
-        Some(".reconcile.lock") | Some(".reconcile")
+        Some(".reconcile.lock") | Some(".reconcile") | Some(".wait.lock")
     )
 }
 

--- a/crates/csa-process/src/tool_liveness_tests.rs
+++ b/crates/csa-process/src/tool_liveness_tests.rs
@@ -233,6 +233,23 @@ fn is_alive_read_only_does_not_persist_liveness_snapshot() {
 }
 
 #[test]
+fn wait_lock_does_not_count_as_liveness_signal() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    fs::write(tmp.path().join(".wait.lock"), "pid = 1\n").expect("write wait lock");
+
+    let signals = ToolLiveness::probe(tmp.path());
+
+    assert!(
+        !signals.session_write,
+        "wait's own lock must not keep an otherwise dead session alive"
+    );
+    assert!(
+        !signals.has_any_signal(),
+        "wait lock alone must not be treated as tool liveness"
+    );
+}
+
+#[test]
 fn probe_detects_spool_byte_growth_after_rotation() {
     let tmp = tempfile::tempdir().expect("tempdir");
     fs::write(

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.986"
-weave = "0.1.986"
+csa = "0.1.990"
+weave = "0.1.990"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Repair runtime wait/result regressions exposed after PR #2173 restored the missing test helper export.
- Prefer valid current-turn manager sidecars before finalizing missing-root-result daemon-completion failures.
- Exclude wait lock files from liveness signals so stale sidecar negative cases fail closed again.
- Restore the stable pre-clear failure diagnostic substring.
- Bump workspace/weave version to 0.1.990 for this follow-up branch.

## Verification
- `cargo test -p cli-sub-agent --bin csa result_toml_path_contract_fails_closed_when_preclear_failed -- --nocapture`
- `cargo test -p cli-sub-agent --bin csa handle_session_wait -- --nocapture`
- `cargo test -p csa-process tool_liveness -- --nocapture`
- hook quality-gates PASS during commit
- CSA Codex review `01KV02YTFFPGN797BTP9Z7HS0S`: PASS for `main...HEAD`

Refs #2172
