### PR TITLE
feat(xurl): add Hermes provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "chrono",
@@ -535,6 +535,7 @@ dependencies = [
  "libc",
  "proptest",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "serial_test",
@@ -703,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -724,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "chrono",
@@ -742,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -759,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "chrono",
@@ -773,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -801,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "chrono",
@@ -820,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "chrono",
@@ -835,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "axum",
@@ -858,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -877,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "chrono",
@@ -896,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -912,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "chrono",
@@ -930,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "chrono",
@@ -956,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4559,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.997"
+version = "0.1.998"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.997"
+version = "0.1.998"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -75,6 +75,7 @@ tempfile = "3.10"
 
 # Utilities
 regex = "1.11"
+rusqlite = { version = "0.37", features = ["bundled"] }
 sha2 = "0.10"
 glob = "0.3"
 ignore = "0.4"

--- a/crates/cli-sub-agent/Cargo.toml
+++ b/crates/cli-sub-agent/Cargo.toml
@@ -45,6 +45,7 @@ which.workspace = true
 glob.workspace = true
 ignore.workspace = true
 regex.workspace = true
+rusqlite.workspace = true
 sha2.workspace = true
 tokuin.workspace = true
 tree-sitter.workspace = true

--- a/crates/cli-sub-agent/src/cli_xurl.rs
+++ b/crates/cli-sub-agent/src/cli_xurl.rs
@@ -2,6 +2,8 @@
 #![allow(dead_code)]
 //! CLI subcommand for xurl thread queries.
 
+use std::path::PathBuf;
+
 use anyhow::Result;
 use clap::Subcommand;
 
@@ -13,9 +15,21 @@ pub enum XurlCommands {
         #[arg(long)]
         keyword: Option<String>,
 
-        /// Filter by provider (amp, codex, claude, gemini, pi, opencode)
+        /// Filter by provider (amp, codex, claude, gemini, pi, opencode, hermes)
         #[arg(long)]
         provider: Option<String>,
+
+        /// Working directory used by the Hermes provider (defaults to process cwd).
+        #[arg(long, value_name = "PATH")]
+        cwd: Option<PathBuf>,
+
+        /// Hermes home directory used by the Hermes provider (defaults to HERMES_HOME or ~/.hermes).
+        #[arg(long, value_name = "PATH")]
+        hermes_home: Option<PathBuf>,
+
+        /// Hermes profile used by the Hermes provider.
+        #[arg(long)]
+        hermes_profile: Option<String>,
 
         /// Maximum results per provider
         #[arg(long, default_value = "20")]
@@ -67,6 +81,22 @@ pub enum XurlCommands {
         /// With `--list` / `--keyword`: cap how many results to return.
         #[arg(long, default_value = "10")]
         limit: usize,
+
+        /// Provider-specific recall backend. Currently supports `hermes`.
+        #[arg(long)]
+        provider: Option<String>,
+
+        /// Working directory used by the Hermes provider (defaults to process cwd).
+        #[arg(long, value_name = "PATH")]
+        cwd: Option<PathBuf>,
+
+        /// Hermes home directory used by the Hermes provider (defaults to HERMES_HOME or ~/.hermes).
+        #[arg(long, value_name = "PATH")]
+        hermes_home: Option<PathBuf>,
+
+        /// Hermes profile used by the Hermes provider.
+        #[arg(long)]
+        hermes_profile: Option<String>,
     },
 }
 
@@ -88,7 +118,7 @@ fn parse_provider(s: &str) -> Result<xurl_core::ProviderKind> {
         "pi" => Ok(xurl_core::ProviderKind::Pi),
         "opencode" => Ok(xurl_core::ProviderKind::Opencode),
         _ => anyhow::bail!(
-            "Unknown provider: '{s}'. Valid: amp, codex, claude, gemini, pi, opencode"
+            "Unknown provider: '{s}'. Valid: amp, codex, claude, gemini, pi, opencode, hermes"
         ),
     }
 }

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -674,7 +674,7 @@ async fn run() -> Result<()> {
             exit_current_process(exit_code);
         }
         Commands::Health(args) => cli::handle_health(args)?,
-        Commands::Xurl { cmd } => xurl_cmd::handle_xurl(cmd)?,
+        Commands::Xurl { cmd } => xurl_cmd::handle_xurl(cmd, output_format)?,
         Commands::Recall(args) => recall_cmd::handle_recall(args.cmd)?,
         Commands::Hooks { cmd } => hooks_cmd::handle_hooks(cmd)?,
     }

--- a/crates/cli-sub-agent/src/recall_cmd.rs
+++ b/crates/cli-sub-agent/src/recall_cmd.rs
@@ -3,7 +3,7 @@
 #[path = "recall_cmd_keyword.rs"]
 mod keyword;
 #[path = "recall_cmd_pages.rs"]
-mod pages;
+pub(crate) mod pages;
 
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, IsTerminal, Write};
@@ -17,7 +17,7 @@ use tracing::debug;
 use crate::cli::RecallCommands;
 
 const HISTORY_FILE_NAME: &str = "main-agent-history.jsonl";
-const OUTPUT_GUARD_BYTES: usize = 50 * 1024;
+pub(crate) const OUTPUT_GUARD_BYTES: usize = 50 * 1024;
 const RECENT_DEDUP_WINDOW: usize = 10;
 const SEARCH_CONTEXT_LINES: usize = 2;
 
@@ -590,13 +590,17 @@ fn recent_duplicate_exists(history_path: &Path, sid: &str) -> Result<bool> {
 }
 
 fn output_guard_message(session_id: &str, content: &str) -> Option<String> {
+    output_guard_message_for_command(&format!("csa recall read {session_id}"), content)
+}
+
+pub(crate) fn output_guard_message_for_command(command: &str, content: &str) -> Option<String> {
     if content.len() < OUTPUT_GUARD_BYTES {
         return None;
     }
 
     let size_kb = content.len().div_ceil(1024);
     Some(format!(
-        "OUTPUT_TOO_LARGE: {size_kb}KB. Use: csa recall read {session_id} | tail -100"
+        "OUTPUT_TOO_LARGE: {size_kb}KB. Use: {command} | tail -100"
     ))
 }
 

--- a/crates/cli-sub-agent/src/recall_cmd_pages.rs
+++ b/crates/cli-sub-agent/src/recall_cmd_pages.rs
@@ -24,7 +24,7 @@ pub(super) fn is_compact_heading(line: &str) -> bool {
 ///
 /// Returns pages in chronological order. The caller maps user-facing page
 /// numbers (0 = newest) via [`resolve_page_index`].
-pub(super) fn split_markdown_pages(content: &str) -> Vec<String> {
+pub(crate) fn split_markdown_pages(content: &str) -> Vec<String> {
     let mut pages: Vec<String> = Vec::new();
     let mut current_start = 0usize;
 
@@ -62,7 +62,7 @@ fn line_byte_offsets(content: &str) -> impl Iterator<Item = (usize, &str)> {
 ///
 /// Page 0 = last (newest) page, page 1 = second-to-last, etc.
 /// Returns `None` if `page >= total`.
-pub(super) fn resolve_page_index(page: u32, total: usize) -> Option<usize> {
+pub(crate) fn resolve_page_index(page: u32, total: usize) -> Option<usize> {
     let n = page as usize;
     if n >= total {
         return None;

--- a/crates/cli-sub-agent/src/xurl_cmd.rs
+++ b/crates/cli-sub-agent/src/xurl_cmd.rs
@@ -6,18 +6,56 @@
 //! reach `crate::recall_cmd::*` without forcing those tests to declare every
 //! transitively referenced module.
 use anyhow::Result;
+use csa_core::types::OutputFormat;
 
 use crate::cli::XurlCommands;
 use crate::recall_cmd;
 
-pub fn handle_xurl(cmd: XurlCommands) -> Result<()> {
+#[path = "xurl_hermes.rs"]
+mod hermes;
+
+struct ThreadDispatch {
+    keyword: Option<String>,
+    provider: Option<String>,
+    cwd: Option<std::path::PathBuf>,
+    hermes_home: Option<std::path::PathBuf>,
+    hermes_profile: Option<String>,
+    limit: usize,
+    json: bool,
+}
+
+struct RecallDispatch {
+    keyword: Option<String>,
+    session: Option<String>,
+    page: Option<u32>,
+    list: bool,
+    all: bool,
+    limit: usize,
+    provider: Option<String>,
+    cwd: Option<std::path::PathBuf>,
+    hermes_home: Option<std::path::PathBuf>,
+    hermes_profile: Option<String>,
+}
+
+pub fn handle_xurl(cmd: XurlCommands, output_format: OutputFormat) -> Result<()> {
     match cmd {
         XurlCommands::Threads {
             keyword,
             provider,
+            cwd,
+            hermes_home,
+            hermes_profile,
             limit,
             json,
-        } => crate::cli::handle_threads(keyword, provider, limit, json),
+        } => handle_threads(ThreadDispatch {
+            keyword,
+            provider,
+            cwd,
+            hermes_home,
+            hermes_profile,
+            limit,
+            json: json || matches!(output_format, OutputFormat::Json),
+        }),
         XurlCommands::Recall {
             keyword,
             session,
@@ -25,18 +63,93 @@ pub fn handle_xurl(cmd: XurlCommands) -> Result<()> {
             list,
             all,
             limit,
-        } => handle_recall(keyword, session, page, list, all, limit),
+            provider,
+            cwd,
+            hermes_home,
+            hermes_profile,
+        } => handle_recall(RecallDispatch {
+            keyword,
+            session,
+            page,
+            list,
+            all,
+            limit,
+            provider,
+            cwd,
+            hermes_home,
+            hermes_profile,
+        }),
     }
 }
 
-fn handle_recall(
-    keyword: Option<String>,
-    session: Option<String>,
-    page: Option<u32>,
-    list: bool,
-    all: bool,
-    limit: usize,
-) -> Result<()> {
+fn handle_threads(args: ThreadDispatch) -> Result<()> {
+    let ThreadDispatch {
+        keyword,
+        provider,
+        cwd,
+        hermes_home,
+        hermes_profile,
+        limit,
+        json,
+    } = args;
+
+    if provider
+        .as_deref()
+        .is_some_and(|p| p.eq_ignore_ascii_case("hermes"))
+    {
+        return hermes::handle_threads(hermes::HermesThreadArgs {
+            keyword,
+            cwd,
+            hermes_home,
+            hermes_profile,
+            limit,
+            json,
+        });
+    }
+    if cwd.is_some() || hermes_home.is_some() || hermes_profile.is_some() {
+        anyhow::bail!("--cwd/--hermes-home/--hermes-profile require --provider hermes");
+    }
+    crate::cli::handle_threads(keyword, provider, limit, json)
+}
+
+fn handle_recall(args: RecallDispatch) -> Result<()> {
+    let RecallDispatch {
+        keyword,
+        session,
+        page,
+        list,
+        all,
+        limit,
+        provider,
+        cwd,
+        hermes_home,
+        hermes_profile,
+    } = args;
+
+    if provider
+        .as_deref()
+        .is_some_and(|p| p.eq_ignore_ascii_case("hermes"))
+    {
+        return hermes::handle_recall(hermes::HermesRecallArgs {
+            keyword,
+            session,
+            page,
+            list,
+            all,
+            limit,
+            cwd,
+            hermes_home,
+            hermes_profile,
+        });
+    }
+    if let Some(provider) = provider {
+        anyhow::bail!(
+            "csa xurl recall --provider currently supports only 'hermes'; got '{provider}'"
+        );
+    }
+    if cwd.is_some() || hermes_home.is_some() || hermes_profile.is_some() {
+        anyhow::bail!("--cwd/--hermes-home/--hermes-profile require --provider hermes");
+    }
     if list {
         return recall_cmd::handle_recall_list_cmd(limit, all);
     }

--- a/crates/cli-sub-agent/src/xurl_hermes.rs
+++ b/crates/cli-sub-agent/src/xurl_hermes.rs
@@ -1,0 +1,295 @@
+//! Hermes-backed xurl provider adapter.
+
+#[path = "xurl_hermes/db.rs"]
+mod db;
+#[path = "xurl_hermes/render.rs"]
+mod render;
+
+#[cfg(test)]
+#[path = "xurl_hermes/tests.rs"]
+mod tests;
+
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+const PROVIDER: &str = "hermes";
+const PREVIEW_WIDTH: usize = 80;
+const SEARCH_CONTEXT_LINES: usize = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CwdMatchKind {
+    Exact,
+    Ancestor,
+    Descendant,
+}
+
+impl CwdMatchKind {
+    fn rank(self) -> u8 {
+        match self {
+            Self::Exact => 0,
+            Self::Ancestor | Self::Descendant => 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HermesSession {
+    id: String,
+    title: Option<String>,
+    cwd: Option<PathBuf>,
+    source: String,
+    started_at: f64,
+    ended_at: Option<f64>,
+    message_count: i64,
+    match_kind: Option<CwdMatchKind>,
+    preview: Option<String>,
+}
+
+impl HermesSession {
+    fn updated_epoch(&self) -> f64 {
+        self.ended_at.unwrap_or(self.started_at)
+    }
+
+    fn updated_at(&self) -> Option<String> {
+        format_unix_seconds(self.ended_at.or(Some(self.started_at)))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HermesMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Clone)]
+struct HermesPaths {
+    state_db: PathBuf,
+    cwd: PathBuf,
+}
+
+pub(crate) struct HermesThreadArgs {
+    pub(crate) keyword: Option<String>,
+    pub(crate) cwd: Option<PathBuf>,
+    pub(crate) hermes_home: Option<PathBuf>,
+    pub(crate) hermes_profile: Option<String>,
+    pub(crate) limit: usize,
+    pub(crate) json: bool,
+}
+
+pub(crate) struct HermesRecallArgs {
+    pub(crate) keyword: Option<String>,
+    pub(crate) session: Option<String>,
+    pub(crate) page: Option<u32>,
+    pub(crate) list: bool,
+    pub(crate) all: bool,
+    pub(crate) limit: usize,
+    pub(crate) cwd: Option<PathBuf>,
+    pub(crate) hermes_home: Option<PathBuf>,
+    pub(crate) hermes_profile: Option<String>,
+}
+
+pub(crate) fn handle_threads(args: HermesThreadArgs) -> Result<()> {
+    let HermesThreadArgs {
+        keyword,
+        cwd,
+        hermes_home,
+        hermes_profile,
+        limit,
+        json,
+    } = args;
+
+    if limit == 0 {
+        anyhow::bail!("--limit must be greater than 0");
+    }
+
+    let paths = db::resolve_paths(
+        cwd.as_deref(),
+        hermes_home.as_deref(),
+        hermes_profile.as_deref(),
+    )?;
+    let conn = db::open_state_db(&paths.state_db)?;
+    let sessions = db::collect_sessions(
+        &conn,
+        &paths.cwd,
+        false,
+        keyword.as_deref(),
+        limit,
+        &paths.state_db,
+    )?;
+
+    if json {
+        println!("{}", render::threads_json(&sessions, &paths.state_db)?);
+    } else {
+        render::print_thread_table(&sessions);
+    }
+    Ok(())
+}
+
+pub(crate) fn handle_recall(args: HermesRecallArgs) -> Result<()> {
+    let HermesRecallArgs {
+        keyword,
+        session,
+        page,
+        list,
+        all,
+        limit,
+        cwd,
+        hermes_home,
+        hermes_profile,
+    } = args;
+
+    if limit == 0 {
+        anyhow::bail!("--limit must be greater than 0");
+    }
+
+    let paths = db::resolve_paths(
+        cwd.as_deref(),
+        hermes_home.as_deref(),
+        hermes_profile.as_deref(),
+    )?;
+    let conn = db::open_state_db(&paths.state_db)?;
+
+    if list {
+        let sessions = db::collect_sessions(&conn, &paths.cwd, all, None, limit, &paths.state_db)?;
+        render::print_recall_list(&sessions);
+        return Ok(());
+    }
+
+    if let Some(keyword) = keyword {
+        let terms = db::split_keyword_terms(&keyword)?;
+        if let Some(selector) = session.as_deref() {
+            let selected = db::select_session(&conn, selector, &paths.cwd, all, &paths.state_db)?;
+            return render::print_in_session_matches(&conn, &selected, &terms, &paths.state_db);
+        }
+
+        let sessions = db::collect_sessions(
+            &conn,
+            &paths.cwd,
+            all,
+            Some(&terms.join(" ")),
+            limit,
+            &paths.state_db,
+        )?;
+        if sessions.is_empty() {
+            let scope = if all {
+                "all Hermes sessions".to_string()
+            } else {
+                format!("Hermes sessions matching cwd {}", paths.cwd.display())
+            };
+            println!("No matches for keyword '{}' in {scope}.", terms.join(" "));
+        } else {
+            render::print_keyword_hits(&sessions);
+        }
+        return Ok(());
+    }
+
+    let selector = session.as_deref().unwrap_or("latest");
+    let selected = db::select_session(&conn, selector, &paths.cwd, all, &paths.state_db)?;
+    let markdown = render::render_session_markdown(&conn, &selected, &paths.state_db)?;
+    if let Some(page_n) = page {
+        let pages = crate::recall_cmd::pages::split_markdown_pages(&markdown);
+        let total = pages.len();
+        let idx =
+            crate::recall_cmd::pages::resolve_page_index(page_n, total).with_context(|| {
+                format!(
+                    "Page {page_n} is out of range: session has {total} page(s) \
+                 (0 = current/newest, {} = oldest)",
+                    total.saturating_sub(1)
+                )
+            })?;
+        print!("{}", pages[idx]);
+    } else if let Some(message) =
+        full_session_output_guard_message(&selected.id, &markdown, std::io::stdout().is_terminal())
+    {
+        println!("{message}");
+    } else {
+        print!("{markdown}");
+    }
+    Ok(())
+}
+
+fn full_session_output_guard_message(
+    session_id: &str,
+    markdown: &str,
+    stdout_is_terminal: bool,
+) -> Option<String> {
+    if !stdout_is_terminal {
+        return None;
+    }
+    let command = format!("csa xurl recall --provider hermes --session {session_id}");
+    crate::recall_cmd::output_guard_message_for_command(&command, markdown)
+}
+
+fn contains_ci(haystack: &str, needle: &str) -> bool {
+    haystack
+        .to_ascii_lowercase()
+        .contains(&needle.to_ascii_lowercase())
+}
+
+fn match_kind_display(kind: Option<CwdMatchKind>) -> &'static str {
+    match kind {
+        Some(CwdMatchKind::Exact) => "exact",
+        Some(CwdMatchKind::Ancestor) => "ancestor",
+        Some(CwdMatchKind::Descendant) => "descendant",
+        None => "-",
+    }
+}
+
+fn thread_source(db_path: &Path, session_id: &str) -> String {
+    format!("{}#session={session_id}", db_path.display())
+}
+
+fn yaml_single_quoted(value: &str) -> String {
+    value.replace('\'', "''")
+}
+
+fn truncate_display(value: &str, width: usize) -> String {
+    let mut chars = value.chars();
+    let preview: String = chars.by_ref().take(width).collect();
+    if chars.next().is_some() && width > 3 {
+        format!("{}...", preview.chars().take(width - 3).collect::<String>())
+    } else {
+        preview
+    }
+}
+
+fn format_unix_seconds(timestamp: Option<f64>) -> Option<String> {
+    let value = timestamp?;
+    if !value.is_finite() {
+        return None;
+    }
+    let mut secs = value.trunc() as i64;
+    let mut nanos = ((value.fract().abs()) * 1_000_000_000.0).round() as u32;
+    if nanos >= 1_000_000_000 {
+        secs = secs.saturating_add(1);
+        nanos = 0;
+    }
+    let datetime: DateTime<Utc> = DateTime::from_timestamp(secs, nanos)?;
+    Some(datetime.to_rfc3339())
+}
+
+fn normalize_path(path: &Path, base: &Path) -> PathBuf {
+    let path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            std::path::Component::RootDir => normalized.push(component.as_os_str()),
+            std::path::Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}

--- a/crates/cli-sub-agent/src/xurl_hermes/db.rs
+++ b/crates/cli-sub-agent/src/xurl_hermes/db.rs
@@ -1,0 +1,476 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use directories::BaseDirs;
+use rusqlite::{Connection, OpenFlags, params};
+
+use super::{
+    CwdMatchKind, HermesPaths, HermesSession, PREVIEW_WIDTH, contains_ci, normalize_path,
+    truncate_display,
+};
+
+pub(super) fn resolve_paths(
+    cwd: Option<&Path>,
+    hermes_home: Option<&Path>,
+    hermes_profile: Option<&str>,
+) -> Result<HermesPaths> {
+    let current_dir = env::current_dir().context("Failed to determine current directory")?;
+    let cwd = normalize_path(cwd.unwrap_or(&current_dir), &current_dir);
+    let state_db = resolve_state_db_path(hermes_home, hermes_profile)?;
+    Ok(HermesPaths { state_db, cwd })
+}
+
+fn resolve_state_db_path(
+    hermes_home: Option<&Path>,
+    hermes_profile: Option<&str>,
+) -> Result<PathBuf> {
+    let home = if let Some(home) = hermes_home {
+        home.to_path_buf()
+    } else if let Some(home) = env::var_os("HERMES_HOME").filter(|v| !v.is_empty()) {
+        PathBuf::from(home)
+    } else {
+        let base_dirs = BaseDirs::new().context("Failed to determine home directory")?;
+        base_dirs.home_dir().join(".hermes")
+    };
+
+    if home.is_file() {
+        return Ok(home);
+    }
+
+    let Some(profile) = hermes_profile.filter(|value| !value.trim().is_empty()) else {
+        return Ok(home.join("state.db"));
+    };
+
+    let profile = profile.trim();
+    let candidates = [
+        home.join(profile).join("state.db"),
+        home.join("profiles").join(profile).join("state.db"),
+        home.join(format!("state.{profile}.db")),
+    ];
+    Ok(candidates
+        .iter()
+        .find(|path| path.exists())
+        .cloned()
+        .unwrap_or_else(|| candidates[0].clone()))
+}
+
+pub(super) fn open_state_db(path: &Path) -> Result<Connection> {
+    if !path.exists() {
+        anyhow::bail!(
+            "Hermes state DB not found at {}. Set HERMES_HOME or pass --hermes-home.",
+            path.display()
+        );
+    }
+
+    let conn = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| {
+        format!(
+            "Failed to open Hermes state DB read-only at {}",
+            path.display()
+        )
+    })?;
+    conn.pragma_update(None, "query_only", "ON")
+        .with_context(|| {
+            format!(
+                "Failed to mark Hermes state DB connection query-only at {}",
+                path.display()
+            )
+        })?;
+    ensure_schema(&conn, path)?;
+    Ok(conn)
+}
+
+fn ensure_schema(conn: &Connection, path: &Path) -> Result<()> {
+    for table in ["sessions", "messages"] {
+        if !sqlite_object_exists(conn, table)? {
+            anyhow::bail!(
+                "Hermes state DB {} is missing required table '{table}'",
+                path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn collect_sessions(
+    conn: &Connection,
+    cwd: &Path,
+    all: bool,
+    keyword: Option<&str>,
+    limit: usize,
+    db_path: &Path,
+) -> Result<Vec<HermesSession>> {
+    let mut sessions = load_sessions(conn)?;
+    if !all {
+        attach_cwd_matches(&mut sessions, cwd);
+        sessions.retain(|session| session.match_kind.is_some());
+    }
+
+    if let Some(keyword) = keyword {
+        let terms = split_keyword_terms(keyword)?;
+        let fts_available = sqlite_object_exists(conn, "messages_fts")?;
+        let mut filtered = Vec::new();
+        for mut session in sessions {
+            if let Some(preview) = search_session_preview(conn, &session.id, &terms, fts_available)?
+            {
+                session.preview = Some(preview);
+                filtered.push(session);
+            }
+        }
+        sessions = filtered;
+    }
+
+    sort_sessions(&mut sessions);
+    sessions.truncate(limit);
+
+    if sessions.is_empty() && !all {
+        tracing::debug!(cwd = %cwd.display(), db = %db_path.display(), "no Hermes sessions matched cwd");
+    }
+    Ok(sessions)
+}
+
+fn load_sessions(conn: &Connection) -> Result<Vec<HermesSession>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, title, cwd, source, started_at, ended_at, COALESCE(message_count, 0) \
+         FROM sessions \
+         WHERE COALESCE(archived, 0) = 0",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        let cwd_raw: Option<String> = row.get(2)?;
+        Ok(HermesSession {
+            id: row.get(0)?,
+            title: row.get(1)?,
+            cwd: cwd_raw
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .map(|value| normalize_path(Path::new(value), Path::new("/"))),
+            source: row.get(3)?,
+            started_at: row.get(4)?,
+            ended_at: row.get(5)?,
+            message_count: row.get(6)?,
+            match_kind: None,
+            preview: None,
+        })
+    })?;
+
+    let mut sessions = Vec::new();
+    for row in rows {
+        sessions.push(row?);
+    }
+    Ok(sessions)
+}
+
+fn attach_cwd_matches(sessions: &mut [HermesSession], cwd: &Path) {
+    for session in sessions {
+        session.match_kind = session
+            .cwd
+            .as_deref()
+            .and_then(|session_cwd| cwd_match_kind(session_cwd, cwd));
+    }
+}
+
+fn cwd_match_kind(session_cwd: &Path, query_cwd: &Path) -> Option<CwdMatchKind> {
+    if session_cwd == query_cwd {
+        return Some(CwdMatchKind::Exact);
+    }
+    if query_cwd.starts_with(session_cwd) {
+        return Some(CwdMatchKind::Ancestor);
+    }
+    if session_cwd.starts_with(query_cwd) {
+        return Some(CwdMatchKind::Descendant);
+    }
+    None
+}
+
+fn sort_sessions(sessions: &mut [HermesSession]) {
+    sessions.sort_by(|a, b| {
+        let rank_a = a.match_kind.map(CwdMatchKind::rank).unwrap_or(2);
+        let rank_b = b.match_kind.map(CwdMatchKind::rank).unwrap_or(2);
+        rank_a
+            .cmp(&rank_b)
+            .then_with(|| b.updated_epoch().total_cmp(&a.updated_epoch()))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+}
+
+pub(super) fn select_session(
+    conn: &Connection,
+    selector: &str,
+    cwd: &Path,
+    all: bool,
+    db_path: &Path,
+) -> Result<HermesSession> {
+    let selector = selector.trim();
+    if selector.is_empty() {
+        anyhow::bail!("Hermes session selector must not be empty");
+    }
+
+    if selector.eq_ignore_ascii_case("latest") {
+        return collect_sessions(conn, cwd, all, None, 1, db_path)?
+            .into_iter()
+            .next()
+            .with_context(|| {
+                if all {
+                    format!("No Hermes sessions found in {}", db_path.display())
+                } else {
+                    format!("No Hermes sessions match cwd {}", cwd.display())
+                }
+            });
+    }
+
+    if let Some(index) = parse_session_index(selector)? {
+        let mut sessions = collect_sessions(conn, cwd, all, None, usize::MAX, db_path)?;
+        let total = sessions.len();
+        if index > total {
+            let scope = if all {
+                format!("Hermes state DB {}", db_path.display())
+            } else {
+                format!("Hermes sessions matching cwd {}", cwd.display())
+            };
+            anyhow::bail!(
+                "Hermes session index {index} is out of range; {scope} has {total} session(s) \
+                 (indices are 1-based)"
+            );
+        }
+        return Ok(sessions.remove(index - 1));
+    }
+
+    if let Some(session) = find_session_by_id(conn, selector)? {
+        return Ok(session);
+    }
+
+    let mut title_matches = find_sessions_by_title(conn, selector)?;
+    if title_matches.is_empty() {
+        anyhow::bail!("No Hermes session found for id or title '{selector}'");
+    }
+    if !all {
+        attach_cwd_matches(&mut title_matches, cwd);
+        title_matches.retain(|session| session.match_kind.is_some());
+        if title_matches.is_empty() {
+            anyhow::bail!(
+                "Hermes title '{selector}' exists, but none of its sessions match cwd {}. \
+                 Pass --all or use --cwd for the owning project.",
+                cwd.display()
+            );
+        }
+    }
+    sort_sessions(&mut title_matches);
+    let best_rank = title_matches
+        .first()
+        .and_then(|session| session.match_kind.map(CwdMatchKind::rank))
+        .unwrap_or(2);
+    let same_best = title_matches
+        .iter()
+        .filter(|session| {
+            session.match_kind.map(CwdMatchKind::rank).unwrap_or(2) == best_rank
+                && (session.updated_epoch() - title_matches[0].updated_epoch()).abs() < f64::EPSILON
+        })
+        .count();
+    if same_best > 1 {
+        anyhow::bail!("{}", ambiguous_title_message(selector, &title_matches));
+    }
+    Ok(title_matches.remove(0))
+}
+
+fn parse_session_index(selector: &str) -> Result<Option<usize>> {
+    if !selector.chars().all(|ch| ch.is_ascii_digit()) {
+        return Ok(None);
+    }
+
+    let index = selector.parse::<usize>().with_context(|| {
+        format!("Hermes session index '{selector}' is too large; indices are 1-based")
+    })?;
+    if index == 0 {
+        anyhow::bail!(
+            "Hermes session index 0 is invalid; indices are 1-based (use 1 for the first listed session)"
+        );
+    }
+    Ok(Some(index))
+}
+
+fn find_session_by_id(conn: &Connection, id: &str) -> Result<Option<HermesSession>> {
+    let mut sessions = load_sessions(conn)?;
+    Ok(sessions.drain(..).find(|session| session.id == id))
+}
+
+fn find_sessions_by_title(conn: &Connection, title: &str) -> Result<Vec<HermesSession>> {
+    Ok(load_sessions(conn)?
+        .into_iter()
+        .filter(|session| session.title.as_deref() == Some(title))
+        .collect())
+}
+
+fn ambiguous_title_message(title: &str, sessions: &[HermesSession]) -> String {
+    let mut message = format!(
+        "Multiple Hermes sessions match title '{title}'. Use --session <id> to disambiguate:"
+    );
+    for session in sessions.iter().take(8) {
+        let updated = session.updated_at().unwrap_or_else(|| "-".to_string());
+        let cwd = session
+            .cwd
+            .as_deref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "-".to_string());
+        message.push_str(&format!("\n  {}  {}  {}", session.id, updated, cwd));
+    }
+    message
+}
+
+fn search_session_preview(
+    conn: &Connection,
+    session_id: &str,
+    terms: &[String],
+    fts_available: bool,
+) -> Result<Option<String>> {
+    if fts_available {
+        match search_session_preview_fts(conn, session_id, terms) {
+            Ok(preview) => return Ok(preview),
+            Err(err) => {
+                tracing::debug!(session_id, error = %err, "Hermes FTS search failed; falling back to LIKE")
+            }
+        }
+    }
+    search_session_preview_like(conn, session_id, terms)
+}
+
+fn search_session_preview_fts(
+    conn: &Connection,
+    session_id: &str,
+    terms: &[String],
+) -> Result<Option<String>> {
+    let fts_query = fts_exact_term(&terms[0]);
+    let mut stmt = conn.prepare(
+        "SELECT m.content \
+         FROM messages_fts \
+         JOIN messages m ON m.id = messages_fts.rowid \
+         WHERE messages_fts MATCH ?1 \
+           AND m.session_id = ?2 \
+           AND COALESCE(m.active, 1) != 0 \
+           AND LOWER(m.role) IN ('user', 'assistant', 'system') \
+           AND m.content IS NOT NULL \
+         ORDER BY m.timestamp ASC, m.id ASC \
+         LIMIT 20",
+    )?;
+    let mut rows = stmt.query_map(params![fts_query, session_id], |row| {
+        row.get::<_, String>(0)
+    })?;
+    let mut preview = None;
+    if let Some(row) = rows.next() {
+        let content = row?;
+        preview = Some(snippet(&content, &terms[0], PREVIEW_WIDTH));
+    }
+    if preview.is_some() && allowed_transcript_has_all_terms(conn, session_id, terms)? {
+        return Ok(preview);
+    }
+    Ok(None)
+}
+
+fn search_session_preview_like(
+    conn: &Connection,
+    session_id: &str,
+    terms: &[String],
+) -> Result<Option<String>> {
+    let primary_pattern = format!("%{}%", escape_like(&terms[0].to_ascii_lowercase()));
+    let mut stmt = conn.prepare(
+        "SELECT content \
+         FROM messages \
+         WHERE session_id = ?1 \
+           AND COALESCE(active, 1) != 0 \
+           AND LOWER(role) IN ('user', 'assistant', 'system') \
+           AND content IS NOT NULL \
+           AND LOWER(content) LIKE ?2 ESCAPE '\\' \
+         ORDER BY timestamp ASC, id ASC \
+         LIMIT 100",
+    )?;
+    let mut rows = stmt.query_map(params![session_id, primary_pattern], |row| {
+        row.get::<_, String>(0)
+    })?;
+    let mut preview = None;
+    if let Some(row) = rows.next() {
+        let content = row?;
+        preview = Some(snippet(&content, &terms[0], PREVIEW_WIDTH));
+    }
+    if preview.is_some() && allowed_transcript_has_all_terms(conn, session_id, terms)? {
+        return Ok(preview);
+    }
+    Ok(None)
+}
+
+pub(super) fn split_keyword_terms(keyword: &str) -> Result<Vec<String>> {
+    let terms = keyword
+        .split_whitespace()
+        .map(str::trim)
+        .filter(|term| !term.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if terms.is_empty() {
+        anyhow::bail!("--keyword must contain at least one non-whitespace term");
+    }
+    Ok(terms)
+}
+
+fn allowed_transcript_has_all_terms(
+    conn: &Connection,
+    session_id: &str,
+    terms: &[String],
+) -> Result<bool> {
+    let mut stmt = conn.prepare(
+        "SELECT content \
+         FROM messages \
+         WHERE session_id = ?1 \
+           AND COALESCE(active, 1) != 0 \
+           AND LOWER(role) IN ('user', 'assistant', 'system') \
+           AND content IS NOT NULL \
+         ORDER BY timestamp ASC, id ASC",
+    )?;
+    let rows = stmt.query_map(params![session_id], |row| row.get::<_, String>(0))?;
+
+    let mut present = vec![false; terms.len()];
+    for row in rows {
+        let content = row?;
+        for (idx, term) in terms.iter().enumerate() {
+            if !present[idx] && contains_ci(&content, term) {
+                present[idx] = true;
+            }
+        }
+        if present.iter().all(|found| *found) {
+            return Ok(true);
+        }
+    }
+    Ok(present.iter().all(|found| *found))
+}
+
+fn fts_exact_term(term: &str) -> String {
+    format!("\"{}\"", term.replace('"', "\"\""))
+}
+
+fn snippet(content: &str, keyword: &str, width: usize) -> String {
+    let line = content
+        .lines()
+        .find(|line| contains_ci(line, keyword))
+        .unwrap_or(content)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    truncate_display(&line, width)
+}
+
+fn escape_like(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
+fn sqlite_object_exists(conn: &Connection, name: &str) -> Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE name = ?1)",
+        params![name],
+        |row| row.get::<_, bool>(0),
+    )
+    .with_context(|| format!("Failed to inspect sqlite object '{name}'"))
+}

--- a/crates/cli-sub-agent/src/xurl_hermes/render.rs
+++ b/crates/cli-sub-agent/src/xurl_hermes/render.rs
@@ -1,0 +1,231 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, params};
+
+use super::{
+    HermesMessage, HermesSession, PREVIEW_WIDTH, PROVIDER, SEARCH_CONTEXT_LINES, contains_ci,
+    match_kind_display, thread_source, truncate_display, yaml_single_quoted,
+};
+
+pub(super) fn render_session_markdown(
+    conn: &Connection,
+    session: &HermesSession,
+    db_path: &Path,
+) -> Result<String> {
+    let messages = load_render_messages(conn, &session.id)?;
+    let uri = format!("hermes://{}", session.id);
+    let source = thread_source(db_path, &session.id);
+
+    let mut output = String::new();
+    output.push_str("---\n");
+    output.push_str(&format!("uri: '{}'\n", yaml_single_quoted(&uri)));
+    output.push_str(&format!(
+        "thread_source: '{}'\n",
+        yaml_single_quoted(&source)
+    ));
+    if let Some(title) = session.title.as_deref() {
+        output.push_str(&format!("title: '{}'\n", yaml_single_quoted(title)));
+    }
+    if let Some(cwd) = session.cwd.as_deref() {
+        output.push_str(&format!(
+            "cwd: '{}'\n",
+            yaml_single_quoted(&cwd.display().to_string())
+        ));
+    }
+    output.push_str("---\n\n# Thread\n\n## Timeline\n\n");
+
+    if messages.is_empty() {
+        output.push_str("_No user/assistant messages found._\n");
+        return Ok(output);
+    }
+
+    for (index, message) in messages.iter().enumerate() {
+        output.push_str(&format!(
+            "## {}. {}\n\n{}\n\n",
+            index + 1,
+            heading_for_message(message),
+            message.content.trim()
+        ));
+    }
+    Ok(output)
+}
+
+fn load_render_messages(conn: &Connection, session_id: &str) -> Result<Vec<HermesMessage>> {
+    let mut stmt = conn.prepare(
+        "SELECT role, content \
+         FROM messages \
+         WHERE session_id = ?1 \
+           AND COALESCE(active, 1) != 0 \
+           AND content IS NOT NULL \
+           AND TRIM(content) != '' \
+           AND LOWER(role) IN ('user', 'assistant', 'system') \
+         ORDER BY timestamp ASC, id ASC",
+    )?;
+    let rows = stmt.query_map(params![session_id], |row| {
+        Ok(HermesMessage {
+            role: row.get(0)?,
+            content: row.get(1)?,
+        })
+    })?;
+
+    let mut messages = Vec::new();
+    for row in rows {
+        messages.push(row?);
+    }
+    Ok(messages)
+}
+
+fn heading_for_message(message: &HermesMessage) -> &'static str {
+    match message.role.to_ascii_lowercase().as_str() {
+        "user" => "User",
+        "assistant" => "Assistant",
+        "system" if message.content.to_ascii_lowercase().contains("compact") => "Context Compacted",
+        "system" => "System",
+        _ => "Message",
+    }
+}
+
+pub(super) fn print_in_session_matches(
+    conn: &Connection,
+    session: &HermesSession,
+    terms: &[String],
+    db_path: &Path,
+) -> Result<()> {
+    let content = render_session_markdown(conn, session, db_path)?;
+    let lines: Vec<&str> = content.lines().collect();
+    let ranges = matching_ranges_any(&lines, terms, SEARCH_CONTEXT_LINES);
+    if ranges.is_empty() {
+        println!(
+            "No matches for '{}' in session {}.",
+            terms.join(" "),
+            session.id
+        );
+        return Ok(());
+    }
+
+    println!("Matches in session {} ({PROVIDER})", session.id);
+    for (start, end) in ranges {
+        println!("\n-- lines {}-{} --", start + 1, end + 1);
+        for (idx, line) in lines.iter().enumerate().take(end + 1).skip(start) {
+            let hit = terms.iter().any(|term| contains_ci(line, term));
+            let marker = if hit { ">" } else { " " };
+            println!("{marker} {:>5} {line}", idx + 1);
+        }
+    }
+    Ok(())
+}
+
+fn matching_ranges_any(lines: &[&str], terms: &[String], context: usize) -> Vec<(usize, usize)> {
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    for (idx, line) in lines.iter().enumerate() {
+        if !terms.iter().any(|term| contains_ci(line, term)) {
+            continue;
+        }
+        let start = idx.saturating_sub(context);
+        let end = (idx + context).min(lines.len().saturating_sub(1));
+        if let Some((_, previous_end)) = ranges.last_mut()
+            && start <= *previous_end + 1
+        {
+            *previous_end = (*previous_end).max(end);
+            continue;
+        }
+        ranges.push((start, end));
+    }
+    ranges
+}
+
+pub(super) fn print_thread_table(sessions: &[HermesSession]) {
+    if sessions.is_empty() {
+        println!("No Hermes threads found.");
+        return;
+    }
+    println!(
+        "{:<12} {:<36} {:<20} {:<12} PREVIEW",
+        "PROVIDER", "THREAD_ID", "UPDATED", "CWD_MATCH"
+    );
+    println!("{}", "-".repeat(120));
+    for session in sessions {
+        let updated = session.updated_at().unwrap_or_else(|| "-".to_string());
+        let preview = session
+            .preview
+            .clone()
+            .or_else(|| session.title.clone())
+            .unwrap_or_default();
+        println!(
+            "{:<12} {:<36} {:<20} {:<12} {}",
+            PROVIDER,
+            truncate_display(&session.id, 36),
+            truncate_display(&updated, 20),
+            match_kind_display(session.match_kind),
+            truncate_display(&preview, 60),
+        );
+    }
+    println!("\nTotal: {} thread(s)", sessions.len());
+}
+
+pub(super) fn print_recall_list(sessions: &[HermesSession]) {
+    if sessions.is_empty() {
+        println!("No Hermes recall sessions found.");
+        return;
+    }
+    println!(
+        "{:<6} {:<20} {:<36} {:<12} TITLE",
+        "INDEX", "UPDATED", "SESSION", "CWD_MATCH"
+    );
+    println!("{}", "-".repeat(120));
+    for (index, session) in sessions.iter().enumerate() {
+        let updated = session.updated_at().unwrap_or_else(|| "-".to_string());
+        println!(
+            "{:<6} {:<20} {:<36} {:<12} {}",
+            index + 1,
+            truncate_display(&updated, 20),
+            truncate_display(&session.id, 36),
+            match_kind_display(session.match_kind),
+            truncate_display(session.title.as_deref().unwrap_or(""), 40),
+        );
+    }
+    println!("\nTotal history entries: {}", sessions.len());
+}
+
+pub(super) fn print_keyword_hits(sessions: &[HermesSession]) {
+    println!(
+        "{:<10} {:<36} {:<20} PREVIEW",
+        "PROVIDER", "SESSION", "UPDATED"
+    );
+    println!("{}", "-".repeat(160));
+    for session in sessions {
+        let updated = session.updated_at().unwrap_or_else(|| "-".to_string());
+        let preview = session.preview.as_deref().unwrap_or("");
+        println!(
+            "{:<10} {:<36} {:<20} {}",
+            PROVIDER,
+            truncate_display(&session.id, 36),
+            truncate_display(&updated, 20),
+            truncate_display(preview, PREVIEW_WIDTH),
+        );
+    }
+    println!("\nTotal matches: {}", sessions.len());
+}
+
+pub(super) fn threads_json(sessions: &[HermesSession], db_path: &Path) -> Result<String> {
+    let items = sessions
+        .iter()
+        .map(|session| {
+            serde_json::json!({
+                "thread_id": session.id,
+                "provider": PROVIDER,
+                "uri": format!("hermes://{}", session.id),
+                "source": thread_source(db_path, &session.id),
+                "updated_at": session.updated_at(),
+                "preview": session.preview.as_deref().or(session.title.as_deref()),
+                "title": session.title.as_deref(),
+                "cwd": session.cwd.as_ref().map(|path| path.display().to_string()),
+                "cwd_match": session.match_kind,
+                "message_count": session.message_count,
+                "session_source": session.source.as_str(),
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::to_string_pretty(&items).context("Failed to serialize Hermes thread JSON")
+}

--- a/crates/cli-sub-agent/src/xurl_hermes/tests.rs
+++ b/crates/cli-sub-agent/src/xurl_hermes/tests.rs
@@ -1,0 +1,491 @@
+use std::path::{Path, PathBuf};
+
+use rusqlite::{Connection, params};
+
+use super::db::{collect_sessions, open_state_db, select_session};
+use super::render::{render_session_markdown, threads_json};
+use super::{CwdMatchKind, full_session_output_guard_message};
+
+fn create_fixture(with_fts: bool) -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let db_path = temp.path().join("state.db");
+    let conn = Connection::open(&db_path).expect("open fixture");
+    conn.execute_batch(
+        "
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            started_at REAL NOT NULL,
+            ended_at REAL,
+            cwd TEXT,
+            title TEXT,
+            message_count INTEGER DEFAULT 0,
+            archived INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            timestamp REAL NOT NULL,
+            active INTEGER NOT NULL DEFAULT 1
+        );
+        ",
+    )
+    .expect("schema");
+    if with_fts {
+        conn.execute_batch(
+            "
+            CREATE VIRTUAL TABLE messages_fts USING fts5(content);
+            CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts(rowid, content) VALUES (new.id, COALESCE(new.content, ''));
+            END;
+            ",
+        )
+        .expect("fts");
+    }
+    drop(conn);
+    (temp, db_path)
+}
+
+fn insert_session(
+    conn: &Connection,
+    id: &str,
+    title: &str,
+    cwd: &str,
+    started_at: f64,
+    ended_at: Option<f64>,
+) {
+    conn.execute(
+        "INSERT INTO sessions (id, source, started_at, ended_at, cwd, title, message_count) \
+         VALUES (?1, 'fixture', ?2, ?3, ?4, ?5, 2)",
+        params![id, started_at, ended_at, cwd, title],
+    )
+    .expect("insert session");
+}
+
+fn insert_message(conn: &Connection, session_id: &str, role: &str, content: &str, timestamp: f64) {
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?1, ?2, ?3, ?4)",
+        params![session_id, role, content, timestamp],
+    )
+    .expect("insert message");
+}
+
+#[test]
+fn cwd_matching_orders_exact_before_descendant_even_when_older() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "exact-old", "Exact", "/repo", 10.0, Some(20.0));
+    insert_session(&conn, "child-new", "Child", "/repo/crate", 30.0, Some(40.0));
+    insert_session(
+        &conn,
+        "other-newest",
+        "Other",
+        "/repo-other",
+        50.0,
+        Some(60.0),
+    );
+
+    let sessions =
+        collect_sessions(&conn, Path::new("/repo"), false, None, 10, &db_path).expect("collect");
+
+    assert_eq!(sessions.len(), 2);
+    assert_eq!(sessions[0].id, "exact-old");
+    assert_eq!(sessions[0].match_kind, Some(CwdMatchKind::Exact));
+    assert_eq!(sessions[1].id, "child-new");
+    assert_eq!(sessions[1].match_kind, Some(CwdMatchKind::Descendant));
+}
+
+#[test]
+fn title_and_session_id_selection_work() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-1", "Readable title", "/repo", 10.0, Some(20.0));
+
+    let by_id =
+        select_session(&conn, "sid-1", Path::new("/repo"), false, &db_path).expect("select by id");
+    let by_title = select_session(&conn, "Readable title", Path::new("/repo"), false, &db_path)
+        .expect("select by title");
+
+    assert_eq!(by_id.id, "sid-1");
+    assert_eq!(by_title.id, "sid-1");
+}
+
+#[test]
+fn numeric_session_index_selects_first_listed_session() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "older-exact", "Older", "/repo", 10.0, Some(20.0));
+    insert_session(&conn, "newer-exact", "Newer", "/repo", 30.0, Some(40.0));
+    insert_session(
+        &conn,
+        "newer-child",
+        "Child",
+        "/repo/crate",
+        50.0,
+        Some(60.0),
+    );
+
+    let listed =
+        collect_sessions(&conn, Path::new("/repo"), false, None, 10, &db_path).expect("collect");
+    let selected =
+        select_session(&conn, "1", Path::new("/repo"), false, &db_path).expect("select index");
+
+    assert_eq!(listed[0].id, "newer-exact");
+    assert_eq!(selected.id, listed[0].id);
+}
+
+#[test]
+fn out_of_range_session_index_reports_available_count() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-only", "Only", "/repo", 10.0, Some(20.0));
+
+    let err = select_session(&conn, "2", Path::new("/repo"), false, &db_path)
+        .expect_err("out-of-range index must fail");
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("Hermes session index 2 is out of range"),
+        "{msg}"
+    );
+    assert!(msg.contains("has 1 session(s)"), "{msg}");
+    assert!(msg.contains("indices are 1-based"), "{msg}");
+}
+
+#[test]
+fn zero_session_index_is_rejected_as_invalid() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-only", "Only", "/repo", 10.0, Some(20.0));
+
+    let err = select_session(&conn, "0", Path::new("/repo"), false, &db_path)
+        .expect_err("zero index must fail");
+    let msg = err.to_string();
+
+    assert!(msg.contains("Hermes session index 0 is invalid"), "{msg}");
+    assert!(msg.contains("indices are 1-based"), "{msg}");
+}
+
+#[test]
+fn session_index_takes_precedence_over_numeric_id_or_title() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "1", "1", "/repo", 10.0, Some(20.0));
+    insert_session(&conn, "sid-first", "First", "/repo", 30.0, Some(40.0));
+
+    let selected =
+        select_session(&conn, "1", Path::new("/repo"), false, &db_path).expect("select index");
+
+    assert_eq!(selected.id, "sid-first");
+}
+
+#[test]
+fn duplicate_title_reports_actionable_disambiguation() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-a", "Repeated", "/repo", 10.0, Some(20.0));
+    insert_session(&conn, "sid-b", "Repeated", "/repo", 10.0, Some(20.0));
+
+    let err = select_session(&conn, "Repeated", Path::new("/repo"), false, &db_path)
+        .expect_err("duplicate title must fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Multiple Hermes sessions match title"),
+        "{msg}"
+    );
+    assert!(msg.contains("sid-a"), "{msg}");
+    assert!(msg.contains("sid-b"), "{msg}");
+    assert!(msg.contains("--session <id>"), "{msg}");
+}
+
+#[test]
+fn keyword_search_falls_back_to_like_without_fts() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-1", "Searchable", "/repo", 10.0, Some(20.0));
+    insert_message(
+        &conn,
+        "sid-1",
+        "user",
+        "please inspect the review finding in this repo",
+        11.0,
+    );
+
+    let sessions = collect_sessions(
+        &conn,
+        Path::new("/repo"),
+        false,
+        Some("review finding"),
+        10,
+        &db_path,
+    )
+    .expect("search");
+
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].id, "sid-1");
+    assert!(
+        sessions[0]
+            .preview
+            .as_deref()
+            .unwrap_or_default()
+            .contains("review finding")
+    );
+}
+
+#[test]
+fn keyword_search_like_matches_terms_across_allowed_messages() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-like", "Searchable", "/repo", 10.0, Some(20.0));
+    insert_message(&conn, "sid-like", "user", "foo appears first", 11.0);
+    insert_message(&conn, "sid-like", "assistant", "bar appears later", 12.0);
+
+    let sessions = collect_sessions(
+        &conn,
+        Path::new("/repo"),
+        false,
+        Some("foo bar"),
+        10,
+        &db_path,
+    )
+    .expect("search");
+
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].id, "sid-like");
+    let preview = sessions[0].preview.as_deref().unwrap_or_default();
+    assert!(preview.contains("foo appears first"), "{preview}");
+}
+
+#[test]
+fn keyword_search_like_rejects_terms_present_only_in_tool_messages() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-like", "Searchable", "/repo", 10.0, Some(20.0));
+    insert_message(&conn, "sid-like", "user", "foo appears first", 11.0);
+    insert_message(&conn, "sid-like", "tool", "bar is hidden tool output", 12.0);
+
+    let sessions = collect_sessions(
+        &conn,
+        Path::new("/repo"),
+        false,
+        Some("foo bar"),
+        10,
+        &db_path,
+    )
+    .expect("search");
+
+    assert!(sessions.is_empty(), "{sessions:?}");
+}
+
+#[test]
+fn keyword_search_like_omits_tool_message_preview() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-like", "Searchable", "/repo", 10.0, Some(20.0));
+    insert_message(
+        &conn,
+        "sid-like",
+        "tool",
+        "needlelike SYNTHETIC_TOOL_SECRET_LIKE",
+        11.0,
+    );
+    insert_message(
+        &conn,
+        "sid-like",
+        "user",
+        "needlelike visible user preview",
+        12.0,
+    );
+
+    let sessions = collect_sessions(
+        &conn,
+        Path::new("/repo"),
+        false,
+        Some("needlelike"),
+        10,
+        &db_path,
+    )
+    .expect("search");
+
+    assert_eq!(sessions.len(), 1);
+    let preview = sessions[0].preview.as_deref().unwrap_or_default();
+    assert!(preview.contains("visible user preview"), "{preview}");
+    assert!(!preview.contains("SYNTHETIC_TOOL_SECRET_LIKE"), "{preview}");
+}
+
+#[test]
+fn keyword_search_fts_matches_terms_across_allowed_messages() {
+    let (_temp, db_path) = create_fixture(true);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-fts", "Searchable", "/repo", 10.0, Some(20.0));
+    insert_message(&conn, "sid-fts", "user", "foo appears first", 11.0);
+    insert_message(&conn, "sid-fts", "assistant", "bar appears later", 12.0);
+
+    let sessions = collect_sessions(
+        &conn,
+        Path::new("/repo"),
+        false,
+        Some("foo bar"),
+        10,
+        &db_path,
+    )
+    .expect("search");
+
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].id, "sid-fts");
+    let preview = sessions[0].preview.as_deref().unwrap_or_default();
+    assert!(preview.contains("foo appears first"), "{preview}");
+}
+
+#[test]
+fn keyword_search_fts_rejects_terms_present_only_in_tool_messages() {
+    let (_temp, db_path) = create_fixture(true);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-fts", "Searchable", "/repo", 10.0, Some(20.0));
+    insert_message(&conn, "sid-fts", "user", "foo appears first", 11.0);
+    insert_message(&conn, "sid-fts", "tool", "bar is hidden tool output", 12.0);
+
+    let sessions = collect_sessions(
+        &conn,
+        Path::new("/repo"),
+        false,
+        Some("foo bar"),
+        10,
+        &db_path,
+    )
+    .expect("search");
+
+    assert!(sessions.is_empty(), "{sessions:?}");
+}
+
+#[test]
+fn keyword_search_fts_omits_tool_message_preview() {
+    let (_temp, db_path) = create_fixture(true);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-fts", "Searchable", "/repo", 10.0, Some(20.0));
+    insert_message(
+        &conn,
+        "sid-fts",
+        "tool",
+        "needlefts SYNTHETIC_TOOL_SECRET_FTS",
+        11.0,
+    );
+    insert_message(
+        &conn,
+        "sid-fts",
+        "assistant",
+        "needlefts visible assistant preview",
+        12.0,
+    );
+
+    let sessions = collect_sessions(
+        &conn,
+        Path::new("/repo"),
+        false,
+        Some("needlefts"),
+        10,
+        &db_path,
+    )
+    .expect("search");
+
+    assert_eq!(sessions.len(), 1);
+    let preview = sessions[0].preview.as_deref().unwrap_or_default();
+    assert!(preview.contains("visible assistant preview"), "{preview}");
+    assert!(!preview.contains("SYNTHETIC_TOOL_SECRET_FTS"), "{preview}");
+}
+
+#[test]
+fn full_session_guard_blocks_large_terminal_output_without_page() {
+    let markdown = "x".repeat(crate::recall_cmd::OUTPUT_GUARD_BYTES);
+    let message =
+        full_session_output_guard_message("sid-large", &markdown, true).expect("guard message");
+
+    assert!(message.contains("OUTPUT_TOO_LARGE"), "{message}");
+    assert!(
+        message.contains("csa xurl recall --provider hermes --session sid-large | tail -100"),
+        "{message}"
+    );
+}
+
+#[test]
+fn full_session_guard_allows_large_non_terminal_output() {
+    let markdown = "x".repeat(crate::recall_cmd::OUTPUT_GUARD_BYTES);
+
+    assert!(full_session_output_guard_message("sid-large", &markdown, false).is_none());
+}
+
+#[test]
+fn threads_json_contains_hermes_fields() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-json", "JSON Title", "/repo", 10.0, Some(20.0));
+
+    let sessions =
+        collect_sessions(&conn, Path::new("/repo"), false, None, 10, &db_path).expect("collect");
+    let json = threads_json(&sessions, &db_path).expect("json");
+    let value: serde_json::Value = serde_json::from_str(&json).expect("parse json");
+
+    assert_eq!(value[0]["provider"], "hermes");
+    assert_eq!(value[0]["thread_id"], "sid-json");
+    assert_eq!(value[0]["title"], "JSON Title");
+    assert_eq!(value[0]["cwd"], "/repo");
+    assert_eq!(value[0]["cwd_match"], "exact");
+}
+
+#[test]
+fn render_session_markdown_omits_tool_messages() {
+    let (_temp, db_path) = create_fixture(false);
+    let conn = Connection::open(&db_path).expect("open");
+    insert_session(&conn, "sid-render", "Render", "/repo", 10.0, Some(20.0));
+    insert_message(&conn, "sid-render", "user", "hello", 11.0);
+    insert_message(
+        &conn,
+        "sid-render",
+        "tool",
+        "{\"secret\":\"tool dump\"}",
+        12.0,
+    );
+    insert_message(&conn, "sid-render", "assistant", "hi", 13.0);
+
+    let session =
+        select_session(&conn, "sid-render", Path::new("/repo"), false, &db_path).expect("select");
+    let markdown = render_session_markdown(&conn, &session, &db_path).expect("render");
+
+    assert!(markdown.contains("## 1. User"));
+    assert!(markdown.contains("hello"));
+    assert!(markdown.contains("## 2. Assistant"));
+    assert!(markdown.contains("hi"));
+    assert!(!markdown.contains("tool dump"));
+}
+
+#[test]
+fn missing_state_db_reports_path() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let missing = temp.path().join("state.db");
+    let err = open_state_db(&missing).expect_err("missing db must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("Hermes state DB not found"), "{msg}");
+    assert!(msg.contains(&missing.display().to_string()), "{msg}");
+}
+
+#[cfg(unix)]
+#[test]
+fn no_permission_state_db_reports_open_error() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let (_temp, db_path) = create_fixture(false);
+    let original = fs::metadata(&db_path).expect("metadata").permissions();
+    fs::set_permissions(&db_path, fs::Permissions::from_mode(0o000)).expect("chmod unreadable");
+
+    let err = open_state_db(&db_path).expect_err("unreadable db must fail");
+    fs::set_permissions(&db_path, original).expect("restore permissions");
+
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("Failed to open Hermes state DB read-only"),
+        "{msg}"
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.997"
-weave = "0.1.997"
+csa = "0.1.998"
+weave = "0.1.998"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Closes #2084.

Adds a Hermes provider for `csa xurl` so the CLI can discover and recall Hermes Agent sessions scoped to the current working directory.

- Adds `csa xurl threads --provider hermes` with cwd-scoped Hermes SQLite discovery.
- Adds `csa xurl recall --provider hermes` for latest/id/title/index session selection and keyword recall.
- Keeps Hermes state access read-only and supports synthetic/test profile DB paths.
- Filters tool-role transcript content from previews/search matching and rendered transcript output.
- Reuses the existing recall large-output guard for full-session terminal output.
- Fixes multi-term keyword matching to operate at transcript/session scope, not single-message scope.
- Adds synthetic fixture tests for cwd matching, JSON/listing, session selection, keyword privacy, output guards, and multi-term recall.

## Local validation

- Hook-enabled commit/amend passed:
  - branch-protection
  - quality-gates
  - clippy clean
- CSA/Codex implementation salvage validation:
  - `cargo test -p cli-sub-agent --bin csa xurl_cmd::hermes::tests -- --nocapture` → 8 passed
  - synthetic CLI smoke for Hermes JSON threads and latest recall → passed
  - `cargo fmt --package cli-sub-agent -- --check` → passed
  - `cargo check -p cli-sub-agent --bin csa` → passed
  - `cargo run --quiet -p cli-sub-agent -- migrate --status` → lock/binary `0.1.998`, pending migrations `0`
  - `just find-monolith-files` → passed, 0 hard failures / 0 warnings
- Review-fix validations:
  - keyword preview role-boundary tests → passed
  - full-session output guard tests → passed
  - numeric session-index tests → passed
  - multi-term keyword recall tests → passed
  - `cargo clippy --workspace --all-features -- -D warnings` → passed after never-loop cleanup
- Final pinned Codex review:
  - `01KV1NDCKFNJWND2SC2VAYFVDN` → PASS

## Notes

- #2196 tracks the initial CSA implementation session that exited 143 during post-bump Hermes validation; the implementation was recovered by conservative fork-from salvage.
- GitHub CI was not watched or used as an agent-side gate per local-gate workflow.
