### PR TITLE
fix(skill): align listed skill sources with run resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "axum",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.999"
+version = "0.1.1000"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.999"
+version = "0.1.1000"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/error_hints.rs
+++ b/crates/cli-sub-agent/src/error_hints.rs
@@ -21,6 +21,7 @@ const HINT_SLOT_EXHAUSTED: &str = "hint: free slots with 'csa gc' or wait with '
 const HINT_SESSION_NOT_FOUND: &str = "hint: list available sessions with 'csa session list'";
 const HINT_CONFIG_ERROR: &str =
     "hint: validate config with 'csa config validate' or reinitialize with 'csa init'";
+const HINT_SKILL_NOT_FOUND: &str = "hint: list runnable skills with 'csa skill list' or install one with 'csa skill install <repo>'";
 const HINT_GEMINI_RUNTIME_HOME: &str = "hint: Gemini ACP needs a writable runtime home; current builds pin TMPDIR to a writable sandbox temp dir (private /tmp in bwrap, session tmp elsewhere) and seed under CSA session state, but older builds may still need re-run with TMPDIR=/tmp";
 const LEFTHOOK_CORE_HOOKSPATH_CONFLICT: &str = "core.hooksPath is set locally";
 const HINT_LEFTHOOK_CORE_HOOKSPATH_CONFLICT: &str = "hint: lefthook blocked git commit because core.hooksPath is set locally. Staged work may be uncommitted. Run `git config --unset-all --local core.hooksPath`, then rerun the commit or continue the session.";
@@ -59,6 +60,10 @@ pub fn suggest_fix(err: &Error) -> Option<String> {
 
     let has_not_installed_or_not_found =
         chain_text.contains("not installed") || chain_text.contains("not found");
+
+    if chain_text.contains("skill '") && chain_text.contains("not found") {
+        return Some(HINT_SKILL_NOT_FOUND.to_string());
+    }
 
     if has_not_installed_or_not_found {
         if chain_text.contains("gemini") {
@@ -251,6 +256,19 @@ mod tests {
         assert!(
             hint.contains("@openai/codex"),
             "should mention the default codex CLI: {hint}"
+        );
+    }
+
+    #[test]
+    fn test_skill_not_found_with_codex_name_does_not_suggest_codex_install() {
+        let err = anyhow::anyhow!(
+            "Skill 'mktsk-codex' not found. Searched:\n  - /project/.codex/skills/mktsk-codex"
+        );
+        let hint = suggest_fix(&err).unwrap();
+        assert!(hint.contains("csa skill list"), "got: {hint}");
+        assert!(
+            !hint.contains("@openai/codex"),
+            "missing skill must not suggest installing Codex CLI: {hint}"
         );
     }
 

--- a/crates/cli-sub-agent/src/skill_cmds.rs
+++ b/crates/cli-sub-agent/src/skill_cmds.rs
@@ -8,6 +8,7 @@ use tracing::info;
 use crate::skill_repo::{
     SkillRepoManager, git_commit_all, git_commit_paths, skill_repo_root, validate_skill_name,
 };
+use crate::skill_resolver;
 
 /// Handle skill install command
 pub(crate) fn handle_skill_install(source: String, target: Option<String>) -> Result<()> {
@@ -45,39 +46,18 @@ pub(crate) fn handle_skill_install(source: String, target: Option<String>) -> Re
     Ok(())
 }
 
-/// Handle skill list command — shows both active (.claude/skills/) and managed (state dir) skills.
+/// Handle skill list command — shows runnable active sources and managed state-dir skills.
 pub(crate) fn handle_skill_list() -> Result<()> {
     let mut any = false;
 
-    // --- Active skills (project + global .claude/skills/) ---
-    let active_dirs = collect_active_skill_dirs();
-    let mut active_skills: Vec<(String, PathBuf)> = Vec::new();
-    for dir in &active_dirs {
-        if !dir.exists() {
-            continue;
-        }
-        for entry in fs::read_dir(dir)?.flatten() {
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-            let name = match path.file_name().and_then(|n| n.to_str()) {
-                Some(n) if !n.starts_with('.') => n.to_string(),
-                _ => continue,
-            };
-            if path.join("SKILL.md").exists() {
-                active_skills.push((name, path));
-            }
-        }
-    }
-    active_skills.sort_by(|a, b| a.0.cmp(&b.0));
-    active_skills.dedup_by(|a, b| a.0 == b.0);
+    // --- Active skills (same runnable search paths as `csa run --skill`) ---
+    let active_skills = collect_active_skill_sources()?;
 
     if !active_skills.is_empty() {
-        eprintln!("Active skills (.claude/skills/):\n");
-        for (name, path) in &active_skills {
-            let title = read_skill_title(path).unwrap_or_else(|| name.clone());
-            println!("  {name} [active] - {title}");
+        eprintln!("Active skills (runnable search paths):\n");
+        for source in &active_skills {
+            let title = read_skill_title(&source.dir).unwrap_or_else(|| source.name.clone());
+            println!("  {} [active] - {title}", source.name);
         }
         any = true;
     }
@@ -334,22 +314,9 @@ pub(crate) fn handle_skill_backup() -> Result<()> {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/// Collect all directories to search for active skills.
-fn collect_active_skill_dirs() -> Vec<PathBuf> {
-    let mut dirs = Vec::new();
-
-    // Project-local
-    if let Ok(cwd) = std::env::current_dir() {
-        dirs.push(cwd.join(".claude").join("skills"));
-        dirs.push(cwd.join(".csa").join("skills"));
-    }
-
-    // Global ~/.claude/skills/
-    if let Some(base) = directories::BaseDirs::new() {
-        dirs.push(base.home_dir().join(".claude").join("skills"));
-    }
-
-    dirs
+fn collect_active_skill_sources() -> Result<Vec<skill_resolver::ActiveSkillSource>> {
+    let cwd = std::env::current_dir().context("Could not determine current directory")?;
+    skill_resolver::list_active_skill_sources(&cwd)
 }
 
 /// Return the current hostname (best-effort, falls back to "host").
@@ -746,18 +713,6 @@ mod tests {
 
         let installed = copy_skills(src.path(), dest.path()).unwrap();
         assert!(installed.is_empty());
-    }
-
-    // --- collect_active_skill_dirs tests ---
-
-    #[test]
-    fn collect_active_skill_dirs_returns_expected_paths() {
-        let dirs = collect_active_skill_dirs();
-        assert!(
-            dirs.iter()
-                .any(|d| d.ends_with(".claude/skills") || d.ends_with(".csa/skills")),
-            "should contain .claude/skills or .csa/skills: {dirs:?}"
-        );
     }
 
     // --- gethostname tests ---

--- a/crates/cli-sub-agent/src/skill_resolver.rs
+++ b/crates/cli-sub-agent/src/skill_resolver.rs
@@ -7,11 +7,14 @@
 //! Search order:
 //! 1. `./.csa/skills/<name>/`                             (project-local, CSA-specific)
 //! 2. `./.claude/skills/<name>/`                          (project-local, Claude Code compat)
-//! 3. `<superproject>/.csa/skills/<name>/`                (submodule only)
-//! 4. `<superproject>/.claude/skills/<name>/`             (submodule only)
-//! 5. `~/.config/cli-sub-agent/skills/<name>/`            (global user config)
-//! 6. `~/.local/state/cli-sub-agent/skills/<name>/`       (CSA-managed inactive skills)
-//! 7. `<global_store>/<name>/<commit>/`                   (weave global store via lockfiles)
+//! 3. `./.codex/skills/<name>/`                           (project-local, Codex compat)
+//! 4. `./.agents/skills/<name>/`                          (project-local, shared agent compat)
+//! 5. `./skills/csa/<name>/` and `./.claude/skills/csa/<name>/`
+//! 6. Matching active skill directories and bundled namespaces in an optional superproject root
+//! 7. `~/.claude/skills/<name>/`, `~/.codex/skills/<name>/`, `~/.agents/skills/<name>/`
+//! 8. `~/.config/cli-sub-agent/skills/<name>/`            (global user config)
+//! 9. `~/.local/state/cli-sub-agent/skills/<name>/`       (CSA-managed inactive skills)
+//! 10. `<global_store>/<name>/<commit>/`                  (weave global store via lockfiles)
 
 use anyhow::{Context, Result, bail};
 use csa_config::paths;
@@ -21,6 +24,8 @@ use weave::package::{self, SourceKind};
 use weave::parser::{AgentConfig, SkillConfig, parse_skill_config};
 
 use crate::skill_repo::sanitize_skill_md;
+
+const CSA_SKILL_DIR: &str = ".csa/skills";
 
 /// A skill resolved from disk, ready for injection into a CSA run.
 #[derive(Debug, Clone)]
@@ -40,6 +45,15 @@ impl ResolvedSkill {
     }
 }
 
+/// A runnable skill discovered for `csa skill list`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ActiveSkillSource {
+    /// Skill name used by `csa run --skill <name>`.
+    pub name: String,
+    /// Directory where the skill lives.
+    pub dir: PathBuf,
+}
+
 /// Resolve a skill by name, searching standard paths in priority order.
 ///
 /// `project_root` is the working directory / project root for the CSA run.
@@ -50,8 +64,11 @@ pub(crate) fn resolve_skill(name: &str, project_root: &Path) -> Result<ResolvedS
     }
 
     let candidates = search_paths(name, project_root);
+    resolve_skill_from_candidates(name, &candidates)
+}
 
-    for dir in &candidates {
+fn resolve_skill_from_candidates(name: &str, candidates: &[PathBuf]) -> Result<ResolvedSkill> {
+    for dir in candidates {
         let skill_md_path = dir.join("SKILL.md");
         if skill_md_path.is_file() {
             let raw_skill_md = std::fs::read_to_string(&skill_md_path)
@@ -80,12 +97,23 @@ pub(crate) fn resolve_skill(name: &str, project_root: &Path) -> Result<ResolvedS
     )
 }
 
+/// List active runnable skills using the same runnable non-store parent
+/// directories searched by the run resolver.
+pub(crate) fn list_active_skill_sources(project_root: &Path) -> Result<Vec<ActiveSkillSource>> {
+    list_active_skill_sources_with_home_and_config(
+        project_root,
+        user_home_dir().as_deref(),
+        paths::config_dir().as_deref(),
+    )
+}
+
 /// Build the ordered list of directories to search for a skill.
 fn search_paths(name: &str, project_root: &Path) -> Vec<PathBuf> {
     search_paths_with_store(
         name,
         project_root,
         package::global_store_root().ok().as_deref(),
+        user_home_dir().as_deref(),
     )
 }
 
@@ -94,31 +122,38 @@ fn search_paths_with_store(
     name: &str,
     project_root: &Path,
     store_root: Option<&Path>,
+    home_dir: Option<&Path>,
 ) -> Vec<PathBuf> {
-    let mut search_roots = Vec::with_capacity(8);
+    search_paths_with_explicit_dirs(
+        name,
+        project_root,
+        store_root,
+        home_dir,
+        paths::config_dir().as_deref(),
+        paths::state_dir_write().as_deref(),
+    )
+}
+
+fn search_paths_with_explicit_dirs(
+    name: &str,
+    project_root: &Path,
+    store_root: Option<&Path>,
+    home_dir: Option<&Path>,
+    config_dir: Option<&Path>,
+    state_dir: Option<&Path>,
+) -> Vec<PathBuf> {
     let repo_roots = discover_repo_roots(project_root);
-
-    // 1. Project-local and ancestor repo roots:
-    //    direct skill names first, then the CSA namespace used by bundled
-    //    compatibility skills.
-    for root in &repo_roots {
-        search_roots.push(root.join(".csa").join("skills").join(name));
-        search_roots.push(root.join(".claude").join("skills").join(name));
-        search_roots.push(root.join("skills").join("csa").join(name));
-        search_roots.push(root.join(".claude").join("skills").join("csa").join(name));
+    let mut parent_dirs =
+        runnable_non_store_skill_parent_dirs_with_config(&repo_roots, home_dir, config_dir);
+    if let Some(state_dir) = state_dir {
+        parent_dirs.push(state_dir.join("skills"));
     }
+    let mut search_roots = parent_dirs
+        .into_iter()
+        .map(|parent| parent.join(name))
+        .collect::<Vec<_>>();
 
-    // 5. Global user config: ~/.config/cli-sub-agent/skills/<name>/ (legacy fallback supported)
-    if let Some(config_dir) = paths::config_dir() {
-        search_roots.push(config_dir.join("skills").join(name));
-    }
-
-    // 6. CSA-managed inactive skills: ~/.local/state/cli-sub-agent/skills/<name>/
-    if let Some(state_dir) = paths::state_dir_write() {
-        search_roots.push(state_dir.join("skills").join(name));
-    }
-
-    // 7. Weave global store: match locked packages by name.
+    // Weave global store: match locked packages by name.
     if let Some(store) = store_root {
         for root in &repo_roots {
             if let Some(lockfile_path) = package::find_lockfile(root)
@@ -142,6 +177,81 @@ fn search_paths_with_store(
     }
 
     search_roots
+}
+
+fn runnable_non_store_skill_parent_dirs_with_config(
+    repo_roots: &[PathBuf],
+    home_dir: Option<&Path>,
+    config_dir: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut dirs = Vec::with_capacity(repo_roots.len() * 6 + 5);
+
+    for root in repo_roots {
+        dirs.extend(repo_active_skill_parent_dirs(root));
+        dirs.push(root.join("skills").join("csa"));
+        dirs.push(root.join(".claude").join("skills").join("csa"));
+    }
+    if let Some(home) = home_dir {
+        dirs.extend(home_active_skill_parent_dirs(home));
+    }
+    if let Some(config_dir) = config_dir {
+        dirs.push(config_dir.join("skills"));
+    }
+
+    dirs
+}
+
+fn repo_active_skill_parent_dirs(root: &Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::with_capacity(weave::check::DEFAULT_LINK_DIRS.len() + 1);
+    dirs.push(root.join(CSA_SKILL_DIR));
+    dirs.extend(
+        weave::check::DEFAULT_LINK_DIRS
+            .iter()
+            .map(|rel| root.join(rel)),
+    );
+    dirs
+}
+
+fn home_active_skill_parent_dirs(home: &Path) -> Vec<PathBuf> {
+    weave::check::DEFAULT_LINK_DIRS
+        .iter()
+        .map(|rel| home.join(rel))
+        .collect()
+}
+
+fn list_active_skill_sources_with_home_and_config(
+    project_root: &Path,
+    home_dir: Option<&Path>,
+    config_dir: Option<&Path>,
+) -> Result<Vec<ActiveSkillSource>> {
+    let mut active_skills = Vec::new();
+    let repo_roots = discover_repo_roots(project_root);
+    for dir in runnable_non_store_skill_parent_dirs_with_config(&repo_roots, home_dir, config_dir) {
+        if !dir.exists() {
+            continue;
+        }
+        for entry in std::fs::read_dir(&dir)?.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) if !n.starts_with('.') => n.to_string(),
+                _ => continue,
+            };
+            if path.join("SKILL.md").exists() {
+                active_skills.push(ActiveSkillSource { name, dir: path });
+            }
+        }
+    }
+
+    active_skills.sort_by(|a, b| a.name.cmp(&b.name));
+    active_skills.dedup_by(|a, b| a.name == b.name);
+    Ok(active_skills)
+}
+
+fn user_home_dir() -> Option<PathBuf> {
+    directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf())
 }
 
 fn discover_repo_roots(project_root: &Path) -> Vec<PathBuf> {

--- a/crates/cli-sub-agent/src/skill_resolver_tests.rs
+++ b/crates/cli-sub-agent/src/skill_resolver_tests.rs
@@ -81,6 +81,35 @@ fn assert_paths_exclude(paths: &[std::path::PathBuf], expected: &Path, msg: &str
     );
 }
 
+fn assert_listed_source_resolves_from_same_dir(project_root: &Path, home: &Path, name: &str) {
+    assert_listed_source_resolves_from_same_dir_with_config(project_root, home, None, name);
+}
+
+fn assert_listed_source_resolves_from_same_dir_with_config(
+    project_root: &Path,
+    home: &Path,
+    config_dir: Option<&Path>,
+    name: &str,
+) {
+    let listed =
+        list_active_skill_sources_with_home_and_config(project_root, Some(home), config_dir)
+            .unwrap();
+    let source = listed
+        .iter()
+        .find(|source| source.name == name)
+        .unwrap_or_else(|| panic!("{name} should be listed as active"));
+    let candidates =
+        search_paths_with_explicit_dirs(name, project_root, None, Some(home), config_dir, None);
+    let resolved = resolve_skill_from_candidates(name, &candidates).unwrap();
+
+    assert!(
+        path_equivalent(&source.dir, &resolved.dir),
+        "listed source and run resolver source should match: listed={}, resolved={}",
+        source.dir.display(),
+        resolved.dir.display()
+    );
+}
+
 #[test]
 fn resolve_skill_from_csa_skills() {
     let tmp = TempDir::new().unwrap();
@@ -131,7 +160,7 @@ tool = "claude-code"
     // Write lockfile referencing this package.
     write_lockfile(tmp.path(), "audit", commit);
 
-    let paths = search_paths_with_store("audit", tmp.path(), Some(store.path()));
+    let paths = search_paths_with_store("audit", tmp.path(), Some(store.path()), None);
     let found = paths.iter().find(|p| p.join("SKILL.md").is_file());
     assert!(found.is_some(), "skill not found in global store paths");
 
@@ -158,7 +187,7 @@ fn search_paths_include_superproject_roots_for_submodule_project_root() {
     )
     .unwrap();
 
-    let paths = search_paths_with_store("dev2merge", &submodule_root, None);
+    let paths = search_paths_with_store("dev2merge", &submodule_root, None, None);
     assert_paths_include(
         &paths,
         &tmp.path().join(".csa").join("skills").join("dev2merge"),
@@ -192,7 +221,7 @@ fn search_paths_include_immediate_parent_for_nested_submodule_project_root() {
     )
     .unwrap();
 
-    let paths = search_paths_with_store("dev2merge", &inner_root, None);
+    let paths = search_paths_with_store("dev2merge", &inner_root, None, None);
     assert_paths_include(
         &paths,
         &tmp.path()
@@ -252,7 +281,7 @@ fn search_paths_include_superproject_roots_for_worktree_submodule_project_root()
     )
     .unwrap();
 
-    let paths = search_paths_with_store("dev2merge", &submodule_root, None);
+    let paths = search_paths_with_store("dev2merge", &submodule_root, None, None);
     assert_paths_include(
         &paths,
         &worktree_root.join(".csa").join("skills").join("dev2merge"),
@@ -289,7 +318,7 @@ fn search_paths_do_not_include_main_root_for_plain_worktree_project_root() {
     )
     .unwrap();
 
-    let paths = search_paths_with_store("dev2merge", &worktree_root, None);
+    let paths = search_paths_with_store("dev2merge", &worktree_root, None, None);
     assert_paths_include(
         &paths,
         &worktree_root.join(".csa").join("skills").join("dev2merge"),
@@ -314,7 +343,7 @@ fn resolve_skill_csa_takes_priority_over_global_store() {
     make_skill_dir(&pkg_dir, ".", "# Global Store Review", None);
     write_lockfile(tmp.path(), "review", commit);
 
-    let paths = search_paths_with_store("review", tmp.path(), Some(store.path()));
+    let paths = search_paths_with_store("review", tmp.path(), Some(store.path()), None);
     let first_match = paths.iter().find(|p| p.join("SKILL.md").is_file());
     assert!(first_match.is_some());
     let content = fs::read_to_string(first_match.unwrap().join("SKILL.md")).unwrap();
@@ -349,6 +378,191 @@ fn resolve_skill_from_csa_namespace() {
     let resolved = resolve_skill("code-health-agent", tmp.path()).unwrap();
     assert!(resolved.skill_md.contains("Code Health Agent"));
     assert!(resolved.dir.ends_with("skills/csa/code-health-agent"));
+}
+
+#[test]
+fn resolve_skill_from_project_claude_csa_namespace() {
+    let tmp = TempDir::new().unwrap();
+    make_skill_dir(
+        tmp.path(),
+        ".claude/skills/csa/review-agent",
+        "# Review Agent\nFrom Claude CSA namespace.",
+        None,
+    );
+
+    let resolved = resolve_skill("review-agent", tmp.path()).unwrap();
+    assert!(resolved.skill_md.contains("Claude CSA namespace"));
+    assert!(resolved.dir.ends_with(".claude/skills/csa/review-agent"));
+}
+
+#[test]
+fn resolve_skill_from_project_codex_skills() {
+    let tmp = TempDir::new().unwrap();
+    make_skill_dir(
+        tmp.path(),
+        ".codex/skills/mktsk-codex",
+        "# mktsk-codex\nFrom project Codex skills.",
+        None,
+    );
+
+    let resolved = resolve_skill("mktsk-codex", tmp.path()).unwrap();
+    assert!(resolved.skill_md.contains("project Codex skills"));
+    assert!(resolved.dir.ends_with(".codex/skills/mktsk-codex"));
+}
+
+#[test]
+fn resolve_skill_from_project_agents_skills() {
+    let tmp = TempDir::new().unwrap();
+    make_skill_dir(
+        tmp.path(),
+        ".agents/skills/code-health-agent",
+        "# code-health-agent\nFrom project agent skills.",
+        None,
+    );
+
+    let resolved = resolve_skill("code-health-agent", tmp.path()).unwrap();
+    assert!(resolved.skill_md.contains("project agent skills"));
+    assert!(resolved.dir.ends_with(".agents/skills/code-health-agent"));
+}
+
+#[test]
+fn listed_project_csa_namespace_skill_resolves_from_same_source() {
+    let tmp = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    make_skill_dir(
+        tmp.path(),
+        "skills/csa/code-health-agent",
+        "# code-health-agent\nListed and runnable from bundled CSA namespace.",
+        None,
+    );
+
+    assert_listed_source_resolves_from_same_dir(tmp.path(), home.path(), "code-health-agent");
+}
+
+#[test]
+fn listed_project_claude_csa_namespace_skill_resolves_from_same_source() {
+    let tmp = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    make_skill_dir(
+        tmp.path(),
+        ".claude/skills/csa/review-agent",
+        "# review-agent\nListed and runnable from Claude CSA namespace.",
+        None,
+    );
+
+    assert_listed_source_resolves_from_same_dir(tmp.path(), home.path(), "review-agent");
+}
+
+#[test]
+fn listed_project_codex_skill_resolves_from_same_source() {
+    let tmp = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    make_skill_dir(
+        tmp.path(),
+        ".codex/skills/mktsk-codex",
+        "# mktsk-codex\nListed and runnable.",
+        None,
+    );
+
+    assert_listed_source_resolves_from_same_dir(tmp.path(), home.path(), "mktsk-codex");
+}
+
+#[test]
+fn listed_project_agents_skill_resolves_from_same_source() {
+    let tmp = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    make_skill_dir(
+        tmp.path(),
+        ".agents/skills/shared-agent",
+        "# shared-agent\nListed and runnable.",
+        None,
+    );
+
+    assert_listed_source_resolves_from_same_dir(tmp.path(), home.path(), "shared-agent");
+}
+
+#[test]
+fn listed_config_skill_resolves_from_same_source() {
+    let tmp = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    let config = TempDir::new().unwrap();
+    make_skill_dir(
+        config.path(),
+        "skills/config-agent",
+        "# config-agent\nListed and runnable from user config.",
+        None,
+    );
+
+    assert_listed_source_resolves_from_same_dir_with_config(
+        tmp.path(),
+        home.path(),
+        Some(config.path()),
+        "config-agent",
+    );
+}
+
+#[test]
+fn listed_global_codex_skill_resolves_from_same_source() {
+    let tmp = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    make_skill_dir(
+        home.path(),
+        ".codex/skills/mktsk-codex",
+        "# mktsk-codex\nFrom global Codex skills.",
+        None,
+    );
+
+    assert_listed_source_resolves_from_same_dir(tmp.path(), home.path(), "mktsk-codex");
+}
+
+#[test]
+fn listed_global_agents_skill_resolves_from_same_source() {
+    let tmp = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    make_skill_dir(
+        home.path(),
+        ".agents/skills/shared-agent",
+        "# shared-agent\nFrom global agent skills.",
+        None,
+    );
+
+    assert_listed_source_resolves_from_same_dir(tmp.path(), home.path(), "shared-agent");
+}
+
+#[test]
+fn listed_duplicate_skill_keeps_resolver_precedence() {
+    let tmp = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+    make_skill_dir(
+        tmp.path(),
+        ".csa/skills/shared",
+        "# shared\nFrom CSA skills.",
+        None,
+    );
+    make_skill_dir(
+        tmp.path(),
+        ".codex/skills/shared",
+        "# shared\nFrom Codex skills.",
+        None,
+    );
+
+    let listed =
+        list_active_skill_sources_with_home_and_config(tmp.path(), Some(home.path()), None)
+            .unwrap();
+    let source = listed
+        .iter()
+        .find(|source| source.name == "shared")
+        .expect("shared should be listed as active");
+    assert!(source.dir.ends_with(".csa/skills/shared"));
+    assert_eq!(
+        listed
+            .iter()
+            .filter(|source| source.name == "shared")
+            .count(),
+        1,
+        "active list should deduplicate duplicate skill names: {listed:?}"
+    );
+    assert_listed_source_resolves_from_same_dir(tmp.path(), home.path(), "shared");
 }
 
 #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.999"
-weave = "0.1.999"
+csa = "0.1.1000"
+weave = "0.1.1000"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Aligns `csa skill list` active source discovery with `csa run --skill` resolution.
- Lists resolver-supported runnable sources including `.csa`, `.claude`, `.codex`, `.agents`, bundled `skills/csa`, global tool skill dirs, and config-dir skills.
- Keeps managed state-dir skills separate from active non-store listing.
- Updates missing-skill hints so names like `mktsk-codex` are treated as skill-resolution problems, not Codex CLI install problems.
- Adds regressions asserting listed sources resolve from the same directory across project, global, config, namespace, and duplicate-precedence cases.

Closes #2070

## Validation

- Hook-enabled amend passed branch-protection and quality-gates.
- CSA full-diff review `01KV21FEQP9RKXE438VSYT1SV5`: PASS/CLEAN for `main...HEAD` at `7369b13b2ec`.
- Review-only `git diff --check main...HEAD`: clean.
