### PR TITLE
fix(run): provide writable Rust session homes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.994"
+version = "0.1.995"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.994"
+version = "0.1.995"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_env.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use csa_config::ProjectConfig;
 use tracing::info;
@@ -47,6 +47,7 @@ pub(crate) fn build_merged_env(request: MergedEnvRequest<'_>) -> HashMap<String,
     {
         merged_env.insert("PATH".to_string(), path.to_string_lossy().into_owned());
     }
+    apply_rust_session_env_contract(&mut merged_env);
     if suppress {
         merged_env.insert("CSA_SUPPRESS_NOTIFY".to_string(), "1".to_string());
     }
@@ -126,6 +127,97 @@ pub(crate) fn build_merged_env(request: MergedEnvRequest<'_>) -> HashMap<String,
     }
 
     merged_env
+}
+
+pub(crate) fn rust_session_writable_paths(env: &HashMap<String, String>) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for key in [
+        csa_core::env::CARGO_HOME_ENV_KEY,
+        csa_core::env::RUSTUP_HOME_ENV_KEY,
+        csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY,
+        csa_core::env::MISE_CONFIG_DIR_ENV_KEY,
+    ] {
+        let Some(value) = env.get(key).filter(|value| !value.trim().is_empty()) else {
+            continue;
+        };
+        let path = PathBuf::from(value.as_str());
+        if path.is_absolute() && !paths.contains(&path) {
+            paths.push(path);
+        }
+    }
+    paths
+}
+
+fn apply_rust_session_env_contract(env: &mut HashMap<String, String>) {
+    let Some(home) = env_path(env, "HOME") else {
+        return;
+    };
+    let cargo_home = home.join(".cargo");
+    normalize_rust_env_path(env, csa_core::env::CARGO_HOME_ENV_KEY, &cargo_home);
+
+    let effective_cargo_home =
+        env_path(env, csa_core::env::CARGO_HOME_ENV_KEY).unwrap_or(cargo_home);
+    normalize_rust_env_path(
+        env,
+        csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY,
+        &effective_cargo_home,
+    );
+
+    let rustup_home = preferred_rustup_home(env, &home);
+    normalize_rust_env_path(env, csa_core::env::RUSTUP_HOME_ENV_KEY, &rustup_home);
+
+    let mise_config_dir = home.join(".config/mise");
+    normalize_rust_env_path(
+        env,
+        csa_core::env::MISE_CONFIG_DIR_ENV_KEY,
+        &mise_config_dir,
+    );
+}
+
+fn normalize_rust_env_path(env: &mut HashMap<String, String>, key: &str, fallback: &Path) {
+    let Some(current) = env_path(env, key) else {
+        return;
+    };
+    if csa_core::env::rust_state_path_needs_session_override(&current) {
+        env.insert(key.to_string(), fallback.to_string_lossy().into_owned());
+    }
+}
+
+fn preferred_rustup_home(env: &HashMap<String, String>, home: &Path) -> PathBuf {
+    for candidate in mise_rust_home_candidates(env) {
+        if candidate.join("settings.toml").is_file()
+            && candidate.join("toolchains").is_dir()
+            && !csa_core::env::rust_state_path_needs_session_override(&candidate)
+        {
+            return candidate;
+        }
+    }
+    home.join(".rustup")
+}
+
+fn mise_rust_home_candidates(env: &HashMap<String, String>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    for data_dir in env_path(env, csa_core::env::MISE_DATA_DIR_ENV_KEY)
+        .into_iter()
+        .chain(Some(PathBuf::from("/usr/local/share/mise")))
+    {
+        let stable = data_dir.join("installs/rust/stable");
+        if !candidates.contains(&stable) {
+            candidates.push(stable);
+        }
+    }
+    candidates
+}
+
+fn env_path(env: &HashMap<String, String>, key: &str) -> Option<PathBuf> {
+    env.get(key)
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| PathBuf::from(value.as_str()))
+        .or_else(|| {
+            std::env::var_os(key)
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
 }
 
 pub(crate) fn apply_review_target_dir(project_root: &Path, tool_name: &str) {

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -4,6 +4,7 @@
 //! Handles enforcement mode checking, capability detection, config resolution,
 //! and first-turn telemetry recording.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use csa_config::ProjectConfig;
@@ -23,6 +24,7 @@ mod memory_balloon;
 mod memory_override;
 #[path = "pipeline_sandbox_writable.rs"]
 mod writable_sources;
+use writable_sources::add_execution_env_writable_paths;
 
 pub(crate) use memory_balloon::maybe_inflate_balloon;
 #[cfg(test)]
@@ -51,6 +53,7 @@ pub(crate) struct SandboxResolveInput<'a> {
     pub(crate) readonly_project_root: bool,
     pub(crate) extra_writable: &'a [PathBuf],
     pub(crate) extra_readable: &'a [PathBuf],
+    pub(crate) execution_env: Option<&'a HashMap<String, String>>,
 }
 
 fn resolve_session_dir_for_sandbox(project_root: &Path, session_id: &str) -> PathBuf {
@@ -128,6 +131,7 @@ pub(crate) fn resolve_sandbox_options(
             readonly_project_root,
             extra_writable,
             extra_readable,
+            execution_env: None,
         },
         RunResourceOverrides::default(),
     )
@@ -150,6 +154,7 @@ pub(crate) fn resolve_sandbox_options_with_overrides(
         readonly_project_root,
         extra_writable,
         extra_readable,
+        execution_env,
     } = input;
     let has_run_memory_override = resource_overrides.memory_max_mb.is_some();
 
@@ -225,8 +230,12 @@ pub(crate) fn resolve_sandbox_options_with_overrides(
             .with_tool_defaults(tool_name, project_root, &session_dir)
             .with_readonly_project_root(readonly_project_root);
 
-        // CSA runtime writable paths (best-effort for profile defaults).
+        // CSA runtime writable paths.
         if !no_fs_sandbox {
+            builder = match add_execution_env_writable_paths(builder, execution_env, project_root) {
+                Ok(builder) => builder,
+                Err(message) => return SandboxResolution::RequiredButUnavailable(message),
+            };
             if let Ok(project_state_root) = csa_session::manager::get_session_root(project_root) {
                 builder = builder.with_writable_path(project_state_root);
             }
@@ -410,11 +419,13 @@ pub(crate) fn resolve_sandbox_options_with_overrides(
         .with_soft_limit_percent(cfg.resources.soft_limit_percent)
         .with_memory_monitor_interval(cfg.resources.memory_monitor_interval_seconds);
 
-    // CSA runtime writable paths: project state root (for fork-call session
-    // creation) and global slots (for lock files).  These are always added
-    // regardless of per-tool REPLACE semantics because CSA needs them to
-    // function even when the tool's project-root access is restricted.
+    // CSA runtime paths must survive per-tool REPLACE semantics so fork-call
+    // session creation and slot locks still work.
     if !no_fs_sandbox {
+        builder = match add_execution_env_writable_paths(builder, execution_env, project_root) {
+            Ok(builder) => builder,
+            Err(message) => return SandboxResolution::RequiredButUnavailable(message),
+        };
         if let Ok(project_state_root) = csa_session::manager::get_session_root(project_root) {
             builder = builder.with_writable_path(project_state_root);
         }

--- a/crates/cli-sub-agent/src/pipeline_sandbox_extra_writable_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_extra_writable_tests.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 
@@ -10,6 +10,151 @@ fn parse_project_config(toml_str: &str) -> csa_config::ProjectConfig {
 
 fn current_project_root() -> PathBuf {
     std::env::current_dir().unwrap_or_default()
+}
+
+fn sandbox_config() -> csa_config::ProjectConfig {
+    parse_project_config(
+        r#"
+[resources]
+memory_max_mb = 2048
+enforcement_mode = "best-effort"
+"#,
+    )
+}
+
+fn resolve_sandbox_options_with_execution_env(
+    cfg: &csa_config::ProjectConfig,
+    project_root: &std::path::Path,
+    execution_env: &HashMap<String, String>,
+) -> SandboxResolution {
+    resolve_sandbox_options_with_overrides(
+        SandboxResolveInput {
+            config: Some(cfg),
+            tool_name: "codex",
+            session_id: "test-session",
+            project_root,
+            stream_mode: StreamMode::BufferOnly,
+            idle_timeout_seconds: 120,
+            liveness_dead_seconds: 600,
+            initial_response_timeout_seconds: Some(120),
+            no_fs_sandbox: false,
+            readonly_project_root: false,
+            extra_writable: &[],
+            extra_readable: &[],
+            execution_env: Some(execution_env),
+        },
+        RunResourceOverrides::default(),
+    )
+}
+
+#[test]
+fn test_rust_env_writable_rejects_sensitive_and_usr_local_paths() {
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let cfg = sandbox_config();
+
+    for (key, value) in [
+        (csa_core::env::CARGO_HOME_ENV_KEY, "/etc"),
+        (csa_core::env::RUSTUP_HOME_ENV_KEY, "/usr/local"),
+        (csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY, "/boot"),
+        (csa_core::env::MISE_CONFIG_DIR_ENV_KEY, "/run/csa-mise"),
+    ] {
+        let execution_env = HashMap::from([(key.to_string(), value.to_string())]);
+        let result =
+            resolve_sandbox_options_with_execution_env(&cfg, project_root.path(), &execution_env);
+
+        assert!(
+            matches!(
+                result,
+                SandboxResolution::RequiredButUnavailable(ref message)
+                    if message.contains("Rust state env writable paths validation failed")
+                        && message.contains(value)
+            ),
+            "{key}={value} should be rejected before being granted writable sandbox access"
+        );
+    }
+}
+
+#[test]
+fn test_rust_env_writable_creates_missing_safe_directory_before_sandbox_launch() {
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let cargo_home = project_root.path().join(".cache/csa-cargo");
+    let cfg = sandbox_config();
+    let execution_env = HashMap::from([(
+        csa_core::env::CARGO_HOME_ENV_KEY.to_string(),
+        cargo_home.to_string_lossy().into_owned(),
+    )]);
+
+    let result =
+        resolve_sandbox_options_with_execution_env(&cfg, project_root.path(), &execution_env);
+
+    let SandboxResolution::Ok(opts) = result else {
+        panic!("Expected fresh Rust env writable path to be prepared before sandbox launch");
+    };
+    assert!(
+        cargo_home.is_dir(),
+        "missing Rust env writable directory should be created"
+    );
+
+    let sandbox = opts.sandbox.expect("expected sandbox context");
+    assert!(
+        sandbox
+            .isolation_plan
+            .writable_paths
+            .contains(&cargo_home.canonicalize().unwrap()),
+        "created Rust env path should be granted writable access, got: {:?}",
+        sandbox.isolation_plan.writable_paths
+    );
+}
+
+#[test]
+fn test_rust_env_writable_preserves_explicit_safe_values() {
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let rust_state = project_root.path().join("rust-state");
+    let cargo_home = rust_state.join("cargo-home");
+    let rustup_home = rust_state.join("rustup-home");
+    let cargo_install_root = rust_state.join("cargo-install-root");
+    let mise_config = rust_state.join("mise-config");
+    for path in [&cargo_home, &rustup_home, &cargo_install_root, &mise_config] {
+        std::fs::create_dir_all(path).expect("create explicit Rust env dir");
+    }
+    let cfg = sandbox_config();
+    let execution_env = HashMap::from([
+        (
+            csa_core::env::CARGO_HOME_ENV_KEY.to_string(),
+            cargo_home.to_string_lossy().into_owned(),
+        ),
+        (
+            csa_core::env::RUSTUP_HOME_ENV_KEY.to_string(),
+            rustup_home.to_string_lossy().into_owned(),
+        ),
+        (
+            csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY.to_string(),
+            cargo_install_root.to_string_lossy().into_owned(),
+        ),
+        (
+            csa_core::env::MISE_CONFIG_DIR_ENV_KEY.to_string(),
+            mise_config.to_string_lossy().into_owned(),
+        ),
+    ]);
+
+    let result =
+        resolve_sandbox_options_with_execution_env(&cfg, project_root.path(), &execution_env);
+
+    let SandboxResolution::Ok(opts) = result else {
+        panic!("Expected explicit safe Rust env writable paths to be preserved");
+    };
+    let sandbox = opts.sandbox.expect("expected sandbox context");
+    for path in [&cargo_home, &rustup_home, &cargo_install_root, &mise_config] {
+        assert!(
+            sandbox
+                .isolation_plan
+                .writable_paths
+                .contains(&path.canonicalize().unwrap()),
+            "explicit Rust env path {} should be granted writable access, got: {:?}",
+            path.display(),
+            sandbox.isolation_plan.writable_paths
+        );
+    }
 }
 
 /// CLI --extra-writable paths are appended to writable_paths (APPEND semantics).

--- a/crates/cli-sub-agent/src/pipeline_sandbox_memory_override_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_memory_override_tests.rs
@@ -60,6 +60,7 @@ fn resolve_with_memory_override(
             readonly_project_root: false,
             extra_writable: &[],
             extra_readable: &[],
+            execution_env: None,
         },
         crate::run_resource_overrides::RunResourceOverrides::new(Some(memory_max_mb), None),
     )

--- a/crates/cli-sub-agent/src/pipeline_sandbox_writable.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_writable.rs
@@ -1,8 +1,28 @@
+use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 
 use csa_config::ProjectConfig;
+use csa_resource::isolation_plan::IsolationPlanBuilder;
 use tracing::{info, warn};
+
+pub(crate) fn add_execution_env_writable_paths(
+    builder: IsolationPlanBuilder,
+    env: Option<&HashMap<String, String>>,
+    project_root: &Path,
+) -> Result<IsolationPlanBuilder, String> {
+    let Some(env) = env else {
+        return Ok(builder);
+    };
+    let paths = crate::pipeline_env::rust_session_writable_paths(env);
+    if paths.is_empty() {
+        return Ok(builder);
+    }
+    let paths = resolve_and_prepare_rust_env_writable_sources(&paths, project_root)?;
+    Ok(paths
+        .into_iter()
+        .fold(builder, IsolationPlanBuilder::with_writable_path))
+}
 
 pub(crate) fn resolve_and_prepare_writable_sources(
     paths: &[PathBuf],
@@ -26,6 +46,14 @@ pub(crate) fn resolve_and_prepare_writable_sources(
         }
     }
     Ok(prepared)
+}
+
+pub(crate) fn resolve_and_prepare_rust_env_writable_sources(
+    paths: &[PathBuf],
+    project_root: &Path,
+) -> Result<Vec<PathBuf>, String> {
+    reject_readonly_usr_local_rust_state_paths(paths)?;
+    resolve_and_prepare_writable_sources(paths, project_root, "Rust state env writable paths")
 }
 
 pub(crate) fn resolve_config_extra_writable_sources(
@@ -77,6 +105,23 @@ fn resolve_paths_with_extra(
         .map_err(|e| format!("Per-tool writable_paths validation failed for '{tool_name}': {e}"))?;
     resolved.extend(resolve_config_extra_writable_sources(config, project_root)?);
     Ok(resolved)
+}
+
+fn reject_readonly_usr_local_rust_state_paths(paths: &[PathBuf]) -> Result<(), String> {
+    let rejected = paths
+        .iter()
+        .filter(|path| csa_core::env::rust_state_path_needs_session_override(path))
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>();
+    if rejected.is_empty() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "Rust state env writable paths validation failed: rejected paths [{}]. \
+         Normalize read-only /usr/local Rust state env before granting sandbox write access",
+        rejected.join(", ")
+    ))
 }
 
 fn prepare_missing_source(

--- a/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
@@ -318,6 +318,7 @@ async fn prepare_session_runtime_inner(
         readonly_project_root: input.readonly_project_root,
         extra_writable: input.extra_writable,
         extra_readable: input.extra_readable,
+        execution_env: Some(&merged_env),
     };
     let mut execute_options = match crate::pipeline_sandbox::resolve_sandbox_options_with_overrides(
         sandbox_input,

--- a/crates/cli-sub-agent/src/pipeline_tests_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_env.rs
@@ -65,6 +65,132 @@ fn build_merged_env_preserves_current_path_for_tool_runtime_resolution() {
 }
 
 #[test]
+fn build_merged_env_normalizes_readonly_usr_local_rust_state() {
+    let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.blocking_lock();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let mise_data = temp.path().join("mise-data");
+    let mise_rust = mise_data.join("installs/rust/stable");
+    std::fs::create_dir_all(home.join(".cargo")).expect("create cargo home");
+    std::fs::create_dir_all(home.join(".config/mise")).expect("create mise config");
+    std::fs::create_dir_all(mise_rust.join("toolchains")).expect("create rust toolchains");
+    std::fs::write(mise_rust.join("settings.toml"), "version = \"12\"\n")
+        .expect("write rustup settings");
+    let _home = ScopedEnvVarRestore::set("HOME", home.to_str().expect("home utf8"));
+    let _cargo_home = ScopedEnvVarRestore::set(csa_core::env::CARGO_HOME_ENV_KEY, "/usr/local");
+    let _rustup_home = ScopedEnvVarRestore::set(csa_core::env::RUSTUP_HOME_ENV_KEY, "/usr/local");
+    let _cargo_install_root =
+        ScopedEnvVarRestore::set(csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY, "/usr/local");
+    let _mise_config =
+        ScopedEnvVarRestore::set(csa_core::env::MISE_CONFIG_DIR_ENV_KEY, "/usr/local");
+    let _mise_data = ScopedEnvVarRestore::set(
+        csa_core::env::MISE_DATA_DIR_ENV_KEY,
+        mise_data.to_str().expect("mise data utf8"),
+    );
+    let cfg = test_config_with_node_heap_limit(None);
+
+    let merged = crate::pipeline_env::build_merged_env(MergedEnvRequest {
+        extra_env: None,
+        config: Some(&cfg),
+        global_config: None,
+        tool_name: "codex",
+        current_depth: 0,
+        pattern_internal: false,
+        allow_git_push: false,
+    });
+
+    assert_eq!(
+        merged
+            .get(csa_core::env::CARGO_HOME_ENV_KEY)
+            .map(String::as_str),
+        Some(home.join(".cargo").to_str().expect("cargo home utf8"))
+    );
+    assert_eq!(
+        merged
+            .get(csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY)
+            .map(String::as_str),
+        Some(home.join(".cargo").to_str().expect("cargo home utf8"))
+    );
+    assert_eq!(
+        merged
+            .get(csa_core::env::RUSTUP_HOME_ENV_KEY)
+            .map(String::as_str),
+        Some(mise_rust.to_str().expect("mise rust utf8"))
+    );
+    assert_eq!(
+        merged
+            .get(csa_core::env::MISE_CONFIG_DIR_ENV_KEY)
+            .map(String::as_str),
+        Some(home.join(".config/mise").to_str().expect("mise config utf8"))
+    );
+}
+
+#[test]
+fn build_merged_env_preserves_explicit_writable_rust_state() {
+    let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.blocking_lock();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let cargo_home = temp.path().join("explicit-cargo");
+    let rustup_home = temp.path().join("explicit-rustup");
+    let cargo_install_root = temp.path().join("explicit-install");
+    let mise_config = temp.path().join("explicit-mise-config");
+    for dir in [&home, &cargo_home, &rustup_home, &cargo_install_root, &mise_config] {
+        std::fs::create_dir_all(dir).expect("create explicit env dir");
+    }
+    let _home = ScopedEnvVarRestore::set("HOME", home.to_str().expect("home utf8"));
+    let _ambient_cargo =
+        ScopedEnvVarRestore::set(csa_core::env::CARGO_HOME_ENV_KEY, "/usr/local");
+    let _ambient_rustup =
+        ScopedEnvVarRestore::set(csa_core::env::RUSTUP_HOME_ENV_KEY, "/usr/local");
+    let cfg = test_config_with_node_heap_limit(None);
+    let extra_env = HashMap::from([
+        (
+            csa_core::env::CARGO_HOME_ENV_KEY.to_string(),
+            cargo_home.to_string_lossy().into_owned(),
+        ),
+        (
+            csa_core::env::RUSTUP_HOME_ENV_KEY.to_string(),
+            rustup_home.to_string_lossy().into_owned(),
+        ),
+        (
+            csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY.to_string(),
+            cargo_install_root.to_string_lossy().into_owned(),
+        ),
+        (
+            csa_core::env::MISE_CONFIG_DIR_ENV_KEY.to_string(),
+            mise_config.to_string_lossy().into_owned(),
+        ),
+    ]);
+
+    let merged = crate::pipeline_env::build_merged_env(MergedEnvRequest {
+        extra_env: Some(&extra_env),
+        config: Some(&cfg),
+        global_config: None,
+        tool_name: "codex",
+        current_depth: 0,
+        pattern_internal: false,
+        allow_git_push: false,
+    });
+
+    assert_eq!(
+        merged.get(csa_core::env::CARGO_HOME_ENV_KEY),
+        extra_env.get(csa_core::env::CARGO_HOME_ENV_KEY)
+    );
+    assert_eq!(
+        merged.get(csa_core::env::RUSTUP_HOME_ENV_KEY),
+        extra_env.get(csa_core::env::RUSTUP_HOME_ENV_KEY)
+    );
+    assert_eq!(
+        merged.get(csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY),
+        extra_env.get(csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY)
+    );
+    assert_eq!(
+        merged.get(csa_core::env::MISE_CONFIG_DIR_ENV_KEY),
+        extra_env.get(csa_core::env::MISE_CONFIG_DIR_ENV_KEY)
+    );
+}
+
+#[test]
 fn build_merged_env_disables_gemini_direct_launch_in_tests() {
     let cfg = test_config_with_node_heap_limit(None);
 

--- a/crates/csa-core/src/env.rs
+++ b/crates/csa-core/src/env.rs
@@ -1,6 +1,21 @@
 /// Reserved executor env var that disables automatic runtime failover/retry paths.
 pub const NO_FAILOVER_ENV_KEY: &str = "_CSA_NO_FAILOVER";
 
+/// Cargo state/cache root.
+pub const CARGO_HOME_ENV_KEY: &str = "CARGO_HOME";
+
+/// Rustup state/toolchain root.
+pub const RUSTUP_HOME_ENV_KEY: &str = "RUSTUP_HOME";
+
+/// Cargo install root used by `cargo install`.
+pub const CARGO_INSTALL_ROOT_ENV_KEY: &str = "CARGO_INSTALL_ROOT";
+
+/// mise configuration directory.
+pub const MISE_CONFIG_DIR_ENV_KEY: &str = "MISE_CONFIG_DIR";
+
+/// mise data directory, which commonly contains installed toolchains.
+pub const MISE_DATA_DIR_ENV_KEY: &str = "MISE_DATA_DIR";
+
 /// Exact model spec inherited by nested CSA invocations in a pinned SA subtree.
 pub const CSA_MODEL_SPEC_ENV_KEY: &str = "CSA_MODEL_SPEC";
 
@@ -50,6 +65,55 @@ pub fn strip_git_push_authorization_keys(env: &mut std::collections::HashMap<Str
     for key in GIT_PUSH_AUTHORIZATION_ENV_KEYS {
         env.remove(*key);
     }
+}
+
+/// Return true when a Rust toolchain state path should be overridden before
+/// spawning a CSA session.
+///
+/// `/usr/local` is a tool-install prefix on the shared hosts CSA commonly runs
+/// on, not a writable Cargo/Rustup state root. Descendants under `/usr/local`
+/// are allowed only when the current namespace can write there; this preserves
+/// intentionally mounted mise Rust homes such as
+/// `/usr/local/share/mise/installs/rust/stable`.
+pub fn rust_state_path_needs_session_override(path: &std::path::Path) -> bool {
+    let usr_local = std::path::Path::new("/usr/local");
+    if path == usr_local {
+        return true;
+    }
+    path.starts_with(usr_local) && !rust_state_path_is_writable(path)
+}
+
+fn rust_state_path_is_writable(path: &std::path::Path) -> bool {
+    let dir = if path.is_dir() {
+        path
+    } else if let Some(parent) = path.parent() {
+        parent
+    } else {
+        return false;
+    };
+    if !dir.is_dir() {
+        return false;
+    }
+
+    for attempt in 0..8 {
+        let probe = dir.join(format!(
+            ".csa-rust-env-probe-{}-{attempt}",
+            std::process::id()
+        ));
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&probe)
+        {
+            Ok(_) => {
+                let _ = std::fs::remove_file(&probe);
+                return true;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(_) => return false,
+        }
+    }
+    false
 }
 
 /// Marker that a CSA command runs INSIDE a weave pattern pipeline (`csa plan
@@ -266,6 +330,20 @@ mod tests {
             );
         }
         assert_eq!(env.get("KEEP_ME").map(String::as_str), Some("value"));
+    }
+
+    #[test]
+    fn rust_state_path_exact_usr_local_needs_session_override() {
+        assert!(rust_state_path_needs_session_override(
+            std::path::Path::new("/usr/local")
+        ));
+    }
+
+    #[test]
+    fn rust_state_path_outside_usr_local_does_not_need_session_override() {
+        assert!(!rust_state_path_needs_session_override(
+            std::path::Path::new("/tmp/csa-rust-home")
+        ));
     }
 
     #[test]

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -277,8 +277,8 @@ impl IsolationPlanBuilder {
             // where the directory doesn't exist yet, we add it anyway so bwrap
             // can create it (the parent must exist).
             let default_cargo_home = home.join(".cargo");
-            if let Ok(cargo_home_env) = std::env::var("CARGO_HOME") {
-                let cargo_home = PathBuf::from(&cargo_home_env);
+            if let Ok(cargo_home_env) = std::env::var(csa_core::env::CARGO_HOME_ENV_KEY) {
+                let cargo_home = rust_state_path_or_default(&cargo_home_env, &default_cargo_home);
                 if cargo_home == default_cargo_home {
                     // CARGO_HOME points to the default — treat as if unset.
                     add_dir_or_creatable_parent(&mut self.writable_paths, &default_cargo_home);
@@ -295,8 +295,8 @@ impl IsolationPlanBuilder {
             // (downloading components, updating toolchains). Same pattern as
             // CARGO_HOME: when explicitly set elsewhere, don't expose ~/.rustup.
             let default_rustup = home.join(".rustup");
-            if let Ok(rustup_home) = std::env::var("RUSTUP_HOME") {
-                let rustup_path = PathBuf::from(&rustup_home);
+            if let Ok(rustup_home) = std::env::var(csa_core::env::RUSTUP_HOME_ENV_KEY) {
+                let rustup_path = rust_state_path_or_default(&rustup_home, &default_rustup);
                 if rustup_path == default_rustup {
                     add_dir_or_creatable_parent(&mut self.writable_paths, &default_rustup);
                 } else {
@@ -438,6 +438,15 @@ fn sandbox_tmpdir_for_capability(filesystem: FilesystemCapability, session_dir: 
     }
 }
 
+fn rust_state_path_or_default(value: &str, default: &Path) -> PathBuf {
+    let path = PathBuf::from(value);
+    if value.trim().is_empty() || csa_core::env::rust_state_path_needs_session_override(&path) {
+        default.to_path_buf()
+    } else {
+        path
+    }
+}
+
 /// Add `dir` to `paths` if it exists, otherwise pre-create it when a
 /// non-root ancestor exists (bwrap `--bind` requires the source path to exist).
 ///
@@ -495,6 +504,10 @@ mod tests;
 #[cfg(test)]
 #[path = "isolation_plan_path_tests.rs"]
 mod path_tests;
+
+#[cfg(test)]
+#[path = "isolation_plan_rust_env_tests.rs"]
+mod rust_env_tests;
 
 #[cfg(test)]
 #[path = "isolation_plan_claude_tests.rs"]

--- a/crates/csa-resource/src/isolation_plan_rust_env_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_rust_env_tests.rs
@@ -1,0 +1,67 @@
+use super::*;
+use std::{ffi::OsString, path::PathBuf};
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: test holds ENV_LOCK while mutating process environment.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, previous }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: test holds ENV_LOCK while mutating process environment.
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        // SAFETY: guard lifetime is contained by the locked test section.
+        unsafe {
+            if let Some(value) = &self.previous {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+}
+
+#[test]
+fn tool_defaults_do_not_expose_usr_local_as_rust_state_home() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(home.join(".cargo")).unwrap();
+    std::fs::create_dir_all(home.join(".rustup")).unwrap();
+    let _home = ScopedEnvVar::set("HOME", &home);
+    let _xdg = ScopedEnvVar::unset("XDG_STATE_HOME");
+    let _cargo_home = ScopedEnvVar::set(csa_core::env::CARGO_HOME_ENV_KEY, "/usr/local");
+    let _rustup_home = ScopedEnvVar::set(csa_core::env::RUSTUP_HOME_ENV_KEY, "/usr/local");
+
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_tool_defaults(
+            "claude-code",
+            &PathBuf::from("/tmp/project"),
+            &PathBuf::from("/tmp/session"),
+        )
+        .build()
+        .expect("should succeed");
+
+    assert!(plan.writable_paths.contains(&home.join(".cargo")));
+    assert!(plan.writable_paths.contains(&home.join(".rustup")));
+    assert!(!plan.writable_paths.contains(&PathBuf::from("/usr/local")));
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.994"
-weave = "0.1.994"
+csa = "0.1.995"
+weave = "0.1.995"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Closes #2090.

This PR prevents Rust CSA sessions from inheriting read-only Cargo/Rustup state homes such as `/usr/local` while preserving `/ssd` build targets.

- Normalizes read-only inherited Rust write-state env before execution.
- Preserves explicit safe writable user env values and `CARGO_TARGET_DIR`.
- Aligns sandbox writable paths with the normalized child env.
- Validates/prepares env-derived Rust writable paths through the same sandbox helper used for explicit writable paths.
- Rejects sensitive system paths and pre-creates safe cold-start directories before bwrap/Landlock grants.
- Bumps workspace version to `0.1.995` and updates `weave.lock` stamps.

## Local validation

- `cargo test -p csa-core rust_state_path -- --nocapture` — PASS
- `cargo test -p cli-sub-agent build_merged_env -- --nocapture` — PASS
- `cargo test -p cli-sub-agent test_csa_state_paths -- --nocapture` — PASS
- `cargo test -p cli-sub-agent run_memory_override -- --nocapture` — PASS
- `cargo test -p csa-resource tool_defaults_do_not_expose_usr_local_as_rust_state_home -- --nocapture` — PASS
- `cargo test -p cli-sub-agent rust_env_writable -- --nocapture` — PASS
- `cargo check -p csa-core -p csa-resource -p cli-sub-agent` — PASS
- `git diff --check && git diff --cached --check` — PASS
- `just find-monolith-files` — PASS with existing #1880 baseline warning only
- Hook-enabled commit/amend quality gates — PASS

## Review

- Exact-head pinned Codex review: `01KV1B21X1EZRYAM66C93NYWE2` — PASS
- `csa review --check-verdict --sa-mode true --range main...HEAD` — PASS/CLEAN

## Notes

- GitHub CI is intentionally not watched/gated; local `just`/lefthook and exact-head review are the gate.
- CSA/Codex implementation retries for this issue hit 143 and are tracked separately in #2189 and #2190.
