### PR TITLE
fix(session): attribute child timeout signal provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.991"
+version = "0.1.992"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.991"
+version = "0.1.992"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -563,7 +563,7 @@ where
         completed_at,
     );
     #[rustfmt::skip]
-    let result_contents = crate::session_kill_diagnostics::signal_toml(&result, &session, session_id, packet.exit_code).context("serialize result")?;
+    let result_contents = crate::session_kill_diagnostics::signal_toml(&result, &session, session_id, session_dir, packet.exit_code).context("serialize result")?;
     match persist_new_result_file(result_path, &result_contents, before_write)? {
         SyntheticResultPersistOutcome::AlreadyExists => {
             let retired = retire_if_dead_with_result_impl(

--- a/crates/cli-sub-agent/src/session_kill_diagnostics.rs
+++ b/crates/cli-sub-agent/src/session_kill_diagnostics.rs
@@ -1,4 +1,5 @@
-//! Best-effort diagnostics for signal exits that often mean host OOM pressure.
+//! Best-effort diagnostics for signal exits that often mean host OOM pressure
+//! or a bounded in-turn child command timing out.
 
 use std::path::{Path, PathBuf};
 
@@ -6,6 +7,13 @@ use anyhow::{Context, Result};
 use csa_session::{
     MetaSessionState, SessionResult, SignalResultMetadata, save_result,
     save_result_with_signal_metadata,
+};
+
+mod child_timeout;
+
+use child_timeout::{
+    ChildTimeoutKind, ChildTimeoutProvenance, detect_child_timeout_provenance, redact_command_text,
+    truncate_one_line,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,6 +66,8 @@ pub(crate) struct KillSignalObservations {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum KillHint {
     CsaTimeout,
+    ChildTimeout,
+    HookCommitTimeout,
     Earlyoom,
     MemoryPressure,
     PossibleMemoryPressure,
@@ -68,6 +78,8 @@ impl KillHint {
     pub(crate) fn as_result_hint(self) -> &'static str {
         match self {
             Self::CsaTimeout => "csa_timeout",
+            Self::ChildTimeout => "child_timeout",
+            Self::HookCommitTimeout => "hook_commit_timeout",
             Self::Earlyoom => "earlyoom",
             Self::MemoryPressure => "memory_pressure",
             Self::PossibleMemoryPressure => "possible_memory_pressure",
@@ -81,6 +93,7 @@ pub(crate) struct KillDiagnostic {
     pub(crate) hint: KillHint,
     pub(crate) observations: KillSignalObservations,
     pub(crate) terminal_reason: Option<String>,
+    pub(crate) child_timeout: Option<ChildTimeoutProvenance>,
 }
 
 impl KillDiagnostic {
@@ -94,6 +107,28 @@ impl KillDiagnostic {
         });
         if self.hint == KillHint::CsaTimeout {
             details.push("CSA supervisor timeout metadata matched signal exit".to_string());
+            return details;
+        }
+        if let Some(child) = &self.child_timeout {
+            details.push("transcript matched bounded child command".to_string());
+            if let Some(seconds) = child.timeout_seconds {
+                details.push(format!("child_timeout_seconds={seconds}"));
+            }
+            if let Some(status) = child
+                .command_status
+                .as_deref()
+                .map(str::trim)
+                .filter(|status| !status.is_empty())
+            {
+                details.push(format!("child_command_status={status}"));
+            }
+            if child.transcript_exit_143 {
+                details.push("transcript reported child exit 143".to_string());
+            }
+            details.push(format!(
+                "child_command={}",
+                redacted_command_one_line(&child.command, 180)
+            ));
             return details;
         }
         if let Some(meminfo) = &self.observations.meminfo {
@@ -132,6 +167,8 @@ impl KillDiagnostic {
             KillHint::MemoryPressure => "memory pressure",
             KillHint::PossibleMemoryPressure => "possible memory pressure",
             KillHint::CsaTimeout => "csa_timeout",
+            KillHint::ChildTimeout => "child_timeout",
+            KillHint::HookCommitTimeout => "hook_commit_timeout",
             KillHint::UnknownSignal => "unknown_signal",
         };
 
@@ -141,6 +178,12 @@ impl KillDiagnostic {
                 "Re-dispatch when host memory frees."
             }
             KillHint::CsaTimeout => "The recorded timeout is the concrete kill reason.",
+            KillHint::ChildTimeout => {
+                "The transcript shows the last tool command was wrapped in a bounded timeout; inspect that child timeout before treating this as an external session kill."
+            }
+            KillHint::HookCommitTimeout => {
+                "The transcript shows a bounded hook-enabled git commit was active; inspect hook duration/toolchain setup or increase the child command timeout before redispatching."
+            }
             KillHint::UnknownSignal => {
                 "No timeout or cgroup OOM evidence was found, and memory checks did not identify a concrete kill source; reason remains unknown."
             }
@@ -148,6 +191,13 @@ impl KillDiagnostic {
         Some(format!(
             "CSA diagnostic: signal kill hint: {hint} ({details}). {suffix}"
         ))
+    }
+
+    pub(crate) fn last_item(&self) -> Option<String> {
+        self.child_timeout
+            .as_ref()
+            .map(|child| redacted_command_one_line(&child.command, 300))
+            .filter(|command| !command.is_empty())
     }
 
     pub(crate) fn ephemeral_line(&self) -> String {
@@ -164,8 +214,10 @@ pub(crate) fn diagnose_signal_kill(
     terminal_reason: Option<&str>,
     tool_name: &str,
     session_id: &str,
+    session_dir: Option<&Path>,
 ) -> Option<KillDiagnostic> {
-    diagnose_signal_kill_with(exit_code, terminal_reason, || {
+    let child_timeout = session_dir.and_then(|dir| detect_child_timeout_provenance(dir, exit_code));
+    diagnose_signal_kill_with_child_timeout(exit_code, terminal_reason, child_timeout, || {
         collect_signal_observations(tool_name, session_id)
     })
 }
@@ -186,6 +238,15 @@ pub(crate) fn diagnose_signal_kill_with(
     terminal_reason: Option<&str>,
     collect: impl FnOnce() -> KillSignalObservations,
 ) -> Option<KillDiagnostic> {
+    diagnose_signal_kill_with_child_timeout(exit_code, terminal_reason, None, collect)
+}
+
+fn diagnose_signal_kill_with_child_timeout(
+    exit_code: i32,
+    terminal_reason: Option<&str>,
+    child_timeout: Option<ChildTimeoutProvenance>,
+    collect: impl FnOnce() -> KillSignalObservations,
+) -> Option<KillDiagnostic> {
     if !matches!(exit_code, 137 | 143) {
         return None;
     }
@@ -194,11 +255,14 @@ pub(crate) fn diagnose_signal_kill_with(
             hint: KillHint::CsaTimeout,
             observations: KillSignalObservations::default(),
             terminal_reason: normalize_terminal_reason(terminal_reason),
+            child_timeout: None,
         });
     }
     Some(classify_signal_kill(
+        exit_code,
         collect(),
         normalize_terminal_reason(terminal_reason),
+        child_timeout,
     ))
 }
 
@@ -213,6 +277,10 @@ pub(crate) fn last_known_work_item<'a>(
         .filter(|summary| !summary.is_empty())
 }
 
+fn redacted_command_one_line(command: &str, max_chars: usize) -> String {
+    truncate_one_line(&redact_command_text(command), max_chars)
+}
+
 pub(crate) fn save_result_with_signal_diagnostic(
     project_root: &Path,
     session: &MetaSessionState,
@@ -221,11 +289,13 @@ pub(crate) fn save_result_with_signal_diagnostic(
     terminal_reason: Option<&str>,
     stderr_output: Option<&mut String>,
 ) -> Result<Option<String>> {
+    let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id).ok();
     let diagnostic = diagnose_signal_kill(
         result.exit_code,
         terminal_reason,
         tool_name,
         &session.meta_session_id,
+        session_dir.as_deref(),
     );
     let diagnostic_line = diagnostic.as_ref().and_then(KillDiagnostic::stderr_line);
     if let Some(line) = &diagnostic_line {
@@ -234,13 +304,18 @@ pub(crate) fn save_result_with_signal_diagnostic(
     }
 
     if let Some(diagnostic) = diagnostic {
+        let diagnostic_last_item = diagnostic.last_item();
+        let last_item = diagnostic_last_item
+            .as_deref()
+            .or_else(|| last_known_work_item(session, tool_name))
+            .map(redact_command_text);
         save_result_with_signal_metadata(
             project_root,
             &session.meta_session_id,
             result,
             SignalResultMetadata {
                 kill_hint: diagnostic.hint.as_result_hint(),
-                last_item: last_known_work_item(session, tool_name),
+                last_item: last_item.as_deref(),
             },
         )?;
     } else {
@@ -264,7 +339,7 @@ pub(crate) fn render_result_toml_with_signal_diagnostic(
         rendered_result.last_item = last_item
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned);
+            .map(redact_command_text);
     }
     toml::to_string_pretty(&rendered_result).context("Failed to render session result")
 }
@@ -273,6 +348,7 @@ pub(crate) fn signal_toml(
     result: &SessionResult,
     session: &MetaSessionState,
     session_id: &str,
+    session_dir: &Path,
     exit_code: i32,
 ) -> Result<String> {
     let diagnostic = diagnose_signal_kill(
@@ -280,12 +356,13 @@ pub(crate) fn signal_toml(
         session.termination_reason.as_deref(),
         &result.tool,
         session_id,
+        Some(session_dir),
     );
-    render_result_toml_with_signal_diagnostic(
-        result,
-        diagnostic.as_ref(),
-        last_known_work_item(session, &result.tool),
-    )
+    let diagnostic_last_item = diagnostic.as_ref().and_then(KillDiagnostic::last_item);
+    let last_item = diagnostic_last_item
+        .as_deref()
+        .or_else(|| last_known_work_item(session, &result.tool));
+    render_result_toml_with_signal_diagnostic(result, diagnostic.as_ref(), last_item)
 }
 
 fn append_stderr_line(stderr_output: Option<&mut String>, line: &str) {
@@ -314,8 +391,10 @@ fn normalize_terminal_reason(reason: Option<&str>) -> Option<String> {
 }
 
 fn classify_signal_kill(
+    exit_code: i32,
     observations: KillSignalObservations,
     terminal_reason: Option<String>,
+    child_timeout: Option<ChildTimeoutProvenance>,
 ) -> KillDiagnostic {
     let very_low_memory = observations
         .meminfo
@@ -335,6 +414,15 @@ fn classify_signal_kill(
         KillHint::MemoryPressure
     } else if possible_low_memory {
         KillHint::PossibleMemoryPressure
+    } else if exit_code == 143
+        && let Some(child_timeout) = child_timeout
+    {
+        return KillDiagnostic {
+            hint: child_timeout_hint(child_timeout.kind),
+            observations,
+            terminal_reason,
+            child_timeout: Some(child_timeout),
+        };
     } else {
         KillHint::UnknownSignal
     };
@@ -343,6 +431,14 @@ fn classify_signal_kill(
         hint,
         observations,
         terminal_reason,
+        child_timeout: None,
+    }
+}
+
+fn child_timeout_hint(kind: ChildTimeoutKind) -> KillHint {
+    match kind {
+        ChildTimeoutKind::BoundedCommand => KillHint::ChildTimeout,
+        ChildTimeoutKind::HookEnabledGitCommit => KillHint::HookCommitTimeout,
     }
 }
 
@@ -491,246 +587,5 @@ fn kb_to_mb(kb: u64) -> u64 {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::cell::Cell;
-
-    #[test]
-    fn parses_meminfo_available_and_total() {
-        let meminfo = parse_meminfo(
-            "\
-MemTotal:       16384000 kB
-MemFree:         1000000 kB
-MemAvailable:    900000 kB
-",
-        )
-        .expect("meminfo should parse");
-
-        assert_eq!(meminfo.total_kb, 16_384_000);
-        assert_eq!(meminfo.available_kb, 900_000);
-        assert!(meminfo.available_below_ten_percent());
-        assert!(!meminfo.available_below_five_percent());
-    }
-
-    #[test]
-    fn classifies_signal_exit_under_possible_memory_pressure() {
-        let diagnostic = diagnose_signal_kill_with(143, None, || KillSignalObservations {
-            meminfo: Some(MemInfo {
-                total_kb: 10_000,
-                available_kb: 999,
-            }),
-            earlyoom_running: false,
-            cgroup_memory_events: None,
-        })
-        .expect("signal exit should produce diagnostic");
-
-        assert_eq!(diagnostic.hint, KillHint::PossibleMemoryPressure);
-        assert!(
-            diagnostic
-                .stderr_line()
-                .expect("memory pressure should render")
-                .contains("MemAvailable: 0 MB / MemTotal: 9 MB")
-        );
-    }
-
-    #[test]
-    fn classifies_signal_exit_under_strong_memory_pressure() {
-        let diagnostic = diagnose_signal_kill_with(143, None, || KillSignalObservations {
-            meminfo: Some(MemInfo {
-                total_kb: 10_000,
-                available_kb: 499,
-            }),
-            earlyoom_running: false,
-            cgroup_memory_events: None,
-        })
-        .expect("signal exit should produce diagnostic");
-
-        assert_eq!(diagnostic.hint, KillHint::MemoryPressure);
-        assert!(
-            diagnostic
-                .stderr_line()
-                .expect("memory pressure should render")
-                .contains("memory pressure")
-        );
-    }
-
-    #[test]
-    fn classifies_unknown_when_earlyoom_runs_without_memory_pressure() {
-        let diagnostic = diagnose_signal_kill_with(137, None, || KillSignalObservations {
-            meminfo: Some(MemInfo {
-                total_kb: 10_000,
-                available_kb: 5_000,
-            }),
-            earlyoom_running: true,
-            cgroup_memory_events: None,
-        })
-        .expect("signal exit should produce diagnostic");
-
-        assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
-        assert!(
-            diagnostic
-                .stderr_line()
-                .expect("unknown signal should render checked evidence")
-                .contains("earlyoom running")
-        );
-    }
-
-    #[test]
-    fn classifies_earlyoom_when_daemon_runs_with_strong_memory_pressure() {
-        let diagnostic = diagnose_signal_kill_with(137, None, || KillSignalObservations {
-            meminfo: Some(MemInfo {
-                total_kb: 10_000,
-                available_kb: 499,
-            }),
-            earlyoom_running: true,
-            cgroup_memory_events: None,
-        })
-        .expect("signal exit should produce diagnostic");
-
-        assert_eq!(diagnostic.hint, KillHint::Earlyoom);
-        assert!(
-            diagnostic
-                .stderr_line()
-                .expect("earlyoom should render")
-                .contains("earlyoom running")
-        );
-    }
-
-    #[test]
-    fn classifies_earlyoom_when_daemon_runs_with_cgroup_oom_kill() {
-        let diagnostic = diagnose_signal_kill_with(137, None, || KillSignalObservations {
-            meminfo: Some(MemInfo {
-                total_kb: 10_000,
-                available_kb: 5_000,
-            }),
-            earlyoom_running: true,
-            cgroup_memory_events: Some(CgroupMemoryEvents {
-                oom: 0,
-                oom_kill: 1,
-            }),
-        })
-        .expect("signal exit should produce diagnostic");
-
-        assert_eq!(diagnostic.hint, KillHint::Earlyoom);
-    }
-
-    #[test]
-    fn does_not_classify_earlyoom_from_oom_without_oom_kill() {
-        let diagnostic = diagnose_signal_kill_with(137, None, || KillSignalObservations {
-            meminfo: Some(MemInfo {
-                total_kb: 10_000,
-                available_kb: 5_000,
-            }),
-            earlyoom_running: true,
-            cgroup_memory_events: Some(CgroupMemoryEvents {
-                oom: 1,
-                oom_kill: 0,
-            }),
-        })
-        .expect("signal exit should produce diagnostic");
-
-        assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
-        assert!(
-            diagnostic
-                .stderr_line()
-                .expect("unknown signal should render checked evidence")
-                .contains("cgroup memory.events oom=1 oom_kill=0")
-        );
-    }
-
-    #[test]
-    fn csa_timeout_terminal_reasons_take_precedence_over_earlyoom() {
-        for terminal_reason in ["timeout", "idle_timeout", "initial_response_timeout"] {
-            let called = Cell::new(false);
-            let diagnostic = diagnose_signal_kill_with(137, Some(terminal_reason), || {
-                called.set(true);
-                KillSignalObservations {
-                    meminfo: Some(MemInfo {
-                        total_kb: 10_000,
-                        available_kb: 999,
-                    }),
-                    earlyoom_running: true,
-                    cgroup_memory_events: Some(CgroupMemoryEvents {
-                        oom: 1,
-                        oom_kill: 1,
-                    }),
-                }
-            })
-            .expect("signal exit should produce diagnostic");
-
-            assert_eq!(diagnostic.hint, KillHint::CsaTimeout);
-            assert!(!called.get(), "{terminal_reason} should skip memory checks");
-            let line = diagnostic
-                .stderr_line()
-                .expect("timeout signal should render timeout reason");
-            assert!(line.contains(terminal_reason));
-            assert!(line.contains("concrete kill reason"));
-        }
-    }
-
-    #[test]
-    fn classifies_unknown_signal_without_memory_evidence() {
-        let diagnostic = diagnose_signal_kill_with(143, None, KillSignalObservations::default)
-            .expect("signal exit should produce diagnostic");
-
-        assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
-        let line = diagnostic
-            .stderr_line()
-            .expect("unknown signal should render checked evidence");
-        assert!(line.contains("unknown_signal"));
-        assert!(line.contains("termination_reason: missing"));
-        assert!(line.contains("MemAvailable: unavailable"));
-        assert!(line.contains("earlyoom not running"));
-        assert!(line.contains("reason remains unknown"));
-    }
-
-    #[test]
-    fn unknown_signal_reports_negative_memory_evidence() {
-        let diagnostic =
-            diagnose_signal_kill_with(143, Some("sigterm"), || KillSignalObservations {
-                meminfo: Some(MemInfo {
-                    total_kb: 16_384_000,
-                    available_kb: 12_288_000,
-                }),
-                earlyoom_running: false,
-                cgroup_memory_events: Some(CgroupMemoryEvents {
-                    oom: 0,
-                    oom_kill: 0,
-                }),
-            })
-            .expect("signal exit should produce diagnostic");
-
-        assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
-        let line = diagnostic
-            .stderr_line()
-            .expect("unknown signal should render checked evidence");
-        assert!(line.contains("termination_reason=sigterm"));
-        assert!(line.contains("MemAvailable: 12000 MB / MemTotal: 16000 MB"));
-        assert!(line.contains("earlyoom not running"));
-        assert!(line.contains("cgroup memory.events oom=0 oom_kill=0"));
-        assert!(line.contains("reason remains unknown"));
-    }
-
-    #[test]
-    fn non_signal_exits_do_not_collect_observations() {
-        for exit_code in [0, 1, 2] {
-            let called = Cell::new(false);
-            let diagnostic = diagnose_signal_kill_with(exit_code, None, || {
-                called.set(true);
-                KillSignalObservations::default()
-            });
-            assert!(diagnostic.is_none());
-            assert!(!called.get(), "exit {exit_code} should not trigger checks");
-        }
-    }
-
-    #[test]
-    fn parses_cgroup_memory_events() {
-        let events = parse_memory_events("low 2\nhigh 3\nmax 4\noom 1\noom_kill 1\n");
-
-        assert_eq!(events.oom, 1);
-        assert_eq!(events.oom_kill, 1);
-        assert!(events.has_oom_event());
-        assert!(events.has_oom_kill_event());
-    }
-}
+#[path = "session_kill_diagnostics_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/session_kill_diagnostics/child_timeout.rs
+++ b/crates/cli-sub-agent/src/session_kill_diagnostics/child_timeout.rs
@@ -1,0 +1,766 @@
+//! Transcript evidence for signal exits caused by bounded child commands.
+
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+    ops::Range,
+    path::Path,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChildTimeoutKind {
+    BoundedCommand,
+    HookEnabledGitCommit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChildTimeoutProvenance {
+    pub(crate) command: String,
+    pub(crate) timeout_seconds: Option<u64>,
+    pub(crate) kind: ChildTimeoutKind,
+    pub(crate) command_status: Option<String>,
+    pub(crate) transcript_exit_143: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ObservedChildCommand {
+    command: String,
+    status: Option<String>,
+    exit_code: Option<i64>,
+    transcript_exit_143: bool,
+}
+
+pub(crate) fn detect_child_timeout_provenance(
+    session_dir: &Path,
+    exit_code: i32,
+) -> Option<ChildTimeoutProvenance> {
+    if exit_code != 143 {
+        return None;
+    }
+
+    let output_log = session_dir.join("output.log");
+    let file = File::open(output_log).ok()?;
+    let reader = BufReader::new(file);
+    let mut last_command: Option<ObservedChildCommand> = None;
+
+    for line_result in reader.lines() {
+        let Ok(line) = line_result else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            mark_exit_143_after_last_command(&line, &mut last_command);
+            continue;
+        };
+        if let Some(command) = observed_child_command(&value) {
+            last_command = Some(command);
+        }
+        mark_exit_143_after_last_command(&line, &mut last_command);
+    }
+
+    let observed = last_command?;
+    if !observed.has_active_timeout_evidence() {
+        return None;
+    }
+    let timeout_seconds = timeout_duration_seconds(&observed.command)?;
+    let kind = if invokes_hook_enabled_git_commit(&observed.command) {
+        ChildTimeoutKind::HookEnabledGitCommit
+    } else {
+        ChildTimeoutKind::BoundedCommand
+    };
+
+    let redacted_command = redact_command_text(&observed.command);
+    Some(ChildTimeoutProvenance {
+        command: truncate_one_line(&redacted_command, 300),
+        timeout_seconds: Some(timeout_seconds),
+        kind,
+        command_status: observed.status,
+        transcript_exit_143: observed.transcript_exit_143 || observed.exit_code == Some(143),
+    })
+}
+
+pub(crate) fn redact_command_text(command: &str) -> String {
+    let redacted = redact_shell_credential_options(command);
+    csa_session::redact_text_content(&redacted)
+}
+
+#[derive(Debug, Clone)]
+struct CommandToken {
+    text: String,
+    start: usize,
+    end: usize,
+    boundary_before: bool,
+    quote_id: Option<usize>,
+    quote_started_before: bool,
+}
+
+#[derive(Debug, Clone)]
+struct CommandRedaction {
+    range: Range<usize>,
+    next_index: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RedactionValueKind {
+    Header,
+    Credential,
+}
+
+fn redact_shell_credential_options(command: &str) -> String {
+    let tokens = command_tokens(command);
+    let mut redactions = Vec::new();
+    let mut index = 0;
+
+    while index < tokens.len() {
+        if let Some(redaction) = header_option_redaction(&tokens, index) {
+            index = redaction.next_index;
+            redactions.push(redaction.range);
+            continue;
+        }
+        if let Some(redaction) = user_option_redaction(&tokens, index) {
+            index = redaction.next_index;
+            redactions.push(redaction.range);
+            continue;
+        }
+        if let Some(redaction) = sensitive_option_redaction(&tokens, index) {
+            index = redaction.next_index;
+            redactions.push(redaction.range);
+            continue;
+        }
+        index += 1;
+    }
+
+    apply_redactions(command, redactions)
+}
+
+fn header_option_redaction(tokens: &[CommandToken], index: usize) -> Option<CommandRedaction> {
+    let token = &tokens[index];
+    let text = token.text.as_str();
+
+    if text == "-H" || text.eq_ignore_ascii_case("--header") {
+        let value_index = following_value_index(tokens, index)?;
+        return Some(value_redaction(
+            tokens,
+            value_index,
+            tokens[value_index].start,
+            tokens[value_index].text.as_str(),
+            RedactionValueKind::Header,
+        ));
+    }
+
+    if let Some(offset) = short_header_value_offset(text) {
+        return inline_value_redaction(tokens, index, offset, RedactionValueKind::Header);
+    }
+
+    if let Some(offset) = long_inline_value_offset(text, "--header") {
+        return inline_value_redaction(tokens, index, offset, RedactionValueKind::Header);
+    }
+
+    None
+}
+
+fn user_option_redaction(tokens: &[CommandToken], index: usize) -> Option<CommandRedaction> {
+    let token = &tokens[index];
+    let text = token.text.as_str();
+
+    if text.eq_ignore_ascii_case("--user") || text.eq_ignore_ascii_case("--proxy-user") {
+        let value_index = following_value_index(tokens, index)?;
+        return Some(value_redaction(
+            tokens,
+            value_index,
+            tokens[value_index].start,
+            tokens[value_index].text.as_str(),
+            RedactionValueKind::Credential,
+        ));
+    }
+
+    for option_name in ["--user", "--proxy-user"] {
+        if let Some(offset) = long_inline_value_offset(text, option_name) {
+            return inline_value_redaction(tokens, index, offset, RedactionValueKind::Credential);
+        }
+    }
+
+    if text == "-u" {
+        let value_index = following_value_index(tokens, index)?;
+        return Some(value_redaction(
+            tokens,
+            value_index,
+            tokens[value_index].start,
+            tokens[value_index].text.as_str(),
+            RedactionValueKind::Credential,
+        ));
+    }
+
+    if let Some(offset) = short_user_value_offset(text) {
+        return inline_value_redaction(tokens, index, offset, RedactionValueKind::Credential);
+    }
+
+    None
+}
+
+fn sensitive_option_redaction(tokens: &[CommandToken], index: usize) -> Option<CommandRedaction> {
+    let token = &tokens[index];
+    let text = token.text.as_str();
+    if !text.starts_with('-') || text == "-" {
+        return None;
+    }
+
+    if let Some(separator_index) = text.find(['=', ':']) {
+        let option_name = &text[..separator_index];
+        if is_sensitive_option_name(option_name) {
+            return inline_value_redaction(
+                tokens,
+                index,
+                separator_index + 1,
+                RedactionValueKind::Credential,
+            );
+        }
+        return None;
+    }
+
+    if !is_sensitive_option_name(text) {
+        return None;
+    }
+    let value_index = following_value_index(tokens, index)?;
+    Some(value_redaction(
+        tokens,
+        value_index,
+        tokens[value_index].start,
+        tokens[value_index].text.as_str(),
+        RedactionValueKind::Credential,
+    ))
+}
+
+fn inline_value_redaction(
+    tokens: &[CommandToken],
+    index: usize,
+    offset: usize,
+    kind: RedactionValueKind,
+) -> Option<CommandRedaction> {
+    let token = &tokens[index];
+    if offset < token.text.len() {
+        return Some(value_redaction(
+            tokens,
+            index,
+            token.start + offset,
+            &token.text[offset..],
+            kind,
+        ));
+    }
+
+    let value_index = following_value_index(tokens, index)?;
+    Some(value_redaction(
+        tokens,
+        value_index,
+        tokens[value_index].start,
+        tokens[value_index].text.as_str(),
+        kind,
+    ))
+}
+
+fn value_redaction(
+    tokens: &[CommandToken],
+    value_index: usize,
+    value_start: usize,
+    value_text: &str,
+    kind: RedactionValueKind,
+) -> CommandRedaction {
+    if !value_text.is_empty()
+        && value_text.chars().all(|ch| ch == '\\')
+        && let Some(last_value_index) = escaped_quoted_value_last_token(tokens, value_index)
+    {
+        return CommandRedaction {
+            range: value_start..tokens[last_value_index].end,
+            next_index: last_value_index + 1,
+        };
+    }
+
+    let starts_at_token_start = value_start == tokens[value_index].start;
+    let last_value_index = match kind {
+        RedactionValueKind::Header => {
+            header_value_last_token(tokens, value_index, value_text, starts_at_token_start)
+        }
+        RedactionValueKind::Credential => {
+            quoted_value_last_token(tokens, value_index, starts_at_token_start)
+                .unwrap_or(value_index)
+        }
+    };
+
+    CommandRedaction {
+        range: value_start..tokens[last_value_index].end,
+        next_index: last_value_index + 1,
+    }
+}
+
+fn header_value_last_token(
+    tokens: &[CommandToken],
+    value_index: usize,
+    value_text: &str,
+    starts_at_token_start: bool,
+) -> usize {
+    if let Some(last_index) = quoted_value_last_token(tokens, value_index, starts_at_token_start) {
+        return last_index;
+    }
+
+    let mut last_index = value_index;
+    let Some((name, after_colon)) = value_text.trim().split_once(':') else {
+        return last_index;
+    };
+    let after_colon = after_colon.trim_start();
+
+    if header_name_is_authorization(name) {
+        if after_colon.is_empty() {
+            if let Some(next_index) = next_header_value_token(tokens, last_index, true) {
+                last_index = next_index;
+                if is_auth_scheme(tokens[last_index].text.as_str())
+                    && let Some(secret_index) = next_header_value_token(tokens, last_index, true)
+                {
+                    last_index = secret_index;
+                }
+            }
+        } else if is_auth_scheme(after_colon)
+            && let Some(secret_index) = next_header_value_token(tokens, last_index, true)
+        {
+            last_index = secret_index;
+        }
+    } else if after_colon.is_empty() {
+        let allow_option_like_token = header_name_is_credential_bearing(name);
+        while let Some(next_index) =
+            next_header_value_token(tokens, last_index, allow_option_like_token)
+        {
+            last_index = next_index;
+        }
+    }
+
+    last_index
+}
+
+fn escaped_quoted_value_last_token(tokens: &[CommandToken], value_index: usize) -> Option<usize> {
+    let quoted_value_index = value_index + 1;
+    if quoted_value_index >= tokens.len() || tokens[quoted_value_index].boundary_before {
+        return None;
+    }
+    quoted_value_last_token(tokens, quoted_value_index, true)
+}
+
+fn quoted_value_last_token(
+    tokens: &[CommandToken],
+    value_index: usize,
+    starts_at_token_start: bool,
+) -> Option<usize> {
+    if !starts_at_token_start || !tokens[value_index].quote_started_before {
+        return None;
+    }
+    let quote_id = tokens[value_index].quote_id?;
+    let mut last_index = value_index;
+    while last_index + 1 < tokens.len() && tokens[last_index + 1].quote_id == Some(quote_id) {
+        last_index += 1;
+    }
+    Some(last_index)
+}
+
+fn following_value_index(tokens: &[CommandToken], option_index: usize) -> Option<usize> {
+    let mut value_index = option_index + 1;
+    if value_index >= tokens.len() || tokens[value_index].boundary_before {
+        return None;
+    }
+    if matches!(tokens[value_index].text.as_str(), "=" | ":") {
+        value_index += 1;
+        if value_index >= tokens.len() || tokens[value_index].boundary_before {
+            return None;
+        }
+    }
+    Some(value_index)
+}
+
+fn next_header_value_token(
+    tokens: &[CommandToken],
+    current_index: usize,
+    allow_option_like_token: bool,
+) -> Option<usize> {
+    let next_index = current_index + 1;
+    if next_index >= tokens.len() || tokens[next_index].boundary_before {
+        return None;
+    }
+    let next_text = tokens[next_index].text.as_str();
+    if looks_like_url(next_text) || (!allow_option_like_token && looks_like_option(next_text)) {
+        return None;
+    }
+    Some(next_index)
+}
+
+fn short_header_value_offset(text: &str) -> Option<usize> {
+    if text == "-H" {
+        None
+    } else if text.starts_with("-H=") || text.starts_with("-H:") {
+        Some(3)
+    } else if text.starts_with("-H") {
+        Some(2)
+    } else {
+        None
+    }
+}
+
+fn short_user_value_offset(text: &str) -> Option<usize> {
+    if text == "-u" {
+        None
+    } else if text.starts_with("-u=") || text.starts_with("-u:") {
+        Some(3)
+    } else if text.starts_with("-u") {
+        Some(2)
+    } else {
+        None
+    }
+}
+
+fn long_inline_value_offset(text: &str, option_name: &str) -> Option<usize> {
+    if text.len() <= option_name.len() {
+        return None;
+    }
+    let (candidate, rest) = text.split_at(option_name.len());
+    if candidate.eq_ignore_ascii_case(option_name)
+        && (rest.starts_with('=') || rest.starts_with(':'))
+    {
+        Some(option_name.len() + 1)
+    } else {
+        None
+    }
+}
+
+fn is_sensitive_option_name(name: &str) -> bool {
+    let normalized = normalize_credential_name(name.trim_start_matches('-'));
+    normalized.contains("apikey")
+        || normalized.contains("auth")
+        || normalized.contains("bearer")
+        || normalized.contains("password")
+        || normalized.contains("passwd")
+        || normalized.contains("pwd")
+        || normalized.contains("secret")
+        || normalized.contains("token")
+}
+
+fn header_name_is_authorization(name: &str) -> bool {
+    normalize_credential_name(name).contains("authorization")
+}
+
+fn header_name_is_credential_bearing(name: &str) -> bool {
+    let normalized = normalize_credential_name(name);
+    normalized.contains("authorization")
+        || normalized.contains("apikey")
+        || normalized.contains("auth")
+        || normalized.contains("password")
+        || normalized.contains("secret")
+        || normalized.contains("token")
+}
+
+fn normalize_credential_name(name: &str) -> String {
+    name.chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn is_auth_scheme(value: &str) -> bool {
+    let normalized = value.trim_matches(|ch: char| !ch.is_ascii_alphanumeric());
+    normalized.eq_ignore_ascii_case("basic")
+        || normalized.eq_ignore_ascii_case("bearer")
+        || normalized.eq_ignore_ascii_case("digest")
+        || normalized.eq_ignore_ascii_case("negotiate")
+        || normalized.eq_ignore_ascii_case("token")
+}
+
+fn looks_like_option(value: &str) -> bool {
+    value.starts_with('-') && value != "-"
+}
+
+fn looks_like_url(value: &str) -> bool {
+    value.contains("://")
+}
+
+fn command_tokens(command: &str) -> Vec<CommandToken> {
+    let mut tokens = Vec::new();
+    let mut token_start = None;
+    let mut token_text = String::new();
+    let mut token_boundary_before = false;
+    let mut token_quote_id = None;
+    let mut token_quote_started_before = false;
+    let mut pending_boundary = false;
+    let mut pending_quote_start = None;
+    let mut quote_stack = Vec::new();
+    let mut next_quote_id = 0;
+
+    for (index, ch) in command.char_indices() {
+        if matches!(ch, '\'' | '"') {
+            push_command_token(
+                &mut tokens,
+                &mut token_start,
+                &mut token_text,
+                token_boundary_before,
+                token_quote_id,
+                token_quote_started_before,
+                index,
+            );
+            if quote_stack.last().is_some_and(|(quote, _)| *quote == ch) {
+                let (_, quote_id) = quote_stack.pop().expect("quote stack should have top");
+                if pending_quote_start == Some(quote_id) {
+                    pending_quote_start = None;
+                }
+            } else {
+                let quote_id = next_quote_id;
+                next_quote_id += 1;
+                quote_stack.push((ch, quote_id));
+                pending_quote_start = Some(quote_id);
+            }
+            continue;
+        }
+
+        if ch.is_whitespace() {
+            push_command_token(
+                &mut tokens,
+                &mut token_start,
+                &mut token_text,
+                token_boundary_before,
+                token_quote_id,
+                token_quote_started_before,
+                index,
+            );
+            continue;
+        }
+
+        if is_shell_control(ch) {
+            push_command_token(
+                &mut tokens,
+                &mut token_start,
+                &mut token_text,
+                token_boundary_before,
+                token_quote_id,
+                token_quote_started_before,
+                index,
+            );
+            pending_boundary = true;
+            continue;
+        }
+
+        if token_start.is_none() {
+            token_start = Some(index);
+            token_boundary_before = pending_boundary;
+            pending_boundary = false;
+            token_quote_id = quote_stack.last().map(|(_, quote_id)| *quote_id);
+            token_quote_started_before =
+                token_quote_id.is_some() && pending_quote_start == token_quote_id;
+            if token_quote_started_before {
+                pending_quote_start = None;
+            }
+        }
+        token_text.push(ch);
+    }
+
+    push_command_token(
+        &mut tokens,
+        &mut token_start,
+        &mut token_text,
+        token_boundary_before,
+        token_quote_id,
+        token_quote_started_before,
+        command.len(),
+    );
+    tokens
+}
+
+fn push_command_token(
+    tokens: &mut Vec<CommandToken>,
+    token_start: &mut Option<usize>,
+    token_text: &mut String,
+    boundary_before: bool,
+    quote_id: Option<usize>,
+    quote_started_before: bool,
+    end: usize,
+) {
+    let Some(start) = token_start.take() else {
+        return;
+    };
+    tokens.push(CommandToken {
+        text: std::mem::take(token_text),
+        start,
+        end,
+        boundary_before,
+        quote_id,
+        quote_started_before,
+    });
+}
+
+fn is_shell_control(ch: char) -> bool {
+    matches!(ch, ';' | '(' | ')' | '&' | '|')
+}
+
+fn apply_redactions(command: &str, mut redactions: Vec<Range<usize>>) -> String {
+    redactions.retain(|range| range.start < range.end && range.end <= command.len());
+    if redactions.is_empty() {
+        return command.to_string();
+    }
+
+    redactions.sort_by_key(|range| (range.start, range.end));
+    let mut merged: Vec<Range<usize>> = Vec::new();
+    for range in redactions {
+        if let Some(last) = merged.last_mut()
+            && range.start <= last.end
+        {
+            last.end = last.end.max(range.end);
+            continue;
+        }
+        merged.push(range);
+    }
+
+    let mut redacted = String::with_capacity(command.len());
+    let mut cursor = 0;
+    for range in merged {
+        redacted.push_str(&command[cursor..range.start]);
+        redacted.push_str("[REDACTED]");
+        cursor = range.end;
+    }
+    redacted.push_str(&command[cursor..]);
+    redacted
+}
+
+fn mark_exit_143_after_last_command(line: &str, last_command: &mut Option<ObservedChildCommand>) {
+    if mentions_exit_143(line)
+        && let Some(command) = last_command
+    {
+        command.transcript_exit_143 = true;
+    }
+}
+
+fn observed_child_command(value: &serde_json::Value) -> Option<ObservedChildCommand> {
+    let item = value.get("item")?;
+    if item.get("type").and_then(serde_json::Value::as_str) != Some("command_execution") {
+        return None;
+    }
+    let command = item
+        .get("command")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|command| !command.is_empty())?;
+    let status = item
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|status| !status.is_empty())
+        .map(ToOwned::to_owned);
+    let exit_code = item.get("exit_code").and_then(serde_json::Value::as_i64);
+    Some(ObservedChildCommand {
+        command: command.to_string(),
+        status,
+        exit_code,
+        transcript_exit_143: exit_code == Some(143),
+    })
+}
+
+impl ObservedChildCommand {
+    fn has_active_timeout_evidence(&self) -> bool {
+        self.transcript_exit_143
+            || self.exit_code == Some(143)
+            || self.status.as_deref() == Some("in_progress")
+    }
+}
+
+fn mentions_exit_143(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    lower.contains("exit code 143")
+        || lower.contains("exited with code 143")
+        || lower.contains("terminated with code 143")
+}
+
+fn timeout_duration_seconds(command: &str) -> Option<u64> {
+    let tokens = shellish_tokens(command);
+    for (index, token) in tokens.iter().enumerate() {
+        if !basename_is(token, "timeout") {
+            continue;
+        }
+        let mut cursor = index + 1;
+        while cursor < tokens.len() {
+            let token = tokens[cursor].as_str();
+            if timeout_option_consumes_next(token) {
+                cursor += 2;
+                continue;
+            }
+            if timeout_option_without_value(token) {
+                cursor += 1;
+                continue;
+            }
+            return parse_duration_seconds(token);
+        }
+    }
+    None
+}
+
+fn invokes_hook_enabled_git_commit(command: &str) -> bool {
+    if shellish_tokens(command)
+        .iter()
+        .any(|token| token == "--no-verify")
+    {
+        return false;
+    }
+    shellish_tokens(command)
+        .windows(2)
+        .any(|window| basename_is(&window[0], "git") && window[1] == "commit")
+}
+
+fn shellish_tokens(command: &str) -> Vec<String> {
+    command
+        .split(|ch: char| {
+            ch.is_whitespace() || matches!(ch, '\'' | '"' | ';' | '(' | ')' | '&' | '|')
+        })
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn basename_is(token: &str, expected: &str) -> bool {
+    token.rsplit('/').next() == Some(expected)
+}
+
+fn timeout_option_consumes_next(token: &str) -> bool {
+    matches!(token, "-k" | "--kill-after" | "-s" | "--signal")
+}
+
+fn timeout_option_without_value(token: &str) -> bool {
+    token == "--foreground"
+        || token == "--preserve-status"
+        || token == "--verbose"
+        || token.starts_with("--kill-after=")
+        || token.starts_with("--signal=")
+        || token.starts_with("-k")
+        || token.starts_with("-s")
+}
+
+fn parse_duration_seconds(raw: &str) -> Option<u64> {
+    let digit_len = raw
+        .as_bytes()
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digit_len == 0 {
+        return None;
+    }
+    let value = raw[..digit_len].parse::<u64>().ok()?;
+    match &raw[digit_len..] {
+        "" | "s" => Some(value),
+        "m" => value.checked_mul(60),
+        "h" => value.checked_mul(60 * 60),
+        "d" => value.checked_mul(24 * 60 * 60),
+        _ => None,
+    }
+}
+
+pub(crate) fn truncate_one_line(value: &str, max_chars: usize) -> String {
+    let one_line = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if one_line.chars().count() <= max_chars {
+        return one_line;
+    }
+    let mut truncated = one_line
+        .chars()
+        .take(max_chars.saturating_sub(3))
+        .collect::<String>();
+    truncated.push_str("...");
+    truncated
+}

--- a/crates/cli-sub-agent/src/session_kill_diagnostics_tests.rs
+++ b/crates/cli-sub-agent/src/session_kill_diagnostics_tests.rs
@@ -1,0 +1,554 @@
+use super::child_timeout::{
+    ChildTimeoutKind, ChildTimeoutProvenance, detect_child_timeout_provenance,
+};
+use super::*;
+use std::{cell::Cell, fs};
+
+#[test]
+fn parses_meminfo_available_and_total() {
+    let meminfo = parse_meminfo(
+        "\
+MemTotal:       16384000 kB
+MemFree:         1000000 kB
+MemAvailable:    900000 kB
+",
+    )
+    .expect("meminfo should parse");
+
+    assert_eq!(meminfo.total_kb, 16_384_000);
+    assert_eq!(meminfo.available_kb, 900_000);
+    assert!(meminfo.available_below_ten_percent());
+    assert!(!meminfo.available_below_five_percent());
+}
+
+#[test]
+fn classifies_signal_exit_under_possible_memory_pressure() {
+    let diagnostic = diagnose_signal_kill_with(143, None, || KillSignalObservations {
+        meminfo: Some(MemInfo {
+            total_kb: 10_000,
+            available_kb: 999,
+        }),
+        earlyoom_running: false,
+        cgroup_memory_events: None,
+    })
+    .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::PossibleMemoryPressure);
+    assert!(
+        diagnostic
+            .stderr_line()
+            .expect("memory pressure should render")
+            .contains("MemAvailable: 0 MB / MemTotal: 9 MB")
+    );
+}
+
+#[test]
+fn classifies_signal_exit_under_strong_memory_pressure() {
+    let diagnostic = diagnose_signal_kill_with(143, None, || KillSignalObservations {
+        meminfo: Some(MemInfo {
+            total_kb: 10_000,
+            available_kb: 499,
+        }),
+        earlyoom_running: false,
+        cgroup_memory_events: None,
+    })
+    .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::MemoryPressure);
+    assert!(
+        diagnostic
+            .stderr_line()
+            .expect("memory pressure should render")
+            .contains("memory pressure")
+    );
+}
+
+#[test]
+fn classifies_unknown_when_earlyoom_runs_without_memory_pressure() {
+    let diagnostic = diagnose_signal_kill_with(137, None, || KillSignalObservations {
+        meminfo: Some(MemInfo {
+            total_kb: 10_000,
+            available_kb: 5_000,
+        }),
+        earlyoom_running: true,
+        cgroup_memory_events: None,
+    })
+    .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
+    assert!(
+        diagnostic
+            .stderr_line()
+            .expect("unknown signal should render checked evidence")
+            .contains("earlyoom running")
+    );
+}
+
+#[test]
+fn classifies_earlyoom_when_daemon_runs_with_strong_memory_pressure() {
+    let diagnostic = diagnose_signal_kill_with(137, None, || KillSignalObservations {
+        meminfo: Some(MemInfo {
+            total_kb: 10_000,
+            available_kb: 499,
+        }),
+        earlyoom_running: true,
+        cgroup_memory_events: None,
+    })
+    .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::Earlyoom);
+    assert!(
+        diagnostic
+            .stderr_line()
+            .expect("earlyoom should render")
+            .contains("earlyoom running")
+    );
+}
+
+#[test]
+fn classifies_earlyoom_when_daemon_runs_with_cgroup_oom_kill() {
+    let diagnostic = diagnose_signal_kill_with(137, None, || KillSignalObservations {
+        meminfo: Some(MemInfo {
+            total_kb: 10_000,
+            available_kb: 5_000,
+        }),
+        earlyoom_running: true,
+        cgroup_memory_events: Some(CgroupMemoryEvents {
+            oom: 0,
+            oom_kill: 1,
+        }),
+    })
+    .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::Earlyoom);
+}
+
+#[test]
+fn does_not_classify_earlyoom_from_oom_without_oom_kill() {
+    let diagnostic = diagnose_signal_kill_with(137, None, || KillSignalObservations {
+        meminfo: Some(MemInfo {
+            total_kb: 10_000,
+            available_kb: 5_000,
+        }),
+        earlyoom_running: true,
+        cgroup_memory_events: Some(CgroupMemoryEvents {
+            oom: 1,
+            oom_kill: 0,
+        }),
+    })
+    .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
+    assert!(
+        diagnostic
+            .stderr_line()
+            .expect("unknown signal should render checked evidence")
+            .contains("cgroup memory.events oom=1 oom_kill=0")
+    );
+}
+
+#[test]
+fn csa_timeout_terminal_reasons_take_precedence_over_earlyoom() {
+    for terminal_reason in ["timeout", "idle_timeout", "initial_response_timeout"] {
+        let called = Cell::new(false);
+        let diagnostic = diagnose_signal_kill_with(137, Some(terminal_reason), || {
+            called.set(true);
+            KillSignalObservations {
+                meminfo: Some(MemInfo {
+                    total_kb: 10_000,
+                    available_kb: 999,
+                }),
+                earlyoom_running: true,
+                cgroup_memory_events: Some(CgroupMemoryEvents {
+                    oom: 1,
+                    oom_kill: 1,
+                }),
+            }
+        })
+        .expect("signal exit should produce diagnostic");
+
+        assert_eq!(diagnostic.hint, KillHint::CsaTimeout);
+        assert!(!called.get(), "{terminal_reason} should skip memory checks");
+        let line = diagnostic
+            .stderr_line()
+            .expect("timeout signal should render timeout reason");
+        assert!(line.contains(terminal_reason));
+        assert!(line.contains("concrete kill reason"));
+    }
+}
+
+#[test]
+fn classifies_unknown_signal_without_memory_evidence() {
+    let diagnostic = diagnose_signal_kill_with(143, None, KillSignalObservations::default)
+        .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
+    let line = diagnostic
+        .stderr_line()
+        .expect("unknown signal should render checked evidence");
+    assert!(line.contains("unknown_signal"));
+    assert!(line.contains("termination_reason: missing"));
+    assert!(line.contains("MemAvailable: unavailable"));
+    assert!(line.contains("earlyoom not running"));
+    assert!(line.contains("reason remains unknown"));
+}
+
+#[test]
+fn unknown_signal_reports_negative_memory_evidence() {
+    let diagnostic = diagnose_signal_kill_with(143, Some("sigterm"), || KillSignalObservations {
+        meminfo: Some(MemInfo {
+            total_kb: 16_384_000,
+            available_kb: 12_288_000,
+        }),
+        earlyoom_running: false,
+        cgroup_memory_events: Some(CgroupMemoryEvents {
+            oom: 0,
+            oom_kill: 0,
+        }),
+    })
+    .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
+    let line = diagnostic
+        .stderr_line()
+        .expect("unknown signal should render checked evidence");
+    assert!(line.contains("termination_reason=sigterm"));
+    assert!(line.contains("MemAvailable: 12000 MB / MemTotal: 16000 MB"));
+    assert!(line.contains("earlyoom not running"));
+    assert!(line.contains("cgroup memory.events oom=0 oom_kill=0"));
+    assert!(line.contains("reason remains unknown"));
+}
+
+#[test]
+fn unknown_signal_last_item_keeps_existing_session_work_item() {
+    let diagnostic =
+        diagnose_signal_kill_with(143, Some("signal"), KillSignalObservations::default)
+            .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
+    assert!(
+        diagnostic.last_item().is_none(),
+        "terminal_reason should not replace the session's last known work item"
+    );
+}
+
+#[test]
+fn codex_timeout_wrapped_git_commit_classifies_hook_commit_timeout() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        temp.path().join("output.log"),
+        concat!(
+            r#"{"type":"item.started","item":{"id":"item_64","type":"command_execution","command":"/usr/bin/zsh -lc 'timeout 240s mise exec rust@stable -- git commit -F \"$CSA_SESSION_DIR/commit-message-415.txt\"'","status":"in_progress"}}"#,
+            "\n",
+            "... process terminated with exit code 143\n",
+        ),
+    )
+    .expect("write output.log");
+
+    let child = detect_child_timeout_provenance(temp.path(), 143)
+        .expect("timeout-wrapped git commit should be detected");
+    assert_eq!(child.kind, ChildTimeoutKind::HookEnabledGitCommit);
+    assert_eq!(child.timeout_seconds, Some(240));
+    assert_eq!(child.command_status.as_deref(), Some("in_progress"));
+    assert!(child.transcript_exit_143);
+
+    let diagnostic = diagnose_signal_kill_with_child_timeout(
+        143,
+        None,
+        Some(child),
+        KillSignalObservations::default,
+    )
+    .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::HookCommitTimeout);
+    assert!(
+        diagnostic
+            .last_item()
+            .is_some_and(|item| item.contains("git commit -F")),
+        "last_item should expose the bounded commit command"
+    );
+    let line = diagnostic
+        .stderr_line()
+        .expect("hook commit timeout should render");
+    assert!(line.contains("hook_commit_timeout"));
+    assert!(line.contains("child_timeout_seconds=240"));
+    assert!(line.contains("bounded hook-enabled git commit"));
+    assert!(!line.contains("reason remains unknown"));
+}
+
+#[test]
+fn timeout_wrapped_non_commit_classifies_child_timeout() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        temp.path().join("output.log"),
+        r#"{"type":"item.started","item":{"type":"command_execution","command":"timeout --foreground 4m cargo test -j1 design_insight","status":"in_progress"}}"#,
+    )
+    .expect("write output.log");
+
+    let child = detect_child_timeout_provenance(temp.path(), 143)
+        .expect("timeout-wrapped command should be detected");
+    assert_eq!(child.kind, ChildTimeoutKind::BoundedCommand);
+    assert_eq!(child.timeout_seconds, Some(240));
+
+    let diagnostic = diagnose_signal_kill_with_child_timeout(
+        143,
+        Some("sigterm"),
+        Some(child),
+        KillSignalObservations::default,
+    )
+    .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::ChildTimeout);
+    assert!(
+        diagnostic
+            .stderr_line()
+            .expect("child timeout should render")
+            .contains("child_timeout")
+    );
+}
+
+#[test]
+fn timeout_child_command_redacts_secrets_from_diagnostic_surfaces() {
+    const API_SECRET: &str = "prod-secret";
+    const BASIC_AUTH_SECRET: &str = "alice:s3cr3t";
+    const SHORT_AUTH_SECRET: &str = "bob:p4ss";
+    const PROXY_AUTH_SECRET: &str = "carol:p4ss";
+    const INLINE_AUTH_SECRET: &str = "dave:inline";
+    const INLINE_PROXY_SECRET: &str = "erin:proxy";
+    const SHORT_EQUALS_AUTH_SECRET: &str = "frank:eq";
+    const INLINE_API_SECRET: &str = "inline-api-value";
+    const INLINE_TOKEN_SECRET: &str = "inline-token-value";
+    const INLINE_PASSWORD_SECRET: &str = "inline-password-value";
+
+    let raw_command = format!(
+        "timeout 120s curl --user {BASIC_AUTH_SECRET} -u {SHORT_AUTH_SECRET} -u={SHORT_EQUALS_AUTH_SECRET} --proxy-user {PROXY_AUTH_SECRET} --user={INLINE_AUTH_SECRET} --proxy-user={INLINE_PROXY_SECRET} --api-key {API_SECRET} --api-key={INLINE_API_SECRET} --token {API_SECRET} --token={INLINE_TOKEN_SECRET} --password {API_SECRET} --password={INLINE_PASSWORD_SECRET} -H 'x-api-key: {API_SECRET}' --header 'x-api-key: {API_SECRET}' https://example.test"
+    );
+    assert_timeout_child_command_redacts_secrets_from_all_surfaces(
+        &raw_command,
+        &[
+            API_SECRET,
+            BASIC_AUTH_SECRET,
+            SHORT_AUTH_SECRET,
+            PROXY_AUTH_SECRET,
+            INLINE_AUTH_SECRET,
+            INLINE_PROXY_SECRET,
+            SHORT_EQUALS_AUTH_SECRET,
+            INLINE_API_SECRET,
+            INLINE_TOKEN_SECRET,
+            INLINE_PASSWORD_SECRET,
+        ],
+        "timeout command",
+    );
+}
+
+#[test]
+fn timeout_child_command_redacts_attached_curl_short_option_secrets_from_diagnostic_surfaces() {
+    const BASIC_AUTH_SECRET: &str = "alice:s3cr3t";
+    const API_SECRET: &str = "prod-secret";
+
+    let raw_command = format!(
+        "timeout 120s curl -u{BASIC_AUTH_SECRET} -Hx-api-key:{API_SECRET} -HAuthorization:Basic {BASIC_AUTH_SECRET} https://example.test"
+    );
+    assert_timeout_child_command_redacts_secrets_from_all_surfaces(
+        &raw_command,
+        &[BASIC_AUTH_SECRET, API_SECRET],
+        "attached curl short-option",
+    );
+}
+
+#[test]
+fn timeout_child_command_redacts_authorization_basic_header_variants_from_diagnostic_surfaces() {
+    const SHORT_COMPACT_SECRET: &str = "alice:s3cr3t-a";
+    const SHORT_SPACED_SECRET: &str = "bruce:p4ss-b";
+    const LONG_COMPACT_SECRET: &str = "carol:p4ss-c";
+    const LONG_SPACED_SECRET: &str = "dave:p4ss-d";
+    const SINGLE_QUOTED_SECRET: &str = "erin:p4ss-e";
+    const DOUBLE_QUOTED_SECRET: &str = "frank:p4ss-f";
+    const EQUALS_COMPACT_SECRET: &str = "grace:p4ss-g";
+    const EQUALS_SPACED_SECRET: &str = "heidi:p4ss-h";
+
+    let raw_command = format!(
+        "timeout 120s curl -H Authorization:Basic {SHORT_COMPACT_SECRET} -H Authorization: Basic {SHORT_SPACED_SECRET} --header Authorization:Basic {LONG_COMPACT_SECRET} --header Authorization: Basic {LONG_SPACED_SECRET} --header='Authorization: Basic {SINGLE_QUOTED_SECRET}' --header=\"Authorization: Basic {DOUBLE_QUOTED_SECRET}\" --header=Authorization:Basic {EQUALS_COMPACT_SECRET} --header=Authorization: Basic {EQUALS_SPACED_SECRET} https://example.test"
+    );
+
+    assert_timeout_child_command_redacts_secrets_from_all_surfaces(
+        &raw_command,
+        &[
+            SHORT_COMPACT_SECRET,
+            SHORT_SPACED_SECRET,
+            LONG_COMPACT_SECRET,
+            LONG_SPACED_SECRET,
+            SINGLE_QUOTED_SECRET,
+            DOUBLE_QUOTED_SECRET,
+            EQUALS_COMPACT_SECRET,
+            EQUALS_SPACED_SECRET,
+        ],
+        "authorization basic header variant",
+    );
+}
+
+fn assert_timeout_child_command_redacts_secrets_from_all_surfaces(
+    raw_command: &str,
+    secrets: &[&str],
+    context: &str,
+) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let event = serde_json::json!({
+        "type": "item.started",
+        "item": {
+            "type": "command_execution",
+            "command": raw_command,
+            "status": "in_progress",
+        }
+    });
+    fs::write(
+        temp.path().join("output.log"),
+        format!("{event}\nprocess terminated with exit code 143\n"),
+    )
+    .expect("write output.log");
+
+    let child = detect_child_timeout_provenance(temp.path(), 143)
+        .expect("timeout-wrapped command should be detected");
+    assert_eq!(child.kind, ChildTimeoutKind::BoundedCommand);
+    assert_eq!(child.timeout_seconds, Some(120));
+    assert!(child.command.contains("[REDACTED]"));
+    assert!(child.command.contains("https://example.test"));
+
+    let diagnostic = diagnose_signal_kill_with_child_timeout(
+        143,
+        Some("sigterm"),
+        Some(child.clone()),
+        KillSignalObservations::default,
+    )
+    .expect("signal exit should produce diagnostic");
+    assert_eq!(diagnostic.hint, KillHint::ChildTimeout);
+
+    let stderr_line = diagnostic
+        .stderr_line()
+        .expect("child timeout should render");
+    let last_item = diagnostic
+        .last_item()
+        .expect("child timeout should expose redacted last item");
+    let now = chrono::Utc::now();
+    let result = csa_session::SessionResult {
+        status: "signal".to_string(),
+        exit_code: 143,
+        summary: "Execution interrupted by SIGTERM".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        ..Default::default()
+    };
+    let rendered =
+        render_result_toml_with_signal_diagnostic(&result, Some(&diagnostic), Some(raw_command))
+            .expect("render signal result");
+
+    for (label, surface) in [
+        ("detected command", child.command.as_str()),
+        ("stderr line", stderr_line.as_str()),
+        ("last item", last_item.as_str()),
+        ("result toml", rendered.as_str()),
+    ] {
+        for secret in secrets {
+            assert!(
+                !surface.contains(secret),
+                "{label} should redact {context} secret {secret}: {surface}"
+            );
+        }
+    }
+    assert!(stderr_line.contains("[REDACTED]"));
+    assert!(last_item.contains("[REDACTED]"));
+    assert!(rendered.contains("[REDACTED]"));
+    assert!(rendered.contains("kill_hint = \"child_timeout\""));
+    assert!(rendered.contains("last_item ="));
+}
+
+#[test]
+fn completed_timeout_command_without_child_exit_143_stays_unknown() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        temp.path().join("output.log"),
+        concat!(
+            r#"{"type":"item.completed","item":{"type":"command_execution","command":"timeout 240s cargo test -j1 design_insight","exit_code":0,"status":"completed"}}"#,
+            "\n",
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"done"}}"#,
+        ),
+    )
+    .expect("write output.log");
+
+    assert!(
+        detect_child_timeout_provenance(temp.path(), 143).is_none(),
+        "a previously completed bounded command is not enough evidence for child timeout"
+    );
+}
+
+#[test]
+fn external_sigterm_without_timeout_child_evidence_stays_unknown() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        temp.path().join("output.log"),
+        r#"{"type":"item.started","item":{"type":"command_execution","command":"git status","status":"in_progress"}}"#,
+    )
+    .expect("write output.log");
+
+    assert!(detect_child_timeout_provenance(temp.path(), 143).is_none());
+
+    let diagnostic = diagnose_signal_kill_with_child_timeout(
+        143,
+        Some("sigterm"),
+        None,
+        KillSignalObservations::default,
+    )
+    .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::UnknownSignal);
+}
+
+#[test]
+fn memory_pressure_precedes_child_timeout_evidence() {
+    let child = ChildTimeoutProvenance {
+        command: "timeout 240s git commit -m test".to_string(),
+        timeout_seconds: Some(240),
+        kind: ChildTimeoutKind::HookEnabledGitCommit,
+        command_status: Some("in_progress".to_string()),
+        transcript_exit_143: true,
+    };
+
+    let diagnostic = diagnose_signal_kill_with_child_timeout(143, None, Some(child), || {
+        KillSignalObservations {
+            meminfo: Some(MemInfo {
+                total_kb: 10_000,
+                available_kb: 499,
+            }),
+            earlyoom_running: false,
+            cgroup_memory_events: None,
+        }
+    })
+    .expect("signal exit should produce diagnostic");
+
+    assert_eq!(diagnostic.hint, KillHint::MemoryPressure);
+    assert!(diagnostic.child_timeout.is_none());
+}
+
+#[test]
+fn non_signal_exits_do_not_collect_observations() {
+    for exit_code in [0, 1, 2] {
+        let called = Cell::new(false);
+        let diagnostic = diagnose_signal_kill_with(exit_code, None, || {
+            called.set(true);
+            KillSignalObservations::default()
+        });
+        assert!(diagnostic.is_none());
+        assert!(!called.get(), "exit {exit_code} should not trigger checks");
+    }
+}
+
+#[test]
+fn parses_cgroup_memory_events() {
+    let events = parse_memory_events("low 2\nhigh 3\nmax 4\noom 1\noom_kill 1\n");
+
+    assert_eq!(events.oom, 1);
+    assert_eq!(events.oom_kill, 1);
+    assert!(events.has_oom_event());
+    assert!(events.has_oom_kill_event());
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.991"
-weave = "0.1.991"
+csa = "0.1.992"
+weave = "0.1.992"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Closes #2177.

This PR improves signal-143 diagnostics so timeout-killed child commands are attributed correctly instead of surfacing as opaque `unknown_signal` when there is no memory-pressure evidence.

- Detects timeout-wrapped child command exits and classifies hook-enabled `git commit` timeouts as child timeout provenance.
- Preserves memory-pressure precedence so OOM/earlyoom evidence still wins over timeout-child evidence.
- Redacts child command diagnostics before they reach stderr, `last_item`, session result TOML, and reconciliation/render paths.
- Replaces narrow command-redaction regexes with conservative token/span redaction for credential-bearing flags and curl header/user options.
- Splits child-timeout diagnostics into a focused module and adds regression coverage for command provenance plus secret-redaction surfaces.

## Validation

Local only; GitHub CI was not watched or used as an agent-side gate.

- `cargo test -p cli-sub-agent session_kill_diagnostics -- --nocapture` — 21 passed.
- `just find-monolith-files` — 0 hard failures / 0 warnings.
- Hook-enabled amend commit — lefthook quality gates and clippy passed.
- Exact-head review gate: `csa review --check-verdict --sa-mode true --range main...HEAD` passed for session `01KV0J4S23101NM71T2NMV0QD6` at `8f8e5e90`.

## Notes

Related follow-up/tooling issues kept open:

- #2180 tracks that CSA/Codex salvage for this same fix also terminated with signal 143 during focused test execution.
- #2183 tracks a review wait inconsistency where `csa session wait` returned exit 0 while the structured review summary was FAIL.
