### PR TITLE
fix(run): filter stale todo noise from success output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.990"
+version = "0.1.991"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.990"
+version = "0.1.991"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_execute_output.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_output.rs
@@ -105,7 +105,7 @@ pub(super) fn render_run_text_output(
     result: &ExecutionResult,
     large_diff_warning: Option<&csa_session::LargeDiffWarningReport>,
 ) -> String {
-    let mut output = result.output.clone();
+    let mut output = render_success_text_output(&result.output, result.exit_code);
     if let Some(warning) = large_diff_warning {
         if !output.is_empty() && !output.ends_with('\n') {
             output.push('\n');
@@ -116,9 +116,21 @@ pub(super) fn render_run_text_output(
     output
 }
 
+fn render_success_text_output(raw_output: &str, exit_code: i32) -> String {
+    if exit_code == 0
+        && crate::codex_transcript_filter::first_non_empty_line_is_thread_started(raw_output)
+    {
+        return crate::codex_transcript_filter::extract_codex_json_event_text(raw_output)
+            .unwrap_or_else(|| raw_output.to_string());
+    }
+
+    raw_output.to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn ephemeral_signal_diagnostic_adds_no_session_metadata() {
@@ -193,6 +205,84 @@ mod tests {
         let rendered = render_run_text_output(&result, None);
 
         assert_eq!(rendered, "done\n");
+    }
+
+    #[test]
+    fn run_text_output_filters_codex_internal_stale_todo_events_on_success() {
+        let final_summary = "\
+<!-- CSA:SECTION:summary -->
+Implemented and committed.
+<!-- CSA:SECTION:summary:END -->";
+        let stale_todo = json!({
+            "todos": [
+                {"text": "implement fix", "completed": false},
+                {"text": "run validation", "completed": false}
+            ]
+        })
+        .to_string();
+        let raw_output = [
+            json!({"type": "thread.started", "thread_id": "thread_1"}).to_string(),
+            json!({
+                "type": "item.completed",
+                "item": {"id": "item_1", "type": "agent_message", "text": final_summary}
+            })
+            .to_string(),
+            json!({
+                "type": "item.completed",
+                "item": {"id": "item_2", "type": "tool_result", "text": stale_todo}
+            })
+            .to_string(),
+            json!({"type": "turn.completed", "usage": {"input_tokens": 100}}).to_string(),
+        ]
+        .join("\n");
+        let result = ExecutionResult {
+            output: raw_output,
+            summary: "Implemented and committed.".to_string(),
+            exit_code: 0,
+            terminal_reason: Some("turn.completed".to_string()),
+            model_completed: Some(true),
+            ..Default::default()
+        };
+
+        let rendered = render_run_text_output(&result, None);
+
+        assert_eq!(rendered, final_summary);
+        assert!(rendered.contains("Implemented and committed."));
+        assert!(!rendered.contains("\"completed\":false"));
+        assert!(!rendered.contains("turn.completed"));
+        assert!(!rendered.trim_end().ends_with("\"completed\":false}]}}"));
+    }
+
+    #[test]
+    fn run_text_output_preserves_codex_raw_output_on_failure() {
+        let raw_output = [
+            json!({"type": "thread.started", "thread_id": "thread_1"}).to_string(),
+            json!({
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
+                    "type": "tool_result",
+                    "text": "{\"todos\":[{\"text\":\"debug\",\"completed\":false}]}"
+                }
+            })
+            .to_string(),
+            json!({"type": "turn.failed", "error": {"message": "tool failed"}}).to_string(),
+        ]
+        .join("\n");
+        let result = ExecutionResult {
+            output: raw_output.clone(),
+            summary: "tool failed".to_string(),
+            exit_code: 1,
+            terminal_reason: Some("failed".to_string()),
+            model_completed: Some(false),
+            ..Default::default()
+        };
+
+        let rendered = render_run_text_output(&result, None);
+
+        assert_eq!(rendered, raw_output);
+        assert!(rendered.contains(r#"\"completed\":false"#));
+        assert!(rendered.contains("turn.failed"));
     }
 
     #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.990"
-weave = "0.1.990"
+csa = "0.1.991"
+weave = "0.1.991"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Filter successful Codex JSON transcripts before rendering caller-facing `csa run` text output.
- Hide stale internal todo/checklist `tool_result` noise on successful runs while keeping failure text output raw for diagnostics.
- Bump workspace version to `0.1.991`.

## Local validation
- `cargo test -p cli-sub-agent run_cmd::execute::run_output::tests::run_text_output -- --nocapture` (4 passed)
- hook-enabled commit quality gates passed
- `csa review --check-verdict --sa-mode true --range main...HEAD` PASS via `01KV06EEJKG41D5EXZ0Y4QMGD1`

Closes #2102.
