### PR TITLE
fix(pr-bot): gate merges on version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.995"
+version = "0.1.996"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.995"
+version = "0.1.996"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot_2014.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot_2014.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 
 const MERGE_COMMAND: &str = r#"gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}"#;
+const VERSION_GATE_COMMAND: &str = r#"bash "${CSA_WORKFLOW_DIR:-patterns/pr-bot}/scripts/pre-merge-version-check.sh" "${REMOTE_NAME}" "${DEFAULT_BRANCH}""#;
+const PRE_MERGE_PUSH: &str = r#"git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}""#;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
@@ -63,6 +65,28 @@ fn pr_bot_final_merge_fails_closed_on_gh_merge_error() {
         for section in sections {
             assert_order(&section, "set -e", MERGE_COMMAND, path);
             assert_order(&section, MERGE_COMMAND, "MERGE_COMPLETED=true", path);
+        }
+    }
+}
+
+#[test]
+fn pr_bot_final_merge_runs_version_gate_before_push_and_merge() {
+    for path in [
+        "patterns/pr-bot/workflow.toml",
+        "patterns/pr-bot/PATTERN.md",
+    ] {
+        let text = artifact_text(path);
+        let sections = if path.ends_with("workflow.toml") {
+            vec![workflow_step(&text, 22), workflow_step(&text, 23)]
+        } else {
+            vec![
+                pattern_section(&text, "## Step 12: Final Merge"),
+                pattern_section(&text, "## Step 12b: Final Merge (Direct or Post-Rebase)"),
+            ]
+        };
+        for section in sections {
+            assert_order(&section, VERSION_GATE_COMMAND, PRE_MERGE_PUSH, path);
+            assert_order(&section, VERSION_GATE_COMMAND, MERGE_COMMAND, path);
         }
     }
 }

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -2132,8 +2132,7 @@ gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${CLEAN_BR
 
 Tool: bash
 OnFail: abort
-
-Merge and update the local default branch.
+Merge the clean PR.
 
 ```bash
 set -e
@@ -2148,6 +2147,7 @@ if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
   exit 1
 fi
 
+bash "${CSA_WORKFLOW_DIR:-patterns/pr-bot}/scripts/pre-merge-version-check.sh" "${REMOTE_NAME}" "${DEFAULT_BRANCH}"
 CSA_SKIP_REVIEW_CHECK=1 \
 CSA_SKIP_REVIEW_CHECK_REASON="pr-bot Step 12 pre-merge push" \
   git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
@@ -2164,7 +2164,7 @@ fi
 # shellcheck disable=SC2086
 gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}
 
-# --- Inline post-merge checkout (defense-in-depth for #1401) ---
+# Inline post-merge checkout.
 _SYNC_BRANCH="${DEFAULT_BRANCH:-}"
 if [ -z "${_SYNC_BRANCH}" ]; then
   _SYNC_BRANCH="$(git symbolic-ref refs/remotes/${REMOTE_NAME:-origin}/HEAD 2>/dev/null | sed "s@^refs/remotes/${REMOTE_NAME:-origin}/@@")"
@@ -2173,7 +2173,7 @@ if [ -n "${_SYNC_BRANCH}" ]; then
   git checkout "${_SYNC_BRANCH}" 2>/dev/null && git pull --ff-only "${REMOTE_NAME:-origin}" "${_SYNC_BRANCH}" 2>/dev/null || true
 fi
 
-# Write pr-bot completion marker (deterministic gate for pre-merge hook).
+# Write pr-bot completion marker.
 MARKER_REPO_SLUG="$(printf '%s' "${REPO_SLUG}" | tr '/' '_')"
 MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG}"
 mkdir -p "${MARKER_DIR}"
@@ -2193,8 +2193,7 @@ echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" requ
 
 Tool: bash
 OnFail: abort
-
-First-pass clean review or Step 10.5 post-rebase success: merge the existing PR directly.
+Merge the existing PR directly.
 
 ```bash
 set -e
@@ -2209,6 +2208,7 @@ if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
   exit 1
 fi
 
+bash "${CSA_WORKFLOW_DIR:-patterns/pr-bot}/scripts/pre-merge-version-check.sh" "${REMOTE_NAME}" "${DEFAULT_BRANCH}"
 CSA_SKIP_REVIEW_CHECK=1 \
 CSA_SKIP_REVIEW_CHECK_REASON="pr-bot Step 12b pre-merge push" \
   git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
@@ -2221,7 +2221,7 @@ fi
 # shellcheck disable=SC2086
 gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}
 
-# --- Inline post-merge checkout (defense-in-depth for #1401) ---
+# Inline post-merge checkout.
 _SYNC_BRANCH="${DEFAULT_BRANCH:-}"
 if [ -z "${_SYNC_BRANCH}" ]; then
   _SYNC_BRANCH="$(git symbolic-ref refs/remotes/${REMOTE_NAME:-origin}/HEAD 2>/dev/null | sed "s@^refs/remotes/${REMOTE_NAME:-origin}/@@")"
@@ -2230,7 +2230,7 @@ if [ -n "${_SYNC_BRANCH}" ]; then
   git checkout "${_SYNC_BRANCH}" 2>/dev/null && git pull --ff-only "${REMOTE_NAME:-origin}" "${_SYNC_BRANCH}" 2>/dev/null || true
 fi
 
-# Write pr-bot completion marker (deterministic gate for pre-merge hook).
+# Write pr-bot completion marker.
 MARKER_REPO_SLUG="$(printf '%s' "${REPO_SLUG}" | tr '/' '_')"
 MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG}"
 mkdir -p "${MARKER_DIR}"

--- a/patterns/pr-bot/scripts/pre-merge-version-check.sh
+++ b/patterns/pr-bot/scripts/pre-merge-version-check.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REMOTE_NAME="${1:-${REMOTE_NAME:-origin}}"
+DEFAULT_BRANCH="${2:-${DEFAULT_BRANCH:-main}}"
+
+if [ "${CSA_SKIP_VERSION_CHECK:-0}" = "1" ]; then
+  exit 0
+fi
+
+if [ ! -f Cargo.toml ]; then
+  echo "pr-bot version gate skipped: no Cargo.toml found"
+  exit 0
+fi
+
+if ! command -v just >/dev/null 2>&1; then
+  echo "ERROR: Cargo.toml exists but 'just' is unavailable; cannot run the pre-merge version gate." >&2
+  echo "Install just or run the repository version check before retrying pr-bot." >&2
+  exit 1
+fi
+
+if ! just --summary 2>/dev/null | tr ' ' '\n' | grep -qx 'check-version-bumped'; then
+  echo "ERROR: Cargo.toml exists but just target 'check-version-bumped' is unavailable." >&2
+  echo "Add a local version bump gate, or set CSA_SKIP_VERSION_CHECK=1 only for release automation." >&2
+  exit 1
+fi
+
+if [ -z "${REMOTE_NAME}" ] || [ -z "${DEFAULT_BRANCH}" ]; then
+  echo "ERROR: REMOTE_NAME and DEFAULT_BRANCH are required for the pre-merge version gate." >&2
+  exit 1
+fi
+
+if ! git fetch --quiet "${REMOTE_NAME}" "refs/heads/${DEFAULT_BRANCH}:refs/heads/${DEFAULT_BRANCH}"; then
+  echo "ERROR: Could not refresh ${REMOTE_NAME}/${DEFAULT_BRANCH} before the pre-merge version gate." >&2
+  echo "Run:  git fetch ${REMOTE_NAME} ${DEFAULT_BRANCH}:${DEFAULT_BRANCH}" >&2
+  exit 1
+fi
+
+if ! just check-version-bumped; then
+  echo "" >&2
+  echo "==========================================" >&2
+  echo "BLOCKED: pre-merge version bump gate failed." >&2
+  echo "==========================================" >&2
+  echo "" >&2
+  echo "The PR branch version still matches ${DEFAULT_BRANCH} after refreshing from ${REMOTE_NAME}." >&2
+  echo "Run:  just bump-patch" >&2
+  echo "Then rerun pr-bot so review and merge use the bumped HEAD." >&2
+  echo "" >&2
+  exit 1
+fi

--- a/patterns/pr-bot/scripts/tests/pre-merge-version-check-tests.sh
+++ b/patterns/pr-bot/scripts/tests/pre-merge-version-check-tests.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+SCRIPT_PATH="${ROOT_DIR}/patterns/pr-bot/scripts/pre-merge-version-check.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+write_cargo_version() {
+  local repo_dir="$1"
+  local version="$2"
+  cat >"${repo_dir}/Cargo.toml" <<EOF
+[workspace]
+members = []
+
+[workspace.package]
+version = "${version}"
+edition = "2024"
+EOF
+}
+
+make_fake_just() {
+  local stub_dir="$1"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/just" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+read_version() {
+  sed -n 's/^version = "\(.*\)"/\1/p' "$1" | head -1
+}
+
+case "${1:-}" in
+  --summary)
+    echo "check-version-bumped"
+    ;;
+  check-version-bumped)
+    current="$(read_version Cargo.toml)"
+    main_version="$(git show main:Cargo.toml | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)"
+    if [ "${current}" = "${main_version}" ]; then
+      echo "Version (${current}) matches main. Run 'just bump-patch' before pushing." >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "unexpected just invocation: $*" >&2
+    exit 2
+    ;;
+esac
+EOF
+  chmod +x "${stub_dir}/just"
+}
+
+make_repo() {
+  local case_dir="$1"
+  local repo_dir="${case_dir}/repo"
+  local remote_dir="${case_dir}/remote"
+
+  mkdir -p "${remote_dir}"
+  git init "${remote_dir}" >/dev/null 2>&1
+  git -C "${remote_dir}" config user.name "Remote User"
+  git -C "${remote_dir}" config user.email "remote@example.com"
+  write_cargo_version "${remote_dir}" "1.0.0"
+  git -C "${remote_dir}" add Cargo.toml
+  git -C "${remote_dir}" commit -m "init" >/dev/null 2>&1
+  git -C "${remote_dir}" branch -M main
+
+  git clone "${remote_dir}" "${repo_dir}" >/dev/null 2>&1
+  git -C "${repo_dir}" config user.name "Test User"
+  git -C "${repo_dir}" config user.email "test@example.com"
+  git -C "${repo_dir}" checkout -b fix/version-gate >/dev/null 2>&1
+
+  printf '%s\n' "${repo_dir}"
+}
+
+advance_remote_main() {
+  local case_dir="$1"
+  local remote_dir="${case_dir}/remote"
+  local version="$2"
+
+  write_cargo_version "${remote_dir}" "${version}"
+  git -C "${remote_dir}" add Cargo.toml
+  git -C "${remote_dir}" commit -m "bump main" >/dev/null 2>&1
+}
+
+assert_main_version() {
+  local repo_dir="$1"
+  local expected="$2"
+  local actual
+  actual="$(git -C "${repo_dir}" show main:Cargo.toml | sed -n 's/^version = "\(.*\)"/\1/p' | head -1)"
+  if [ "${actual}" != "${expected}" ]; then
+    echo "expected local main version ${expected}, got ${actual}" >&2
+    exit 1
+  fi
+}
+
+run_stale_main_blocks_test() {
+  local case_dir="${TMP_ROOT}/stale-main-blocks"
+  local stub_dir="${case_dir}/bin"
+  local repo_dir
+  local stderr_file="${case_dir}/stderr.txt"
+  mkdir -p "${case_dir}"
+  repo_dir="$(make_repo "${case_dir}")"
+  make_fake_just "${stub_dir}"
+
+  write_cargo_version "${repo_dir}" "1.0.1"
+  git -C "${repo_dir}" add Cargo.toml
+  git -C "${repo_dir}" commit -m "feature bump" >/dev/null 2>&1
+  advance_remote_main "${case_dir}" "1.0.1"
+
+  set +e
+  (
+    cd "${repo_dir}"
+    PATH="${stub_dir}:${PATH}" bash "${SCRIPT_PATH}" origin main
+  ) >"${case_dir}/stdout.txt" 2>"${stderr_file}"
+  rc=$?
+  set -e
+
+  if [ "${rc}" -eq 0 ]; then
+    echo "expected stale-main version gate to block" >&2
+    exit 1
+  fi
+  grep -q "BLOCKED: pre-merge version bump gate failed" "${stderr_file}"
+  grep -q "Run:  just bump-patch" "${stderr_file}"
+  assert_main_version "${repo_dir}" "1.0.1"
+}
+
+run_bumped_version_passes_test() {
+  local case_dir="${TMP_ROOT}/bumped-version-passes"
+  local stub_dir="${case_dir}/bin"
+  local repo_dir
+  local stderr_file="${case_dir}/stderr.txt"
+  mkdir -p "${case_dir}"
+  repo_dir="$(make_repo "${case_dir}")"
+  make_fake_just "${stub_dir}"
+
+  advance_remote_main "${case_dir}" "1.0.1"
+  write_cargo_version "${repo_dir}" "1.0.2"
+  git -C "${repo_dir}" add Cargo.toml
+  git -C "${repo_dir}" commit -m "feature bump" >/dev/null 2>&1
+
+  (
+    cd "${repo_dir}"
+    PATH="${stub_dir}:${PATH}" bash "${SCRIPT_PATH}" origin main
+  ) >"${case_dir}/stdout.txt" 2>"${stderr_file}"
+
+  if grep -q "BLOCKED: pre-merge version bump gate failed" "${stderr_file}"; then
+    echo "green path unexpectedly emitted block diagnostic" >&2
+    exit 1
+  fi
+  assert_main_version "${repo_dir}" "1.0.1"
+}
+
+run_stale_main_blocks_test
+run_bumped_version_passes_test
+
+echo "pre-merge-version-check tests: PASS"

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -2626,8 +2626,7 @@ tool = "bash"
 prompt = '''
 > **Layer**: 0 (Orchestrator) -- final merge command, no code analysis.
 
-
-Merge and update the local default branch.
+Merge the clean PR.
 
 ```bash
 set -e
@@ -2642,6 +2641,7 @@ if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
   exit 1
 fi
 
+bash "${CSA_WORKFLOW_DIR:-patterns/pr-bot}/scripts/pre-merge-version-check.sh" "${REMOTE_NAME}" "${DEFAULT_BRANCH}"
 CSA_SKIP_REVIEW_CHECK=1 \
 CSA_SKIP_REVIEW_CHECK_REASON="pr-bot Step 12 pre-merge push" \
   git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
@@ -2658,7 +2658,7 @@ fi
 # shellcheck disable=SC2086
 gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}
 
-# --- Inline post-merge checkout (defense-in-depth for #1401) ---
+# Inline post-merge checkout.
 _SYNC_BRANCH="${DEFAULT_BRANCH:-}"
 if [ -z "${_SYNC_BRANCH}" ]; then
   _SYNC_BRANCH="$(git symbolic-ref refs/remotes/${REMOTE_NAME:-origin}/HEAD 2>/dev/null | sed "s@^refs/remotes/${REMOTE_NAME:-origin}/@@")"
@@ -2667,7 +2667,7 @@ if [ -n "${_SYNC_BRANCH}" ]; then
   git checkout "${_SYNC_BRANCH}" 2>/dev/null && git pull --ff-only "${REMOTE_NAME:-origin}" "${_SYNC_BRANCH}" 2>/dev/null || true
 fi
 
-# Write pr-bot completion marker (deterministic gate for pre-merge hook).
+# Write pr-bot completion marker.
 MARKER_REPO_SLUG="$(printf '%s' "${REPO_SLUG}" | tr '/' '_')"
 MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG}"
 mkdir -p "${MARKER_DIR}"
@@ -2688,8 +2688,7 @@ tool = "bash"
 prompt = '''
 > **Layer**: 0 (Orchestrator) -- direct merge, no code analysis needed.
 
-
-First-pass clean review or Step 10.5 post-rebase success: merge the existing PR directly.
+Merge the existing PR directly.
 
 ```bash
 set -e
@@ -2704,6 +2703,7 @@ if [ "${REBASE_REVIEW_HAS_ISSUES}" = "true" ]; then
   exit 1
 fi
 
+bash "${CSA_WORKFLOW_DIR:-patterns/pr-bot}/scripts/pre-merge-version-check.sh" "${REMOTE_NAME}" "${DEFAULT_BRANCH}"
 CSA_SKIP_REVIEW_CHECK=1 \
 CSA_SKIP_REVIEW_CHECK_REASON="pr-bot Step 12b pre-merge push" \
   git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
@@ -2716,7 +2716,7 @@ fi
 # shellcheck disable=SC2086
 gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}
 
-# --- Inline post-merge checkout (defense-in-depth for #1401) ---
+# Inline post-merge checkout.
 _SYNC_BRANCH="${DEFAULT_BRANCH:-}"
 if [ -z "${_SYNC_BRANCH}" ]; then
   _SYNC_BRANCH="$(git symbolic-ref refs/remotes/${REMOTE_NAME:-origin}/HEAD 2>/dev/null | sed "s@^refs/remotes/${REMOTE_NAME:-origin}/@@")"
@@ -2725,7 +2725,7 @@ if [ -n "${_SYNC_BRANCH}" ]; then
   git checkout "${_SYNC_BRANCH}" 2>/dev/null && git pull --ff-only "${REMOTE_NAME:-origin}" "${_SYNC_BRANCH}" 2>/dev/null || true
 fi
 
-# Write pr-bot completion marker (deterministic gate for pre-merge hook).
+# Write pr-bot completion marker.
 MARKER_REPO_SLUG="$(printf '%s' "${REPO_SLUG}" | tr '/' '_')"
 MARKER_DIR="${HOME}/.local/state/cli-sub-agent/pr-bot-markers/${MARKER_REPO_SLUG}"
 mkdir -p "${MARKER_DIR}"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.995"
-weave = "0.1.995"
+csa = "0.1.996"
+weave = "0.1.996"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Closes #2088.

This PR adds a deterministic local version-bump gate to pr-bot before it can merge a PR.

- Adds `patterns/pr-bot/scripts/pre-merge-version-check.sh`.
- Runs that gate in both final pr-bot merge paths before pre-merge push / `gh pr merge`.
- Keeps `patterns/pr-bot/PATTERN.md` and `patterns/pr-bot/workflow.toml` synchronized.
- Adds shell regression coverage for stale-main/same-version blocking and bumped-version success.
- Adds Rust workflow-order coverage to ensure the gate runs before push/merge.
- Bumps workspace version to `0.1.996` and updates `weave.lock` stamps.

## Local validation

- `bash patterns/pr-bot/scripts/tests/pre-merge-version-check-tests.sh` — PASS
- `cargo test -p cli-sub-agent tests_pr_bot_2014::pr_bot_final_merge_runs_version_gate_before_push_and_merge -- --nocapture` — PASS
- `cargo fmt --package cli-sub-agent -- --check` — PASS
- `cargo check -p cli-sub-agent --bin csa` — PASS
- `git diff --check && git diff --cached --check` — PASS
- `just find-monolith-files` — PASS with existing #1880 baseline warnings only for pr-bot pattern files
- Hook-enabled commit quality gates — PASS

## Review

- Exact-head pinned Codex review: `01KV1DVQ1SJS5RJEB6YB2KFYXP` — PASS
- `csa review --check-verdict --sa-mode true --range main...HEAD` — PASS/CLEAN

## Notes

- GitHub CI is intentionally not watched/gated; local `just`/lefthook and exact-head review are the gate.
- Initial CSA implementation exited 143 during partial `just bump-patch`; this is tracked separately in #2192. Recovery used partial-version-bump handling and did not double-bump.
