### PR TITLE
fix(run): preserve nested commit session lineage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.992"
+version = "0.1.993"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.992"
+version = "0.1.993"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec_bootstrap.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_bootstrap.rs
@@ -92,9 +92,9 @@ pub(super) async fn bootstrap_session(
         // Auto-generate description from prompt when not provided
         let effective_description = description.or_else(|| Some(truncate_prompt(prompt, 80)));
         let parent_id = match parent_session_source {
-            ParentSessionSource::ExplicitOrEnv => {
-                parent.or_else(|| startup_env.session_id().map(ToOwned::to_owned))
-            }
+            ParentSessionSource::ExplicitOrEnv => parent.or_else(|| {
+                inherited_parent_session_id_for_new_session(startup_env).map(ToOwned::to_owned)
+            }),
             ParentSessionSource::ExplicitOnly => parent,
         };
         let mut new_session = match session_creation_mode {
@@ -175,4 +175,84 @@ pub(super) async fn bootstrap_session(
         session,
         resolved_provider_session_id,
     })
+}
+
+fn inherited_parent_session_id_for_new_session(startup_env: &StartupSubtreeEnv) -> Option<&str> {
+    let inherited_session = startup_env.session_id()?;
+    if std::env::var("CSA_DAEMON_SESSION_ID").ok().as_deref() == Some(inherited_session) {
+        return startup_env.parent_session();
+    }
+    Some(inherited_session)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::inherited_parent_session_id_for_new_session;
+    use crate::startup_env::StartupSubtreeEnv;
+    use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+    use csa_core::env::{
+        CSA_PARENT_SESSION_ENV_KEY, CSA_SESSION_DIR_ENV_KEY, CSA_SESSION_ID_ENV_KEY,
+    };
+    use std::collections::HashMap;
+
+    #[test]
+    fn inherited_parent_session_uses_session_id_for_foreground_nested_run() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let _daemon = ScopedEnvVarRestore::unset("CSA_DAEMON_SESSION_ID");
+        let startup_env = StartupSubtreeEnv::from_values(HashMap::from([(
+            CSA_SESSION_ID_ENV_KEY,
+            "01PARENT".to_string(),
+        )]));
+
+        assert_eq!(
+            inherited_parent_session_id_for_new_session(&startup_env),
+            Some("01PARENT")
+        );
+    }
+
+    #[test]
+    fn inherited_parent_session_uses_parent_for_daemon_child_run() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let _daemon = ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_ID", "01CHILD");
+        let startup_env = StartupSubtreeEnv::from_values(HashMap::from([
+            (CSA_SESSION_ID_ENV_KEY, "01PARENT".to_string()),
+            (CSA_SESSION_DIR_ENV_KEY, "/repo/parent".to_string()),
+        ]))
+        .with_current_session("01CHILD", "/repo/child");
+
+        assert_eq!(
+            inherited_parent_session_id_for_new_session(&startup_env),
+            Some("01PARENT")
+        );
+    }
+
+    #[test]
+    fn inherited_parent_session_returns_none_for_top_level_daemon_child() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let _daemon = ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_ID", "01CHILD");
+        let startup_env = StartupSubtreeEnv::from_values(HashMap::from([(
+            CSA_SESSION_ID_ENV_KEY,
+            "01CHILD".to_string(),
+        )]));
+
+        assert_eq!(
+            inherited_parent_session_id_for_new_session(&startup_env),
+            None
+        );
+    }
+
+    #[test]
+    fn inherited_parent_session_preserves_explicit_parent_snapshot_for_daemon_child() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let _daemon = ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_ID", "01CHILD");
+        let startup_env = StartupSubtreeEnv::from_values(HashMap::from([
+            (CSA_SESSION_ID_ENV_KEY, "01CHILD".to_string()),
+            (CSA_PARENT_SESSION_ENV_KEY, "01PARENT".to_string()),
+        ]));
+
+        assert_eq!(
+            inherited_parent_session_id_for_new_session(&startup_env),
+            Some("01PARENT")
+        );
+    }
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_locking.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_locking.rs
@@ -247,6 +247,70 @@ async fn debate_write_mode_fails_fast_when_worktree_write_lock_is_held() {
 }
 
 #[tokio::test]
+async fn run_commit_child_reenters_under_ancestor_worktree_write_lock() {
+    let temp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
+    let project_root = temp.path();
+
+    let holder =
+        csa_session::create_session(project_root, Some("holder"), None, Some("codex")).unwrap();
+    let _worktree_lock =
+        csa_lock::acquire_worktree_write_lock(project_root, &holder.meta_session_id, &[], |_| {
+            false
+        })
+        .expect("ancestor worktree write lock should succeed");
+    let child = csa_session::create_session(
+        project_root,
+        Some("skill:commit"),
+        Some(&holder.meta_session_id),
+        Some("codex"),
+    )
+    .unwrap();
+    let child_dir = csa_session::get_session_dir(project_root, &child.meta_session_id).unwrap();
+    let _child_session_lock =
+        csa_lock::acquire_lock(&child_dir, "codex", "active commit child").unwrap();
+
+    let execution = run_pipeline_for_worktree_lock_test(
+        project_root,
+        Some("run"),
+        Some(child.meta_session_id),
+        false,
+    )
+    .await;
+
+    assert_blocked_on_session_lock_not_worktree(execution);
+}
+
+#[tokio::test]
+async fn run_child_of_different_parent_fails_fast_when_worktree_write_lock_is_held() {
+    let temp = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
+    let project_root = temp.path();
+
+    let (holder_session_id, _worktree_lock) = acquire_active_holder_worktree_lock(project_root);
+    let other_parent =
+        csa_session::create_session(project_root, Some("other parent"), None, Some("codex"))
+            .unwrap();
+    let child = csa_session::create_session(
+        project_root,
+        Some("skill:commit"),
+        Some(&other_parent.meta_session_id),
+        Some("codex"),
+    )
+    .unwrap();
+
+    let execution = run_pipeline_for_worktree_lock_test(
+        project_root,
+        Some("run"),
+        Some(child.meta_session_id),
+        false,
+    )
+    .await;
+
+    assert_worktree_write_lock_blocked(execution, project_root, &holder_session_id);
+}
+
+#[tokio::test]
 async fn readonly_review_is_not_blocked_by_worktree_write_lock() {
     let temp = tempfile::tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new(&temp).await;

--- a/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
@@ -360,7 +360,10 @@ fn daemon_child_startup_env_uses_preassigned_session_context() {
             csa_core::env::CSA_SESSION_ID_ENV_KEY,
             parent_session_id.clone(),
         ),
-        (csa_core::env::CSA_SESSION_DIR_ENV_KEY, parent_session_dir),
+        (
+            csa_core::env::CSA_SESSION_DIR_ENV_KEY,
+            parent_session_dir.clone(),
+        ),
     ]));
 
     let effective = daemon_child_startup_env(
@@ -376,6 +379,11 @@ fn daemon_child_startup_env_uses_preassigned_session_context() {
         .to_string();
     assert_eq!(effective.session_id(), Some(actual_session_id.as_str()));
     assert_eq!(effective.session_dir(), Some(expected_session_dir.as_str()));
+    assert_eq!(effective.parent_session(), Some(parent_session_id.as_str()));
+    assert_eq!(
+        effective.parent_session_dir(),
+        Some(parent_session_dir.as_str())
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/run_cmd_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_policy.rs
@@ -322,6 +322,10 @@ pub(crate) fn format_post_run_commit_guard_message(
     lines.push(format!(
         "Next step: run `{recovery_command}` and continue with PR/review workflow."
     ));
+    lines.push(
+        "Nested commit runs inside an active CSA session are supported as lineage-scoped child sessions; unrelated writers remain serialized by the worktree lock."
+            .to_string(),
+    );
     if !guard.changed_paths.is_empty() {
         lines.push(format!("Changed paths: {}", guard.changed_paths.join(", ")));
     }

--- a/crates/cli-sub-agent/src/run_cmd_tests_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_policy.rs
@@ -171,6 +171,7 @@ fn format_post_run_commit_guard_message_includes_next_step_and_paths() {
     let message = format_post_run_commit_guard_message(&guard, false, false, Some("codex"));
     assert!(message.contains("WARNING"));
     assert!(message.contains("csa run --tool codex --skill commit"));
+    assert!(message.contains("lineage-scoped child sessions"));
     assert!(message.contains("Cargo.lock"));
     assert!(message.contains("uncommitted workspace mutations"));
 }

--- a/crates/cli-sub-agent/src/startup_env.rs
+++ b/crates/cli-sub-agent/src/startup_env.rs
@@ -155,10 +155,20 @@ impl StartupSubtreeEnv {
         session_id: impl AsRef<str>,
         session_dir: impl AsRef<str>,
     ) -> Self {
+        let previous_session_id = self.session_id.clone();
+        let previous_session_dir = self.session_dir.clone();
         self.session_id = non_empty_str(session_id.as_ref());
         self.raw_session_id = self.session_id.clone();
         self.session_dir = non_empty_str(session_dir.as_ref());
         self.raw_session_dir = self.session_dir.clone();
+        if let Some(previous_session_id) = previous_session_id
+            && self.session_id.as_deref() != Some(previous_session_id.as_str())
+        {
+            self.parent_session = Some(previous_session_id.clone());
+            self.raw_parent_session = Some(previous_session_id);
+            self.parent_session_dir = previous_session_dir.clone();
+            self.raw_parent_session_dir = previous_session_dir;
+        }
         self
     }
 
@@ -236,7 +246,6 @@ impl StartupSubtreeEnv {
         self.session_dir.as_deref()
     }
 
-    #[cfg(test)]
     pub(crate) fn parent_session(&self) -> Option<&str> {
         self.parent_session.as_deref()
     }
@@ -541,6 +550,8 @@ mod tests {
 
         assert_eq!(startup.session_id(), Some("01KCHILD"));
         assert_eq!(startup.session_dir(), Some("/repo/child"));
+        assert_eq!(startup.parent_session(), Some("01KPARENT"));
+        assert_eq!(startup.parent_session_dir(), Some("/repo/parent"));
         assert_eq!(
             child_env,
             vec![
@@ -548,6 +559,39 @@ mod tests {
                 (
                     CSA_SESSION_DIR_ENV_KEY.to_string(),
                     "/repo/child".to_string()
+                ),
+                (
+                    CSA_PARENT_SESSION_ENV_KEY.to_string(),
+                    "01KPARENT".to_string()
+                ),
+                (
+                    CSA_PARENT_SESSION_DIR_ENV_KEY.to_string(),
+                    "/repo/parent".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn startup_subtree_env_with_current_session_does_not_self_parent() {
+        let values = HashMap::from([
+            (CSA_SESSION_ID_ENV_KEY, "01KSESSION".to_string()),
+            (CSA_SESSION_DIR_ENV_KEY, "/repo/session".to_string()),
+        ]);
+
+        let startup = StartupSubtreeEnv::from_values(values)
+            .with_current_session("01KSESSION", "/repo/session");
+
+        assert_eq!(startup.session_id(), Some("01KSESSION"));
+        assert_eq!(startup.session_dir(), Some("/repo/session"));
+        assert_eq!(startup.parent_session(), None);
+        assert_eq!(
+            startup.to_child_env_vars(),
+            vec![
+                (CSA_SESSION_ID_ENV_KEY.to_string(), "01KSESSION".to_string()),
+                (
+                    CSA_SESSION_DIR_ENV_KEY.to_string(),
+                    "/repo/session".to_string()
                 ),
             ]
         );

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.992"
-weave = "0.1.992"
+csa = "0.1.993"
+weave = "0.1.993"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Closes #2101.

This PR fixes nested commit workflow re-entry when a parent CSA writer already holds the worktree lock.

- Preserves immediate parent lineage when daemon child sessions initialize startup environment.
- Resolves daemon-child inherited parent session from `CSA_PARENT_SESSION` when `CSA_SESSION_ID` is the daemon session id.
- Keeps the single-worktree writer lock model intact: re-entry is only allowed when the existing lock holder is an active ancestor of the candidate session.
- Updates commit-policy guidance so nested commit runs have an explicit, supported lineage-scoped path instead of the generic concurrent-writer denial.
- Adds regression coverage for parent-child lineage, daemon startup, lock re-entry, and policy messaging.

## Validation

Local only; GitHub CI was not watched or used as an agent-side gate.

- CSA/Codex implementation session `01KV0JW9AT1GEZ4ZASAB9K6Q3C`:
  - `cargo test --package cli-sub-agent locking_tests -- --nocapture` — 9 passed.
  - `cargo test --package cli-sub-agent inherited_parent_session -- --nocapture` — 5 passed.
  - `cargo test --package cli-sub-agent run_cmd_daemon -- --nocapture` — 23 passed.
  - `cargo test --package cli-sub-agent startup_subtree_env_with_current_session -- --nocapture` — 2 passed.
  - `cargo test --package cli-sub-agent format_post_run_commit_guard_message_includes_next_step_and_paths -- --nocapture` — 1 passed.
  - `cargo fmt --package cli-sub-agent -- --check` — passed.
  - `git diff --check` / `git diff --cached --check` — passed.
  - `just find-monolith-files` — passed.
- Version bumped to `0.1.993`; `csa migrate` updated `weave.lock` stamps.
- Hook-enabled commit `341f0ee4` passed lefthook quality gates and clippy.
- Exact-head full-diff review `01KV0P67KANSZH7CRPGDRD888X` passed for `main...HEAD`.
