### PR TITLE
fix(review): fail wait on fail verdict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "axum",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1002"
+version = "0.1.1003"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1002"
+version = "0.1.1003"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -360,6 +360,11 @@ fn read_review_verdict_label(
     session_dir: &Path,
     result: &csa_session::SessionResult,
 ) -> Option<String> {
+    let summary_requires_failed_gate =
+        crate::session_observability::human_review_summary_requires_failed_gate(
+            session_dir,
+            &result.summary,
+        );
     if let Some(artifact) = read_review_verdict_artifact(session_dir) {
         let meta = read_review_meta_for_label(session_dir);
         if let Some(label) = meta
@@ -368,6 +373,9 @@ fn read_review_verdict_label(
             .or_else(|| format_fix_loop_noop_label(artifact.failure_reason.as_deref()))
         {
             return Some(label);
+        }
+        if summary_requires_failed_gate {
+            return Some("FAIL".to_string());
         }
         if artifact.decision == ReviewDecision::Pass {
             if !wait_result_allows_pass_verdict(result) {
@@ -400,10 +408,17 @@ fn read_review_verdict_label(
         if let Some(label) = format_fix_loop_noop_label(meta.failure_reason.as_deref()) {
             return Some(label);
         }
+        if summary_requires_failed_gate {
+            return Some("FAIL".to_string());
+        }
         if meta.fix_attempted && !meta.fix_clean_converged() {
             return Some("UNAVAILABLE".to_string());
         }
         return Some(normalize_review_verdict_label(&meta.decision, result));
+    }
+
+    if summary_requires_failed_gate {
+        return Some("FAIL".to_string());
     }
 
     None

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -863,5 +863,7 @@ mod tail_tests_wait_lock;
 mod tail_tests_wait_regression;
 #[path = "session_cmds_tests_tail_wait_2105.rs"]
 mod w;
+#[path = "session_cmds_tests_tail_wait_2183.rs"]
+mod w2183;
 #[path = "session_cmds_tests_tail_wait_resume_wrapper.rs"]
 mod wait_resume;

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2183.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2183.rs
@@ -1,0 +1,169 @@
+use super::*;
+use crate::session_cmds_daemon::{
+    WaitBehavior, WaitLoopTiming, handle_session_wait_with_hooks, render_wait_result_summary,
+};
+use crate::test_env_lock::TEST_ENV_LOCK;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn write_clean_review_meta(session_dir: &Path, session_id: &str) {
+    let meta = csa_session::state::ReviewSessionMeta {
+        session_id: session_id.to_string(),
+        head_sha: "deadbeef".to_string(),
+        decision: csa_core::types::ReviewDecision::Pass.as_str().to_string(),
+        verdict: "CLEAN".to_string(),
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool: "codex".to_string(),
+        scope: "range:main...HEAD".to_string(),
+        exit_code: 0,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+        review_mode: None,
+        fix_convergence: None,
+    };
+    csa_session::state::write_review_meta(session_dir, &meta).expect("write review meta");
+}
+
+fn write_transport_success(project: &Path, session_id: &str, session_dir: &Path) {
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write success completion packet");
+    write_clean_review_meta(session_dir, session_id);
+    save_result(
+        project,
+        session_id,
+        &SessionResult {
+            summary: r#"{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":25}}"#
+                .to_string(),
+            ..make_result("success", 0)
+        },
+    )
+    .expect("save transport success result");
+}
+
+#[test]
+fn issue_2183_wait_fails_structured_fail_summary_even_when_transport_succeeded() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-structured-fail-summary"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    write_transport_success(project, &session_id, &session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nFAIL: one high-severity security finding remains\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist structured fail summary");
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("structured FAIL summary should short-circuit before reconcile");
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should fail the review gate");
+
+    assert_eq!(exit_code, 1);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id.clone(), "failure".to_string(), 1, false))
+    );
+    let persisted = load_result(project, &session_id)
+        .expect("load result")
+        .expect("result should remain terminal");
+    assert_eq!(persisted.status, "failure");
+    assert_eq!(persisted.exit_code, 1);
+    let summary = render_wait_result_summary(&session_dir, &session_id, &persisted);
+    assert!(summary.contains("Review verdict: FAIL"));
+    assert!(!summary.contains("Review verdict: PASS"));
+    assert!(summary.contains("Summary: FAIL"));
+}
+
+#[test]
+fn issue_2183_wait_preserves_structured_pass_summary_success() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-structured-pass-summary"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    write_transport_success(project, &session_id, &session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nPASS: no blocking findings remain\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist structured pass summary");
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("structured PASS summary should short-circuit before reconcile");
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should preserve the clean review gate");
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id.clone(), "success".to_string(), 0, false))
+    );
+    let persisted = load_result(project, &session_id)
+        .expect("load result")
+        .expect("result should remain terminal");
+    assert_eq!(persisted.status, "success");
+    assert_eq!(persisted.exit_code, 0);
+    let summary = render_wait_result_summary(&session_dir, &session_id, &persisted);
+    assert!(summary.contains("Review verdict: PASS"));
+    assert!(summary.contains("Summary: PASS"));
+}

--- a/crates/cli-sub-agent/src/session_observability.rs
+++ b/crates/cli-sub-agent/src/session_observability.rs
@@ -117,21 +117,28 @@ pub(crate) fn enrich_result_from_session_dir(
 }
 
 fn sync_review_verdict_exit_code(session_dir: &Path, result: &mut SessionResult) -> Result<bool> {
-    let Some(exit_code) = read_review_verdict_exit_code(session_dir)? else {
-        return Ok(sync_review_summary_exit_code(session_dir, result));
+    let exit_code = if human_review_summary_requires_failed_gate(session_dir, &result.summary) {
+        Some(1)
+    } else {
+        read_review_verdict_exit_code(session_dir)?
+    };
+    let Some(exit_code) = exit_code else {
+        return Ok(false);
     };
     Ok(sync_result_exit_code(result, exit_code))
 }
 
-fn sync_review_summary_exit_code(session_dir: &Path, result: &mut SessionResult) -> bool {
-    let summary_has_fail_verdict = review_summary_has_fail_verdict(&result.summary);
-    let review_summary_has_blocking_outcome = session_dir.join("review_meta.json").is_file()
-        && review_summary_has_blocking_outcome(&result.summary);
-    if !(summary_has_fail_verdict || review_summary_has_blocking_outcome) {
-        return false;
-    }
-
-    sync_result_exit_code(result, 1)
+pub(crate) fn human_review_summary_requires_failed_gate(
+    session_dir: &Path,
+    raw_summary: &str,
+) -> bool {
+    crate::session_summary_text::human_session_summary(session_dir, raw_summary).is_some_and(
+        |summary| {
+            review_summary_has_fail_verdict(&summary)
+                || session_dir.join("review_meta.json").is_file()
+                    && review_summary_has_blocking_outcome(&summary)
+        },
+    )
 }
 
 fn review_summary_has_fail_verdict(summary: &str) -> bool {

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1002"
-weave = "0.1.1002"
+csa = "0.1.1003"
+weave = "0.1.1003"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Make `csa session wait` fail the review gate when the structured/human review summary reports a failing or blocking verdict, even if transport status is successful.
- Keep PASS/CLEAN review waits successful and preserve existing `csa review --check-verdict` behavior.
- Add #2183 regression coverage for FAIL and PASS review-summary wait outcomes.

Closes #2183

## Validation

- `cargo test -p cli-sub-agent issue_2183 -- --nocapture`
- `cargo test -p cli-sub-agent tail_tests_wait_1951 -- --nocapture`
- `cargo test -p cli-sub-agent check_verdict_rejects_non_pass_artifact_even_when_meta_is_pass -- --nocapture`
- `cargo test -p cli-sub-agent issue_1953_structured_pass_empty_findings_updates_meta_wait_and_check_verdict -- --nocapture`
- `cargo fmt -- --check`
- `git diff --check`
- `git diff --cached --check`
- `just find-monolith-files`
- hook-enabled commit quality gates
- CSA full-diff review `01KV2DFTBYY10YPKFV53AW5JTN`: PASS/CLEAN

## Notes

- CSA evidence issue #2215 tracks implementation/review unknown-signal friction and will be consolidated after this lands.
