### PR TITLE
fix(pr-bot): make version-bump gate optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "axum",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1000"
+version = "0.1.1001"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1000"
+version = "0.1.1001"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/pr-bot/scripts/pre-merge-version-check.sh
+++ b/patterns/pr-bot/scripts/pre-merge-version-check.sh
@@ -14,16 +14,44 @@ if [ ! -f Cargo.toml ]; then
   exit 0
 fi
 
+require_version_check() {
+  [ "${CSA_REQUIRE_VERSION_CHECK:-0}" = "1" ]
+}
+
+has_justfile() {
+  [ -f justfile ] || [ -f Justfile ] || [ -f .justfile ]
+}
+
 if ! command -v just >/dev/null 2>&1; then
-  echo "ERROR: Cargo.toml exists but 'just' is unavailable; cannot run the pre-merge version gate." >&2
-  echo "Install just or run the repository version check before retrying pr-bot." >&2
-  exit 1
+  if require_version_check; then
+    echo "ERROR: CSA_REQUIRE_VERSION_CHECK=1 but 'just' is unavailable; cannot run the pre-merge version gate." >&2
+    echo "Install just or unset CSA_REQUIRE_VERSION_CHECK for repositories without a mandatory version gate." >&2
+    exit 1
+  fi
+  echo "pr-bot version gate skipped: 'just' is unavailable"
+  exit 0
 fi
 
-if ! just --summary 2>/dev/null | tr ' ' '\n' | grep -qx 'check-version-bumped'; then
-  echo "ERROR: Cargo.toml exists but just target 'check-version-bumped' is unavailable." >&2
-  echo "Add a local version bump gate, or set CSA_SKIP_VERSION_CHECK=1 only for release automation." >&2
-  exit 1
+JUST_SUMMARY=""
+if ! JUST_SUMMARY="$(just --summary 2>&1)"; then
+  if require_version_check || has_justfile; then
+    echo "ERROR: Could not inspect just targets before the pre-merge version gate." >&2
+    printf '%s\n' "${JUST_SUMMARY}" >&2
+    echo "Fix the justfile or unset CSA_REQUIRE_VERSION_CHECK for repositories without a mandatory version gate." >&2
+    exit 1
+  fi
+  echo "pr-bot version gate skipped: just targets are unavailable"
+  exit 0
+fi
+
+if ! printf '%s\n' "${JUST_SUMMARY}" | tr ' ' '\n' | grep -qx 'check-version-bumped'; then
+  if require_version_check; then
+    echo "ERROR: CSA_REQUIRE_VERSION_CHECK=1 but just target 'check-version-bumped' is unavailable." >&2
+    echo "Add a local just target named 'check-version-bumped' or unset CSA_REQUIRE_VERSION_CHECK." >&2
+    exit 1
+  fi
+  echo "pr-bot version gate skipped: just target 'check-version-bumped' is unavailable"
+  exit 0
 fi
 
 if [ -z "${REMOTE_NAME}" ] || [ -z "${DEFAULT_BRANCH}" ]; then

--- a/patterns/pr-bot/scripts/tests/pre-merge-version-check-tests.sh
+++ b/patterns/pr-bot/scripts/tests/pre-merge-version-check-tests.sh
@@ -52,6 +52,47 @@ EOF
   chmod +x "${stub_dir}/just"
 }
 
+make_fake_just_without_version_target() {
+  local stub_dir="$1"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/just" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  --summary)
+    echo "fmt test"
+    ;;
+  *)
+    echo "unexpected just invocation: $*" >&2
+    exit 2
+    ;;
+esac
+EOF
+  chmod +x "${stub_dir}/just"
+}
+
+make_fake_just_summary_failure() {
+  local stub_dir="$1"
+  mkdir -p "${stub_dir}"
+  cat >"${stub_dir}/just" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  --summary)
+    echo "error: failed to parse justfile" >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected just invocation: $*" >&2
+    exit 2
+    ;;
+esac
+EOF
+  chmod +x "${stub_dir}/just"
+}
+
 make_repo() {
   local case_dir="$1"
   local repo_dir="${case_dir}/repo"
@@ -152,7 +193,138 @@ run_bumped_version_passes_test() {
   assert_main_version "${repo_dir}" "1.0.1"
 }
 
+run_missing_version_target_skips_test() {
+  local case_dir="${TMP_ROOT}/missing-version-target-skips"
+  local stub_dir="${case_dir}/bin"
+  local repo_dir
+  local stdout_file="${case_dir}/stdout.txt"
+  local stderr_file="${case_dir}/stderr.txt"
+  mkdir -p "${case_dir}"
+  repo_dir="$(make_repo "${case_dir}")"
+  make_fake_just_without_version_target "${stub_dir}"
+
+  (
+    cd "${repo_dir}"
+    PATH="${stub_dir}:${PATH}" bash "${SCRIPT_PATH}" origin main
+  ) >"${stdout_file}" 2>"${stderr_file}"
+
+  grep -q "pr-bot version gate skipped: just target 'check-version-bumped' is unavailable" "${stdout_file}"
+  if [ -s "${stderr_file}" ]; then
+    echo "missing version target skip unexpectedly wrote stderr" >&2
+    cat "${stderr_file}" >&2
+    exit 1
+  fi
+}
+
+run_missing_just_skips_test() {
+  local case_dir="${TMP_ROOT}/missing-just-skips"
+  local repo_dir
+  local bash_bin
+  local stdout_file="${case_dir}/stdout.txt"
+  local stderr_file="${case_dir}/stderr.txt"
+  mkdir -p "${case_dir}"
+  mkdir -p "${case_dir}/no-just-bin"
+  repo_dir="$(make_repo "${case_dir}")"
+  bash_bin="$(command -v bash)"
+
+  (
+    cd "${repo_dir}"
+    PATH="${case_dir}/no-just-bin" "${bash_bin}" "${SCRIPT_PATH}" origin main
+  ) >"${stdout_file}" 2>"${stderr_file}"
+
+  grep -q "pr-bot version gate skipped: 'just' is unavailable" "${stdout_file}"
+  if [ -s "${stderr_file}" ]; then
+    echo "missing just skip unexpectedly wrote stderr" >&2
+    cat "${stderr_file}" >&2
+    exit 1
+  fi
+}
+
+run_required_missing_just_blocks_test() {
+  local case_dir="${TMP_ROOT}/required-missing-just-blocks"
+  local repo_dir
+  local bash_bin
+  local stdout_file="${case_dir}/stdout.txt"
+  local stderr_file="${case_dir}/stderr.txt"
+  mkdir -p "${case_dir}"
+  mkdir -p "${case_dir}/no-just-bin"
+  repo_dir="$(make_repo "${case_dir}")"
+  bash_bin="$(command -v bash)"
+
+  set +e
+  (
+    cd "${repo_dir}"
+    PATH="${case_dir}/no-just-bin" CSA_REQUIRE_VERSION_CHECK=1 "${bash_bin}" "${SCRIPT_PATH}" origin main
+  ) >"${stdout_file}" 2>"${stderr_file}"
+  rc=$?
+  set -e
+
+  if [ "${rc}" -eq 0 ]; then
+    echo "expected required missing just to block" >&2
+    exit 1
+  fi
+  grep -q "CSA_REQUIRE_VERSION_CHECK=1 but 'just' is unavailable" "${stderr_file}"
+  grep -q "Install just or unset CSA_REQUIRE_VERSION_CHECK" "${stderr_file}"
+}
+
+run_required_missing_version_target_blocks_test() {
+  local case_dir="${TMP_ROOT}/required-missing-version-target-blocks"
+  local stub_dir="${case_dir}/bin"
+  local repo_dir
+  local stdout_file="${case_dir}/stdout.txt"
+  local stderr_file="${case_dir}/stderr.txt"
+  mkdir -p "${case_dir}"
+  repo_dir="$(make_repo "${case_dir}")"
+  make_fake_just_without_version_target "${stub_dir}"
+
+  set +e
+  (
+    cd "${repo_dir}"
+    PATH="${stub_dir}:${PATH}" CSA_REQUIRE_VERSION_CHECK=1 bash "${SCRIPT_PATH}" origin main
+  ) >"${stdout_file}" 2>"${stderr_file}"
+  rc=$?
+  set -e
+
+  if [ "${rc}" -eq 0 ]; then
+    echo "expected required missing version target to block" >&2
+    exit 1
+  fi
+  grep -q "CSA_REQUIRE_VERSION_CHECK=1 but just target 'check-version-bumped' is unavailable" "${stderr_file}"
+  grep -q "Add a local just target named 'check-version-bumped'" "${stderr_file}"
+}
+
+run_just_summary_failure_blocks_when_justfile_exists_test() {
+  local case_dir="${TMP_ROOT}/summary-failure-blocks"
+  local stub_dir="${case_dir}/bin"
+  local repo_dir
+  local stderr_file="${case_dir}/stderr.txt"
+  mkdir -p "${case_dir}"
+  repo_dir="$(make_repo "${case_dir}")"
+  make_fake_just_summary_failure "${stub_dir}"
+  printf 'check-version-bumped:\n' >"${repo_dir}/justfile"
+
+  set +e
+  (
+    cd "${repo_dir}"
+    PATH="${stub_dir}:${PATH}" bash "${SCRIPT_PATH}" origin main
+  ) >"${case_dir}/stdout.txt" 2>"${stderr_file}"
+  rc=$?
+  set -e
+
+  if [ "${rc}" -eq 0 ]; then
+    echo "expected just summary failure to block when justfile exists" >&2
+    exit 1
+  fi
+  grep -q "Could not inspect just targets before the pre-merge version gate" "${stderr_file}"
+  grep -q "failed to parse justfile" "${stderr_file}"
+}
+
 run_stale_main_blocks_test
 run_bumped_version_passes_test
+run_missing_version_target_skips_test
+run_missing_just_skips_test
+run_required_missing_just_blocks_test
+run_required_missing_version_target_blocks_test
+run_just_summary_failure_blocks_when_justfile_exists_test
 
 echo "pre-merge-version-check tests: PASS"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1000"
-weave = "0.1.1000"
+csa = "0.1.1001"
+weave = "0.1.1001"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Makes the pr-bot pre-merge version-bump check optional when a Cargo repository does not provide the `just check-version-bumped` target.
- Preserves strict behavior when the gate is explicitly required with `CSA_REQUIRE_VERSION_CHECK=1`.
- Keeps fail-closed behavior for broken `just --summary` / invalid justfiles instead of silently treating those as unsupported.
- Adds shell regression coverage for missing `just`, missing target, required-mode blocking, existing failing target, and justfile parse failure.

Closes #2207

## Validation

- Hook-enabled commit passed branch-protection and quality-gates.
- `bash patterns/pr-bot/scripts/tests/pre-merge-version-check-tests.sh`: PASS
- `cargo test -p cli-sub-agent pr_bot_final_merge -- --nocapture`: PASS (2 tests)
- CSA full-diff review `01KV242ADYJWKGB0JVSFS23S8W`: PASS/CLEAN for `main...HEAD` at `92283c37cd7`.
