### PR TITLE
fix(plan): surface mktd step failure details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "chrono",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.996"
+version = "0.1.997"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.996"
+version = "0.1.997"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure.rs
@@ -93,6 +93,9 @@ impl PlanFailureReport {
             if let Some(detail) = step.actionable_failure_detail() {
                 lines.push(format!("Failure detail: {detail}"));
             }
+            if let Some(hint) = step.recovery_hint() {
+                lines.push(format!("Recovery hint: {hint}"));
+            }
         }
         if let Some(recovery) = &self.recovery {
             lines.push(format!("Recovery status: {}", recovery.status.as_str()));
@@ -115,6 +118,9 @@ impl PlanFailureReport {
             details.push_str(&format!("\n### Step {}: {}\n\n", step.step_id, step.title));
             details.push_str(&format!("- Exit code: `{}`\n", step.exit_code));
             details.push_str(&format!("- Skipped: `{}`\n", step.skipped));
+            if let Some(hint) = step.recovery_hint() {
+                details.push_str(&format!("- Recovery hint: {hint}\n"));
+            }
             if let Some(command) = step.command.as_deref().filter(|value| !value.is_empty()) {
                 details.push_str("\nCommand:\n\n```bash\n");
                 details.push_str(command.trim_end());
@@ -147,14 +153,27 @@ impl PlanFailureReport {
 
 impl FailedPlanStep {
     fn actionable_failure_detail(&self) -> Option<String> {
-        self.stderr_excerpt
+        self.error
             .as_deref()
             .and_then(failure_detail::select_actionable_failure_line)
             .or_else(|| {
-                self.error
+                self.stderr_excerpt
                     .as_deref()
                     .and_then(failure_detail::select_actionable_failure_line)
             })
+    }
+
+    fn recovery_hint(&self) -> Option<&'static str> {
+        let command_mentions_mktd = self
+            .command
+            .as_deref()
+            .is_some_and(|command| command.contains("patterns/mktd/workflow.toml"));
+        if self.title.to_ascii_lowercase().contains("mktd") || command_mentions_mktd {
+            return Some(
+                "Inspect the mktd failure detail above, fix the reported mktd/TODO validation error, then rerun dev2merge. The parent structured output is the diagnostic source; hidden child transcripts should not be required.",
+            );
+        }
+        None
     }
 }
 

--- a/crates/cli-sub-agent/src/plan_cmd_failure_detail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_detail.rs
@@ -26,6 +26,7 @@ fn is_low_signal_failure_line(line: &str) -> bool {
         || line.starts_with("Exit code ")
         || (line.starts_with("Error: ") && line.contains(" step(s) failed"))
         || line.starts_with("stderr (last ")
+        || line.starts_with("stdout (last ")
         || line == "```text"
         || line == "```"
 }

--- a/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
@@ -152,6 +152,78 @@ fn failure_summary_surfaces_actionable_step_stderr() {
 }
 
 #[test]
+fn failure_summary_surfaces_mktd_stdout_for_post_2082_issue_body_shape() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let workflow_path = temp.path().join("workflow.toml");
+    let results = vec![StepResult {
+        step_id: 7,
+        title: "Plan with mktd".to_string(),
+        exit_code: 1,
+        duration_secs: 0.0,
+        skipped: false,
+        error: Some(
+            [
+                "Exit code 1",
+                "stderr (last 20 lines):",
+                "ERROR: mktd did not produce a TODO for branch fix/2086-require-commit-openai-fallback.",
+                "stdout (last 20 lines):",
+                "## Command",
+                "```bash",
+                "csa run --tool codex --tier tier-2-standard --allow-fallback --require-commit --prompt-file /dev/stdin",
+                "```",
+                "## Observed",
+                "```text",
+                "WARNING: csa run completed but run left uncommitted workspace mutations compared to start.",
+                "ERROR csa::pipeline: Tool 'openai-compat' is not installed.",
+                "Error: Tool 'openai-compat' is not installed or not in PATH",
+                "```",
+                "Error: 1 step(s) failed (1 execution, 0 unsupported-skip)",
+            ]
+            .join("\n"),
+        ),
+        output: None,
+        session_id: None,
+        command: Some("timeout -k 30 1800 csa plan run --sa-mode true patterns/mktd/workflow.toml --var FEATURE='Plan dev2merge for branch fix/2086'".to_string()),
+        stderr: Some(
+            "ERROR: mktd did not produce a TODO for branch fix/2086-require-commit-openai-fallback."
+                .to_string(),
+        ),
+    }];
+    let report = PlanFailureReport::from_results(
+        "dev2merge",
+        &workflow_path,
+        "1 step(s) failed".to_string(),
+        &results,
+        None,
+    );
+
+    let summary_line = report.summary_line("patterns/dev2merge/workflow.toml");
+    let summary_section = report.render_summary_section();
+    let details_section = report.render_details_section();
+
+    assert!(
+        summary_line.contains("detail=Error: Tool 'openai-compat' is not installed or not in PATH"),
+        "result summary should prefer concrete child mktd stdout over generic Step 7 gate text: {summary_line}"
+    );
+    assert!(
+        summary_section.contains(
+            "Failure detail: Error: Tool 'openai-compat' is not installed or not in PATH"
+        ),
+        "structured summary should expose concrete child mktd stdout detail: {summary_section}"
+    );
+    assert!(
+        summary_section.contains("Recovery hint: Inspect the mktd failure detail above"),
+        "structured summary should include an actionable mktd recovery hint: {summary_section}"
+    );
+    assert!(
+        details_section.contains("stdout (last 20 lines):")
+            && details_section.contains("--prompt-file /dev/stdin")
+            && details_section.contains("openai-compat"),
+        "details should preserve the post-#2082 issue-body shape and child failure context: {details_section}"
+    );
+}
+
+#[test]
 fn recovery_ignores_untracked_plan_journal_after_snapshot() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let project_root = temp.path().join("repo");

--- a/crates/cli-sub-agent/src/plan_cmd_step_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_step_failure.rs
@@ -2,8 +2,8 @@ use weave::compiler::PlanStep;
 
 use super::{StepResult, StepTarget};
 
-const STEP_FAILURE_STDERR_TAIL_LINES: usize = 20;
-const STEP_FAILURE_STDERR_TAIL_MAX_CHARS: usize = 4000;
+const STEP_FAILURE_STREAM_TAIL_LINES: usize = 20;
+const STEP_FAILURE_STREAM_TAIL_MAX_CHARS: usize = 4000;
 
 pub(super) fn describe_step_command(
     target: &StepTarget,
@@ -40,11 +40,19 @@ pub(super) fn describe_step_command(
     }
 }
 
-pub(super) fn format_step_failure_error(exit_code: i32, stderr: &str) -> String {
+pub(super) fn format_step_failure_error(exit_code: i32, stderr: &str, stdout: &str) -> String {
     let mut error = format!("Exit code {exit_code}");
-    if let Some(stderr_tail) = stderr_tail(stderr) {
+    let stderr_tail = stream_tail(stderr);
+    if let Some(stderr_tail) = &stderr_tail {
         error.push_str(&format!(
-            "\nstderr (last {STEP_FAILURE_STDERR_TAIL_LINES} lines):\n{stderr_tail}"
+            "\nstderr (last {STEP_FAILURE_STREAM_TAIL_LINES} lines):\n{stderr_tail}"
+        ));
+    }
+    if let Some(stdout_tail) =
+        stream_tail(stdout).filter(|tail| Some(tail.as_str()) != stderr_tail.as_deref())
+    {
+        error.push_str(&format!(
+            "\nstdout (last {STEP_FAILURE_STREAM_TAIL_LINES} lines):\n{stdout_tail}"
         ));
     }
     error
@@ -56,23 +64,27 @@ pub(super) fn serialize_step_result_json(result: &StepResult) -> String {
 }
 
 pub(super) fn stderr_tail(stderr: &str) -> Option<String> {
-    let mut lines = stderr
+    stream_tail(stderr)
+}
+
+fn stream_tail(stream: &str) -> Option<String> {
+    let mut lines = stream
         .lines()
         .filter(|line| !line.trim().is_empty())
         .rev()
-        .take(STEP_FAILURE_STDERR_TAIL_LINES)
+        .take(STEP_FAILURE_STREAM_TAIL_LINES)
         .collect::<Vec<_>>();
     if lines.is_empty() {
         return None;
     }
     lines.reverse();
     let mut tail = lines.join("\n");
-    if tail.len() > STEP_FAILURE_STDERR_TAIL_MAX_CHARS {
+    if tail.len() > STEP_FAILURE_STREAM_TAIL_MAX_CHARS {
         let keep_from = tail
             .char_indices()
             .rev()
             .find_map(|(idx, _)| {
-                (tail.len() - idx <= STEP_FAILURE_STDERR_TAIL_MAX_CHARS).then_some(idx)
+                (tail.len() - idx <= STEP_FAILURE_STREAM_TAIL_MAX_CHARS).then_some(idx)
             })
             .unwrap_or(0);
         tail = format!("...{}", &tail[keep_from..]);

--- a/crates/cli-sub-agent/src/plan_cmd_steps.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps.rs
@@ -585,8 +585,12 @@ pub(crate) async fn execute_step_with_workflow(
         .as_ref()
         .map(|outcome| outcome.stderr.as_str())
         .unwrap_or_default();
+    let failure_stdout = last_failure
+        .as_ref()
+        .map(|outcome| outcome.output.as_str())
+        .unwrap_or_default();
     let failure_stderr_tail = stderr_tail(failure_stderr);
-    let failure_error = format_step_failure_error(exit_code, failure_stderr);
+    let failure_error = format_step_failure_error(exit_code, failure_stderr, failure_stdout);
 
     // Handle on_fail
     match &step.on_fail {

--- a/crates/cli-sub-agent/src/plan_cmd_tests_step_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_step_failure.rs
@@ -52,3 +52,40 @@ async fn execute_step_failure_reports_stderr_tail() {
         "structured stderr excerpt must keep the same tail as the error summary: {stderr}"
     );
 }
+
+#[tokio::test]
+async fn execute_step_failure_reports_stdout_tail() {
+    let step = PlanStep {
+        id: 7,
+        title: "stdout failure".into(),
+        tool: Some("bash".into()),
+        prompt:
+            "```bash\nfor i in $(seq 1 25); do printf 'out-%02d\\n' \"$i\"; done\nprintf 'generic wrapper failure\\n' >&2\nexit 1\n```"
+                .into(),
+        tier: None,
+        depends_on: vec![],
+        on_fail: FailAction::Abort,
+        condition: None,
+        loop_var: None,
+        session: None,
+        workspace_access: None,
+    };
+    let vars = HashMap::new();
+    let tmp = tempfile::tempdir().unwrap();
+    let result = execute_step(&step, &vars, tmp.path(), None, None, None).await;
+
+    assert_eq!(result.exit_code, 1);
+    let error = result.error.as_deref().unwrap_or_default();
+    assert!(
+        error.contains("stdout (last 20 lines):"),
+        "failure summary must label stdout tail: {error}"
+    );
+    assert!(
+        error.contains("out-25"),
+        "failure summary must include final stdout line: {error}"
+    );
+    assert!(
+        !error.contains("out-01"),
+        "failure summary must keep only the stdout tail: {error}"
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.996"
-weave = "0.1.996"
+csa = "0.1.997"
+weave = "0.1.997"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Closes #2087.

This PR makes dev2merge/mktd Step 7 failures actionable instead of reporting only `exited 1`.

- Includes failed-step stdout tails in structured failure context alongside stderr.
- Makes plan failure summaries prefer the merged `StepResult.error` context so child-plan output is visible.
- Adds a targeted mktd/dev2merge recovery hint when Step 7 fails.
- Filters low-signal stdout/stderr section headers so actionable child errors are selected.
- Adds regression coverage for the post-#2082 issue-body shape and stdout/stderr failure-tail behavior.
- Bumps workspace version to `0.1.997` and updates lock/version stamps.

## Local validation

- `cargo test -p cli-sub-agent --bin csa failure_summary_surfaces_mktd_stdout_for_post_2082_issue_body_shape -- --nocapture` — PASS
- `cargo test -p cli-sub-agent --bin csa execute_step_failure_reports_stdout_tail -- --nocapture` — PASS
- `cargo test -p cli-sub-agent --bin csa execute_step_failure_reports_stderr_tail -- --nocapture` — PASS
- `cargo fmt --package cli-sub-agent -- --check` — PASS
- `cargo check -p cli-sub-agent --bin csa` — PASS
- `cargo run --quiet -p cli-sub-agent -- migrate --status` — PASS, pending migrations 0
- `git diff --check && git diff --cached --check` — PASS
- `just find-monolith-files` — PASS, 0 hard failures / 0 warnings
- Hook-enabled commit quality gates — PASS

## Review

- Exact-head pinned Codex review: `01KV1FQJ59E4BJEMZ42WP8CKC0` — PASS
- `csa review --check-verdict --sa-mode true --range main...HEAD` — PASS/CLEAN

## Notes

- GitHub CI is intentionally not watched/gated; local `just`/lefthook and exact-head review are the gate.
- Initial CSA implementation exited 143 while waiting on cargo build/package lock after useful WIP; this is tracked separately in #2194. Recovery used conservative fork-from salvage with serial validation.
