### PR TITLE
fix(mktd): validate spec artifact shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "axum",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1001"
+version = "0.1.1002"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1001"
+version = "0.1.1002"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
@@ -297,6 +297,13 @@ fn mktd_save_step_uses_session_output_artifacts_and_persist() {
             r#"SAVE_DIR="${CSA_SESSION_DIR:?CSA_SESSION_DIR must be set}/output/mktd-save""#,
             r#"TODO_ARTIFACT="${SAVE_DIR}/TODO.md""#,
             r#"SPEC_ARTIFACT="${SAVE_DIR}/spec.toml""#,
+            r#"FIRST_SPEC_LINE=$(sed -n 's/^[[:space:]]*//; /[^[:space:]]/{p;q;}' "${SPEC_ARTIFACT}")"#,
+            r#"LOWER_SPEC_LINE="${FIRST_SPEC_LINE,,}""#,
+            r#"SPEC_MARKER_KIND="""#,
+            r#"SPEC_MARKER_KIND="CSA section marker""#,
+            r#"spec artifact-shape error: expected TOML spec.toml"#,
+            r#"first marker kind: %s"#,
+            r#"Spec artifact path: %s"#,
             r#"csa todo persist -t "${TODO_TS}""#,
             r#"--todo-file "${TODO_ARTIFACT}""#,
             r#"--spec-file "${SPEC_ARTIFACT}""#,
@@ -312,6 +319,8 @@ fn mktd_save_step_uses_session_output_artifacts_and_persist() {
             r#"> "${SPEC_PATH}""#,
             r#"> "${EPIC_PATH}""#,
             "csa todo save -t",
+            r#"Artifact preview:"#,
+            r#"sed -n '1,8p' "${SPEC_ARTIFACT}""#,
         ] {
             assert!(
                 !content.contains(forbidden),
@@ -328,9 +337,18 @@ fn mktd_save_step_uses_session_output_artifacts_and_persist() {
         let validate_idx = content
             .find(r#"grep -qE '^- \[ \] .+' "${TODO_ARTIFACT}""#)
             .unwrap_or_else(|| panic!("{name} must validate the TODO artifact before persist"));
+        let shape_idx = content
+            .find(
+                r#"FIRST_SPEC_LINE=$(sed -n 's/^[[:space:]]*//; /[^[:space:]]/{p;q;}' "${SPEC_ARTIFACT}")"#,
+            )
+            .unwrap_or_else(|| panic!("{name} must shape-check spec artifact before persist"));
         assert!(
             validate_idx < persist_idx,
             "{name} must validate artifacts BEFORE csa todo persist (commit), not after"
+        );
+        assert!(
+            shape_idx < persist_idx,
+            "{name} must reject markdown/HTML-shaped spec artifacts BEFORE csa todo persist"
         );
 
         for forbidden_postcommit in [

--- a/crates/cli-sub-agent/src/todo_persist_cmd.rs
+++ b/crates/cli-sub-agent/src/todo_persist_cmd.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
-use csa_todo::{EpicPlan, GeneratedPlanPersistRequest, SpecDocument, TodoManager};
+use csa_todo::{
+    EpicPlan, GeneratedPlanPersistRequest, SpecDocument, TodoManager, parse_spec_document,
+};
 
 use crate::cli::TodoCommands;
 
@@ -34,8 +36,7 @@ pub(crate) fn handle_persist(
         .map_err(|e| anyhow::anyhow!("failed to read TODO file '{}': {}", todo_file, e))?;
     let spec_content = std::fs::read_to_string(&spec_file)
         .map_err(|e| anyhow::anyhow!("failed to read spec file '{}': {}", spec_file, e))?;
-    let spec: SpecDocument = toml::from_str(&spec_content)
-        .map_err(|e| anyhow::anyhow!("failed to parse spec file '{}': {}", spec_file, e))?;
+    let spec: SpecDocument = parse_spec_document(&spec_content, &spec_file)?;
     let epic_plan: Option<EpicPlan> = epic_plan_file
         .as_deref()
         .map(|path| {

--- a/crates/cli-sub-agent/src/todo_persist_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/todo_persist_cmd_tests.rs
@@ -146,6 +146,64 @@ fn git_head(dir: &std::path::Path) -> anyhow::Result<String> {
     Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
+#[test]
+fn handle_persist_rejects_spec_section_marker_without_committing() -> anyhow::Result<()> {
+    let project_dir = tempdir()?;
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let manager = TodoManager::new(project_dir.path())?;
+    csa_todo::git::ensure_git_init(manager.todos_dir())?;
+    let plan = manager.create("Reject marker spec", Some("fix/reject-marker-spec"))?;
+    csa_todo::git::save(manager.todos_dir(), &plan.timestamp, "create plan")?
+        .ok_or_else(|| anyhow::anyhow!("initial plan should commit"))?;
+    let head_before = git_head(manager.todos_dir())?;
+
+    let artifact_dir = project_dir.path().join("session-output");
+    std::fs::create_dir_all(&artifact_dir)?;
+    let todo_file = artifact_dir.join("TODO.md");
+    let spec_file = artifact_dir.join("spec.toml");
+    std::fs::write(
+        &todo_file,
+        "# Marker spec plan\n\n## Tasks\n\n- [ ] Reject non-TOML spec artifacts.\n  DONE WHEN: csa todo persist reports an artifact-shape diagnostic before commit.\n",
+    )?;
+    std::fs::write(
+        &spec_file,
+        "<!-- CSA:SECTION:summary -->\nMCP schema mismatch details are not TOML.\napi_key=fixture12345\nAuthorization: Bearer fixturebearertoken\n<!-- CSA:SECTION:summary:END -->\n",
+    )?;
+
+    let err = handle_persist(
+        plan.timestamp.clone(),
+        todo_file.display().to_string(),
+        spec_file.display().to_string(),
+        None,
+        Some("finalize marker spec".to_string()),
+        Some(project_dir.path().display().to_string()),
+    )
+    .expect_err("persist must reject CSA section marker spec artifacts");
+    let message = err.to_string();
+    assert!(message.contains("spec artifact-shape error"));
+    assert!(message.contains("CSA section marker"));
+    assert!(message.contains("inspect the producing step"));
+    assert!(!message.contains("MCP schema mismatch details"));
+    assert!(!message.contains("fixture12345"));
+    assert!(!message.contains("fixturebearertoken"));
+    assert!(!message.contains("Authorization: Bearer"));
+
+    assert_eq!(
+        head_before,
+        git_head(manager.todos_dir())?,
+        "no new todos-git commit may exist for a rejected spec artifact"
+    );
+    let status = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(manager.todos_dir())
+        .output()?;
+    assert!(
+        String::from_utf8_lossy(&status.stdout).trim().is_empty(),
+        "todos git status must stay clean when spec artifact shape is rejected"
+    );
+    Ok(())
+}
+
 /// Round-5 regression: a generated TODO that lacks a `DONE WHEN` clause must be
 /// rejected fail-closed by `csa todo persist` BEFORE it commits, so no invalid
 /// plan can enter the todos git history (the hard-gate contract). Proven by

--- a/crates/csa-todo/src/lib.rs
+++ b/crates/csa-todo/src/lib.rs
@@ -33,7 +33,7 @@ const LOCK_FILE: &str = ".lock";
 pub use epic_plan::{EpicMeta, EpicPlan, ScaleSignals, Story, StoryStatus};
 pub use generated_plan::{GeneratedPlanPersistRequest, GeneratedPlanPersistResult};
 pub use reference::{ReferenceFile, ReferenceIndex, ReferenceSource};
-pub use spec::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument};
+pub use spec::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, parse_spec_document};
 
 mod attestation;
 pub mod epic_plan;
@@ -352,7 +352,7 @@ impl TodoManager {
 
         let content = std::fs::read_to_string(&spec_path)
             .with_context(|| format!("Failed to read spec: {}", spec_path.display()))?;
-        let spec: SpecDocument = toml::from_str(&content)
+        let spec = parse_spec_document(&content, &spec_path.display().to_string())
             .with_context(|| format!("Failed to parse spec: {}", spec_path.display()))?;
         Ok(Some(spec))
     }

--- a/crates/csa-todo/src/spec.rs
+++ b/crates/csa-todo/src/spec.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 fn default_schema_version() -> u32 {
@@ -51,9 +52,65 @@ impl Default for SpecDocument {
     }
 }
 
+/// Parse a `spec.toml` document after rejecting known non-TOML artifact shapes.
+///
+/// Generated plans pass through session-output files before they are persisted.
+/// If a producing step writes a CSA return packet or markdown fence into
+/// `spec.toml`, plain TOML parsing reports a low-level syntax error that hides
+/// the real contract breach. This parser keeps normal TOML errors intact while
+/// failing early for those artifact-shape mismatches.
+pub fn parse_spec_document(content: &str, source: &str) -> Result<SpecDocument> {
+    reject_non_toml_artifact_shape(content, source)?;
+    toml::from_str(content)
+        .map_err(|e| anyhow::anyhow!("failed to parse spec file '{}': {}", source, e))
+}
+
+fn reject_non_toml_artifact_shape(content: &str, source: &str) -> Result<()> {
+    let Some((line_number, line)) = content
+        .lines()
+        .enumerate()
+        .find(|(_, line)| !line.trim().is_empty())
+    else {
+        return Ok(());
+    };
+
+    let trimmed = line
+        .trim_start()
+        .trim_start_matches('\u{feff}')
+        .trim_start();
+    let lower_trimmed = trimmed.to_ascii_lowercase();
+    let marker_kind = if trimmed.starts_with("<!-- CSA:SECTION:") {
+        Some("a CSA section marker")
+    } else if trimmed.starts_with("<!--") {
+        Some("an HTML marker")
+    } else if lower_trimmed.starts_with("<!doctype html") || lower_trimmed.starts_with("<html") {
+        Some("an HTML document marker")
+    } else if trimmed.starts_with("```") {
+        Some("a Markdown code fence")
+    } else {
+        None
+    };
+
+    if let Some(marker_kind) = marker_kind {
+        let redacted_marker = csa_session::redact_text_content(line.trim());
+        anyhow::bail!(
+            "spec artifact-shape error in '{}': expected TOML spec.toml, but line {} starts \
+             with {}: `{}`. This usually means a CSA return packet, markdown output, or \
+             upstream MCP/tool error was written to spec.toml; inspect the producing step \
+             before running `csa todo persist`.",
+            source,
+            line_number + 1,
+            marker_kind,
+            redacted_marker
+        );
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument};
+    use super::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument, parse_spec_document};
 
     fn sample_criterion() -> SpecCriterion {
         SpecCriterion {
@@ -112,5 +169,64 @@ description = "Missing status should default to pending."
             toml::from_str(&toml).expect("document should deserialize from TOML");
 
         assert_eq!(decoded, document);
+    }
+
+    #[test]
+    fn parse_spec_document_rejects_csa_section_marker_artifact_shape() {
+        let err = parse_spec_document(
+            "<!-- CSA:SECTION:summary -->\nnot a toml spec\n<!-- CSA:SECTION:summary:END -->\n",
+            "output/mktd-save/spec.toml",
+        )
+        .expect_err("CSA section marker must be rejected before TOML parsing");
+        let message = err.to_string();
+
+        assert!(message.contains("spec artifact-shape error"));
+        assert!(message.contains("CSA section marker"));
+        assert!(message.contains("output/mktd-save/spec.toml"));
+        assert!(!message.contains("not a toml spec"));
+        assert!(message.contains("inspect the producing step"));
+    }
+
+    #[test]
+    fn parse_spec_document_rejects_markdown_fence_artifact_shape() {
+        let err = parse_spec_document(
+            "```toml\nschema_version = 1\n```\n",
+            "output/mktd-save/spec.toml",
+        )
+        .expect_err("markdown-fenced spec artifact must be rejected before TOML parsing");
+        let message = err.to_string();
+
+        assert!(message.contains("spec artifact-shape error"));
+        assert!(message.contains("Markdown code fence"));
+    }
+
+    #[test]
+    fn parse_spec_document_rejects_html_document_artifact_shape() {
+        let err = parse_spec_document(
+            "<!doctype html>\n<html><body>mempal MCP schema mismatch</body></html>\n",
+            "output/mktd-save/spec.toml",
+        )
+        .expect_err("HTML spec artifact must be rejected before TOML parsing");
+        let message = err.to_string();
+
+        assert!(message.contains("spec artifact-shape error"));
+        assert!(message.contains("HTML document marker"));
+        assert!(!message.contains("mempal MCP schema mismatch"));
+    }
+
+    #[test]
+    fn parse_spec_document_redacts_secret_like_marker_line() {
+        let err = parse_spec_document(
+            "<!-- CSA:SECTION:summary --> api_key=fixture12345\nAuthorization: Bearer fixturebearertoken\n",
+            "output/mktd-save/spec.toml",
+        )
+        .expect_err("CSA section marker must be rejected before TOML parsing");
+        let message = err.to_string();
+
+        assert!(message.contains("spec artifact-shape error"));
+        assert!(message.contains("[REDACTED]"));
+        assert!(!message.contains("fixture12345"));
+        assert!(!message.contains("fixturebearertoken"));
+        assert!(!message.contains("Authorization: Bearer"));
     }
 }

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -693,19 +693,22 @@ SPEC_CONTENT="${STEP_8_OUTPUT//__PLAN_ID__/${TODO_TS}}"
 printf '%s\n' "${SPEC_CONTENT}" > "${SPEC_ARTIFACT}" || { echo "write spec artifact failed" >&2; exit 1; }
 [[ -s "${TODO_ARTIFACT}" ]] || { echo "TODO artifact is empty" >&2; exit 1; }
 [[ -s "${SPEC_ARTIFACT}" ]] || { echo "spec artifact is empty" >&2; exit 1; }
-# Hard-gate: validate the RENDERED artifacts BEFORE `csa todo persist` commits
-# them. An invalid plan must NEVER reach the persist/commit step (#1820/#1822
-# hard-gate contract; round-5 ordering fix). `csa todo persist` ALSO re-checks
-# the core invariants fail-closed inside its locked commit (defense-in-depth)
-# — including the spec-criteria check that replaces the former post-commit
-# `csa todo show --spec` render gate — so NO content validation runs after the
-# commit.
+FIRST_SPEC_LINE=$(sed -n 's/^[[:space:]]*//; /[^[:space:]]/{p;q;}' "${SPEC_ARTIFACT}") || { echo "read spec artifact failed" >&2; exit 1; }
+LOWER_SPEC_LINE="${FIRST_SPEC_LINE,,}"
+SPEC_MARKER_KIND=""
+case "${LOWER_SPEC_LINE}" in
+  '<!-- csa:section:'*) SPEC_MARKER_KIND="CSA section marker" ;;
+  '<!--'*) SPEC_MARKER_KIND="HTML marker" ;;
+  '<!doctype html'*|'<html'*) SPEC_MARKER_KIND="HTML document marker" ;;
+  '```'*) SPEC_MARKER_KIND="Markdown code fence" ;;
+esac
+if [[ -n "${SPEC_MARKER_KIND}" ]]; then
+  printf 'spec artifact-shape error: expected TOML spec.toml; first marker kind: %s\nSpec artifact path: %s\n' "${SPEC_MARKER_KIND}" "${SPEC_ARTIFACT}" >&2
+  exit 1
+fi
+# Pre-persist gates must run before commit; `csa todo persist` repeats core checks under lock.
 grep -qE '^- \[ \] .+' "${TODO_ARTIFACT}" || { echo "TODO artifact has no non-empty checkbox tasks" >&2; exit 1; }
-# Per-task gate: EVERY open checkbox task must carry its OWN mechanically
-# verifiable `DONE WHEN:` clause (AGENTS.md Meta 005). A single global match is
-# insufficient — a bare keyword mention in a subject, or one task's clause, must
-# not cover another open task's gap. `csa todo persist` re-applies the same
-# per-task check fail-closed under the write lock (defense-in-depth).
+# Every open task needs its own `DONE WHEN:`; persist repeats this under lock.
 awk '
 function flush() { if (in_open == 1 && has_clause == 0) bad = 1; in_open = 0; has_clause = 0 }
 function scan(text,   pos, rest) {

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -741,19 +741,22 @@ SPEC_CONTENT="${STEP_8_OUTPUT//__PLAN_ID__/${TODO_TS}}"
 printf '%s\n' "${SPEC_CONTENT}" > "${SPEC_ARTIFACT}" || { echo "write spec artifact failed" >&2; exit 1; }
 [[ -s "${TODO_ARTIFACT}" ]] || { echo "TODO artifact is empty" >&2; exit 1; }
 [[ -s "${SPEC_ARTIFACT}" ]] || { echo "spec artifact is empty" >&2; exit 1; }
-# Hard-gate: validate the RENDERED artifacts BEFORE `csa todo persist` commits
-# them. An invalid plan must NEVER reach the persist/commit step (#1820/#1822
-# hard-gate contract; round-5 ordering fix). `csa todo persist` ALSO re-checks
-# the core invariants fail-closed inside its locked commit (defense-in-depth)
-# — including the spec-criteria check that replaces the former post-commit
-# `csa todo show --spec` render gate — so NO content validation runs after the
-# commit.
+FIRST_SPEC_LINE=$(sed -n 's/^[[:space:]]*//; /[^[:space:]]/{p;q;}' "${SPEC_ARTIFACT}") || { echo "read spec artifact failed" >&2; exit 1; }
+LOWER_SPEC_LINE="${FIRST_SPEC_LINE,,}"
+SPEC_MARKER_KIND=""
+case "${LOWER_SPEC_LINE}" in
+  '<!-- csa:section:'*) SPEC_MARKER_KIND="CSA section marker" ;;
+  '<!--'*) SPEC_MARKER_KIND="HTML marker" ;;
+  '<!doctype html'*|'<html'*) SPEC_MARKER_KIND="HTML document marker" ;;
+  '```'*) SPEC_MARKER_KIND="Markdown code fence" ;;
+esac
+if [[ -n "${SPEC_MARKER_KIND}" ]]; then
+  printf 'spec artifact-shape error: expected TOML spec.toml; first marker kind: %s\nSpec artifact path: %s\n' "${SPEC_MARKER_KIND}" "${SPEC_ARTIFACT}" >&2
+  exit 1
+fi
+# Pre-persist gates must run before commit; `csa todo persist` repeats core checks under lock.
 grep -qE '^- \[ \] .+' "${TODO_ARTIFACT}" || { echo "TODO artifact has no non-empty checkbox tasks" >&2; exit 1; }
-# Per-task gate: EVERY open checkbox task must carry its OWN mechanically
-# verifiable `DONE WHEN:` clause (AGENTS.md Meta 005). A single global match is
-# insufficient — a bare keyword mention in a subject, or one task's clause, must
-# not cover another open task's gap. `csa todo persist` re-applies the same
-# per-task check fail-closed under the write lock (defense-in-depth).
+# Every open task needs its own `DONE WHEN:`; persist repeats this under lock.
 awk '
 function flush() { if (in_open == 1 && has_clause == 0) bad = 1; in_open = 0; has_clause = 0 }
 function scan(text,   pos, rest) {

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1001"
-weave = "0.1.1001"
+csa = "0.1.1002"
+weave = "0.1.1002"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Validate mktd/todo-persist `spec.toml` artifacts by shape before falling through to low-level TOML parsing.
- Detect obvious CSA/HTML/markdown/tool-output artifacts and report actionable diagnostics instead of parsing them as TOML.
- Redact or omit artifact preview/body content on user-visible error paths so malformed artifacts cannot leak fixture-secret-like values.
- Keep the mktd `PATTERN.md` and `workflow.toml` save-step behavior synchronized.

Closes #2201.
Related: #2212.

## Validation

- Parent hook-enabled commit/amend passed branch-protection and quality-gates.
- `cargo clippy --workspace --all-features -- -D warnings` passed in hooks.
- Fresh pinned Codex full-diff review passed: `01KV29KKJ6EW2SRFQ6SQGYFQMF`.
- Short salvage checks before amend passed: `cargo fmt -- --check`, diff checks, PATTERN/workflow sync check, production raw-preview static check, and `just find-monolith-files`.
