### PR TITLE
fix(session): surface post-exec gate failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "axum",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.998"
+version = "0.1.999"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.998"
+version = "0.1.999"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_post_gate_report.rs
+++ b/crates/cli-sub-agent/src/run_cmd_post_gate_report.rs
@@ -34,14 +34,6 @@ use csa_session::{
 /// already-prepended banner (idempotency) so re-entry never double-stamps.
 const GATE_BANNER_HEADER: &str = "> ⚠️ **POST-EXEC GATE FAILED";
 
-/// Leading marker for the reconciled `result.toml` summary. Kept as a constant
-/// so tests assert the non-contradiction contract rather than prose wording.
-pub(crate) const GATE_SUMMARY_LEAD: &str = "POST-EXEC GATE FAILED";
-
-/// How many failing test names to inline into the one-line `result.toml`
-/// summary before collapsing the rest into a `(+N more)` suffix.
-const SUMMARY_MAX_INLINE_TESTS: usize = 5;
-
 /// How many failing test names to list in the (multi-line) section banner.
 const BANNER_MAX_LISTED_TESTS: usize = 10;
 
@@ -173,31 +165,7 @@ fn overwrite_result_with_report(
 /// (exit code + failing step) and points at the full log, so an orchestrator
 /// reading only `result.summary` cannot mistake the run for a success.
 fn build_failure_summary(report: &PostExecGateReport) -> String {
-    let mut summary = format!("{GATE_SUMMARY_LEAD} (exit={}", report.exit_code);
-    if let Some(step) = &report.failing_step {
-        summary.push_str(&format!(", step={step}"));
-    }
-    summary.push_str(") — employee self-report SUPERSEDED by gate verdict; full output: ");
-    summary.push_str(&report.log_path);
-
-    if !report.failing_tests.is_empty() {
-        let shown: Vec<&str> = report
-            .failing_tests
-            .iter()
-            .take(SUMMARY_MAX_INLINE_TESTS)
-            .map(String::as_str)
-            .collect();
-        summary.push_str("; failing tests: ");
-        summary.push_str(&shown.join(", "));
-        let extra = report
-            .failing_tests
-            .len()
-            .saturating_sub(SUMMARY_MAX_INLINE_TESTS);
-        if extra > 0 {
-            summary.push_str(&format!(" (+{extra} more)"));
-        }
-    }
-    summary
+    csa_session::post_exec_gate_failure_summary(report)
 }
 
 /// Build the multi-line markdown banner prepended to `summary.md`/`details.md`.
@@ -316,7 +284,7 @@ mod tests {
     fn summary_leads_with_gate_verdict_not_success() {
         let summary = build_failure_summary(&report_with(100, Some("just test"), &["pkg::a"]));
         // Leads with the gate verdict marker.
-        assert!(summary.starts_with(GATE_SUMMARY_LEAD));
+        assert!(summary.starts_with(csa_session::GATE_SUMMARY_LEAD));
         assert!(summary.contains("exit=100"));
         assert!(summary.contains("step=just test"));
         assert!(summary.contains("SUPERSEDED"));
@@ -327,7 +295,7 @@ mod tests {
     #[test]
     fn summary_handles_missing_step_and_tests() {
         let summary = build_failure_summary(&report_with(1, None, &[]));
-        assert!(summary.starts_with(GATE_SUMMARY_LEAD));
+        assert!(summary.starts_with(csa_session::GATE_SUMMARY_LEAD));
         assert!(summary.contains("exit=1"));
         assert!(!summary.contains("step="));
         assert!(!summary.contains("failing tests"));

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -141,10 +141,14 @@ pub(crate) fn render_wait_result_summary(
         lines.push(format!("Warning: {warning}"));
     }
 
-    if let Some(summary) =
-        crate::session_summary_text::human_session_summary(session_dir, &result.summary)
-            .and_then(|text| compact_wait_summary_text(&text))
-    {
+    if let Some(report) = result.post_exec_gate.as_ref() {
+        lines.push(format!(
+            "Post-exec gate: {}",
+            csa_session::post_exec_gate_failure_label(report)
+        ));
+    }
+
+    if let Some(summary) = wait_display_summary(session_dir, result) {
         lines.push(format!("Summary: {summary}"));
     }
 
@@ -217,12 +221,20 @@ fn render_wait_result_json(
         "review_verdict": read_review_verdict_label(session_dir, result),
         "failover": format_failover_chain_label(session_dir, result),
         "kill_hint": result.kill_hint.as_deref(),
+        "post_exec_gate": result.post_exec_gate.as_ref(),
         "large_diff_warning": result.large_diff_warning.as_ref(),
         "warnings": result.warnings,
-        "summary": crate::session_summary_text::human_session_summary(session_dir, &result.summary)
-            .and_then(|text| compact_wait_summary_text(&text)),
+        "summary": wait_display_summary(session_dir, result),
     });
     serde_json::to_string_pretty(&value).map_err(Into::into)
+}
+
+fn wait_display_summary(session_dir: &Path, result: &csa_session::SessionResult) -> Option<String> {
+    if let Some(report) = result.post_exec_gate.as_ref() {
+        return compact_wait_summary_text(&csa_session::post_exec_gate_failure_summary(report));
+    }
+    crate::session_summary_text::human_session_summary(session_dir, &result.summary)
+        .and_then(|text| compact_wait_summary_text(&text))
 }
 
 fn wait_result_tool_label(result: &csa_session::SessionResult) -> String {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -121,6 +121,58 @@ fn compact_summary_includes_signal_kill_hint() {
 }
 
 #[test]
+fn compact_summary_prefers_post_exec_gate_failure_over_success_markdown() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let output_dir = temp.path().join("output");
+    std::fs::create_dir_all(&output_dir).expect("output dir should be created");
+    std::fs::write(
+        output_dir.join("summary.md"),
+        "Fixed and committed the remaining medium finding. Did not push; working tree clean.",
+    )
+    .expect("success-looking summary should be written");
+    std::fs::write(
+        temp.path().join(csa_session::GATE_FAILURE_LOG_REL_PATH),
+        "FAIL [   0.005s] cli_sub_agent::gate::fails\nerror: Recipe `test` failed on line 42 with exit code 100\n",
+    )
+    .expect("gate failure log should be written");
+
+    let now = Utc::now();
+    let report = csa_session::PostExecGateReport::from_redacted_gate_output(
+        "post-exec gate",
+        1,
+        "FAIL [   0.005s] cli_sub_agent::gate::fails\nerror: Recipe `test` failed on line 42 with exit code 100\n",
+    );
+    let result = csa_session::SessionResult {
+        post_exec_gate: Some(report),
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "POST-EXEC GATE FAILED (exit=1, step=just test)".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: vec![csa_session::SessionArtifact::new(
+            csa_session::GATE_FAILURE_LOG_REL_PATH,
+        )],
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITGATE", &result);
+
+    assert!(summary.contains("Post-exec gate: failed"));
+    assert!(summary.contains("step=just test"));
+    assert!(summary.contains(csa_session::GATE_FAILURE_LOG_REL_PATH));
+    assert!(summary.contains("Summary: POST-EXEC GATE FAILED"));
+    assert!(
+        !summary.contains("working tree clean"),
+        "wait summary must not show child success markdown as authoritative: {summary}"
+    );
+}
+
+#[test]
 fn compact_summary_includes_unknown_signal_evidence() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let now = Utc::now();

--- a/crates/cli-sub-agent/src/session_cmds_result_display.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_display.rs
@@ -32,10 +32,13 @@ pub(super) fn display_result_text(
     println!("Tool:    {}", envelope.tool);
     println!("Started: {}", envelope.started_at);
     println!("Ended:   {}", envelope.completed_at);
-    if let Some(summary) =
-        crate::session_summary_text::human_session_summary(session_dir, &envelope.summary)
-    {
-        let summary = crate::session_summary_text::enrich_review_summary(session_dir, &summary);
+    if let Some(report) = envelope.post_exec_gate.as_ref() {
+        println!(
+            "Post-exec gate: {}",
+            csa_session::post_exec_gate_failure_label(report)
+        );
+    }
+    if let Some(summary) = result_display_summary(session_dir, envelope) {
         println!("Summary: {summary}");
     }
     if !envelope.artifacts.is_empty() {
@@ -151,6 +154,10 @@ pub(super) fn build_result_json_payload(
     token_usage: Option<&TokenUsage>,
 ) -> Result<serde_json::Value> {
     let mut payload = serde_json::to_value(&result.envelope)?;
+    if let Some(report) = result.envelope.post_exec_gate.as_ref() {
+        payload["summary"] =
+            serde_json::Value::String(csa_session::post_exec_gate_failure_summary(report));
+    }
     if let Some(sidecar) = result
         .manager_sidecar
         .as_ref()
@@ -185,6 +192,17 @@ pub(super) fn build_result_json_payload(
         payload["total_token_usage"] = value;
     }
     Ok(payload)
+}
+
+fn result_display_summary(
+    session_dir: &Path,
+    envelope: &csa_session::SessionResult,
+) -> Option<String> {
+    if let Some(report) = envelope.post_exec_gate.as_ref() {
+        return Some(csa_session::post_exec_gate_failure_summary(report));
+    }
+    crate::session_summary_text::human_session_summary(session_dir, &envelope.summary)
+        .map(|summary| crate::session_summary_text::enrich_review_summary(session_dir, &summary))
 }
 
 fn normalized_token_usage_for_output(usage: &TokenUsage) -> TokenUsage {

--- a/crates/cli-sub-agent/src/session_observability.rs
+++ b/crates/cli-sub-agent/src/session_observability.rs
@@ -6,6 +6,9 @@ use anyhow::Result;
 use csa_session::{ReviewVerdictArtifact, SessionArtifact, SessionResult};
 use tracing::debug;
 
+#[path = "session_observability_gate.rs"]
+mod gate;
+
 const SUMMARY_MAX_CHARS: usize = 200;
 const REVIEW_SUMMARY_FAIL_TOKENS: &[&str] = &["FAIL", "HAS_ISSUES", "REJECT"];
 
@@ -60,6 +63,9 @@ pub(crate) fn refresh_and_repair_result_from_dir(
     if sync_review_verdict_exit_code(session_dir, &mut result)? {
         changed = true;
     }
+    if gate::infer_post_exec_gate_failure_from_log(session_dir, &result_path, &mut result)? {
+        changed = true;
+    }
 
     if changed && let Ok(serialized) = toml::to_string_pretty(&result) {
         let tmp = result_path.with_extension("toml.tmp");
@@ -94,6 +100,11 @@ pub(crate) fn enrich_result_from_session_dir(
     }
 
     if sync_review_verdict_exit_code(session_dir, result)? {
+        changed = true;
+    }
+
+    let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
+    if gate::infer_post_exec_gate_failure_from_log(session_dir, &result_path, result)? {
         changed = true;
     }
 

--- a/crates/cli-sub-agent/src/session_observability_gate.rs
+++ b/crates/cli-sub-agent/src/session_observability_gate.rs
@@ -1,0 +1,92 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+use csa_session::{GATE_FAILURE_LOG_REL_PATH, PostExecGateReport, SessionArtifact, SessionResult};
+
+const INFERRED_GATE_COMMAND: &str = "post-exec gate";
+
+pub(super) fn infer_post_exec_gate_failure_from_log(
+    session_dir: &Path,
+    result_path: &Path,
+    result: &mut SessionResult,
+) -> Result<bool> {
+    if result.post_exec_gate.is_some() || !result_failed(result) {
+        return Ok(false);
+    }
+    let log_path = session_dir.join(GATE_FAILURE_LOG_REL_PATH);
+    if !log_path.is_file() {
+        return Ok(false);
+    }
+    if !gate_log_matches_current_failure(result, &log_path, result_path) {
+        return Ok(false);
+    }
+
+    let raw = fs::read_to_string(&log_path)?;
+    let redacted = csa_session::redact_text_content(&raw);
+    let gate_exit_code = if result.exit_code == 0 {
+        1
+    } else {
+        result.exit_code
+    };
+    let report = PostExecGateReport::from_redacted_gate_output(
+        INFERRED_GATE_COMMAND,
+        gate_exit_code,
+        &redacted,
+    );
+
+    result.exit_code = gate_exit_code;
+    result.status = SessionResult::status_from_exit_code(gate_exit_code);
+    result.summary = csa_session::post_exec_gate_failure_summary(&report);
+    result.post_exec_gate = Some(report);
+    ensure_gate_failure_artifact(result);
+    Ok(true)
+}
+
+fn gate_log_matches_current_failure(
+    result: &SessionResult,
+    log_path: &Path,
+    result_path: &Path,
+) -> bool {
+    result_owns_gate_failure_log(result) || gate_log_is_fresh_for_result(log_path, result_path)
+}
+
+fn result_owns_gate_failure_log(result: &SessionResult) -> bool {
+    result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.path == GATE_FAILURE_LOG_REL_PATH && !artifact.display_only)
+}
+
+fn gate_log_is_fresh_for_result(log_path: &Path, result_path: &Path) -> bool {
+    let Ok(log_modified) = fs::metadata(log_path).and_then(|metadata| metadata.modified()) else {
+        return false;
+    };
+    let Ok(result_modified) = fs::metadata(result_path).and_then(|metadata| metadata.modified())
+    else {
+        return false;
+    };
+
+    log_modified >= result_modified
+}
+
+fn result_failed(result: &SessionResult) -> bool {
+    result.exit_code != 0 || !result.status.eq_ignore_ascii_case("success")
+}
+
+fn ensure_gate_failure_artifact(result: &mut SessionResult) {
+    if let Some(artifact) = result
+        .artifacts
+        .iter_mut()
+        .find(|artifact| artifact.path == GATE_FAILURE_LOG_REL_PATH)
+    {
+        artifact.display_only = false;
+        return;
+    }
+    result
+        .artifacts
+        .push(SessionArtifact::new(GATE_FAILURE_LOG_REL_PATH));
+    result
+        .artifacts
+        .sort_by(|left, right| left.path.cmp(&right.path));
+}

--- a/crates/cli-sub-agent/src/session_observability_result_artifact_tests.rs
+++ b/crates/cli-sub-agent/src/session_observability_result_artifact_tests.rs
@@ -19,6 +19,253 @@ fn runtime_result(summary: &str, artifact_path: &str) -> SessionResult {
     }
 }
 
+fn failed_runtime_result(summary: &str) -> SessionResult {
+    let now = chrono::Utc::now();
+    SessionResult {
+        post_exec_gate: None,
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: summary.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: vec![SessionArtifact::new(csa_session::GATE_FAILURE_LOG_REL_PATH)],
+        ..Default::default()
+    }
+}
+
+fn unrelated_failed_runtime_result(summary: &str) -> SessionResult {
+    let now = chrono::Utc::now();
+    SessionResult {
+        post_exec_gate: None,
+        status: SessionResult::status_from_exit_code(143),
+        exit_code: 143,
+        summary: summary.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 1,
+        artifacts: Vec::new(),
+        ..Default::default()
+    }
+}
+
+fn set_file_mtime_seconds_ago(path: &std::path::Path, seconds_ago: u64) {
+    let target = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(seconds_ago))
+        .expect("target mtime before now");
+    let file = fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .expect("open file for mtime update");
+    file.set_times(std::fs::FileTimes::new().set_modified(target))
+        .expect("set file mtime");
+}
+
+struct StaleGateLogFixture {
+    _temp: tempfile::TempDir,
+    _state_guard: crate::test_env_lock::ScopedTestEnvVar,
+    project_root: std::path::PathBuf,
+    session_id: String,
+    session_dir: std::path::PathBuf,
+}
+
+fn create_stale_gate_log_failure_fixture() -> StaleGateLogFixture {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let state_guard =
+        crate::test_env_lock::ScopedTestEnvVar::set("XDG_STATE_HOME", temp.path().join("state"));
+    let project_root = temp.path().join("project");
+    fs::create_dir_all(&project_root).expect("create project");
+    let session = csa_session::create_session(
+        &project_root,
+        Some("stale gate failure log regression"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session_id).expect("session dir");
+    let output_dir = session_dir.join("output");
+    fs::create_dir_all(&output_dir).expect("create output dir");
+    let gate_log_path = session_dir.join(csa_session::GATE_FAILURE_LOG_REL_PATH);
+    fs::write(
+        &gate_log_path,
+        "running just pre-commit\nFAIL [   0.005s] old_gate::fails\n",
+    )
+    .expect("write stale gate failure log");
+    set_file_mtime_seconds_ago(&gate_log_path, 600);
+    csa_session::save_result(
+        &project_root,
+        &session_id,
+        &unrelated_failed_runtime_result("terminated by model signal 143"),
+    )
+    .expect("save unrelated failure envelope");
+
+    StaleGateLogFixture {
+        _temp: temp,
+        _state_guard: state_guard,
+        project_root,
+        session_id,
+        session_dir,
+    }
+}
+
+fn assert_unrelated_signal_failure_preserved(result: &SessionResult) {
+    assert_eq!(result.status, "signal");
+    assert_eq!(result.exit_code, 143);
+    assert_eq!(result.summary, "terminated by model signal 143");
+    assert!(
+        result.post_exec_gate.is_none(),
+        "stale gate-failure.log must not be attached to an unrelated current failure"
+    );
+}
+
+fn assert_gate_log_is_diagnostic_only(result: &SessionResult) {
+    let artifact = result
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.path == csa_session::GATE_FAILURE_LOG_REL_PATH)
+        .expect("observed stale gate-failure.log should remain listed for diagnostics");
+    assert!(
+        artifact.display_only,
+        "directory-scanned gate-failure.log must not prove current-result ownership"
+    );
+}
+
+#[test]
+fn refresh_and_repair_result_infers_gate_failure_from_log_artifact() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let _state_guard =
+        crate::test_env_lock::ScopedTestEnvVar::set("XDG_STATE_HOME", temp.path().join("state"));
+    let project_root = temp.path().join("project");
+    fs::create_dir_all(&project_root).expect("create project");
+    let session = csa_session::create_session(
+        &project_root,
+        Some("gate failure artifact regression"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session.meta_session_id).expect("session dir");
+    let output_dir = session_dir.join("output");
+    fs::create_dir_all(&output_dir).expect("create output dir");
+    fs::write(
+        output_dir.join("summary.md"),
+        "Fixed and committed the remaining medium finding. Did not push; working tree clean.",
+    )
+    .expect("write success-looking summary");
+    fs::write(
+        session_dir.join(csa_session::GATE_FAILURE_LOG_REL_PATH),
+        "running just pre-commit\nFAIL [   0.005s] cli_sub_agent::gate::fails\nsecret=topsecret\nerror: Recipe `test` failed on line 42 with exit code 100\n",
+    )
+    .expect("write gate failure log");
+    csa_session::save_result(
+        &project_root,
+        &session.meta_session_id,
+        &failed_runtime_result(
+            "Fixed and committed the remaining medium finding. Did not push; working tree clean.",
+        ),
+    )
+    .expect("save failure envelope");
+
+    let refreshed = refresh_and_repair_result(&project_root, &session.meta_session_id)
+        .expect("refresh result")
+        .expect("result should exist");
+
+    assert_eq!(refreshed.status, "failure");
+    assert_eq!(refreshed.exit_code, 1);
+    assert!(
+        refreshed.summary.starts_with("POST-EXEC GATE FAILED"),
+        "summary must lead with gate failure, got: {}",
+        refreshed.summary
+    );
+    assert!(
+        !refreshed.summary.contains("working tree clean"),
+        "success-looking child summary must not remain authoritative: {}",
+        refreshed.summary
+    );
+    let report = refreshed
+        .post_exec_gate
+        .expect("post_exec_gate should be inferred from gate-failure.log");
+    assert_eq!(report.gate_command, "post-exec gate");
+    assert_eq!(report.exit_code, 1);
+    assert_eq!(report.failing_step.as_deref(), Some("just test"));
+    assert!(
+        report
+            .failing_tests
+            .iter()
+            .any(|test| test == "cli_sub_agent::gate::fails")
+    );
+    assert_eq!(report.log_path, csa_session::GATE_FAILURE_LOG_REL_PATH);
+    assert!(
+        !report.output_tail.contains("topsecret"),
+        "inferred report must use redacted log content"
+    );
+
+    let loaded = csa_session::load_result(&project_root, &session.meta_session_id)
+        .expect("load result")
+        .expect("result should exist");
+    assert!(
+        loaded.post_exec_gate.is_some(),
+        "repair must persist the inferred gate detail for session result/wait"
+    );
+}
+
+#[test]
+fn refresh_and_repair_result_ignores_stale_gate_failure_log_for_unrelated_failure() {
+    let fixture = create_stale_gate_log_failure_fixture();
+
+    let refreshed = refresh_and_repair_result(&fixture.project_root, &fixture.session_id)
+        .expect("refresh result")
+        .expect("result should exist");
+
+    assert_unrelated_signal_failure_preserved(&refreshed);
+    assert_gate_log_is_diagnostic_only(&refreshed);
+}
+
+#[test]
+fn refresh_and_repair_result_from_dir_ignores_stale_gate_failure_log_for_unrelated_failure() {
+    let fixture = create_stale_gate_log_failure_fixture();
+
+    let refreshed = refresh_and_repair_result_from_dir(&fixture.session_dir)
+        .expect("refresh result")
+        .expect("result should exist");
+
+    assert_unrelated_signal_failure_preserved(&refreshed);
+}
+
+#[test]
+fn enrich_result_from_session_dir_ignores_stale_gate_failure_log_for_unrelated_failure() {
+    let fixture = create_stale_gate_log_failure_fixture();
+    let mut result = csa_session::load_result(&fixture.project_root, &fixture.session_id)
+        .expect("load result")
+        .expect("result should exist");
+
+    let changed = enrich_result_from_session_dir(
+        &fixture.project_root,
+        &fixture.session_id,
+        &fixture.session_dir,
+        &mut result,
+    )
+    .expect("enrich result");
+
+    assert!(
+        changed,
+        "diagnostic artifact discovery should update result"
+    );
+    assert_unrelated_signal_failure_preserved(&result);
+    assert_gate_log_is_diagnostic_only(&result);
+}
+
 #[test]
 fn refresh_and_repair_result_does_not_overwrite_in_flight_turn_sidecar() {
     let temp = tempfile::TempDir::new().expect("temp dir");

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -75,7 +75,8 @@ pub use output_section::{
 };
 pub use post_exec_gate_report::{
     GATE_FAILURE_LOG_REL_PATH, GATE_OUTPUT_TAIL_MAX_BYTES, GATE_OUTPUT_TAIL_MAX_LINES,
-    PostExecGateReport, bound_output_tail, parse_failing_step, parse_nextest_failing_tests,
+    GATE_SUMMARY_LEAD, PostExecGateReport, bound_output_tail, parse_failing_step,
+    parse_nextest_failing_tests, post_exec_gate_failure_label, post_exec_gate_failure_summary,
 };
 pub use process_tree_memory::{SessionTreeMemorySampler, session_tree_rss_mb};
 pub use redact::{redact_event, redact_text_content};

--- a/crates/csa-session/src/manager_result_artifacts.rs
+++ b/crates/csa-session/src/manager_result_artifacts.rs
@@ -60,12 +60,14 @@ pub fn is_manager_result_artifact_path(artifact_path: &str) -> bool {
 
 /// Convert an observed session artifact path into an ownership-safe artifact.
 ///
-/// Manager result artifacts discovered by directory scans are diagnostics only:
-/// callers must prove current-turn ownership before such paths can drive
-/// manager sidecar overlay or write-target selection.
+/// Manager result artifacts and gate-failure logs discovered by directory
+/// scans are diagnostics only: callers must prove current-turn ownership
+/// before such paths can drive result repair or manager sidecar selection.
 pub fn observed_session_artifact(artifact_path: impl Into<String>) -> SessionArtifact {
     let artifact_path = artifact_path.into();
-    if is_manager_result_artifact_path(&artifact_path) {
+    if is_manager_result_artifact_path(&artifact_path)
+        || artifact_path == crate::post_exec_gate_report::GATE_FAILURE_LOG_REL_PATH
+    {
         SessionArtifact::display_only(artifact_path)
     } else {
         SessionArtifact::new(artifact_path)

--- a/crates/csa-session/src/manager_tests_turn_results.rs
+++ b/crates/csa-session/src/manager_tests_turn_results.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::post_exec_gate_report::GATE_FAILURE_LOG_REL_PATH;
 use tempfile::tempdir;
 
 fn runtime_result(summary: &str, artifact_path: &str) -> crate::result::SessionResult {
@@ -445,5 +446,12 @@ fn test_observed_session_artifact_marks_manager_results_display_only() {
     assert!(
         !observed_log.display_only,
         "ordinary observed artifacts remain owned artifacts"
+    );
+
+    let observed_gate_log = observed_session_artifact(GATE_FAILURE_LOG_REL_PATH);
+    assert_eq!(observed_gate_log.path, GATE_FAILURE_LOG_REL_PATH);
+    assert!(
+        observed_gate_log.display_only,
+        "observed gate-failure logs must not prove current result ownership"
     );
 }

--- a/crates/csa-session/src/post_exec_gate_report.rs
+++ b/crates/csa-session/src/post_exec_gate_report.rs
@@ -26,6 +26,18 @@ pub const GATE_OUTPUT_TAIL_MAX_LINES: usize = 100;
 /// The full output always lives in [`GATE_FAILURE_LOG_REL_PATH`].
 pub const GATE_OUTPUT_TAIL_MAX_BYTES: usize = 8 * 1024;
 
+/// Leading marker for gate-failure summaries. Callers and tests key off this
+/// marker to distinguish the authoritative gate verdict from the employee's
+/// pre-gate self-report.
+pub const GATE_SUMMARY_LEAD: &str = "POST-EXEC GATE FAILED";
+
+/// How many failing test names to inline into one-line summaries before
+/// collapsing the rest into a `(+N more)` suffix.
+const SUMMARY_MAX_INLINE_TESTS: usize = 5;
+
+/// Maximum size of the single-line tail excerpt embedded in summary text.
+const SUMMARY_OUTPUT_EXCERPT_MAX_CHARS: usize = 240;
+
 /// Structured detail of a failed post-exec verification gate.
 ///
 /// Serialized as the `[post_exec_gate]` table of `result.toml`. Present ONLY
@@ -77,6 +89,86 @@ impl PostExecGateReport {
             log_path: GATE_FAILURE_LOG_REL_PATH.to_string(),
         }
     }
+}
+
+/// Build the caller-facing one-line failure summary for a post-exec gate
+/// report. It always leads with [`GATE_SUMMARY_LEAD`] and includes bounded
+/// context only; the full output remains in [`PostExecGateReport::log_path`].
+pub fn post_exec_gate_failure_summary(report: &PostExecGateReport) -> String {
+    let mut summary = format!(
+        "{GATE_SUMMARY_LEAD} (phase=post-exec, command={}, exit={}",
+        report.gate_command, report.exit_code
+    );
+    if let Some(step) = &report.failing_step {
+        summary.push_str(&format!(", step={step}"));
+    }
+    summary.push_str(") - employee self-report SUPERSEDED by gate verdict; full output: ");
+    summary.push_str(&report.log_path);
+    append_failing_tests(&mut summary, report);
+    append_tail_excerpt(&mut summary, report);
+    summary
+}
+
+/// Build a compact label for terminal summaries, e.g. the `csa session wait`
+/// compact output.
+pub fn post_exec_gate_failure_label(report: &PostExecGateReport) -> String {
+    let mut label = format!(
+        "failed (phase=post-exec, command={}, exit={}",
+        report.gate_command, report.exit_code
+    );
+    if let Some(step) = &report.failing_step {
+        label.push_str(&format!(", step={step}"));
+    }
+    label.push_str(&format!(", log={})", report.log_path));
+    append_failing_tests(&mut label, report);
+    label
+}
+
+fn append_failing_tests(message: &mut String, report: &PostExecGateReport) {
+    if report.failing_tests.is_empty() {
+        return;
+    }
+    let shown: Vec<&str> = report
+        .failing_tests
+        .iter()
+        .take(SUMMARY_MAX_INLINE_TESTS)
+        .map(String::as_str)
+        .collect();
+    message.push_str("; failing tests: ");
+    message.push_str(&shown.join(", "));
+    let extra = report
+        .failing_tests
+        .len()
+        .saturating_sub(SUMMARY_MAX_INLINE_TESTS);
+    if extra > 0 {
+        message.push_str(&format!(" (+{extra} more)"));
+    }
+}
+
+fn append_tail_excerpt(message: &mut String, report: &PostExecGateReport) {
+    let Some(excerpt) = compact_tail_excerpt(&report.output_tail) else {
+        return;
+    };
+    message.push_str("; tail: ");
+    message.push_str(&excerpt);
+}
+
+fn compact_tail_excerpt(output_tail: &str) -> Option<String> {
+    let line = output_tail
+        .lines()
+        .rev()
+        .map(str::trim)
+        .find(|line| !line.is_empty())?;
+    let normalized = line.split_whitespace().collect::<Vec<_>>().join(" ");
+    Some(clip_chars(&normalized, SUMMARY_OUTPUT_EXCERPT_MAX_CHARS))
+}
+
+fn clip_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let truncated: String = value.chars().take(max_chars.saturating_sub(1)).collect();
+    format!("{}…", truncated.trim_end())
 }
 
 /// Parse failed test names from `cargo nextest` output.
@@ -299,5 +391,40 @@ error: Recipe `clippy` failed on line 7 with exit code 101";
         assert_eq!(loaded, report);
         assert_eq!(loaded.failing_tests, vec!["pkg::a".to_string()]);
         assert_eq!(loaded.failing_step.as_deref(), Some("just test"));
+    }
+
+    #[test]
+    fn failure_summary_leads_with_gate_and_includes_bounded_tail() {
+        let report = PostExecGateReport::from_redacted_gate_output(
+            "post-exec gate",
+            1,
+            "FAIL [   0.005s] pkg::a\nerror: Recipe `test` failed on line 1 with exit code 100\n",
+        );
+
+        let summary = post_exec_gate_failure_summary(&report);
+
+        assert!(summary.starts_with(GATE_SUMMARY_LEAD));
+        assert!(summary.contains("phase=post-exec"));
+        assert!(summary.contains("command=post-exec gate"));
+        assert!(summary.contains("step=just test"));
+        assert!(summary.contains("pkg::a"));
+        assert!(summary.contains(GATE_FAILURE_LOG_REL_PATH));
+        assert!(summary.contains("tail: error: Recipe `test` failed"));
+    }
+
+    #[test]
+    fn failure_label_is_compact() {
+        let report = PostExecGateReport::from_redacted_gate_output(
+            "just pre-commit",
+            100,
+            "FAIL [   0.005s] pkg::a\nerror: Recipe `test` failed on line 1 with exit code 100\n",
+        );
+
+        let label = post_exec_gate_failure_label(&report);
+
+        assert!(label.starts_with("failed (phase=post-exec"));
+        assert!(label.contains("command=just pre-commit"));
+        assert!(label.contains("step=just test"));
+        assert!(label.contains(GATE_FAILURE_LOG_REL_PATH));
     }
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.998"
-weave = "0.1.998"
+csa = "0.1.999"
+weave = "0.1.999"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Closes #2078.

Surfaces post-exec gate failures directly in CSA session result/wait summaries instead of allowing a child/tool success-looking summary to hide a failed caller gate.

- Adds bounded post-exec gate failure report rendering and shared result repair logic.
- Repairs result/wait display paths so current gate failures dominate compact summaries.
- Makes gate-failure-log inference ownership/freshness-aware so stale `output/gate-failure.log` files from earlier runs cannot relabel unrelated later failures.
- Marks directory-scanned gate-failure logs display-only unless the current result owns/freshly produced them.
- Adds regression coverage for result artifact repair, wait-summary output, stale gate logs, and csa-session observed artifact ownership.
- Bumps project version to `0.1.999`.

## Local validation

- Hook-enabled commit/amend PASS:
  - branch-protection
  - quality-gates
- Focused/native fallback validation PASS:
  - `cargo test -p cli-sub-agent --bin csa session_observability::result_artifact_tests -- --test-threads=1`
  - `cargo test -p csa-session observed_session_artifact_marks_manager_results_display_only -- --test-threads=1`
  - `cargo test -p cli-sub-agent --bin csa compact_summary_prefers_post_exec_gate_failure_over_success_markdown -- --test-threads=1`
  - `cargo test -p cli-sub-agent --bin csa session_cmds_daemon::wait::summary::wait_output_tests -- --test-threads=1`
  - `cargo test -p cli-sub-agent --bin csa run_cmd_post_gate_report::tests -- --test-threads=1`
  - `cargo test -p csa-session post_exec_gate_report::tests -- --test-threads=1`
  - `cargo fmt --package cli-sub-agent -- --check`
  - `cargo fmt --package csa-session -- --check`
  - `cargo check -p cli-sub-agent --bin csa`
  - `git diff --check && git diff --cached --check`
  - `just find-monolith-files`
- Exact-head pinned CSA/Codex full-diff review PASS:
  - `01KV1VY0K2MHFYSPN4EXJWH8AM`

## Notes

GitHub CI is intentionally not used as the agent-side gate; local hooks plus exact-head pinned review are the gate for this workflow.

CSA/Codex signal-143 evidence observed during the implementation/review-fix path is tracked separately in #2198, #2199, #2200, and #2202.