### PR TITLE
fix(run): allow trusted nested model pin inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.993"
+version = "0.1.994"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.993"
+version = "0.1.994"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -102,6 +102,21 @@ pub(crate) async fn handle_debate(
             thinking: args.thinking.is_some(),
         },
         inherited_trusted_pin,
+    })
+    .map_err(|err| {
+        crate::session_guard::persist_pre_exec_error_result(crate::session_guard::PreExecErrorCtx {
+            project_root: &project_root,
+            session_id: args.session.as_deref(),
+            description: Some("debate"),
+            parent: None,
+            tool_name: match args.tool.as_ref() {
+                Some(ToolArg::Specific(tool)) => Some(tool.as_str()),
+                Some(ToolArg::Auto | ToolArg::AnyAvailable | ToolArg::Alias(_)) | None => None,
+            },
+            task_type: Some("debate"),
+            tier_name: args.tier.as_deref(),
+            error: err,
+        })
     })?;
     let pre_session_hook = csa_hooks::load_global_pre_session_hook_invocation();
 

--- a/crates/cli-sub-agent/src/mcp_server_model_pin_tests.rs
+++ b/crates/cli-sub-agent/src/mcp_server_model_pin_tests.rs
@@ -1,0 +1,209 @@
+use super::*;
+use std::collections::HashMap;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn trusted_startup_env_for_pinned_mcp_session(
+    project_root: &Path,
+    model_spec: &str,
+    no_failover: bool,
+) -> crate::startup_env::StartupSubtreeEnv {
+    let session = create_session(
+        project_root,
+        Some("mcp pinned startup"),
+        None,
+        Some("codex"),
+    )
+    .expect("create mcp pinned session");
+    let session_dir = get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let pin =
+        crate::run_cmd_model_pin::resolve_subtree_model_pin(Some(model_spec), true, no_failover)
+            .expect("trusted pin");
+    crate::run_cmd_model_pin::sync_subtree_model_pin_sidecar(
+        project_root,
+        &session.meta_session_id,
+        &session_dir,
+        Some(&pin),
+    )
+    .expect("write trusted pin sidecar");
+
+    crate::startup_env::StartupSubtreeEnv::from_values(HashMap::from([
+        (
+            csa_core::env::CSA_DEPTH_ENV_KEY,
+            session.genealogy.depth.saturating_add(1).to_string(),
+        ),
+        (
+            csa_core::env::CSA_INTERNAL_INVOCATION_ENV_KEY,
+            "1".to_string(),
+        ),
+        (
+            csa_core::env::CSA_SESSION_ID_ENV_KEY,
+            session.meta_session_id,
+        ),
+        (
+            csa_core::env::CSA_SESSION_DIR_ENV_KEY,
+            session_dir.display().to_string(),
+        ),
+        (
+            csa_core::env::CSA_PROJECT_ROOT_ENV_KEY,
+            project_root.display().to_string(),
+        ),
+        (
+            csa_core::env::CSA_MODEL_SPEC_ENV_KEY,
+            model_spec.to_string(),
+        ),
+        (
+            csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY,
+            "1".to_string(),
+        ),
+        (
+            csa_core::env::CSA_NO_FAILOVER_ENV_KEY,
+            if no_failover { "1" } else { "0" }.to_string(),
+        ),
+    ]))
+}
+
+#[test]
+fn mcp_model_pin_resolution_inherits_server_startup_pin() {
+    let _guard = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
+    let project = tempdir().expect("project tempdir");
+    let xdg = tempdir().expect("xdg tempdir");
+    let _xdg_guard = EnvVarGuard::set("XDG_STATE_HOME", xdg.path());
+    let startup_env = trusted_startup_env_for_pinned_mcp_session(
+        project.path(),
+        "codex/openai/gpt-5.5/xhigh",
+        true,
+    );
+
+    let resolution = resolve_mcp_model_pin(None, Some("quality"), false, &startup_env);
+
+    assert_eq!(
+        resolution.model_spec.as_deref(),
+        Some("codex/openai/gpt-5.5/xhigh")
+    );
+    assert_eq!(resolution.tier, None);
+    assert!(resolution.force_ignore_tier_setting);
+    assert!(resolution.no_failover);
+    assert!(resolution.inherited_trusted_pin);
+}
+
+#[test]
+fn mcp_model_pin_resolution_ignores_ambient_pin_without_sidecar() {
+    let startup_env = crate::startup_env::StartupSubtreeEnv::from_values(HashMap::from([
+        (csa_core::env::CSA_DEPTH_ENV_KEY, "1".to_string()),
+        (
+            csa_core::env::CSA_INTERNAL_INVOCATION_ENV_KEY,
+            "1".to_string(),
+        ),
+        (
+            csa_core::env::CSA_SESSION_ID_ENV_KEY,
+            "01KPINNEDSESSION0000000000".to_string(),
+        ),
+        (
+            csa_core::env::CSA_SESSION_DIR_ENV_KEY,
+            "/tmp/csa-spoof/sessions/01KPINNEDSESSION0000000000".to_string(),
+        ),
+        (
+            csa_core::env::CSA_PROJECT_ROOT_ENV_KEY,
+            "/tmp/csa-spoof".to_string(),
+        ),
+        (
+            csa_core::env::CSA_MODEL_SPEC_ENV_KEY,
+            "codex/openai/gpt-5.5/xhigh".to_string(),
+        ),
+        (
+            csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY,
+            "1".to_string(),
+        ),
+        (csa_core::env::CSA_NO_FAILOVER_ENV_KEY, "1".to_string()),
+    ]));
+
+    let resolution = resolve_mcp_model_pin(None, Some("quality"), false, &startup_env);
+
+    assert!(resolution.model_spec.is_none());
+    assert_eq!(resolution.tier.as_deref(), Some("quality"));
+    assert!(!resolution.force_ignore_tier_setting);
+    assert!(!resolution.no_failover);
+    assert!(!resolution.inherited_trusted_pin);
+}
+
+#[test]
+fn mcp_model_pin_resolution_keeps_explicit_model_spec_over_inherited_pin() {
+    let _guard = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
+    let project = tempdir().expect("project tempdir");
+    let xdg = tempdir().expect("xdg tempdir");
+    let _xdg_guard = EnvVarGuard::set("XDG_STATE_HOME", xdg.path());
+    let startup_env = trusted_startup_env_for_pinned_mcp_session(
+        project.path(),
+        "codex/openai/gpt-5.5/xhigh",
+        false,
+    );
+
+    let resolution = resolve_mcp_model_pin(
+        Some("gemini-cli/google/gemini-2.5-pro/high"),
+        Some("quality"),
+        false,
+        &startup_env,
+    );
+
+    assert_eq!(
+        resolution.model_spec.as_deref(),
+        Some("gemini-cli/google/gemini-2.5-pro/high")
+    );
+    assert_eq!(resolution.tier.as_deref(), Some("quality"));
+    assert!(!resolution.force_ignore_tier_setting);
+    assert!(!resolution.no_failover);
+    assert!(!resolution.inherited_trusted_pin);
+}
+
+#[tokio::test]
+async fn mcp_run_allows_inherited_model_spec_when_project_tiers_exist_and_policy_is_default() {
+    let _guard = crate::test_env_lock::TEST_ENV_LOCK.lock().await;
+    let project = tempdir().expect("project tempdir");
+    let config_dir = project.path().join(".csa");
+    std::fs::create_dir_all(&config_dir).expect("create project config dir");
+    std::fs::write(
+        config_dir.join("config.toml"),
+        r#"
+[tiers.quality]
+description = "quality"
+models = ["codex/openai/gpt-5.5/xhigh"]
+"#,
+    )
+    .expect("write project config");
+
+    let xdg = tempdir().expect("xdg tempdir");
+    let state_home = xdg.path().join("state");
+    let _xdg_config_guard = EnvVarGuard::set("XDG_CONFIG_HOME", xdg.path());
+    let _xdg_state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let _cwd_guard = CurrentDirGuard::set(project.path());
+    let startup_env = trusted_startup_env_for_pinned_mcp_session(
+        project.path(),
+        "codex/openai/gpt-5.5/xhigh",
+        true,
+    );
+    let empty_path = tempdir().expect("empty PATH tempdir");
+    let _path_guard = EnvVarGuard::set("PATH", empty_path.path());
+
+    let response = handle_run_tool(
+        serde_json::json!({
+            "prompt": "hello",
+            "tier": "quality"
+        }),
+        &startup_env,
+    )
+    .await
+    .expect("inherited trusted pin should bypass the tier gate before tool availability");
+
+    let text = response
+        .get("content")
+        .and_then(|content| content.get(0))
+        .and_then(|entry| entry.get("text"))
+        .and_then(|text| text.as_str())
+        .expect("response text");
+    assert!(text.contains("Tool 'codex' is not installed"));
+}

--- a/crates/cli-sub-agent/src/mcp_server_tests.rs
+++ b/crates/cli-sub-agent/src/mcp_server_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use csa_session::{
-    SessionPhase, SessionResult, ToolState, create_session, get_session_root, save_result,
-    save_session,
+    SessionPhase, SessionResult, ToolState, create_session, get_session_dir, get_session_root,
+    save_result, save_session,
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -75,6 +75,9 @@ impl Drop for CurrentDirGuard {
         std::env::set_current_dir(&self.original).expect("restore current dir");
     }
 }
+
+#[path = "mcp_server_model_pin_tests.rs"]
+mod model_pin_tests;
 
 fn seed_retired_runtime_session(project_root: &Path) -> (String, PathBuf) {
     std::fs::create_dir_all(project_root).expect("create project root");
@@ -458,64 +461,6 @@ async fn mcp_gc_reap_runtime_protects_hosting_session_runtime() {
     );
 }
 
-#[test]
-fn mcp_model_pin_resolution_inherits_server_startup_pin() {
-    let startup_env = crate::startup_env::StartupSubtreeEnv::from_values(HashMap::from([
-        (csa_core::env::CSA_DEPTH_ENV_KEY, "1".to_string()),
-        (
-            csa_core::env::CSA_MODEL_SPEC_ENV_KEY,
-            "codex/openai/gpt-5.5/xhigh".to_string(),
-        ),
-        (
-            csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY,
-            "1".to_string(),
-        ),
-        (csa_core::env::CSA_NO_FAILOVER_ENV_KEY, "1".to_string()),
-    ]));
-
-    let resolution = resolve_mcp_model_pin(None, Some("quality"), false, &startup_env);
-
-    assert_eq!(
-        resolution.model_spec.as_deref(),
-        Some("codex/openai/gpt-5.5/xhigh")
-    );
-    assert_eq!(resolution.tier, None);
-    assert!(resolution.force_ignore_tier_setting);
-    assert!(resolution.no_failover);
-    assert!(resolution.inherited_trusted_pin);
-}
-
-#[test]
-fn mcp_model_pin_resolution_keeps_explicit_model_spec_over_inherited_pin() {
-    let startup_env = crate::startup_env::StartupSubtreeEnv::from_values(HashMap::from([
-        (csa_core::env::CSA_DEPTH_ENV_KEY, "1".to_string()),
-        (
-            csa_core::env::CSA_MODEL_SPEC_ENV_KEY,
-            "codex/openai/gpt-5.5/xhigh".to_string(),
-        ),
-        (
-            csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY,
-            "1".to_string(),
-        ),
-    ]));
-
-    let resolution = resolve_mcp_model_pin(
-        Some("gemini-cli/google/gemini-2.5-pro/high"),
-        Some("quality"),
-        false,
-        &startup_env,
-    );
-
-    assert_eq!(
-        resolution.model_spec.as_deref(),
-        Some("gemini-cli/google/gemini-2.5-pro/high")
-    );
-    assert_eq!(resolution.tier.as_deref(), Some("quality"));
-    assert!(!resolution.force_ignore_tier_setting);
-    assert!(!resolution.no_failover);
-    assert!(!resolution.inherited_trusted_pin);
-}
-
 #[tokio::test]
 async fn mcp_run_rejects_model_spec_when_project_tiers_exist_and_policy_is_default() {
     let _guard = crate::test_env_lock::TEST_ENV_LOCK.lock().await;
@@ -549,59 +494,6 @@ models = ["codex/openai/gpt-5/high"]
     assert!(message.contains("Tier bypass is disabled"));
     assert!(message.contains("--model-spec"));
     assert!(message.contains("[tier_policy].allow_force_bypass"));
-}
-
-#[tokio::test]
-async fn mcp_run_allows_inherited_model_spec_when_project_tiers_exist_and_policy_is_default() {
-    let _guard = crate::test_env_lock::TEST_ENV_LOCK.lock().await;
-    let project = tempdir().expect("project tempdir");
-    let config_dir = project.path().join(".csa");
-    std::fs::create_dir_all(&config_dir).expect("create project config dir");
-    std::fs::write(
-        config_dir.join("config.toml"),
-        r#"
-[tiers.quality]
-description = "quality"
-models = ["codex/openai/gpt-5.5/xhigh"]
-"#,
-    )
-    .expect("write project config");
-
-    let xdg = tempdir().expect("xdg tempdir");
-    let empty_path = tempdir().expect("empty PATH tempdir");
-    let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", xdg.path());
-    let _path_guard = EnvVarGuard::set("PATH", empty_path.path());
-    let _cwd_guard = CurrentDirGuard::set(project.path());
-    let startup_env = crate::startup_env::StartupSubtreeEnv::from_values(HashMap::from([
-        (csa_core::env::CSA_DEPTH_ENV_KEY, "1".to_string()),
-        (
-            csa_core::env::CSA_MODEL_SPEC_ENV_KEY,
-            "codex/openai/gpt-5.5/xhigh".to_string(),
-        ),
-        (
-            csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY,
-            "1".to_string(),
-        ),
-        (csa_core::env::CSA_NO_FAILOVER_ENV_KEY, "1".to_string()),
-    ]));
-
-    let response = handle_run_tool(
-        serde_json::json!({
-            "prompt": "hello",
-            "tier": "quality"
-        }),
-        &startup_env,
-    )
-    .await
-    .expect("inherited trusted pin should bypass the tier gate before tool availability");
-
-    let text = response
-        .get("content")
-        .and_then(|content| content.get(0))
-        .and_then(|entry| entry.get("text"))
-        .and_then(|text| text.as_str())
-        .expect("response text");
-    assert!(text.contains("Tool 'codex' is not installed"));
 }
 
 #[tokio::test]

--- a/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
@@ -211,6 +211,12 @@ async fn prepare_session_runtime_inner(
         input.session_dir,
         session.turn_count,
     );
+    crate::run_cmd_model_pin::sync_subtree_model_pin_sidecar(
+        input.project_root,
+        &session.meta_session_id,
+        input.session_dir,
+        input.subtree_pin,
+    )?;
     let execution_start_time = chrono::Utc::now();
     let sa_mode =
         std::env::var_os(crate::pipeline::prompt_guard::PROMPT_GUARD_CALLER_INJECTION_ENV)

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -144,10 +144,12 @@ async fn spawn_bash(
     // This bash step is a CSA-child boundary because it may run nested `csa`
     // commands. Reserve the protected contract keys before re-applying CSA's
     // trusted startup snapshot, so workflow/user env cannot spoof session
-    // genealogy or subtree pins.
+    // genealogy or subtree pins. A bash step has no session state/sidecar of its
+    // own, so nested plan runs that reuse an inherited session contract must not
+    // advance CSA_DEPTH beyond the depth that contract can validate.
     csa_core::env::scrub_subtree_contract_env_tokio(&mut cmd);
     cmd.env("CSA_PROJECT_ROOT", project_root)
-        .env("CSA_DEPTH", startup_env.next_depth_string())
+        .env("CSA_DEPTH", bash_step_depth_string(startup_env))
         .env("CSA_INTERNAL_INVOCATION", "1")
         // Every bash step of a weave pattern is pattern-internal: mark it so any
         // `csa run`/`review`/`debate` it invokes (and their nested CSA children)
@@ -160,6 +162,17 @@ async fn spawn_bash(
         .stderr(std::process::Stdio::piped())
         .output()
         .await
+}
+
+fn bash_step_depth_string(startup_env: &StartupSubtreeEnv) -> String {
+    // Root/foreground plan sessions may have no startup depth yet; keep the
+    // historical child marker there. Once a real parent depth exists, preserve
+    // it because the session sidecar/state contract is still the same session.
+    if startup_env.current_depth() > 0 {
+        return startup_env.current_depth().to_string();
+    }
+
+    startup_env.next_depth_string()
 }
 
 fn apply_startup_child_contract_env(

--- a/crates/cli-sub-agent/src/plan_cmd_exec_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec_tests.rs
@@ -3,17 +3,91 @@
 //! Split out of plan_cmd_exec.rs to stay under the monolith token budget.
 
 use super::*;
-use crate::test_env_lock::TEST_ENV_LOCK;
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 
 fn startup_env_with_pin(depth: u32) -> crate::startup_env::StartupSubtreeEnv {
     crate::startup_env::StartupSubtreeEnv::from_values(HashMap::from([
         (csa_core::env::CSA_DEPTH_ENV_KEY, depth.to_string()),
+        (
+            csa_core::env::CSA_INTERNAL_INVOCATION_ENV_KEY,
+            "1".to_string(),
+        ),
+        (
+            csa_core::env::CSA_SESSION_ID_ENV_KEY,
+            "01KPINNEDSESSION0000000000".to_string(),
+        ),
+        (
+            csa_core::env::CSA_SESSION_DIR_ENV_KEY,
+            "/repo/.csa/sessions/01KPINNEDSESSION0000000000".to_string(),
+        ),
+        (csa_core::env::CSA_PROJECT_ROOT_ENV_KEY, "/repo".to_string()),
         (csa_core::env::CSA_MODEL_SPEC_ENV_KEY, PIN_SPEC.to_string()),
         (
             csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY,
             "1".to_string(),
         ),
         (csa_core::env::CSA_NO_FAILOVER_ENV_KEY, "1".to_string()),
+    ]))
+}
+
+fn trusted_startup_env_for_pinned_plan_session(
+    project_root: &std::path::Path,
+    model_spec: &str,
+    no_failover: bool,
+) -> crate::startup_env::StartupSubtreeEnv {
+    let session = csa_session::create_session(
+        project_root,
+        Some("plan pinned startup"),
+        None,
+        Some("codex"),
+    )
+    .expect("create pinned plan session");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let pin =
+        crate::run_cmd_model_pin::resolve_subtree_model_pin(Some(model_spec), true, no_failover)
+            .expect("typed pin");
+    crate::run_cmd_model_pin::sync_subtree_model_pin_sidecar(
+        project_root,
+        &session.meta_session_id,
+        &session_dir,
+        Some(&pin),
+    )
+    .expect("write trusted pin sidecar");
+
+    crate::startup_env::StartupSubtreeEnv::from_values(HashMap::from([
+        (
+            csa_core::env::CSA_DEPTH_ENV_KEY,
+            session.genealogy.depth.saturating_add(1).to_string(),
+        ),
+        (
+            csa_core::env::CSA_INTERNAL_INVOCATION_ENV_KEY,
+            "1".to_string(),
+        ),
+        (
+            csa_core::env::CSA_SESSION_ID_ENV_KEY,
+            session.meta_session_id,
+        ),
+        (
+            csa_core::env::CSA_SESSION_DIR_ENV_KEY,
+            session_dir.display().to_string(),
+        ),
+        (
+            csa_core::env::CSA_PROJECT_ROOT_ENV_KEY,
+            project_root.display().to_string(),
+        ),
+        (
+            csa_core::env::CSA_MODEL_SPEC_ENV_KEY,
+            model_spec.to_string(),
+        ),
+        (
+            csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY,
+            "1".to_string(),
+        ),
+        (
+            csa_core::env::CSA_NO_FAILOVER_ENV_KEY,
+            if no_failover { "1" } else { "0" }.to_string(),
+        ),
     ]))
 }
 
@@ -201,6 +275,21 @@ fn recorded_env(
         .collect()
 }
 
+fn startup_env_from_recorded_env(
+    env: &std::collections::HashMap<String, Option<String>>,
+) -> crate::startup_env::StartupSubtreeEnv {
+    let mut values = HashMap::new();
+    for key in csa_core::env::STARTUP_SUBTREE_ENV_KEYS {
+        if let Some(Some(value)) = env.get(*key) {
+            values.insert(*key, value.clone());
+        }
+    }
+    if let Some(Some(value)) = env.get(csa_core::env::CSA_PATTERN_INTERNAL_ENV_KEY) {
+        values.insert(csa_core::env::CSA_PATTERN_INTERNAL_ENV_KEY, value.clone());
+    }
+    crate::startup_env::StartupSubtreeEnv::from_values(values)
+}
+
 /// #1741 round-6: a bash step is marked nested (CSA_DEPTH set) and inherits
 /// the parent env. When the parent is ROOT (depth 0) but ambient
 /// SUBTREE_PIN_ENV_KEYS are present (a user-controlled spoof attempt), the
@@ -212,6 +301,10 @@ fn spawn_bash_env_strips_ambient_subtree_pin_when_not_legitimately_inherited() {
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let original: Vec<(&str, Option<String>)> = [
         "CSA_DEPTH",
+        csa_core::env::CSA_INTERNAL_INVOCATION_ENV_KEY,
+        csa_core::env::CSA_SESSION_ID_ENV_KEY,
+        csa_core::env::CSA_SESSION_DIR_ENV_KEY,
+        csa_core::env::CSA_PROJECT_ROOT_ENV_KEY,
         csa_core::env::CSA_MODEL_SPEC_ENV_KEY,
         csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY,
         csa_core::env::CSA_NO_FAILOVER_ENV_KEY,
@@ -224,6 +317,16 @@ fn spawn_bash_env_strips_ambient_subtree_pin_when_not_legitimately_inherited() {
     unsafe {
         // Root depth: any ambient pin is NOT a CSA-injected inherited pin.
         std::env::set_var("CSA_DEPTH", "0");
+        std::env::set_var(csa_core::env::CSA_INTERNAL_INVOCATION_ENV_KEY, "1");
+        std::env::set_var(
+            csa_core::env::CSA_SESSION_ID_ENV_KEY,
+            "01KPINNEDSESSION0000000000",
+        );
+        std::env::set_var(
+            csa_core::env::CSA_SESSION_DIR_ENV_KEY,
+            "/repo/.csa/sessions/01KPINNEDSESSION0000000000",
+        );
+        std::env::set_var(csa_core::env::CSA_PROJECT_ROOT_ENV_KEY, "/repo");
         std::env::set_var(csa_core::env::CSA_MODEL_SPEC_ENV_KEY, PIN_SPEC);
         std::env::set_var(csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1");
         std::env::set_var(csa_core::env::CSA_NO_FAILOVER_ENV_KEY, "1");
@@ -257,39 +360,35 @@ fn spawn_bash_env_strips_ambient_subtree_pin_when_not_legitimately_inherited() {
     }
 }
 
-/// #1741 round-6: a legitimately-propagated subtree pin (this process is a
-/// genuine pinned child: CSA_DEPTH > 0 + well-formed pin in env, as written
-/// by the parent's trusted typed channel) MUST still cascade to the nested
-/// bash step. The strip-then-reapply path re-writes the pin keys from the
-/// typed channel, so legitimate propagation is preserved.
+/// #1741 round-6/#2097: a legitimately-propagated subtree pin (this process is
+/// a genuine pinned child: CSA_DEPTH > 0 + child contract backed by persisted
+/// session state + matching subtree-model-pin.toml sidecar) MUST still cascade
+/// to the nested bash step. The strip-then-reapply path re-writes the pin keys
+/// from the typed channel, so legitimate propagation is preserved.
 #[test]
 fn spawn_bash_env_reapplies_legitimately_inherited_subtree_pin() {
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
-    let original: Vec<(&str, Option<String>)> = [
-        "CSA_DEPTH",
-        csa_core::env::CSA_MODEL_SPEC_ENV_KEY,
-        csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY,
-        csa_core::env::CSA_NO_FAILOVER_ENV_KEY,
-    ]
-    .iter()
-    .map(|k| (*k, std::env::var(k).ok()))
-    .collect();
-
-    // SAFETY: test-scoped env mutation, serialized by TEST_ENV_LOCK.
-    unsafe {
-        // Child depth + well-formed pin + paired force-ignore marker =
-        // a genuine CSA-injected inherited pin.
-        std::env::set_var("CSA_DEPTH", "2");
-        std::env::set_var(csa_core::env::CSA_MODEL_SPEC_ENV_KEY, PIN_SPEC);
-        std::env::set_var(csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1");
-        std::env::set_var(csa_core::env::CSA_NO_FAILOVER_ENV_KEY, "1");
-    }
-
-    let startup_env = startup_env_with_pin(2);
+    let xdg = tempfile::tempdir().expect("xdg tempdir");
+    let _xdg_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", xdg.path());
+    let project = tempfile::tempdir().expect("project tempdir");
+    let startup_env = trusted_startup_env_for_pinned_plan_session(project.path(), PIN_SPEC, true);
     let mut cmd = tokio::process::Command::new("bash");
+    cmd.env(csa_core::env::CSA_PROJECT_ROOT_ENV_KEY, project.path())
+        .env(
+            csa_core::env::CSA_DEPTH_ENV_KEY,
+            bash_step_depth_string(&startup_env),
+        )
+        .env(csa_core::env::CSA_INTERNAL_INVOCATION_ENV_KEY, "1")
+        .env(csa_core::env::CSA_PATTERN_INTERNAL_ENV_KEY, "1");
     apply_startup_child_contract_env(&mut cmd, &startup_env);
     let env = recorded_env(&cmd);
 
+    assert_eq!(
+        env.get(csa_core::env::CSA_DEPTH_ENV_KEY),
+        Some(&Some(startup_env.current_depth().to_string())),
+        "plan bash reuses the same trusted session sidecar/state contract, so \
+         it must not advance CSA_DEPTH beyond that session's startup depth"
+    );
     assert_eq!(
         env.get(csa_core::env::CSA_MODEL_SPEC_ENV_KEY),
         Some(&Some(PIN_SPEC.to_string())),
@@ -306,15 +405,12 @@ fn spawn_bash_env_reapplies_legitimately_inherited_subtree_pin() {
         "no-failover must cascade when the inherited pin carries it"
     );
 
-    // SAFETY: restore original env values.
-    unsafe {
-        for (key, value) in original {
-            match value {
-                Some(v) => std::env::set_var(key, v),
-                None => std::env::remove_var(key),
-            }
-        }
-    }
+    let nested_startup_env = startup_env_from_recorded_env(&env);
+    let inherited = crate::run_cmd_model_pin::inherited_model_pin_from_startup(&nested_startup_env)
+        .expect("plan bash env must still validate against the trusted sidecar");
+    assert_eq!(inherited.model_spec, PIN_SPEC);
+    assert!(inherited.force_ignore_tier_setting);
+    assert!(inherited.no_failover);
 }
 
 /// #1750 round-4: foreground nested plan bash steps are CSA-child boundaries.

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -72,6 +72,8 @@ mod reviewers;
 mod session_fix;
 #[path = "review_cmd_subtree_pin.rs"]
 mod subtree_pin;
+#[path = "review_cmd_tier_gate.rs"]
+mod tier_gate;
 #[cfg(test)]
 pub(crate) use bug_class_pipeline::try_extract_recurring_bug_class_skills;
 #[cfg(test)]
@@ -139,18 +141,14 @@ pub(crate) async fn handle_review(
     let inherited_trusted_pin = subtree_pin::apply_subtree_pin(&mut args, inherited_model_pin);
     let (effective_tier, args_tool) = resolve_review_effective_tier(&args, config.as_ref())?;
     let selection = session_fix::resolve_selection_tool(&args, &project_root, args_tool)?;
-    crate::run_helpers::enforce_tier_bypass_gate(crate::run_helpers::TierBypassGateCtx {
-        project_config: config.as_ref(),
-        global_config: &global_config,
-        flags: crate::run_helpers::TierBypassGateFlags {
-            model_spec: args.model_spec.is_some(),
-            force: false,
-            force_ignore_tier_setting: args.force_ignore_tier_setting,
-            model: args.model.is_some(),
-            thinking: args.thinking.is_some(),
-        },
+    tier_gate::enforce_review_tier_bypass_gate(
+        &args,
+        config.as_ref(),
+        &global_config,
         inherited_trusted_pin,
-    })?;
+        effective_tier.as_deref(),
+        &project_root,
+    )?;
     validate_review_direct_tool_tier_restriction(
         selection.direct_tool_requested,
         config.as_ref(),

--- a/crates/cli-sub-agent/src/review_cmd_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prior_rounds.rs
@@ -40,3 +40,21 @@ pub(super) fn explicit_review_tool(args: &ReviewArgs) -> Option<csa_core::types:
             .and_then(|tool_name| crate::run_helpers::parse_tool_name(tool_name).ok())
     })
 }
+
+pub(super) fn persist_tier_bypass_pre_exec_error(
+    args: &ReviewArgs,
+    project_root: &std::path::Path,
+    effective_tier: Option<&str>,
+    err: anyhow::Error,
+) -> anyhow::Error {
+    crate::session_guard::persist_pre_exec_error_result(crate::session_guard::PreExecErrorCtx {
+        project_root,
+        session_id: review_pre_exec_session_id(args),
+        description: Some("review"),
+        parent: None,
+        tool_name: explicit_review_tool(args).map(|tool| tool.as_str()),
+        task_type: Some("review"),
+        tier_name: effective_tier,
+        error: err,
+    })
+}

--- a/crates/cli-sub-agent/src/review_cmd_tier_gate.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tier_gate.rs
@@ -1,0 +1,36 @@
+use std::path::Path;
+
+use anyhow::Result;
+use csa_config::{GlobalConfig, ProjectConfig};
+
+use crate::cli::ReviewArgs;
+
+pub(super) fn enforce_review_tier_bypass_gate(
+    args: &ReviewArgs,
+    project_config: Option<&ProjectConfig>,
+    global_config: &GlobalConfig,
+    inherited_trusted_pin: bool,
+    effective_tier: Option<&str>,
+    project_root: &Path,
+) -> Result<()> {
+    crate::run_helpers::enforce_tier_bypass_gate(crate::run_helpers::TierBypassGateCtx {
+        project_config,
+        global_config,
+        flags: crate::run_helpers::TierBypassGateFlags {
+            model_spec: args.model_spec.is_some(),
+            force: false,
+            force_ignore_tier_setting: args.force_ignore_tier_setting,
+            model: args.model.is_some(),
+            thinking: args.thinking.is_some(),
+        },
+        inherited_trusted_pin,
+    })
+    .map_err(|err| {
+        super::prior_rounds::persist_tier_bypass_pre_exec_error(
+            args,
+            project_root,
+            effective_tier,
+            err,
+        )
+    })
+}

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -125,23 +125,13 @@ impl DaemonSpawnOptions {
     }
 }
 
-/// Guard returned by [`check_daemon_flags`] when running as daemon child.
-///
-/// Holds the stderr rotation guard (if installed) so that stderr.log rotation
-/// remains active for the entire daemon child lifetime.  Must be kept alive
-/// until the process exits.
-///
-/// Call [`finalize`](Self::finalize) explicitly before any `process::exit()`
-/// since `exit()` skips Drop destructors.
+/// Daemon child resources; call [`finalize`](Self::finalize) before `process::exit()`.
 pub(crate) struct DaemonChildGuard {
-    /// Kept alive to maintain stderr rotation; dropped on process exit.
     _stderr_rotation: Option<csa_process::daemon_stderr::StderrRotationGuard>,
 }
 
 impl DaemonChildGuard {
-    /// Explicitly shut down the stderr rotation guard before process exit.
-    ///
-    /// This is a no-op if no stderr rotation was installed.
+    /// Shut down stderr rotation before process exit.
     pub(crate) fn finalize(&mut self) {
         if let Some(guard) = &mut self._stderr_rotation {
             guard.finalize();
@@ -149,11 +139,7 @@ impl DaemonChildGuard {
     }
 }
 
-/// Check daemon flags and either spawn+exit or propagate session ID.
-///
-/// Returns `Ok(guard)` when the caller should proceed with the child path.
-/// The returned guard must be kept alive for the duration of the process.
-/// **Never returns** when daemon spawn succeeds (calls `process::exit(0)`).
+/// Check daemon flags; spawns+exits on parent path, returns a child guard otherwise.
 pub(crate) fn check_daemon_flags(
     subcommand: &str,
     no_daemon: bool,
@@ -177,9 +163,7 @@ pub(crate) fn check_daemon_flags(
             std::env::set_var(csa_core::env::CSA_SESSION_ID_ENV_KEY, sid);
         }
         crate::session_cmds_daemon::seed_daemon_session_env(sid, cd);
-        // Keep ordinary run/review/debate daemon children in sync with the plan-daemon
-        // invariant established by `inject_plan_daemon_session_into_startup_env`: after
-        // daemon bootstrap, StartupSubtreeEnv::session_id() names the executing session.
+        // Keep daemon children aligned with plan-daemon's executing-session invariant.
         *startup_env = daemon_child_startup_env(startup_env, sid, cd)?;
 
         // Install stderr rotation so daemon stderr.log is bounded.
@@ -188,8 +172,7 @@ pub(crate) fn check_daemon_flags(
         // Install panic hook so daemon-completion.toml is written even on panic.
         install_daemon_panic_hook();
 
-        // Spawn a background task that writes daemon-completion.toml on SIGTERM/SIGINT.
-        // This runs inside the tokio runtime (we are inside `#[tokio::main]`).
+        // Write daemon-completion.toml on SIGTERM/SIGINT.
         spawn_daemon_signal_handler();
     }
     Ok(DaemonChildGuard {
@@ -202,17 +185,25 @@ fn daemon_child_startup_env(
     session_id: &str,
     cd: Option<&str>,
 ) -> Result<StartupSubtreeEnv> {
+    // Wrapper sidecar is written later; carry only the already sidecar-validated pin.
+    let trusted_inherited_pin =
+        crate::run_cmd_model_pin::inherited_model_pin_from_startup(startup_env);
     let project_root = crate::pipeline::determine_project_root(cd)?;
     let session_dir = csa_session::get_session_dir(&project_root, session_id)?;
-    Ok(startup_env
+    let mut daemon_startup_env = startup_env
         .clone()
-        .with_current_session(session_id, session_dir.display().to_string()))
+        .with_current_session(session_id, session_dir.display().to_string());
+    if let Some(pin) = trusted_inherited_pin {
+        daemon_startup_env = daemon_startup_env.with_trusted_inherited_model_pin(
+            pin.model_spec,
+            pin.force_ignore_tier_setting,
+            pin.no_failover,
+        );
+    }
+    Ok(daemon_startup_env)
 }
 
-/// Install a custom panic hook that writes `daemon-completion.toml` before
-/// chaining to the default hook (preserving backtrace output).
-///
-/// Exit code 101 is Rust's conventional panic exit code.
+/// Install a panic hook that writes `daemon-completion.toml` before chaining.
 fn install_daemon_panic_hook() {
     let prev_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -221,9 +212,7 @@ fn install_daemon_panic_hook() {
     }));
 }
 
-/// Spawn a tokio task that listens for SIGTERM and SIGINT, writes
-/// `daemon-completion.toml` with the conventional signal exit code
-/// (128 + signal number), then exits.
+/// Persist daemon completion on SIGTERM/SIGINT, then exit with 128+signal.
 fn spawn_daemon_signal_handler() {
     tokio::spawn(async {
         #[cfg(unix)]
@@ -265,10 +254,7 @@ fn spawn_daemon_signal_handler() {
     });
 }
 
-/// Best-effort stderr rotation install for daemon child processes.
-///
-/// Reads `stderr_spool_max_mb` and `spool_keep_rotated` from project config.
-/// Falls back to defaults on any error.
+/// Best-effort daemon stderr rotation using config spool limits when readable.
 fn install_daemon_stderr_rotation(
     session_id: &str,
     cd: Option<&str>,
@@ -313,13 +299,7 @@ fn resolve_stderr_spool_config(project_root: &std::path::Path) -> (u64, bool, st
     )
 }
 
-/// Fork a daemon child and exit the parent process.
-///
-/// The daemon child will re-exec with `--daemon-child --session-id <ID>`
-/// and the same flags the parent received. stdout.log / stderr.log are
-/// captured in the session directory.
-///
-/// This function **never returns on success** — it calls `process::exit(0)`.
+/// Fork a daemon child, capture logs in its session, and exit parent on success.
 pub(crate) fn spawn_and_exit(
     subcommand: &str,
     cd: Option<&str>,
@@ -337,10 +317,7 @@ pub(crate) fn spawn_and_exit(
     persist_daemon_placeholder_session(&project_root, &session_dir, &sid, subcommand)?;
     let prompt_input_file = write_daemon_prompt_input_if_needed(&session_dir, prompt_input)?;
 
-    // Collect args to forward: everything after the subcommand verb.
-    // spawn_daemon() injects '<subcommand> --daemon-child --session-id <ID>' itself.
-    // We find the subcommand by position (not substring) to handle global flags
-    // that may appear before the subcommand (e.g. `csa --format json review ...`).
+    // Forward args after the subcommand verb; spawn_daemon injects child/session flags.
     let all_args: Vec<String> = std::env::args().collect();
     let forwarded_args = build_forwarded_args(
         &all_args,

--- a/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
@@ -1,5 +1,117 @@
 use super::*;
 
+const PINNED_SPEC: &str = "codex/openai/gpt-5.5/xhigh";
+
+fn trusted_startup_env_for_daemon_parent(
+    project_root: &Path,
+    spec: &str,
+    no_failover: bool,
+) -> StartupSubtreeEnv {
+    let session = csa_session::create_session(
+        project_root,
+        Some("pinned daemon parent"),
+        None,
+        Some("codex"),
+    )
+    .expect("create pinned daemon parent session");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let typed_pin =
+        crate::run_cmd_model_pin::resolve_subtree_model_pin(Some(spec), true, no_failover)
+            .expect("typed pin");
+    crate::run_cmd_model_pin::sync_subtree_model_pin_sidecar(
+        project_root,
+        &session.meta_session_id,
+        &session_dir,
+        Some(&typed_pin),
+    )
+    .expect("write trusted pin sidecar");
+
+    StartupSubtreeEnv::from_values(std::collections::HashMap::from([
+        (
+            csa_core::env::CSA_DEPTH_ENV_KEY,
+            session.genealogy.depth.saturating_add(1).to_string(),
+        ),
+        (
+            csa_core::env::CSA_INTERNAL_INVOCATION_ENV_KEY,
+            "1".to_string(),
+        ),
+        (
+            csa_core::env::CSA_SESSION_ID_ENV_KEY,
+            session.meta_session_id,
+        ),
+        (
+            csa_core::env::CSA_SESSION_DIR_ENV_KEY,
+            session_dir.display().to_string(),
+        ),
+        (
+            csa_core::env::CSA_PROJECT_ROOT_ENV_KEY,
+            project_root.display().to_string(),
+        ),
+        (csa_core::env::CSA_MODEL_SPEC_ENV_KEY, spec.to_string()),
+        (
+            csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY,
+            "1".to_string(),
+        ),
+        (
+            csa_core::env::CSA_NO_FAILOVER_ENV_KEY,
+            if no_failover { "1" } else { "0" }.to_string(),
+        ),
+    ]))
+}
+
+fn assert_daemon_wrapper_pin_resolves_for_command(command: &str, startup_env: &StartupSubtreeEnv) {
+    let inherited = crate::run_cmd_model_pin::inherited_model_pin_from_startup(startup_env)
+        .unwrap_or_else(|| panic!("{command} daemon wrapper must preserve inherited pin trust"));
+
+    match command {
+        "run" => {
+            let mut skill_res = crate::run_cmd_tool_selection::SkillResolution {
+                prompt_text: "prompt".to_string(),
+                frontmatter_difficulty: None,
+                resolved_skill: None,
+                tool: None,
+                model: None,
+                thinking: None,
+            };
+            let mut user_explicit_tool = false;
+            let resolved = crate::run_cmd_model_pin::resolve_handle_run_model_pin(
+                crate::run_cmd_model_pin::RunModelPinInput {
+                    model_spec: None,
+                    tier: Some("tier-4-critical".to_string()),
+                    auto_route: Some("complex".to_string()),
+                    force_ignore_tier_setting: false,
+                    no_failover: false,
+                },
+                Some(inherited),
+                false,
+                &mut skill_res,
+                &mut user_explicit_tool,
+            );
+            assert_eq!(resolved.model_spec.as_deref(), Some(PINNED_SPEC));
+            assert!(resolved.tier.is_none());
+            assert!(resolved.auto_route.is_none());
+            assert!(resolved.inherited_trusted_pin);
+            assert!(resolved.subtree_model_pin_active);
+        }
+        "review" | "debate" => {
+            let resolved = crate::run_cmd_model_pin::apply_inherited_pin_for_review_debate(
+                None,
+                Some("tier-4-critical".to_string()),
+                false,
+                false,
+                Some(inherited),
+            );
+            assert_eq!(resolved.model_spec.as_deref(), Some(PINNED_SPEC));
+            assert!(resolved.tier.is_none());
+            assert!(resolved.force_ignore_tier_setting);
+            assert!(resolved.no_failover);
+            assert!(resolved.inherited);
+        }
+        other => panic!("unexpected command variant {other}"),
+    }
+}
+
 #[test]
 fn run_daemon_options_detect_omitted_stdin_prompt_without_skill() {
     let options = DaemonSpawnOptions::for_run(None, None, None, None, false, &[]);
@@ -346,6 +458,9 @@ fn bounded_stdin_prompt_rejects_prompt_over_limit() {
 
 #[test]
 fn daemon_child_startup_env_uses_preassigned_session_context() {
+    let _lock = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let parent_session_id = csa_session::new_session_id();
     let actual_session_id = csa_session::new_session_id();
@@ -387,7 +502,91 @@ fn daemon_child_startup_env_uses_preassigned_session_context() {
 }
 
 #[test]
+fn daemon_child_startup_env_preserves_trusted_pin_for_run_review_debate() {
+    let _lock = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
+    let xdg = tempfile::tempdir().expect("xdg tempdir");
+    let _xdg_guard = crate::test_env_lock::ScopedEnvVarRestore::set("XDG_STATE_HOME", xdg.path());
+    let project = tempfile::tempdir().expect("project tempdir");
+    let startup_env = trusted_startup_env_for_daemon_parent(project.path(), PINNED_SPEC, true);
+    let original_session_id = startup_env
+        .session_id()
+        .expect("trusted fixture has session id")
+        .to_string();
+    let wrapper_session_id = csa_session::new_session_id();
+
+    let effective = daemon_child_startup_env(
+        &startup_env,
+        &wrapper_session_id,
+        Some(project.path().to_str().expect("temp path should be utf-8")),
+    )
+    .expect("daemon child startup env should resolve");
+
+    assert_eq!(effective.session_id(), Some(wrapper_session_id.as_str()));
+    assert_eq!(
+        effective.parent_session(),
+        Some(original_session_id.as_str())
+    );
+    for command in ["run", "review", "debate"] {
+        assert_daemon_wrapper_pin_resolves_for_command(command, &effective);
+    }
+}
+
+#[test]
+fn daemon_child_startup_env_does_not_trust_ambient_pin_without_sidecar() {
+    let _lock = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let wrapper_session_id = csa_session::new_session_id();
+    let startup_env = StartupSubtreeEnv::from_values(std::collections::HashMap::from([
+        (csa_core::env::CSA_DEPTH_ENV_KEY, "1".to_string()),
+        (
+            csa_core::env::CSA_INTERNAL_INVOCATION_ENV_KEY,
+            "1".to_string(),
+        ),
+        (
+            csa_core::env::CSA_SESSION_ID_ENV_KEY,
+            "01KPINNEDSESSION0000000000".to_string(),
+        ),
+        (
+            csa_core::env::CSA_SESSION_DIR_ENV_KEY,
+            "/tmp/csa-spoof/sessions/01KPINNEDSESSION0000000000".to_string(),
+        ),
+        (
+            csa_core::env::CSA_PROJECT_ROOT_ENV_KEY,
+            temp.path().display().to_string(),
+        ),
+        (
+            csa_core::env::CSA_MODEL_SPEC_ENV_KEY,
+            PINNED_SPEC.to_string(),
+        ),
+        (
+            csa_core::env::CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY,
+            "1".to_string(),
+        ),
+        (csa_core::env::CSA_NO_FAILOVER_ENV_KEY, "1".to_string()),
+    ]));
+
+    let effective = daemon_child_startup_env(
+        &startup_env,
+        &wrapper_session_id,
+        Some(temp.path().to_str().expect("temp path should be utf-8")),
+    )
+    .expect("daemon child startup env should resolve");
+
+    assert!(
+        crate::run_cmd_model_pin::inherited_model_pin_from_startup(&effective).is_none(),
+        "raw ambient pin env must still fail closed after daemon wrapper rewrite"
+    );
+}
+
+#[test]
 fn daemon_started_session_is_waitable_and_listed_before_marker_emit() {
+    let _lock = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let project_root = temp.path().join("project");
     std::fs::create_dir_all(&project_root).expect("project root should be created");
@@ -421,6 +620,9 @@ fn daemon_started_session_is_waitable_and_listed_before_marker_emit() {
 
 #[test]
 fn daemon_started_marker_is_blocked_when_session_state_is_unreadable() {
+    let _lock = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let project_root = temp.path().join("project");
     std::fs::create_dir_all(&project_root).expect("project root should be created");

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -30,7 +30,6 @@ use crate::run_helpers::{
 use crate::run_helpers_branch_guard::{
     BranchGuardRuntime, evaluate_and_emit_refusal, observe_branch_state,
 };
-use crate::session_guard::{PreExecErrorCtx, persist_pre_exec_error_result};
 use crate::startup_env::StartupSubtreeEnv;
 #[path = "run_cmd_execute_post_exec_gate.rs"]
 mod post_exec_gate;
@@ -54,9 +53,9 @@ use post_exec_gate::{
 };
 use reuse_hint::emit_reusable_session_hint;
 use routing::{
-    RunModelSelectionFlags, enforce_run_tier_bypass_gate, resolve_primary_writer_spec_for_run,
-    resolve_run_effective_tier, resolve_run_fallback_tier_name, resolve_run_no_failover,
-    resolve_run_subtree_pin_selection, resolve_run_tier_context, resolve_run_tool_strategy,
+    RunModelSelectionFlags, resolve_primary_writer_spec_for_run, resolve_run_effective_tier,
+    resolve_run_fallback_tier_name, resolve_run_no_failover, resolve_run_subtree_pin_selection,
+    resolve_run_tier_context, resolve_run_tool_strategy,
 };
 use run_cli_flags::{
     resolve_return_target, warn_deprecated_session_flags,
@@ -65,7 +64,10 @@ use run_cli_flags::{
 use run_context::finalize_prompt_text;
 use run_output::emit_run_result_output;
 use skill_resume::maybe_auto_resume_interrupted_skill_session;
-use tier_guard::{DirectToolTierGuardCtx, enforce_direct_tool_tier_guard};
+use tier_guard::{
+    DirectToolTierGuardCtx, RunPreExecErrorCtx, RunTierBypassPersistCtx,
+    enforce_direct_tool_tier_guard, enforce_run_tier_bypass_gate_or_persist,
+};
 
 use super::attempt::{RunLoopCompletion, RunLoopRequest, execute_run_loop};
 use super::resume::{
@@ -275,6 +277,28 @@ pub(crate) async fn handle_run(
     let thinking = skill_res.thinking;
     let model = skill_res.model;
     let skill_session_tag = skill.as_deref().map(skill_session_description);
+    let fallback_description = truncate_prompt(&prompt_text, 80);
+    let pre_exec_description = description
+        .as_deref()
+        .or(skill_session_tag.as_deref())
+        .or(Some(fallback_description.as_str()));
+    let pre_exec_parent = if is_fork {
+        session_arg.as_deref().or(parent.as_deref())
+    } else {
+        parent.as_deref()
+    };
+    let explicit_tool_name = match skill_res.tool.as_ref() {
+        Some(ToolArg::Specific(tool)) => Some(tool.as_str()),
+        _ => None,
+    };
+    let pre_exec_error = RunPreExecErrorCtx {
+        project_root: &project_root,
+        is_fork,
+        session_arg: session_arg.as_deref(),
+        description: pre_exec_description,
+        parent: pre_exec_parent,
+        tool_name: explicit_tool_name,
+    };
     let model_selection_flags = RunModelSelectionFlags {
         tool: user_explicit_tool,
         auto_route: auto_route.is_some(),
@@ -287,14 +311,16 @@ pub(crate) async fn handle_run(
         tier: tier.is_some(),
         hint_difficulty: hint_difficulty.is_some() || frontmatter_difficulty.is_some(),
     };
-    enforce_run_tier_bypass_gate(
-        config.as_ref(),
-        &global_config,
-        model_selection_flags,
+    enforce_run_tier_bypass_gate_or_persist(RunTierBypassPersistCtx {
+        config: config.as_ref(),
+        global_config: &global_config,
+        selection_flags: model_selection_flags,
         force,
         force_ignore_tier_setting,
-        model_pin_resolution.inherited_trusted_pin,
-    )?;
+        inherited_trusted_pin: model_pin_resolution.inherited_trusted_pin,
+        pre_exec: pre_exec_error,
+        tier_name: tier.as_deref(),
+    })?;
     if model_selection_flags.model_spec
         && tier_bypass_allowed(
             config.as_ref(),
@@ -312,21 +338,6 @@ pub(crate) async fn handle_run(
     if let Some(c) = config.as_ref() {
         merged_aliases.extend(c.tool_aliases.iter().map(|(k, v)| (k.clone(), v.clone())));
     }
-    let explicit_tool_name = match skill_res.tool.as_ref() {
-        Some(ToolArg::Specific(tool)) => Some(tool.as_str()),
-        _ => None,
-    };
-    let fallback_description = truncate_prompt(&prompt_text, 80);
-    let pre_exec_description = description
-        .as_deref()
-        .or(skill_session_tag.as_deref())
-        .or(Some(fallback_description.as_str()));
-    let pre_exec_parent = if is_fork {
-        session_arg.as_deref().or(parent.as_deref())
-    } else {
-        parent.as_deref()
-    };
-
     let effective_tier = resolve_run_effective_tier(
         config.as_ref(),
         tier.as_deref(),
@@ -343,22 +354,7 @@ pub(crate) async fn handle_run(
         config.as_ref(),
     ) {
         Ok(pair) => pair,
-        Err(err) => {
-            return Err(persist_pre_exec_error_result(PreExecErrorCtx {
-                project_root: &project_root,
-                session_id: if is_fork {
-                    None
-                } else {
-                    session_arg.as_deref()
-                },
-                description: pre_exec_description,
-                parent: pre_exec_parent,
-                tool_name: explicit_tool_name,
-                task_type: Some("run"),
-                tier_name: None,
-                error: err,
-            }));
-        }
+        Err(err) => return Err(pre_exec_error.persist(None, err)),
     };
     skill_res.tool = compounded_tool;
 
@@ -369,12 +365,7 @@ pub(crate) async fn handle_run(
         model_spec: model_spec.as_deref(),
         force_ignore_tier_setting,
         force,
-        project_root: &project_root,
-        is_fork,
-        session_arg: session_arg.as_deref(),
-        pre_exec_description,
-        pre_exec_parent,
-        explicit_tool_name,
+        pre_exec: pre_exec_error,
     })?;
 
     warn_if_tier_without_tool(tier.as_deref(), user_explicit_tool);
@@ -419,20 +410,7 @@ pub(crate) async fn handle_run(
     )
     .map_err(|err| {
         if is_routing_conflict(&err) {
-            persist_pre_exec_error_result(PreExecErrorCtx {
-                project_root: &project_root,
-                session_id: if is_fork {
-                    None
-                } else {
-                    session_arg.as_deref()
-                },
-                description: pre_exec_description,
-                parent: pre_exec_parent,
-                tool_name: explicit_tool_name,
-                task_type: Some("run"),
-                tier_name: effective_tier.as_deref(),
-                error: err,
-            })
+            pre_exec_error.persist(effective_tier.as_deref(), err)
         } else {
             err
         }

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -141,7 +141,7 @@ async fn run_preflight_fixture(project_root: &Path, no_preflight: bool) -> anyho
 }
 
 #[tokio::test]
-async fn handle_run_rejects_model_spec_tier_bypass_before_session_creation() {
+async fn handle_run_persists_model_spec_tier_bypass_pre_exec_result() {
     let project_dir = tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let config = run_config_with_tier(
@@ -226,9 +226,27 @@ async fn handle_run_rejects_model_spec_tier_bypass_before_session_creation() {
     );
 
     let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
+    assert_eq!(
+        sessions.len(),
+        1,
+        "tier bypass gate should persist a structured pre-exec failure session"
+    );
+    let session_id = &sessions[0].meta_session_id;
+    let result = csa_session::load_result(project_dir.path(), session_id)
+        .expect("pre-exec failure should write result.toml")
+        .expect("result.toml should exist");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.tool, "unknown");
     assert!(
-        sessions.is_empty(),
-        "tier bypass gate should reject before session creation"
+        result.summary.contains("Tier bypass is disabled"),
+        "summary should name tier bypass policy: {}",
+        result.summary
+    );
+    assert!(
+        result.summary.contains("Refused flags: --model-spec"),
+        "summary should name refused flags: {}",
+        result.summary
     );
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
@@ -1,7 +1,7 @@
+use super::routing::enforce_run_tier_bypass_gate;
 use super::{
-    RunModelSelectionFlags, enforce_run_tier_bypass_gate, finalize_prompt_text,
-    resolve_primary_writer_spec_for_run, resolve_run_no_failover,
-    resolve_run_subtree_pin_selection, resolve_run_tier_context,
+    RunModelSelectionFlags, finalize_prompt_text, resolve_primary_writer_spec_for_run,
+    resolve_run_no_failover, resolve_run_subtree_pin_selection, resolve_run_tier_context,
 };
 use crate::run_cmd_model_pin::{InheritedModelPin, RunModelPinInput, apply_inherited_model_pin};
 use crate::run_cmd_tool_selection::{resolve_skill_and_prompt, resolve_tool_by_strategy};
@@ -283,8 +283,7 @@ fn finalize_prompt_text_uses_subprocess_preamble_when_only_session_id_is_set() {
     let mut sandbox = ScopedSessionSandbox::new_blocking(&tmp);
     sandbox.track_env("CSA_DEPTH");
     sandbox.track_env("CSA_SESSION_ID");
-    // Treat CSA_SESSION_ID alone as subprocess so detached child contexts still avoid the
-    // unavailable /commit slash-command path.
+    // CSA_SESSION_ID alone means detached subprocess; avoid unavailable /commit slash path.
     // SAFETY: ScopedSessionSandbox holds TEST_ENV_LOCK for the full test.
     unsafe {
         std::env::remove_var("CSA_DEPTH");

--- a/crates/cli-sub-agent/src/run_cmd_execute_tier_guard.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_tier_guard.rs
@@ -2,7 +2,34 @@ use std::path::Path;
 
 use anyhow::Result;
 
-use csa_config::ProjectConfig;
+use csa_config::{GlobalConfig, ProjectConfig};
+
+use super::routing::{RunModelSelectionFlags, enforce_run_tier_bypass_gate};
+
+#[derive(Clone, Copy)]
+pub(super) struct RunPreExecErrorCtx<'a> {
+    pub(super) project_root: &'a Path,
+    pub(super) is_fork: bool,
+    pub(super) session_arg: Option<&'a str>,
+    pub(super) description: Option<&'a str>,
+    pub(super) parent: Option<&'a str>,
+    pub(super) tool_name: Option<&'a str>,
+}
+
+impl RunPreExecErrorCtx<'_> {
+    pub(super) fn persist(self, tier_name: Option<&str>, error: anyhow::Error) -> anyhow::Error {
+        crate::session_guard::persist_pre_exec_error_result(crate::session_guard::PreExecErrorCtx {
+            project_root: self.project_root,
+            session_id: if self.is_fork { None } else { self.session_arg },
+            description: self.description,
+            parent: self.parent,
+            tool_name: self.tool_name,
+            task_type: Some("run"),
+            tier_name,
+            error,
+        })
+    }
+}
 
 pub(super) struct DirectToolTierGuardCtx<'a> {
     pub(super) config: Option<&'a ProjectConfig>,
@@ -11,12 +38,7 @@ pub(super) struct DirectToolTierGuardCtx<'a> {
     pub(super) model_spec: Option<&'a str>,
     pub(super) force_ignore_tier_setting: bool,
     pub(super) force: bool,
-    pub(super) project_root: &'a Path,
-    pub(super) is_fork: bool,
-    pub(super) session_arg: Option<&'a str>,
-    pub(super) pre_exec_description: Option<&'a str>,
-    pub(super) pre_exec_parent: Option<&'a str>,
-    pub(super) explicit_tool_name: Option<&'a str>,
+    pub(super) pre_exec: RunPreExecErrorCtx<'a>,
 }
 
 pub(super) fn enforce_direct_tool_tier_guard(ctx: DirectToolTierGuardCtx<'_>) -> Result<()> {
@@ -45,16 +67,30 @@ pub(super) fn enforce_direct_tool_tier_guard(ctx: DirectToolTierGuardCtx<'_>) ->
          Available tiers: {}",
         tier_list.join(", ")
     );
-    Err(crate::session_guard::persist_pre_exec_error_result(
-        crate::session_guard::PreExecErrorCtx {
-            project_root: ctx.project_root,
-            session_id: if ctx.is_fork { None } else { ctx.session_arg },
-            description: ctx.pre_exec_description,
-            parent: ctx.pre_exec_parent,
-            tool_name: ctx.explicit_tool_name,
-            task_type: Some("run"),
-            tier_name: ctx.effective_tier,
-            error: err,
-        },
-    ))
+    Err(ctx.pre_exec.persist(ctx.effective_tier, err))
+}
+
+pub(super) struct RunTierBypassPersistCtx<'a> {
+    pub(super) config: Option<&'a ProjectConfig>,
+    pub(super) global_config: &'a GlobalConfig,
+    pub(super) selection_flags: RunModelSelectionFlags,
+    pub(super) force: bool,
+    pub(super) force_ignore_tier_setting: bool,
+    pub(super) inherited_trusted_pin: bool,
+    pub(super) pre_exec: RunPreExecErrorCtx<'a>,
+    pub(super) tier_name: Option<&'a str>,
+}
+
+pub(super) fn enforce_run_tier_bypass_gate_or_persist(
+    ctx: RunTierBypassPersistCtx<'_>,
+) -> Result<()> {
+    enforce_run_tier_bypass_gate(
+        ctx.config,
+        ctx.global_config,
+        ctx.selection_flags,
+        ctx.force,
+        ctx.force_ignore_tier_setting,
+        ctx.inherited_trusted_pin,
+    )
+    .map_err(|err| ctx.pre_exec.persist(ctx.tier_name, err))
 }

--- a/crates/cli-sub-agent/src/run_cmd_model_pin.rs
+++ b/crates/cli-sub-agent/src/run_cmd_model_pin.rs
@@ -1,7 +1,14 @@
+#[path = "run_cmd_model_pin_sidecar.rs"]
+mod sidecar;
+
 #[cfg(test)]
 use csa_core::env::{
-    CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, CSA_MODEL_SPEC_ENV_KEY, CSA_NO_FAILOVER_ENV_KEY,
+    CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, CSA_INTERNAL_INVOCATION_ENV_KEY, CSA_MODEL_SPEC_ENV_KEY,
+    CSA_NO_FAILOVER_ENV_KEY, CSA_PROJECT_ROOT_ENV_KEY, CSA_SESSION_DIR_ENV_KEY,
+    CSA_SESSION_ID_ENV_KEY,
 };
+
+pub(crate) use sidecar::sync_subtree_model_pin_sidecar;
 
 use crate::run_cmd_tool_selection::SkillResolution;
 use crate::startup_env::StartupSubtreeEnv;
@@ -46,11 +53,40 @@ pub(crate) struct HandleRunModelPinResolution {
 pub(crate) fn inherited_model_pin_from_startup(
     startup_env: &StartupSubtreeEnv,
 ) -> Option<InheritedModelPin> {
-    inherited_model_pin_from_values(
-        startup_env.current_depth(),
-        startup_env.model_spec(),
-        startup_env.force_ignore_tier_setting(),
-        startup_env.no_failover(),
+    let pin = inherited_model_pin_from_values(InheritedModelPinValues {
+        current_depth: startup_env.current_depth(),
+        child_contract: InheritedModelPinChildContract {
+            internal_invocation: startup_env.internal_invocation(),
+            session_id: startup_env.session_id(),
+            session_dir: startup_env.session_dir(),
+            project_root: startup_env.project_root(),
+        },
+        model_spec: startup_env.model_spec(),
+        force_ignore_tier_setting: startup_env.force_ignore_tier_setting(),
+        no_failover: startup_env.no_failover(),
+    })?;
+
+    if startup_env_trusted_pin_matches(startup_env, &pin) {
+        return Some(pin);
+    }
+
+    if !sidecar::startup_env_sidecar_trusts_pin(startup_env, &pin) {
+        return None;
+    }
+
+    Some(pin)
+}
+
+fn startup_env_trusted_pin_matches(
+    startup_env: &StartupSubtreeEnv,
+    pin: &InheritedModelPin,
+) -> bool {
+    startup_env.trusted_inherited_model_pin().is_some_and(
+        |(model_spec, force_ignore_tier_setting, no_failover)| {
+            model_spec == pin.model_spec.as_str()
+                && force_ignore_tier_setting == pin.force_ignore_tier_setting
+                && no_failover == pin.no_failover
+        },
     )
 }
 
@@ -59,29 +95,94 @@ fn inherited_model_pin_from_lookup<F>(current_depth: u32, lookup: F) -> Option<I
 where
     F: Fn(&str) -> Option<String>,
 {
-    inherited_model_pin_from_values(
+    let raw_internal_invocation = lookup(CSA_INTERNAL_INVOCATION_ENV_KEY);
+    let raw_session_id = lookup(CSA_SESSION_ID_ENV_KEY);
+    let raw_session_dir = lookup(CSA_SESSION_DIR_ENV_KEY);
+    let raw_project_root = lookup(CSA_PROJECT_ROOT_ENV_KEY);
+    let raw_model_spec = lookup(CSA_MODEL_SPEC_ENV_KEY);
+    let raw_force_ignore_tier_setting = lookup(CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY);
+    let raw_no_failover = lookup(CSA_NO_FAILOVER_ENV_KEY);
+
+    inherited_model_pin_from_values(InheritedModelPinValues {
         current_depth,
-        lookup(CSA_MODEL_SPEC_ENV_KEY).as_deref(),
-        lookup(CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY)
+        child_contract: InheritedModelPinChildContract {
+            internal_invocation: raw_internal_invocation
+                .as_deref()
+                .is_some_and(is_truthy_env_value),
+            session_id: raw_session_id.as_deref(),
+            session_dir: raw_session_dir.as_deref(),
+            project_root: raw_project_root.as_deref(),
+        },
+        model_spec: raw_model_spec.as_deref(),
+        force_ignore_tier_setting: raw_force_ignore_tier_setting
             .as_deref()
             .is_some_and(is_truthy_env_value),
-        lookup(CSA_NO_FAILOVER_ENV_KEY)
-            .as_deref()
-            .is_some_and(is_truthy_env_value),
-    )
+        no_failover: raw_no_failover.as_deref().is_some_and(is_truthy_env_value),
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+struct InheritedModelPinValues<'a> {
+    current_depth: u32,
+    child_contract: InheritedModelPinChildContract<'a>,
+    model_spec: Option<&'a str>,
+    force_ignore_tier_setting: bool,
+    no_failover: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct InheritedModelPinChildContract<'a> {
+    internal_invocation: bool,
+    session_id: Option<&'a str>,
+    session_dir: Option<&'a str>,
+    project_root: Option<&'a str>,
+}
+
+impl InheritedModelPinChildContract<'_> {
+    fn is_complete(self) -> bool {
+        self.internal_invocation
+            && self.has_session_id()
+            && self.has_session_dir()
+            && self.has_project_root()
+    }
+
+    fn has_session_id(self) -> bool {
+        self.session_id
+            .is_some_and(|value| !value.trim().is_empty())
+    }
+
+    fn has_session_dir(self) -> bool {
+        self.session_dir
+            .is_some_and(|value| !value.trim().is_empty())
+    }
+
+    fn has_project_root(self) -> bool {
+        self.project_root
+            .is_some_and(|value| !value.trim().is_empty())
+    }
 }
 
 fn inherited_model_pin_from_values(
-    current_depth: u32,
-    model_spec: Option<&str>,
-    force_ignore_tier_setting: bool,
-    no_failover: bool,
+    values: InheritedModelPinValues<'_>,
 ) -> Option<InheritedModelPin> {
-    if current_depth == 0 {
+    if values.current_depth == 0 {
         return None;
     }
 
-    let model_spec = model_spec?;
+    let child_contract = values.child_contract;
+    if !child_contract.is_complete() {
+        tracing::warn!(
+            current_depth = values.current_depth,
+            has_session_id = child_contract.has_session_id(),
+            has_session_dir = child_contract.has_session_dir(),
+            has_project_root = child_contract.has_project_root(),
+            internal_invocation = child_contract.internal_invocation,
+            "ignoring CSA_MODEL_SPEC because the startup child contract is incomplete"
+        );
+        return None;
+    }
+
+    let model_spec = values.model_spec?;
     let model_spec = model_spec.trim();
     if model_spec.is_empty() {
         return None;
@@ -95,7 +196,7 @@ fn inherited_model_pin_from_values(
     // pins the subtree and drops tier routing. (The ambient value is also
     // reserved at the spawn boundary; this is the reader-side belt to the
     // spawn-side braces.)
-    if !force_ignore_tier_setting {
+    if !values.force_ignore_tier_setting {
         tracing::warn!(
             model_spec,
             "ignoring CSA_MODEL_SPEC without paired CSA_FORCE_IGNORE_TIER_SETTING \
@@ -117,8 +218,8 @@ fn inherited_model_pin_from_values(
 
     Some(InheritedModelPin {
         model_spec: model_spec.to_string(),
-        force_ignore_tier_setting,
-        no_failover,
+        force_ignore_tier_setting: values.force_ignore_tier_setting,
+        no_failover: values.no_failover,
     })
 }
 
@@ -138,6 +239,21 @@ pub(crate) fn apply_inherited_model_pin(
     };
 
     if input.model_spec.is_some() {
+        if input.model_spec.as_deref() == Some(pin.model_spec.as_str())
+            && input.tier.is_none()
+            && input.auto_route.is_none()
+        {
+            return RunModelPinResolution {
+                model_spec: Some(pin.model_spec.clone()),
+                tier: None,
+                auto_route: None,
+                force_ignore_tier_setting: input.force_ignore_tier_setting
+                    || pin.force_ignore_tier_setting,
+                no_failover: input.no_failover || pin.no_failover,
+                inherited_pin: Some(pin),
+            };
+        }
+
         return RunModelPinResolution {
             model_spec: input.model_spec,
             tier: input.tier,
@@ -256,7 +372,8 @@ pub(crate) fn resolve_handle_run_model_pin(
 ///
 /// `model_spec` MUST originate from validated CSA state (the spec the caller
 /// resolved itself, or one returned by the startup-captured inherited-pin
-/// reader, which gates on the force-ignore marker + `ModelSpec` well-formedness).
+/// reader, which gates on the force-ignore marker, `ModelSpec` well-formedness,
+/// and the CSA-owned session sidecar).
 pub(crate) fn resolve_subtree_model_pin(
     model_spec: Option<&str>,
     force_ignore_tier_setting: bool,
@@ -308,7 +425,10 @@ pub(crate) fn subtree_model_pin_prompt_guard(
         "<csa-subtree-model-pin>\n\
          The caller pinned this CSA subtree to --model-spec {model_spec} \
          with --force-ignore-tier-setting.\n\
-         Every nested CSA worker dispatch you create MUST reuse: \
+         Nested CSA worker dispatches SHOULD omit --model-spec and \
+         --force-ignore-tier-setting; CSA_MODEL_SPEC carries the already \
+         authorized exact pin to children automatically. If a legacy workflow \
+         still repeats the pin, it MUST repeat the same spec: \
          --model-spec {model_spec} --force-ignore-tier-setting{no_failover_flag}\n\
          Do not replace this pin with --tier or --auto-route unless the user \
          explicitly changes the pin.\n\

--- a/crates/cli-sub-agent/src/run_cmd_model_pin_sidecar.rs
+++ b/crates/cli-sub-agent/src/run_cmd_model_pin_sidecar.rs
@@ -1,0 +1,282 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::InheritedModelPin;
+use crate::startup_env::StartupSubtreeEnv;
+
+const SUBTREE_MODEL_PIN_SIDECAR: &str = "subtree-model-pin.toml";
+const SUBTREE_MODEL_PIN_SIDECAR_SCHEMA_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct SubtreeModelPinSidecar {
+    schema_version: u8,
+    session_id: String,
+    project_root: String,
+    session_dir: String,
+    model_spec: String,
+    force_ignore_tier_setting: bool,
+    no_failover: bool,
+}
+
+impl SubtreeModelPinSidecar {
+    fn from_pin(
+        project_root: &Path,
+        session_id: &str,
+        session_dir: &Path,
+        pin: &csa_core::env::SubtreeModelPin,
+    ) -> Self {
+        Self {
+            schema_version: SUBTREE_MODEL_PIN_SIDECAR_SCHEMA_VERSION,
+            session_id: session_id.to_string(),
+            project_root: project_root.to_string_lossy().into_owned(),
+            session_dir: session_dir.to_string_lossy().into_owned(),
+            model_spec: pin.model_spec().to_string(),
+            force_ignore_tier_setting: true,
+            no_failover: pin.no_failover(),
+        }
+    }
+
+    fn matches_inherited_pin(
+        &self,
+        pin: &InheritedModelPin,
+        project_root: &Path,
+        session_id: &str,
+        session_dir: &Path,
+    ) -> bool {
+        self.schema_version == SUBTREE_MODEL_PIN_SIDECAR_SCHEMA_VERSION
+            && self.session_id == session_id
+            && paths_equivalent(Path::new(&self.project_root), project_root)
+            && paths_equivalent(Path::new(&self.session_dir), session_dir)
+            && self.model_spec == pin.model_spec
+            && self.force_ignore_tier_setting == pin.force_ignore_tier_setting
+            && self.no_failover == pin.no_failover
+    }
+}
+
+pub(crate) fn sync_subtree_model_pin_sidecar(
+    project_root: &Path,
+    session_id: &str,
+    session_dir: &Path,
+    pin: Option<&csa_core::env::SubtreeModelPin>,
+) -> Result<()> {
+    let path = subtree_model_pin_sidecar_path(session_dir);
+    let Some(pin) = pin else {
+        match std::fs::remove_file(&path) {
+            Ok(()) => return Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!(
+                        "Failed to remove stale subtree model pin sidecar: {}",
+                        path.display()
+                    )
+                });
+            }
+        }
+    };
+
+    std::fs::create_dir_all(session_dir).with_context(|| {
+        format!(
+            "Failed to create session directory for subtree model pin sidecar: {}",
+            session_dir.display()
+        )
+    })?;
+    let contents = toml::to_string_pretty(&SubtreeModelPinSidecar::from_pin(
+        project_root,
+        session_id,
+        session_dir,
+        pin,
+    ))
+    .context("Failed to serialize subtree model pin sidecar")?;
+    std::fs::write(&path, contents).with_context(|| {
+        format!(
+            "Failed to write subtree model pin sidecar: {}",
+            path.display()
+        )
+    })
+}
+
+fn subtree_model_pin_sidecar_path(session_dir: &Path) -> PathBuf {
+    session_dir.join(SUBTREE_MODEL_PIN_SIDECAR)
+}
+
+pub(super) fn startup_env_sidecar_trusts_pin(
+    startup_env: &StartupSubtreeEnv,
+    pin: &InheritedModelPin,
+) -> bool {
+    let Some(session_id) = startup_env.session_id() else {
+        return false;
+    };
+    let Some(session_dir) = startup_env.session_dir() else {
+        return false;
+    };
+    let Some(project_root) = startup_env.project_root() else {
+        return false;
+    };
+
+    let session_dir_path = Path::new(session_dir);
+    let sidecar_path = subtree_model_pin_sidecar_path(session_dir_path);
+    let sidecar = match read_subtree_model_pin_sidecar(&sidecar_path) {
+        Ok(sidecar) => sidecar,
+        Err(err) => {
+            tracing::warn!(
+                session_id,
+                session_dir,
+                sidecar_path = %sidecar_path.display(),
+                error = %err,
+                "ignoring inherited CSA_MODEL_SPEC because the trusted pin sidecar is missing or invalid"
+            );
+            return false;
+        }
+    };
+
+    let project_root_path = Path::new(project_root);
+    if !sidecar.matches_inherited_pin(pin, project_root_path, session_id, session_dir_path) {
+        tracing::warn!(
+            session_id,
+            session_dir,
+            sidecar_path = %sidecar_path.display(),
+            env_model_spec = %pin.model_spec,
+            sidecar_session_id = %sidecar.session_id,
+            sidecar_project_root = %sidecar.project_root,
+            sidecar_session_dir = %sidecar.session_dir,
+            sidecar_model_spec = %sidecar.model_spec,
+            "ignoring inherited CSA_MODEL_SPEC because the trusted pin sidecar does not match the startup env"
+        );
+        return false;
+    }
+
+    startup_env_session_contract_matches_state(startup_env, project_root, session_id, session_dir)
+}
+
+fn read_subtree_model_pin_sidecar(path: &Path) -> Result<SubtreeModelPinSidecar> {
+    let contents = std::fs::read_to_string(path).with_context(|| {
+        format!(
+            "Failed to read subtree model pin sidecar: {}",
+            path.display()
+        )
+    })?;
+    toml::from_str(&contents).with_context(|| {
+        format!(
+            "Failed to parse subtree model pin sidecar: {}",
+            path.display()
+        )
+    })
+}
+
+fn startup_env_session_contract_matches_state(
+    startup_env: &StartupSubtreeEnv,
+    project_root: &str,
+    session_id: &str,
+    session_dir: &str,
+) -> bool {
+    let project_root_path = Path::new(project_root);
+    let state = match csa_session::load_session(project_root_path, session_id) {
+        Ok(state) => state,
+        Err(err) => {
+            tracing::warn!(
+                session_id,
+                project_root,
+                error = %err,
+                "ignoring inherited CSA_MODEL_SPEC because the startup session state could not be loaded"
+            );
+            return false;
+        }
+    };
+
+    if state.meta_session_id != session_id {
+        tracing::warn!(
+            session_id,
+            state_session_id = %state.meta_session_id,
+            "ignoring inherited CSA_MODEL_SPEC because startup session id does not match persisted state"
+        );
+        return false;
+    }
+
+    if !paths_equivalent(Path::new(&state.project_path), project_root_path) {
+        tracing::warn!(
+            session_id,
+            project_root,
+            state_project_root = %state.project_path,
+            "ignoring inherited CSA_MODEL_SPEC because startup project root does not match persisted state"
+        );
+        return false;
+    }
+
+    let expected_session_dir = match csa_session::get_session_dir(project_root_path, session_id) {
+        Ok(path) => path,
+        Err(err) => {
+            tracing::warn!(
+                session_id,
+                project_root,
+                error = %err,
+                "ignoring inherited CSA_MODEL_SPEC because the startup session directory could not be resolved"
+            );
+            return false;
+        }
+    };
+    if !paths_equivalent(Path::new(session_dir), &expected_session_dir) {
+        tracing::warn!(
+            session_id,
+            session_dir,
+            expected_session_dir = %expected_session_dir.display(),
+            "ignoring inherited CSA_MODEL_SPEC because startup session dir does not match persisted state"
+        );
+        return false;
+    }
+
+    let expected_child_depth = state.genealogy.depth.saturating_add(1);
+    if startup_env.current_depth() != expected_child_depth {
+        tracing::warn!(
+            session_id,
+            startup_depth = startup_env.current_depth(),
+            state_depth = state.genealogy.depth,
+            "ignoring inherited CSA_MODEL_SPEC because startup depth does not match persisted session genealogy"
+        );
+        return false;
+    }
+
+    if state.genealogy.parent_session_id.as_deref() != startup_env.parent_session() {
+        tracing::warn!(
+            session_id,
+            startup_parent = startup_env.parent_session(),
+            state_parent = state.genealogy.parent_session_id.as_deref(),
+            "ignoring inherited CSA_MODEL_SPEC because startup parent session does not match persisted state"
+        );
+        return false;
+    }
+
+    if let Some(parent_session_dir) = startup_env.parent_session_dir()
+        && let Some(parent_session_id) = state.genealogy.parent_session_id.as_deref()
+        && !parent_session_dir_matches(project_root_path, parent_session_id, parent_session_dir)
+    {
+        tracing::warn!(
+            session_id,
+            parent_session_id,
+            parent_session_dir,
+            "ignoring inherited CSA_MODEL_SPEC because startup parent session dir does not match persisted state"
+        );
+        return false;
+    }
+
+    true
+}
+
+fn parent_session_dir_matches(
+    project_root: &Path,
+    parent_session_id: &str,
+    parent_session_dir: &str,
+) -> bool {
+    csa_session::get_session_dir(project_root, parent_session_id)
+        .map(|expected| paths_equivalent(Path::new(parent_session_dir), &expected))
+        .unwrap_or(false)
+}
+
+fn paths_equivalent(left: &Path, right: &Path) -> bool {
+    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
+}

--- a/crates/cli-sub-agent/src/run_cmd_model_pin_sidecar_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_model_pin_sidecar_tests.rs
@@ -1,0 +1,80 @@
+use super::*;
+
+#[test]
+fn csa_injected_pin_still_propagates() {
+    let _lock = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
+    let xdg = tempfile::tempdir().expect("xdg tempdir");
+    let _xdg_guard = crate::test_env_lock::ScopedEnvVarRestore::set("XDG_STATE_HOME", xdg.path());
+    let project = tempfile::tempdir().expect("project tempdir");
+    let startup_env = trusted_startup_env_for_pinned_session(project.path(), PINNED_SPEC, true);
+
+    let pin = inherited_model_pin_from_startup(&startup_env).expect("CSA-injected pin is honored");
+    assert_eq!(pin.model_spec, PINNED_SPEC);
+    assert!(pin.force_ignore_tier_setting);
+    assert!(pin.no_failover);
+}
+
+#[test]
+fn complete_ambient_env_spoof_without_sidecar_is_not_inherited() {
+    let startup_env = StartupSubtreeEnv::from_values(std::collections::HashMap::from([
+        (csa_core::env::CSA_DEPTH_ENV_KEY, "1".to_string()),
+        (CSA_INTERNAL_INVOCATION_ENV_KEY, "1".to_string()),
+        (CSA_SESSION_ID_ENV_KEY, TEST_SESSION_ID.to_string()),
+        (CSA_SESSION_DIR_ENV_KEY, TEST_SESSION_DIR.to_string()),
+        (CSA_PROJECT_ROOT_ENV_KEY, TEST_PROJECT_ROOT.to_string()),
+        (CSA_MODEL_SPEC_ENV_KEY, PINNED_SPEC.to_string()),
+        (CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1".to_string()),
+        (CSA_NO_FAILOVER_ENV_KEY, "1".to_string()),
+    ]));
+
+    assert!(
+        inherited_model_pin_from_startup(&startup_env).is_none(),
+        "complete ambient CSA_* values without CSA-owned sidecar must not bypass tier policy"
+    );
+}
+
+#[test]
+fn inherited_pin_requires_sidecar_session_contract_match() {
+    let _lock = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
+    let xdg = tempfile::tempdir().expect("xdg tempdir");
+    let _xdg_guard = crate::test_env_lock::ScopedEnvVarRestore::set("XDG_STATE_HOME", xdg.path());
+    let project = tempfile::tempdir().expect("project tempdir");
+    let session =
+        csa_session::create_session(project.path(), Some("pinned subtree"), None, Some("codex"))
+            .expect("create pinned session");
+    let session_dir = csa_session::get_session_dir(project.path(), &session.meta_session_id)
+        .expect("session dir");
+    let pin = resolve_subtree_model_pin(Some(PINNED_SPEC), true, true).expect("typed pin");
+    sync_subtree_model_pin_sidecar(
+        project.path(),
+        "01KWRONGSESSION0000000000",
+        &session_dir,
+        Some(&pin),
+    )
+    .expect("write mismatched sidecar");
+    let startup_env = StartupSubtreeEnv::from_values(std::collections::HashMap::from([
+        (
+            csa_core::env::CSA_DEPTH_ENV_KEY,
+            session.genealogy.depth.saturating_add(1).to_string(),
+        ),
+        (CSA_INTERNAL_INVOCATION_ENV_KEY, "1".to_string()),
+        (CSA_SESSION_ID_ENV_KEY, session.meta_session_id),
+        (CSA_SESSION_DIR_ENV_KEY, session_dir.display().to_string()),
+        (
+            CSA_PROJECT_ROOT_ENV_KEY,
+            project.path().display().to_string(),
+        ),
+        (CSA_MODEL_SPEC_ENV_KEY, PINNED_SPEC.to_string()),
+        (CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1".to_string()),
+        (CSA_NO_FAILOVER_ENV_KEY, "1".to_string()),
+    ]));
+
+    assert!(
+        inherited_model_pin_from_startup(&startup_env).is_none(),
+        "sidecar identity must match the startup session contract before a pin is trusted"
+    );
+}

--- a/crates/cli-sub-agent/src/run_cmd_model_pin_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_model_pin_tests.rs
@@ -5,8 +5,52 @@ use csa_config::{
     GlobalConfig, ProjectConfig, ProjectMeta, ResourcesConfig, TierConfig, TierStrategy, ToolConfig,
 };
 use csa_core::types::{ToolName, ToolSelectionStrategy};
+use std::path::Path;
 
 const PINNED_SPEC: &str = "codex/openai/gpt-5.5/xhigh";
+const TEST_SESSION_ID: &str = "01KPINNEDSESSION0000000000";
+const TEST_SESSION_DIR: &str = "/repo/.csa/sessions/01KPINNEDSESSION0000000000";
+const TEST_PROJECT_ROOT: &str = "/repo";
+
+#[path = "run_cmd_model_pin_sidecar_tests.rs"]
+mod sidecar_tests;
+
+fn trusted_startup_env_for_pinned_session(
+    project_root: &Path,
+    spec: &str,
+    no_failover: bool,
+) -> StartupSubtreeEnv {
+    let session =
+        csa_session::create_session(project_root, Some("pinned subtree"), None, Some("codex"))
+            .expect("create pinned session");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let typed_pin = resolve_subtree_model_pin(Some(spec), true, no_failover).expect("typed pin");
+    sync_subtree_model_pin_sidecar(
+        project_root,
+        &session.meta_session_id,
+        &session_dir,
+        Some(&typed_pin),
+    )
+    .expect("write trusted pin sidecar");
+
+    StartupSubtreeEnv::from_values(std::collections::HashMap::from([
+        (
+            csa_core::env::CSA_DEPTH_ENV_KEY,
+            session.genealogy.depth.saturating_add(1).to_string(),
+        ),
+        (CSA_INTERNAL_INVOCATION_ENV_KEY, "1".to_string()),
+        (CSA_SESSION_ID_ENV_KEY, session.meta_session_id),
+        (CSA_SESSION_DIR_ENV_KEY, session_dir.display().to_string()),
+        (CSA_PROJECT_ROOT_ENV_KEY, project_root.display().to_string()),
+        (CSA_MODEL_SPEC_ENV_KEY, spec.to_string()),
+        (CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1".to_string()),
+        (
+            CSA_NO_FAILOVER_ENV_KEY,
+            if no_failover { "1" } else { "0" }.to_string(),
+        ),
+    ]))
+}
 
 #[test]
 fn pinned_child_inherits_model_spec_and_drops_tier_routing() {
@@ -128,6 +172,52 @@ fn explicit_child_model_spec_overrides_inherited_pin() {
 }
 
 #[test]
+fn explicit_child_same_model_spec_reuses_inherited_pin() {
+    let resolution = apply_inherited_model_pin(
+        RunModelPinInput {
+            model_spec: Some(PINNED_SPEC.to_string()),
+            tier: None,
+            auto_route: None,
+            force_ignore_tier_setting: true,
+            no_failover: false,
+        },
+        Some(InheritedModelPin {
+            model_spec: PINNED_SPEC.to_string(),
+            force_ignore_tier_setting: true,
+            no_failover: true,
+        }),
+    );
+
+    assert_eq!(resolution.model_spec.as_deref(), Some(PINNED_SPEC));
+    assert!(resolution.force_ignore_tier_setting);
+    assert!(resolution.no_failover);
+    assert!(resolution.inherited_pin.is_some());
+}
+
+#[test]
+fn explicit_child_same_model_spec_with_tier_is_not_inherited() {
+    let resolution = apply_inherited_model_pin(
+        RunModelPinInput {
+            model_spec: Some(PINNED_SPEC.to_string()),
+            tier: Some("tier-4-critical".to_string()),
+            auto_route: None,
+            force_ignore_tier_setting: true,
+            no_failover: false,
+        },
+        Some(InheritedModelPin {
+            model_spec: PINNED_SPEC.to_string(),
+            force_ignore_tier_setting: true,
+            no_failover: true,
+        }),
+    );
+
+    assert_eq!(resolution.model_spec.as_deref(), Some(PINNED_SPEC));
+    assert_eq!(resolution.tier.as_deref(), Some("tier-4-critical"));
+    assert!(!resolution.no_failover);
+    assert!(resolution.inherited_pin.is_none());
+}
+
+#[test]
 fn subtree_env_requires_force_ignore_pin() {
     // Without force_ignore_tier_setting, no typed pin is produced.
     assert!(resolve_subtree_model_pin(Some(PINNED_SPEC), false, true).is_none());
@@ -154,8 +244,12 @@ fn subtree_env_requires_force_ignore_pin() {
 }
 
 #[test]
-fn inherited_pin_from_lookup_requires_child_depth() {
+fn raw_inherited_pin_parser_requires_child_depth() {
     let lookup = |key: &str| match key {
+        CSA_INTERNAL_INVOCATION_ENV_KEY => Some("1".to_string()),
+        CSA_SESSION_ID_ENV_KEY => Some(TEST_SESSION_ID.to_string()),
+        CSA_SESSION_DIR_ENV_KEY => Some(TEST_SESSION_DIR.to_string()),
+        CSA_PROJECT_ROOT_ENV_KEY => Some(TEST_PROJECT_ROOT.to_string()),
         CSA_MODEL_SPEC_ENV_KEY => Some(PINNED_SPEC.to_string()),
         CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY => Some("true".to_string()),
         CSA_NO_FAILOVER_ENV_KEY => Some("yes".to_string()),
@@ -169,12 +263,31 @@ fn inherited_pin_from_lookup_requires_child_depth() {
     assert!(pin.no_failover);
 }
 
+#[test]
+fn raw_inherited_pin_parser_requires_csa_child_contract() {
+    let lookup = |key: &str| match key {
+        CSA_MODEL_SPEC_ENV_KEY => Some(PINNED_SPEC.to_string()),
+        CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY => Some("1".to_string()),
+        CSA_NO_FAILOVER_ENV_KEY => Some("1".to_string()),
+        _ => None,
+    };
+
+    assert!(
+        inherited_model_pin_from_lookup(1, lookup).is_none(),
+        "depth plus pin env is not enough; unrelated sessions must not spoof a CSA child pin"
+    );
+}
+
 /// #1741: an ambient CSA_MODEL_SPEC set in a NON-pinned root (no paired
 /// CSA_FORCE_IGNORE_TIER_SETTING marker) must NOT be honored as a subtree pin —
 /// the child preserves tier auto-routing.
 #[test]
 fn ambient_model_spec_without_force_ignore_is_not_inherited() {
     let lookup = |key: &str| match key {
+        CSA_INTERNAL_INVOCATION_ENV_KEY => Some("1".to_string()),
+        CSA_SESSION_ID_ENV_KEY => Some(TEST_SESSION_ID.to_string()),
+        CSA_SESSION_DIR_ENV_KEY => Some(TEST_SESSION_DIR.to_string()),
+        CSA_PROJECT_ROOT_ENV_KEY => Some(TEST_PROJECT_ROOT.to_string()),
         CSA_MODEL_SPEC_ENV_KEY => Some(PINNED_SPEC.to_string()),
         // No CSA_FORCE_IGNORE_TIER_SETTING — simulates a value leaked into the
         // shell rather than a CSA-injected pin.
@@ -192,6 +305,10 @@ fn ambient_model_spec_without_force_ignore_is_not_inherited() {
 #[test]
 fn malformed_inherited_model_spec_is_ignored() {
     let lookup = |key: &str| match key {
+        CSA_INTERNAL_INVOCATION_ENV_KEY => Some("1".to_string()),
+        CSA_SESSION_ID_ENV_KEY => Some(TEST_SESSION_ID.to_string()),
+        CSA_SESSION_DIR_ENV_KEY => Some(TEST_SESSION_DIR.to_string()),
+        CSA_PROJECT_ROOT_ENV_KEY => Some(TEST_PROJECT_ROOT.to_string()),
         CSA_MODEL_SPEC_ENV_KEY => Some("not-a-valid-spec".to_string()),
         CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY => Some("1".to_string()),
         _ => None,
@@ -203,31 +320,12 @@ fn malformed_inherited_model_spec_is_ignored() {
     );
 }
 
-/// #1741: a CSA-injected pin (paired force-ignore marker + well-formed spec at
-/// child depth) still propagates — the legitimate subtree-pin path stays green.
-#[test]
-fn csa_injected_pin_still_propagates() {
-    // Build the exact child env CSA's trusted typed channel writes for a pinned
-    // subtree, then prove the reader honors it (the legitimate path stays green).
-    let typed_pin = resolve_subtree_model_pin(Some(PINNED_SPEC), true, true).expect("typed pin");
-    let env: std::collections::HashMap<String, String> = typed_pin
-        .pin_env_entries()
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect();
-
-    let lookup = |key: &str| env.get(key).cloned();
-    let pin = inherited_model_pin_from_lookup(1, lookup).expect("CSA-injected pin is honored");
-    assert_eq!(pin.model_spec, PINNED_SPEC);
-    assert!(pin.force_ignore_tier_setting);
-    assert!(pin.no_failover);
-}
-
 #[test]
 fn subtree_prompt_guard_mentions_required_flags() {
     let guard =
         subtree_model_pin_prompt_guard(Some(PINNED_SPEC), true, true).expect("prompt guard");
 
+    assert!(guard.contains("SHOULD omit --model-spec"));
     assert!(guard.contains("--model-spec codex/openai/gpt-5.5/xhigh"));
     assert!(guard.contains("--force-ignore-tier-setting"));
     assert!(guard.contains("--no-failover"));
@@ -238,38 +336,25 @@ fn subtree_prompt_guard_mentions_required_flags() {
 //
 // These exercise `apply_inherited_pin_for_review_debate`, the adapter both
 // `handle_review` and `handle_debate` call before building executor
-// candidates. Env mutation is serialized via TEST_ENV_LOCK and restored by
-// ScopedEnvVarRestore guards (process-wide env).
-
-fn set_subtree_pin_env(
-    spec: &str,
-    force_ignore: bool,
-    no_failover: bool,
-) -> Vec<crate::test_env_lock::ScopedEnvVarRestore> {
-    use crate::test_env_lock::ScopedEnvVarRestore;
-    vec![
-        ScopedEnvVarRestore::set(CSA_MODEL_SPEC_ENV_KEY, spec),
-        ScopedEnvVarRestore::set(
-            CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY,
-            if force_ignore { "1" } else { "0" },
-        ),
-        ScopedEnvVarRestore::set(CSA_NO_FAILOVER_ENV_KEY, if no_failover { "1" } else { "0" }),
-    ]
-}
+// candidates. Trusted inheritance uses a real session plus CSA-owned sidecar;
+// raw env-only fixtures are intentionally not accepted as trusted.
 
 #[test]
 fn review_debate_inherits_env_pin_and_drops_tier() {
     let _lock = crate::test_env_lock::TEST_ENV_LOCK
         .clone()
         .blocking_lock_owned();
-    let _guards = set_subtree_pin_env(PINNED_SPEC, true, true);
+    let xdg = tempfile::tempdir().expect("xdg tempdir");
+    let _xdg_guard = crate::test_env_lock::ScopedEnvVarRestore::set("XDG_STATE_HOME", xdg.path());
+    let project = tempfile::tempdir().expect("project tempdir");
+    let startup_env = trusted_startup_env_for_pinned_session(project.path(), PINNED_SPEC, true);
 
     let resolved = apply_inherited_pin_for_review_debate(
         None,
         Some("tier-4-critical".to_string()),
         false,
         false,
-        inherited_model_pin_from_lookup(1, |key| std::env::var(key).ok()),
+        inherited_model_pin_from_startup(&startup_env),
     );
 
     assert_eq!(resolved.model_spec.as_deref(), Some(PINNED_SPEC));
@@ -284,14 +369,17 @@ fn review_debate_inherited_pin_selects_pinned_model_not_tier_first_tool() {
     let _lock = crate::test_env_lock::TEST_ENV_LOCK
         .clone()
         .blocking_lock_owned();
-    let _guards = set_subtree_pin_env(PINNED_SPEC, true, true);
+    let xdg = tempfile::tempdir().expect("xdg tempdir");
+    let _xdg_guard = crate::test_env_lock::ScopedEnvVarRestore::set("XDG_STATE_HOME", xdg.path());
+    let project = tempfile::tempdir().expect("project tempdir");
+    let startup_env = trusted_startup_env_for_pinned_session(project.path(), PINNED_SPEC, true);
 
     let resolved = apply_inherited_pin_for_review_debate(
         None,
         Some("tier-4-critical".to_string()),
         false,
         false,
-        inherited_model_pin_from_lookup(1, |key| std::env::var(key).ok()),
+        inherited_model_pin_from_startup(&startup_env),
     );
 
     let temp = tempfile::tempdir().expect("tempdir");
@@ -333,7 +421,10 @@ fn review_debate_explicit_model_spec_overrides_env_pin() {
     let _lock = crate::test_env_lock::TEST_ENV_LOCK
         .clone()
         .blocking_lock_owned();
-    let _guards = set_subtree_pin_env(PINNED_SPEC, true, true);
+    let xdg = tempfile::tempdir().expect("xdg tempdir");
+    let _xdg_guard = crate::test_env_lock::ScopedEnvVarRestore::set("XDG_STATE_HOME", xdg.path());
+    let project = tempfile::tempdir().expect("project tempdir");
+    let startup_env = trusted_startup_env_for_pinned_session(project.path(), PINNED_SPEC, true);
     let explicit = "gemini-cli/google/gemini-3.1-pro-preview/xhigh";
 
     let resolved = apply_inherited_pin_for_review_debate(
@@ -341,7 +432,7 @@ fn review_debate_explicit_model_spec_overrides_env_pin() {
         None,
         false,
         false,
-        inherited_model_pin_from_lookup(1, |key| std::env::var(key).ok()),
+        inherited_model_pin_from_startup(&startup_env),
     );
 
     assert_eq!(resolved.model_spec.as_deref(), Some(explicit));
@@ -352,18 +443,12 @@ fn review_debate_explicit_model_spec_overrides_env_pin() {
 
 #[test]
 fn review_debate_unpinned_preserves_tier() {
-    let _lock = crate::test_env_lock::TEST_ENV_LOCK
-        .clone()
-        .blocking_lock_owned();
-    use crate::test_env_lock::ScopedEnvVarRestore;
-    let _g = ScopedEnvVarRestore::unset(CSA_MODEL_SPEC_ENV_KEY);
-
     let resolved = apply_inherited_pin_for_review_debate(
         None,
         Some("tier-4-critical".to_string()),
         false,
         false,
-        inherited_model_pin_from_lookup(1, |key| std::env::var(key).ok()),
+        None,
     );
 
     assert!(resolved.model_spec.is_none());
@@ -375,17 +460,12 @@ fn review_debate_unpinned_preserves_tier() {
 
 #[test]
 fn review_debate_depth_zero_ignores_env_pin() {
-    let _lock = crate::test_env_lock::TEST_ENV_LOCK
-        .clone()
-        .blocking_lock_owned();
-    let _guards = set_subtree_pin_env(PINNED_SPEC, true, true);
-
     let resolved = apply_inherited_pin_for_review_debate(
         None,
         Some("tier-4-critical".to_string()),
         false,
         false,
-        inherited_model_pin_from_lookup(0, |key| std::env::var(key).ok()),
+        None,
     );
 
     assert!(resolved.model_spec.is_none());
@@ -445,17 +525,17 @@ fn review_debate_spawn_unpinned_does_not_inject_pin() {
 #[test]
 fn propagate_inherited_subtree_pin_passes_pin_through_at_child_depth() {
     // batch / plan / claude-sub-agent path: the process inherited a pin
-    // (CSA_DEPTH>0 + pin env) and must cascade it to its child unchanged.
+    // (CSA_DEPTH>0 + child contract + trusted sidecar) and must cascade it to
+    // its child unchanged.
     let _lock = crate::test_env_lock::TEST_ENV_LOCK
         .clone()
         .blocking_lock_owned();
-    let mut guards = set_subtree_pin_env(PINNED_SPEC, true, true);
-    guards.push(crate::test_env_lock::ScopedEnvVarRestore::set(
-        "CSA_DEPTH",
-        "2",
-    ));
+    let xdg = tempfile::tempdir().expect("xdg tempdir");
+    let _xdg_guard = crate::test_env_lock::ScopedEnvVarRestore::set("XDG_STATE_HOME", xdg.path());
+    let project = tempfile::tempdir().expect("project tempdir");
+    let startup_env = trusted_startup_env_for_pinned_session(project.path(), PINNED_SPEC, true);
 
-    let inherited = inherited_model_pin_from_lookup(2, |key| std::env::var(key).ok());
+    let inherited = inherited_model_pin_from_startup(&startup_env);
     let pin = inherited_subtree_model_pin(inherited.as_ref())
         .expect("inherited pin must cascade to the child env");
     let entries = pin_entries_map(&pin);
@@ -473,16 +553,6 @@ fn propagate_inherited_subtree_pin_passes_pin_through_at_child_depth() {
 
 #[test]
 fn propagate_inherited_subtree_pin_noop_at_root_depth() {
-    let _lock = crate::test_env_lock::TEST_ENV_LOCK
-        .clone()
-        .blocking_lock_owned();
-    let mut guards = set_subtree_pin_env(PINNED_SPEC, true, true);
-    // Root process (depth 0) never inherits a pin, so nothing cascades.
-    guards.push(crate::test_env_lock::ScopedEnvVarRestore::set(
-        "CSA_DEPTH",
-        "0",
-    ));
-
     assert!(
         inherited_subtree_model_pin(None).is_none(),
         "root-depth must not cascade a pin"
@@ -491,14 +561,6 @@ fn propagate_inherited_subtree_pin_noop_at_root_depth() {
 
 #[test]
 fn propagate_inherited_subtree_pin_noop_when_unpinned() {
-    let _lock = crate::test_env_lock::TEST_ENV_LOCK
-        .clone()
-        .blocking_lock_owned();
-    use crate::test_env_lock::ScopedEnvVarRestore;
-    // Child depth but no pin env → nothing to cascade.
-    let _g1 = ScopedEnvVarRestore::unset(CSA_MODEL_SPEC_ENV_KEY);
-    let _g2 = ScopedEnvVarRestore::set("CSA_DEPTH", "3");
-
     assert!(
         inherited_subtree_model_pin(None).is_none(),
         "unpinned child must not cascade a pin"

--- a/crates/cli-sub-agent/src/startup_env.rs
+++ b/crates/cli-sub-agent/src/startup_env.rs
@@ -41,6 +41,17 @@ pub(crate) struct StartupSubtreeEnv {
     raw_model_spec: Option<String>,
     raw_force_ignore_tier_setting: Option<String>,
     raw_no_failover: Option<String>,
+    // In-memory only: set after the current startup sidecar/session contract
+    // has already validated an inherited pin, before daemon wrappers rewrite
+    // StartupSubtreeEnv to the preassigned wrapper session.
+    trusted_inherited_model_pin: Option<TrustedInheritedModelPin>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TrustedInheritedModelPin {
+    model_spec: String,
+    force_ignore_tier_setting: bool,
+    no_failover: bool,
 }
 
 #[cfg(test)]
@@ -67,6 +78,7 @@ pub(crate) static EMPTY_STARTUP_SUBTREE_ENV: StartupSubtreeEnv = StartupSubtreeE
     raw_model_spec: None,
     raw_force_ignore_tier_setting: None,
     raw_no_failover: None,
+    trusted_inherited_model_pin: None,
 };
 
 impl StartupSubtreeEnv {
@@ -135,6 +147,7 @@ impl StartupSubtreeEnv {
             raw_model_spec,
             raw_force_ignore_tier_setting,
             raw_no_failover,
+            trusted_inherited_model_pin: None,
         }
     }
 
@@ -161,6 +174,7 @@ impl StartupSubtreeEnv {
         self.raw_session_id = self.session_id.clone();
         self.session_dir = non_empty_str(session_dir.as_ref());
         self.raw_session_dir = self.session_dir.clone();
+        self.trusted_inherited_model_pin = None;
         if let Some(previous_session_id) = previous_session_id
             && self.session_id.as_deref() != Some(previous_session_id.as_str())
         {
@@ -170,6 +184,30 @@ impl StartupSubtreeEnv {
             self.raw_parent_session_dir = previous_session_dir;
         }
         self
+    }
+
+    pub(crate) fn with_trusted_inherited_model_pin(
+        mut self,
+        model_spec: String,
+        force_ignore_tier_setting: bool,
+        no_failover: bool,
+    ) -> Self {
+        self.trusted_inherited_model_pin = Some(TrustedInheritedModelPin {
+            model_spec,
+            force_ignore_tier_setting,
+            no_failover,
+        });
+        self
+    }
+
+    pub(crate) fn trusted_inherited_model_pin(&self) -> Option<(&str, bool, bool)> {
+        self.trusted_inherited_model_pin.as_ref().map(|pin| {
+            (
+                pin.model_spec.as_str(),
+                pin.force_ignore_tier_setting,
+                pin.no_failover,
+            )
+        })
     }
 
     pub(crate) fn apply_to_child_env(&self, env: &mut HashMap<String, String>) {
@@ -250,7 +288,6 @@ impl StartupSubtreeEnv {
         self.parent_session.as_deref()
     }
 
-    #[cfg(test)]
     pub(crate) fn parent_session_dir(&self) -> Option<&str> {
         self.parent_session_dir.as_deref()
     }
@@ -307,321 +344,5 @@ pub(crate) fn is_truthy_env_value(raw: &str) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::test_env_lock::ScopedEnvVarRestore;
-    use serial_test::serial;
-
-    #[test]
-    fn startup_subtree_env_parses_values_without_process_env() {
-        let values = HashMap::from([
-            (
-                CSA_SESSION_ID_ENV_KEY,
-                "01KTESTSESSION0000000000".to_string(),
-            ),
-            (CSA_DEPTH_ENV_KEY, "3".to_string()),
-            (CSA_PROJECT_ROOT_ENV_KEY, "/repo".to_string()),
-            (CSA_SESSION_DIR_ENV_KEY, "/repo/.csa/session".to_string()),
-            (
-                CSA_PARENT_SESSION_ENV_KEY,
-                "01KPARENTSESSION00000000".to_string(),
-            ),
-            (
-                CSA_PARENT_SESSION_DIR_ENV_KEY,
-                "/repo/.csa/parent".to_string(),
-            ),
-            (CSA_INTERNAL_INVOCATION_ENV_KEY, "yes".to_string()),
-            (
-                CSA_MODEL_SPEC_ENV_KEY,
-                "codex/openai/gpt-5.5/xhigh".to_string(),
-            ),
-            (CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1".to_string()),
-            (CSA_NO_FAILOVER_ENV_KEY, "true".to_string()),
-        ]);
-
-        let startup = StartupSubtreeEnv::from_values(values);
-
-        assert_eq!(startup.session_id(), Some("01KTESTSESSION0000000000"));
-        assert_eq!(startup.current_depth(), 3);
-        assert_eq!(startup.next_depth_string(), "4");
-        assert_eq!(startup.project_root(), Some("/repo"));
-        assert_eq!(startup.session_dir(), Some("/repo/.csa/session"));
-        assert_eq!(startup.parent_session(), Some("01KPARENTSESSION00000000"));
-        assert_eq!(startup.parent_session_dir(), Some("/repo/.csa/parent"));
-        assert!(startup.internal_invocation());
-        assert_eq!(startup.model_spec(), Some("codex/openai/gpt-5.5/xhigh"));
-        assert!(startup.force_ignore_tier_setting());
-        assert!(startup.no_failover());
-    }
-
-    #[test]
-    fn startup_subtree_env_reemits_only_captured_keys() {
-        let values = HashMap::from([
-            (CSA_DEPTH_ENV_KEY, "0".to_string()),
-            (CSA_PROJECT_ROOT_ENV_KEY, "/repo".to_string()),
-            (CSA_INTERNAL_INVOCATION_ENV_KEY, "1".to_string()),
-            (CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "false".to_string()),
-            (CSA_NO_FAILOVER_ENV_KEY, "0".to_string()),
-        ]);
-
-        let startup = StartupSubtreeEnv::from_values(values);
-        let child_env = startup.to_child_env_vars();
-
-        assert_eq!(
-            child_env,
-            vec![
-                (CSA_DEPTH_ENV_KEY.to_string(), "0".to_string()),
-                (CSA_PROJECT_ROOT_ENV_KEY.to_string(), "/repo".to_string()),
-                (CSA_INTERNAL_INVOCATION_ENV_KEY.to_string(), "1".to_string()),
-            ]
-        );
-        assert!(!startup.force_ignore_tier_setting());
-        assert!(!startup.no_failover());
-    }
-
-    #[test]
-    fn pattern_internal_marker_is_captured_and_reemitted_to_children() {
-        // A CSA process that inherited CSA_PATTERN_INTERNAL re-emits it to its
-        // own children, so by induction the marker reaches depth>=2 nested CSA
-        // sessions (#1847).
-        let startup = StartupSubtreeEnv::from_values(HashMap::from([
-            (CSA_DEPTH_ENV_KEY, "1".to_string()),
-            (CSA_PATTERN_INTERNAL_ENV_KEY, "1".to_string()),
-        ]));
-
-        assert!(startup.pattern_internal());
-        assert!(
-            startup
-                .to_child_env_vars()
-                .contains(&(CSA_PATTERN_INTERNAL_ENV_KEY.to_string(), "1".to_string())),
-            "captured pattern-internal marker must propagate to the child env"
-        );
-    }
-
-    #[test]
-    fn pattern_internal_marker_absent_is_not_emitted() {
-        // Interactive callers (no marker) must NOT propagate it (#1847 (iii)).
-        let startup =
-            StartupSubtreeEnv::from_values(HashMap::from([(CSA_DEPTH_ENV_KEY, "0".to_string())]));
-
-        assert!(!startup.pattern_internal());
-        assert!(
-            !startup
-                .to_child_env_vars()
-                .iter()
-                .any(|(key, _)| key == CSA_PATTERN_INTERNAL_ENV_KEY)
-        );
-    }
-
-    #[test]
-    fn pattern_internal_marker_survives_two_nested_csa_hops() {
-        // Canonical #1847 depth-2 chain: `csa plan run` sets the marker in the
-        // bash step env -> `csa run --skill mktd` (depth 1) -> `csa debate`
-        // (depth 2). Compose the capture->re-emit cycle twice and assert the
-        // marker still reaches the depth-2 grandchild, justifying mktd dropping
-        // its redundant per-step `--no-error-marker-scan`. The depth-1 base case
-        // (plan-run bash step exposing the marker) is covered by
-        // `spawn_bash_step_exposes_pattern_internal_marker` in plan_cmd_exec.
-
-        // A child only learns the marker if its parent actually emitted it, so
-        // each hop's inheritance genuinely depends on the prior re-emission.
-        fn captured_from_parent(
-            parent_child_env: &[(String, String)],
-            depth: &str,
-        ) -> HashMap<&'static str, String> {
-            let mut values = HashMap::from([(CSA_DEPTH_ENV_KEY, depth.to_string())]);
-            if parent_child_env
-                .iter()
-                .any(|(key, value)| key == CSA_PATTERN_INTERNAL_ENV_KEY && value == "1")
-            {
-                values.insert(CSA_PATTERN_INTERNAL_ENV_KEY, "1".to_string());
-            }
-            values
-        }
-
-        // Depth 1: `csa run --skill mktd` inherits the marker from the plan-run
-        // bash step env, then re-emits it to the mktd worker it spawns.
-        let depth1 = StartupSubtreeEnv::from_values(HashMap::from([
-            (CSA_DEPTH_ENV_KEY, "1".to_string()),
-            (CSA_PATTERN_INTERNAL_ENV_KEY, "1".to_string()),
-        ]));
-        let depth1_child_env = depth1.to_child_env_vars();
-        assert!(
-            depth1_child_env.contains(&(CSA_PATTERN_INTERNAL_ENV_KEY.to_string(), "1".to_string())),
-            "depth-1 csa process must re-emit the marker to its child"
-        );
-
-        // Depth 2: `csa debate`, spawned from inside mktd, captures that
-        // re-emitted env and must still see the marker (and keep propagating).
-        let depth2 = StartupSubtreeEnv::from_values(captured_from_parent(&depth1_child_env, "2"));
-        assert_eq!(depth2.current_depth(), 2);
-        assert!(
-            depth2.pattern_internal(),
-            "depth-2 csa debate must inherit the pattern-internal marker"
-        );
-        assert!(
-            depth2
-                .to_child_env_vars()
-                .contains(&(CSA_PATTERN_INTERNAL_ENV_KEY.to_string(), "1".to_string())),
-            "marker must keep propagating beyond depth 2"
-        );
-    }
-
-    #[test]
-    fn startup_subtree_env_child_contract_env_reemits_identity_parent_and_trusted_pin() {
-        let values = HashMap::from([
-            (CSA_SESSION_ID_ENV_KEY, "01KSESSION".to_string()),
-            (CSA_SESSION_DIR_ENV_KEY, "/repo/session".to_string()),
-            (CSA_PARENT_SESSION_ENV_KEY, "01KPARENT".to_string()),
-            (CSA_PARENT_SESSION_DIR_ENV_KEY, "/repo/parent".to_string()),
-            (CSA_DEPTH_ENV_KEY, "2".to_string()),
-            (
-                CSA_MODEL_SPEC_ENV_KEY,
-                "codex/openai/gpt-5.5/xhigh".to_string(),
-            ),
-            (CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1".to_string()),
-            (CSA_NO_FAILOVER_ENV_KEY, "1".to_string()),
-        ]);
-
-        let startup = StartupSubtreeEnv::from_values(values);
-        let child_contract_env = startup.to_csa_child_contract_env_vars();
-
-        assert_eq!(
-            child_contract_env,
-            vec![
-                (CSA_SESSION_ID_ENV_KEY.to_string(), "01KSESSION".to_string()),
-                (
-                    CSA_SESSION_DIR_ENV_KEY.to_string(),
-                    "/repo/session".to_string()
-                ),
-                (
-                    CSA_PARENT_SESSION_ENV_KEY.to_string(),
-                    "01KPARENT".to_string()
-                ),
-                (
-                    CSA_PARENT_SESSION_DIR_ENV_KEY.to_string(),
-                    "/repo/parent".to_string()
-                ),
-                (
-                    CSA_MODEL_SPEC_ENV_KEY.to_string(),
-                    "codex/openai/gpt-5.5/xhigh".to_string(),
-                ),
-                (
-                    CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY.to_string(),
-                    "1".to_string(),
-                ),
-                (CSA_NO_FAILOVER_ENV_KEY.to_string(), "1".to_string()),
-            ]
-        );
-    }
-
-    #[test]
-    fn startup_subtree_env_child_contract_env_does_not_emit_root_pin() {
-        let values = HashMap::from([
-            (CSA_DEPTH_ENV_KEY, "0".to_string()),
-            (
-                CSA_MODEL_SPEC_ENV_KEY,
-                "codex/openai/gpt-5.5/xhigh".to_string(),
-            ),
-            (CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1".to_string()),
-            (CSA_NO_FAILOVER_ENV_KEY, "1".to_string()),
-        ]);
-
-        let startup = StartupSubtreeEnv::from_values(values);
-        let child_contract_env = startup.to_csa_child_contract_env_vars();
-
-        assert!(child_contract_env.is_empty());
-    }
-
-    #[test]
-    fn startup_subtree_env_with_current_session_updates_child_env() {
-        let values = HashMap::from([
-            (CSA_SESSION_ID_ENV_KEY, "01KPARENT".to_string()),
-            (CSA_SESSION_DIR_ENV_KEY, "/repo/parent".to_string()),
-            (
-                CSA_MODEL_SPEC_ENV_KEY,
-                "codex/openai/gpt-5.5/xhigh".to_string(),
-            ),
-        ]);
-
-        let startup =
-            StartupSubtreeEnv::from_values(values).with_current_session("01KCHILD", "/repo/child");
-        let child_env = startup.to_child_env_vars();
-
-        assert_eq!(startup.session_id(), Some("01KCHILD"));
-        assert_eq!(startup.session_dir(), Some("/repo/child"));
-        assert_eq!(startup.parent_session(), Some("01KPARENT"));
-        assert_eq!(startup.parent_session_dir(), Some("/repo/parent"));
-        assert_eq!(
-            child_env,
-            vec![
-                (CSA_SESSION_ID_ENV_KEY.to_string(), "01KCHILD".to_string()),
-                (
-                    CSA_SESSION_DIR_ENV_KEY.to_string(),
-                    "/repo/child".to_string()
-                ),
-                (
-                    CSA_PARENT_SESSION_ENV_KEY.to_string(),
-                    "01KPARENT".to_string()
-                ),
-                (
-                    CSA_PARENT_SESSION_DIR_ENV_KEY.to_string(),
-                    "/repo/parent".to_string()
-                ),
-            ]
-        );
-    }
-
-    #[test]
-    fn startup_subtree_env_with_current_session_does_not_self_parent() {
-        let values = HashMap::from([
-            (CSA_SESSION_ID_ENV_KEY, "01KSESSION".to_string()),
-            (CSA_SESSION_DIR_ENV_KEY, "/repo/session".to_string()),
-        ]);
-
-        let startup = StartupSubtreeEnv::from_values(values)
-            .with_current_session("01KSESSION", "/repo/session");
-
-        assert_eq!(startup.session_id(), Some("01KSESSION"));
-        assert_eq!(startup.session_dir(), Some("/repo/session"));
-        assert_eq!(startup.parent_session(), None);
-        assert_eq!(
-            startup.to_child_env_vars(),
-            vec![
-                (CSA_SESSION_ID_ENV_KEY.to_string(), "01KSESSION".to_string()),
-                (
-                    CSA_SESSION_DIR_ENV_KEY.to_string(),
-                    "/repo/session".to_string()
-                ),
-            ]
-        );
-    }
-
-    #[test]
-    #[serial]
-    fn startup_capture_preserves_subtree_keys_in_process_env() {
-        let _depth = ScopedEnvVarRestore::set(CSA_DEPTH_ENV_KEY, "2");
-        let _session = ScopedEnvVarRestore::set(CSA_SESSION_ID_ENV_KEY, "01KTESTSESSION");
-        let _model = ScopedEnvVarRestore::set(CSA_MODEL_SPEC_ENV_KEY, "codex/openai/gpt-5/xhigh");
-        let _force = ScopedEnvVarRestore::set(CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1");
-
-        let startup = StartupSubtreeEnv::capture_from_process_env();
-
-        assert_eq!(startup.current_depth(), 2);
-        assert_eq!(startup.session_id(), Some("01KTESTSESSION"));
-        assert_eq!(startup.model_spec(), Some("codex/openai/gpt-5/xhigh"));
-        assert_eq!(std::env::var(CSA_DEPTH_ENV_KEY).as_deref(), Ok("2"));
-        assert_eq!(
-            std::env::var(CSA_SESSION_ID_ENV_KEY).as_deref(),
-            Ok("01KTESTSESSION")
-        );
-        assert_eq!(
-            std::env::var(CSA_MODEL_SPEC_ENV_KEY).as_deref(),
-            Ok("codex/openai/gpt-5/xhigh")
-        );
-        assert_eq!(
-            std::env::var(CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY).as_deref(),
-            Ok("1")
-        );
-    }
-}
+#[path = "startup_env_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/startup_env_tests.rs
+++ b/crates/cli-sub-agent/src/startup_env_tests.rs
@@ -1,0 +1,336 @@
+use super::*;
+use crate::test_env_lock::ScopedEnvVarRestore;
+use serial_test::serial;
+
+#[test]
+fn startup_subtree_env_parses_values_without_process_env() {
+    let values = HashMap::from([
+        (
+            CSA_SESSION_ID_ENV_KEY,
+            "01KTESTSESSION0000000000".to_string(),
+        ),
+        (CSA_DEPTH_ENV_KEY, "3".to_string()),
+        (CSA_PROJECT_ROOT_ENV_KEY, "/repo".to_string()),
+        (CSA_SESSION_DIR_ENV_KEY, "/repo/.csa/session".to_string()),
+        (
+            CSA_PARENT_SESSION_ENV_KEY,
+            "01KPARENTSESSION00000000".to_string(),
+        ),
+        (
+            CSA_PARENT_SESSION_DIR_ENV_KEY,
+            "/repo/.csa/parent".to_string(),
+        ),
+        (CSA_INTERNAL_INVOCATION_ENV_KEY, "yes".to_string()),
+        (
+            CSA_MODEL_SPEC_ENV_KEY,
+            "codex/openai/gpt-5.5/xhigh".to_string(),
+        ),
+        (CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1".to_string()),
+        (CSA_NO_FAILOVER_ENV_KEY, "true".to_string()),
+    ]);
+
+    let startup = StartupSubtreeEnv::from_values(values);
+
+    assert_eq!(startup.session_id(), Some("01KTESTSESSION0000000000"));
+    assert_eq!(startup.current_depth(), 3);
+    assert_eq!(startup.next_depth_string(), "4");
+    assert_eq!(startup.project_root(), Some("/repo"));
+    assert_eq!(startup.session_dir(), Some("/repo/.csa/session"));
+    assert_eq!(startup.parent_session(), Some("01KPARENTSESSION00000000"));
+    assert_eq!(startup.parent_session_dir(), Some("/repo/.csa/parent"));
+    assert!(startup.internal_invocation());
+    assert_eq!(startup.model_spec(), Some("codex/openai/gpt-5.5/xhigh"));
+    assert!(startup.force_ignore_tier_setting());
+    assert!(startup.no_failover());
+}
+
+#[test]
+fn startup_subtree_env_reemits_only_captured_keys() {
+    let values = HashMap::from([
+        (CSA_DEPTH_ENV_KEY, "0".to_string()),
+        (CSA_PROJECT_ROOT_ENV_KEY, "/repo".to_string()),
+        (CSA_INTERNAL_INVOCATION_ENV_KEY, "1".to_string()),
+        (CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "false".to_string()),
+        (CSA_NO_FAILOVER_ENV_KEY, "0".to_string()),
+    ]);
+
+    let startup = StartupSubtreeEnv::from_values(values);
+    let child_env = startup.to_child_env_vars();
+
+    assert_eq!(
+        child_env,
+        vec![
+            (CSA_DEPTH_ENV_KEY.to_string(), "0".to_string()),
+            (CSA_PROJECT_ROOT_ENV_KEY.to_string(), "/repo".to_string()),
+            (CSA_INTERNAL_INVOCATION_ENV_KEY.to_string(), "1".to_string()),
+        ]
+    );
+    assert!(!startup.force_ignore_tier_setting());
+    assert!(!startup.no_failover());
+}
+
+#[test]
+fn pattern_internal_marker_is_captured_and_reemitted_to_children() {
+    let startup = StartupSubtreeEnv::from_values(HashMap::from([
+        (CSA_DEPTH_ENV_KEY, "1".to_string()),
+        (CSA_PATTERN_INTERNAL_ENV_KEY, "1".to_string()),
+    ]));
+
+    assert!(startup.pattern_internal());
+    assert!(
+        startup
+            .to_child_env_vars()
+            .contains(&(CSA_PATTERN_INTERNAL_ENV_KEY.to_string(), "1".to_string())),
+        "captured pattern-internal marker must propagate to the child env"
+    );
+}
+
+#[test]
+fn pattern_internal_marker_absent_is_not_emitted() {
+    let startup =
+        StartupSubtreeEnv::from_values(HashMap::from([(CSA_DEPTH_ENV_KEY, "0".to_string())]));
+
+    assert!(!startup.pattern_internal());
+    assert!(
+        !startup
+            .to_child_env_vars()
+            .iter()
+            .any(|(key, _)| key == CSA_PATTERN_INTERNAL_ENV_KEY)
+    );
+}
+
+#[test]
+fn pattern_internal_marker_survives_two_nested_csa_hops() {
+    fn captured_from_parent(
+        parent_child_env: &[(String, String)],
+        depth: &str,
+    ) -> HashMap<&'static str, String> {
+        let mut values = HashMap::from([(CSA_DEPTH_ENV_KEY, depth.to_string())]);
+        if parent_child_env
+            .iter()
+            .any(|(key, value)| key == CSA_PATTERN_INTERNAL_ENV_KEY && value == "1")
+        {
+            values.insert(CSA_PATTERN_INTERNAL_ENV_KEY, "1".to_string());
+        }
+        values
+    }
+
+    let depth1 = StartupSubtreeEnv::from_values(HashMap::from([
+        (CSA_DEPTH_ENV_KEY, "1".to_string()),
+        (CSA_PATTERN_INTERNAL_ENV_KEY, "1".to_string()),
+    ]));
+    let depth1_child_env = depth1.to_child_env_vars();
+    assert!(
+        depth1_child_env.contains(&(CSA_PATTERN_INTERNAL_ENV_KEY.to_string(), "1".to_string())),
+        "depth-1 csa process must re-emit the marker to its child"
+    );
+
+    let depth2 = StartupSubtreeEnv::from_values(captured_from_parent(&depth1_child_env, "2"));
+    assert_eq!(depth2.current_depth(), 2);
+    assert!(
+        depth2.pattern_internal(),
+        "depth-2 csa debate must inherit the pattern-internal marker"
+    );
+    assert!(
+        depth2
+            .to_child_env_vars()
+            .contains(&(CSA_PATTERN_INTERNAL_ENV_KEY.to_string(), "1".to_string())),
+        "marker must keep propagating beyond depth 2"
+    );
+}
+
+#[test]
+fn startup_subtree_env_child_contract_env_reemits_identity_parent_and_trusted_pin() {
+    let _lock = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
+    let xdg = tempfile::tempdir().expect("xdg tempdir");
+    let _xdg_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", xdg.path());
+    let project = tempfile::tempdir().expect("project tempdir");
+    let parent = csa_session::create_session(
+        project.path(),
+        Some("startup pin parent"),
+        None,
+        Some("codex"),
+    )
+    .expect("create parent session");
+    let child = csa_session::create_session(
+        project.path(),
+        Some("startup pin child"),
+        Some(&parent.meta_session_id),
+        Some("codex"),
+    )
+    .expect("create child session");
+    let child_dir =
+        csa_session::get_session_dir(project.path(), &child.meta_session_id).expect("child dir");
+    let parent_dir =
+        csa_session::get_session_dir(project.path(), &parent.meta_session_id).expect("parent dir");
+    let pin = crate::run_cmd_model_pin::resolve_subtree_model_pin(
+        Some("codex/openai/gpt-5.5/xhigh"),
+        true,
+        true,
+    )
+    .expect("trusted pin");
+    crate::run_cmd_model_pin::sync_subtree_model_pin_sidecar(
+        project.path(),
+        &child.meta_session_id,
+        &child_dir,
+        Some(&pin),
+    )
+    .expect("write trusted pin sidecar");
+
+    let startup = StartupSubtreeEnv::from_values(HashMap::from([
+        (CSA_SESSION_ID_ENV_KEY, child.meta_session_id.clone()),
+        (CSA_SESSION_DIR_ENV_KEY, child_dir.display().to_string()),
+        (CSA_PARENT_SESSION_ENV_KEY, parent.meta_session_id.clone()),
+        (
+            CSA_PARENT_SESSION_DIR_ENV_KEY,
+            parent_dir.display().to_string(),
+        ),
+        (
+            CSA_DEPTH_ENV_KEY,
+            child.genealogy.depth.saturating_add(1).to_string(),
+        ),
+        (
+            CSA_PROJECT_ROOT_ENV_KEY,
+            project.path().display().to_string(),
+        ),
+        (CSA_INTERNAL_INVOCATION_ENV_KEY, "1".to_string()),
+        (
+            CSA_MODEL_SPEC_ENV_KEY,
+            "codex/openai/gpt-5.5/xhigh".to_string(),
+        ),
+        (CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1".to_string()),
+        (CSA_NO_FAILOVER_ENV_KEY, "1".to_string()),
+    ]));
+
+    assert_eq!(
+        startup.to_csa_child_contract_env_vars(),
+        vec![
+            (CSA_SESSION_ID_ENV_KEY.to_string(), child.meta_session_id),
+            (
+                CSA_SESSION_DIR_ENV_KEY.to_string(),
+                child_dir.display().to_string(),
+            ),
+            (
+                CSA_PARENT_SESSION_ENV_KEY.to_string(),
+                parent.meta_session_id,
+            ),
+            (
+                CSA_PARENT_SESSION_DIR_ENV_KEY.to_string(),
+                parent_dir.display().to_string(),
+            ),
+            (
+                CSA_MODEL_SPEC_ENV_KEY.to_string(),
+                "codex/openai/gpt-5.5/xhigh".to_string(),
+            ),
+            (
+                CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY.to_string(),
+                "1".to_string(),
+            ),
+            (CSA_NO_FAILOVER_ENV_KEY.to_string(), "1".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn startup_subtree_env_child_contract_env_does_not_emit_root_pin() {
+    let startup = StartupSubtreeEnv::from_values(HashMap::from([
+        (CSA_DEPTH_ENV_KEY, "0".to_string()),
+        (
+            CSA_MODEL_SPEC_ENV_KEY,
+            "codex/openai/gpt-5.5/xhigh".to_string(),
+        ),
+        (CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1".to_string()),
+        (CSA_NO_FAILOVER_ENV_KEY, "1".to_string()),
+    ]));
+
+    assert!(startup.to_csa_child_contract_env_vars().is_empty());
+}
+
+#[test]
+fn startup_subtree_env_with_current_session_updates_child_env() {
+    let startup = StartupSubtreeEnv::from_values(HashMap::from([
+        (CSA_SESSION_ID_ENV_KEY, "01KPARENT".to_string()),
+        (CSA_SESSION_DIR_ENV_KEY, "/repo/parent".to_string()),
+        (
+            CSA_MODEL_SPEC_ENV_KEY,
+            "codex/openai/gpt-5.5/xhigh".to_string(),
+        ),
+    ]))
+    .with_current_session("01KCHILD", "/repo/child");
+
+    assert_eq!(startup.session_id(), Some("01KCHILD"));
+    assert_eq!(startup.session_dir(), Some("/repo/child"));
+    assert_eq!(startup.parent_session(), Some("01KPARENT"));
+    assert_eq!(startup.parent_session_dir(), Some("/repo/parent"));
+    assert_eq!(
+        startup.to_child_env_vars(),
+        vec![
+            (CSA_SESSION_ID_ENV_KEY.to_string(), "01KCHILD".to_string()),
+            (
+                CSA_SESSION_DIR_ENV_KEY.to_string(),
+                "/repo/child".to_string(),
+            ),
+            (
+                CSA_PARENT_SESSION_ENV_KEY.to_string(),
+                "01KPARENT".to_string(),
+            ),
+            (
+                CSA_PARENT_SESSION_DIR_ENV_KEY.to_string(),
+                "/repo/parent".to_string(),
+            ),
+        ]
+    );
+}
+
+#[test]
+fn startup_subtree_env_with_current_session_does_not_self_parent() {
+    let startup = StartupSubtreeEnv::from_values(HashMap::from([
+        (CSA_SESSION_ID_ENV_KEY, "01KSESSION".to_string()),
+        (CSA_SESSION_DIR_ENV_KEY, "/repo/session".to_string()),
+    ]))
+    .with_current_session("01KSESSION", "/repo/session");
+
+    assert_eq!(startup.session_id(), Some("01KSESSION"));
+    assert_eq!(startup.session_dir(), Some("/repo/session"));
+    assert_eq!(startup.parent_session(), None);
+    assert_eq!(
+        startup.to_child_env_vars(),
+        vec![
+            (CSA_SESSION_ID_ENV_KEY.to_string(), "01KSESSION".to_string()),
+            (
+                CSA_SESSION_DIR_ENV_KEY.to_string(),
+                "/repo/session".to_string(),
+            ),
+        ]
+    );
+}
+
+#[test]
+#[serial]
+fn startup_capture_preserves_subtree_keys_in_process_env() {
+    let _depth = ScopedEnvVarRestore::set(CSA_DEPTH_ENV_KEY, "2");
+    let _session = ScopedEnvVarRestore::set(CSA_SESSION_ID_ENV_KEY, "01KTESTSESSION");
+    let _model = ScopedEnvVarRestore::set(CSA_MODEL_SPEC_ENV_KEY, "codex/openai/gpt-5/xhigh");
+    let _force = ScopedEnvVarRestore::set(CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY, "1");
+
+    let startup = StartupSubtreeEnv::capture_from_process_env();
+
+    assert_eq!(startup.current_depth(), 2);
+    assert_eq!(startup.session_id(), Some("01KTESTSESSION"));
+    assert_eq!(startup.model_spec(), Some("codex/openai/gpt-5/xhigh"));
+    assert_eq!(std::env::var(CSA_DEPTH_ENV_KEY).as_deref(), Ok("2"));
+    assert_eq!(
+        std::env::var(CSA_SESSION_ID_ENV_KEY).as_deref(),
+        Ok("01KTESTSESSION")
+    );
+    assert_eq!(
+        std::env::var(CSA_MODEL_SPEC_ENV_KEY).as_deref(),
+        Ok("codex/openai/gpt-5/xhigh")
+    );
+    assert_eq!(
+        std::env::var(CSA_FORCE_IGNORE_TIER_SETTING_ENV_KEY).as_deref(),
+        Ok("1")
+    );
+}

--- a/crates/csa-core/src/env.rs
+++ b/crates/csa-core/src/env.rs
@@ -118,9 +118,10 @@ pub fn strip_reserved_pin_keys(env: &mut std::collections::HashMap<String, Strin
 /// **if and only if CSA itself decided to pin**. This type is the sole carrier
 /// of that decision: it can only be built from validated CSA state (see
 /// [`SubtreeModelPin::from_validated_spec`], fed by the inherited-pin reader
-/// which already requires the force-ignore marker + `ModelSpec::parse`, or by a
-/// locally resolved spec), and [`SubtreeModelPin::pin_env_entries`] is the ONLY
-/// function in the codebase that emits the pin keys for injection.
+/// which already requires the force-ignore marker, `ModelSpec::parse`, and a
+/// CSA-owned session sidecar check, or by a locally resolved spec), and
+/// [`SubtreeModelPin::pin_env_entries`] is the ONLY function in the codebase
+/// that emits the pin keys for injection.
 ///
 /// Because the pin travels in this typed channel — never inside the generic
 /// `extra_env` map that user/request/config input flows through (those are
@@ -139,8 +140,9 @@ impl SubtreeModelPin {
     ///
     /// `model_spec` MUST originate from validated CSA state: either a spec the
     /// current process resolved itself, or one returned by the inherited-pin
-    /// reader (which gates on the paired force-ignore marker and `ModelSpec`
-    /// well-formedness). A blank spec yields `None` (no pin).
+    /// reader (which gates on the paired force-ignore marker, `ModelSpec`
+    /// well-formedness, and a CSA-owned session sidecar). A blank spec yields
+    /// `None` (no pin).
     ///
     /// The pin always carries `CSA_FORCE_IGNORE_TIER_SETTING=1` because a CSA
     /// subtree pin is, by definition, a force-ignore-tier pin; `no_failover`

--- a/crates/csa-executor/src/transport_cli.rs
+++ b/crates/csa-executor/src/transport_cli.rs
@@ -441,11 +441,11 @@ const CLI_TRANSPORT_CSA_OWNED_ENV_VARS: &[&str] = &[
     "CSA_DAEMON_SESSION_DIR",
     csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
 ];
-
 fn inject_cli_session_env(cmd: &mut Command, session: &MetaSessionState) {
     cmd.env("CSA_SESSION_ID", &session.meta_session_id);
     cmd.env("CSA_DEPTH", (session.genealogy.depth + 1).to_string());
     cmd.env("CSA_PROJECT_ROOT", &session.project_path);
+    cmd.env(csa_core::env::CSA_INTERNAL_INVOCATION_ENV_KEY, "1");
     cmd.env("CSA_TOOL", "claude-code");
     if let Ok(current_tool) = std::env::var("CSA_TOOL") {
         cmd.env("CSA_PARENT_TOOL", current_tool);

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -31,6 +31,8 @@ const CSA_DEPTH_ENV: &str = "CSA_DEPTH";
 #[cfg(feature = "acp")]
 const CSA_PROJECT_ROOT_ENV: &str = "CSA_PROJECT_ROOT";
 #[cfg(feature = "acp")]
+const CSA_INTERNAL_INVOCATION_ENV: &str = csa_core::env::CSA_INTERNAL_INVOCATION_ENV_KEY;
+#[cfg(feature = "acp")]
 const CSA_TOOL_ENV: &str = "CSA_TOOL";
 #[cfg(feature = "acp")]
 const CSA_IS_SUBPROCESS_ENV: &str = "CSA_IS_SUBPROCESS";
@@ -47,6 +49,7 @@ const CSA_OWNED_ENV_KEYS: &[&str] = &[
     CSA_SESSION_ID_ENV,
     CSA_DEPTH_ENV,
     CSA_PROJECT_ROOT_ENV,
+    CSA_INTERNAL_INVOCATION_ENV,
     CSA_TOOL_ENV,
     CSA_IS_SUBPROCESS_ENV,
     CSA_PARENT_TOOL_ENV,
@@ -212,6 +215,7 @@ impl AcpTransport {
             CSA_PROJECT_ROOT_ENV.to_string(),
             session.project_path.clone(),
         );
+        env.insert(CSA_INTERNAL_INVOCATION_ENV.to_string(), "1".to_string());
         env.insert(CSA_TOOL_ENV.to_string(), self.tool_name.clone());
         // Mark this process as a CSA subprocess so child tools can detect
         // recursion risk (e.g. claude-code reading CLAUDE.md rules that say
@@ -528,6 +532,7 @@ mod tests {
                 CSA_PROJECT_ROOT_ENV.to_string(),
                 "/tmp/spoofed-root".to_string(),
             ),
+            (CSA_INTERNAL_INVOCATION_ENV.to_string(), "0".to_string()),
             (CSA_TOOL_ENV.to_string(), "spoofed-tool".to_string()),
             (CSA_IS_SUBPROCESS_ENV.to_string(), "0".to_string()),
             (
@@ -568,6 +573,10 @@ mod tests {
         assert_eq!(
             env.get(CSA_PROJECT_ROOT_ENV).map(String::as_str),
             Some("/tmp/test")
+        );
+        assert_eq!(
+            env.get(CSA_INTERNAL_INVOCATION_ENV).map(String::as_str),
+            Some("1")
         );
         assert_eq!(
             env.get(CSA_TOOL_ENV).map(String::as_str),

--- a/crates/csa-executor/src/transport_tmux.rs
+++ b/crates/csa-executor/src/transport_tmux.rs
@@ -493,6 +493,10 @@ impl TmuxTransport {
                     (session.genealogy.depth + 1).to_string(),
                 );
                 env.insert("CSA_PROJECT_ROOT".into(), session.project_path.clone());
+                env.insert(
+                    csa_core::env::CSA_INTERNAL_INVOCATION_ENV_KEY.into(),
+                    "1".into(),
+                );
                 env.insert("CSA_TOOL".into(), "claude-code".into());
                 if let Ok(current_tool) = std::env::var("CSA_TOOL") {
                     env.insert("CSA_PARENT_TOOL".into(), current_tool);

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,7 +27,7 @@ csa run --sa-mode false [OPTIONS] [PROMPT]
 | `--model <MODEL>` | Override tool default model |
 | `--thinking <LEVEL>` | Thinking budget: `low`, `medium`, `high`, `xhigh` |
 | `--force` | Emergency direct-routing override. With configured tiers, rejected unless the global tier-policy escape hatch is enabled |
-| `--force-ignore-tier-setting` / `--force-tier` | Emergency tier bypass for direct tool/model routing. Invalid with `--tier`; rejected under configured tiers unless the global tier-policy escape hatch is enabled |
+| `--force-ignore-tier-setting` / `--force-tier` | Emergency tier bypass for direct tool/model routing. Invalid with `--tier`; rejected under configured tiers unless the global tier-policy escape hatch is enabled or CSA is continuing the same inherited subtree pin |
 | `--no-failover` | Disable automatic 429 failover |
 | `--wait` | Block-wait for a free slot instead of failing |
 | `--idle-timeout <SECS>` | Kill when no output for N seconds |
@@ -46,6 +46,13 @@ the tier. Exact model and force-bypass flags are reserved
 for emergency use and require `[tier_policy].allow_force_bypass = true` in the
 global config, not project `.csa/config.toml`, unless CSA is continuing an
 already-trusted inherited subtree pin.
+
+Inside a model-pinned CSA subtree, nested workers should invoke
+`csa run --skill ...`, `csa review`, or `csa debate` without repeating
+`--model-spec` or `--force-ignore-tier-setting`. CSA passes the already
+authorized exact pin through `CSA_MODEL_SPEC`; repeating the same inherited
+spec remains accepted for older prompts, but changing the spec is treated as a
+new bypass attempt.
 
 **Examples:**
 
@@ -79,7 +86,7 @@ csa review --sa-mode false [OPTIONS]
 | `--tier <NAME>` | Canonical selector when `[tiers]` is configured |
 | `--hint-difficulty <LABEL>` | Resolve a difficulty label through `[tier_mapping]` when no explicit `--tier` or permitted direct model bypass is set |
 | `--model <MODEL>` | Override model |
-| `--force-ignore-tier-setting` / `--force-tier` | Emergency tier bypass; rejected under configured tiers unless the global tier-policy escape hatch is enabled |
+| `--force-ignore-tier-setting` / `--force-tier` | Emergency tier bypass; rejected under configured tiers unless the global tier-policy escape hatch is enabled or CSA is continuing the same inherited subtree pin |
 | `--fix` | Review-and-fix mode (apply fixes directly) |
 | `--security-mode <MODE>` | `auto`, `on`, or `off` |
 | `--reviewers <N>` | Number of parallel reviewers (default: 1) |
@@ -117,7 +124,7 @@ csa debate --sa-mode false [OPTIONS] [QUESTION]
 | `--session <ID>` | Resume existing debate session |
 | `--model <MODEL>` | Override model |
 | `--thinking <LEVEL>` | Thinking budget |
-| `--force-ignore-tier-setting` / `--force-tier` | Emergency tier bypass; rejected under configured tiers unless the global tier-policy escape hatch is enabled |
+| `--force-ignore-tier-setting` / `--force-tier` | Emergency tier bypass; rejected under configured tiers unless the global tier-policy escape hatch is enabled or CSA is continuing the same inherited subtree pin |
 | `--rounds <N>` | Number of debate rounds (default: 3) |
 | `--timeout <SECS>` | Absolute wall-clock timeout |
 | `--idle-timeout <SECS>` | Kill on output silence |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,14 @@ inherited subtree pin. This escape hatch covers `--model-spec`,
 `--force-ignore-tier-setting`/`--force-tier`, and broad direct-routing force
 flags.
 
+Pinned CSA subtrees do not need to repeat bypass flags for nested
+`csa run --skill ...`, `csa review`, or `csa debate` calls. When CSA itself
+spawned the parent with an exact model pin, it passes that pin to children via
+the reserved `CSA_MODEL_SPEC` child contract. Nested workers should omit
+`--model-spec` and `--force-ignore-tier-setting`; repeating the same inherited
+spec is accepted for compatibility, but changing the spec or using an unrelated
+session is still rejected by the configured tier policy.
+
 This field is global-only. A project `.csa/config.toml` cannot grant
 `[tier_policy].allow_force_bypass`; CSA rejects that as a privilege-escalation
 guard because a repository must not be able to authorize its own tier bypass.

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.993"
-weave = "0.1.993"
+csa = "0.1.994"
+weave = "0.1.994"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Closes #2097.

This PR fixes trusted nested model-pin inheritance without allowing ambient env spoofing to bypass tier policy.

- Adds sidecar-backed validation for inherited subtree model pins.
- Preserves trusted inherited pins across nested run/review/debate and plan/bash paths.
- Keeps ambient/user-controlled `CSA_*` model-pin env spoofing fail-closed.
- Updates MCP, plan/bash, daemon, run/review/debate regression coverage.

## Local validation

- Hook-enabled commit/amend quality gates: PASS.
- `cargo test -p cli-sub-agent run_cmd_daemon -- --nocapture`: 25 passed.
- `cargo test -p cli-sub-agent run_cmd_model_pin -- --nocapture`: 25 passed.
- `cargo test -p cli-sub-agent spawn_bash_env -- --nocapture`: 4 passed.
- `cargo test -p cli-sub-agent test_review_ -- --nocapture`: 11 passed.
- `cargo test -p cli-sub-agent test_debate_ -- --nocapture`: 9 passed.
- `cargo test -p cli-sub-agent mcp_model_pin -- --nocapture`: 3 passed.
- `just find-monolith-files`: PASS.
- `git diff --check` / `git diff --cached --check`: PASS.

## Review

Pinned Codex exact-head full-diff review PASS:

- Session: `01KV149YP440FXN0EK38XRDFE3`
- Range: `main...HEAD`
- Reviewed commit: `cb5347fd`

## Notes

- CSA/Codex implementation/fix SIGTERM evidence filed separately as #2186 and #2187.
- GitHub CI is not used as the agent-side gate; this PR is gated by local hooks/tests and exact-head CSA/Codex review.
