### PR TITLE
fix(commit): make no-op failures actionable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "axum",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1003"
+version = "0.1.1004"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1003"
+version = "0.1.1004"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -310,9 +310,13 @@ pub(crate) async fn process_execution_result(
         && elapsed_secs < no_op::ELAPSED_THRESHOLD_SECS
     {
         let original_summary = session_result.summary.clone();
-        let no_op_summary = format!(
-            "no-op exit detected: turn_count={}, elapsed={}s, no tool calls. Original: {}",
-            session.turn_count, elapsed_secs, original_summary,
+        let no_op_summary = no_op::build_no_op_failure_summary(
+            session.turn_count,
+            elapsed_secs,
+            ctx.executor.tool_name(),
+            session.description.as_deref(),
+            ctx.prompt,
+            &original_summary,
         );
         warn!(
             session = %session.meta_session_id,
@@ -565,6 +569,10 @@ mod tests;
 #[cfg(test)]
 #[path = "pipeline_tests_no_op_gate.rs"]
 mod no_op_gate_tests;
+
+#[cfg(test)]
+#[path = "pipeline_tests_no_op_gate_2181.rs"]
+mod no_op_gate_2181_tests;
 
 #[cfg(test)]
 #[path = "pipeline_tests_no_progress.rs"]

--- a/crates/cli-sub-agent/src/pipeline_post_exec_no_op.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_no_op.rs
@@ -1,11 +1,17 @@
 //! No-op exit classification helpers.
 
+use std::path::Path;
+
 use csa_session::TokenUsage;
 
 /// Sessions shorter than this threshold (in seconds) that exit 0 with zero
 /// tool calls in sa-mode are classified as no-op exits.
 pub(super) const ELAPSED_THRESHOLD_SECS: i64 = 60;
 const MEANINGFUL_OUTPUT_TOKENS: u64 = 1000;
+const SUMMARY_MAX_CHARS: usize = 500;
+const TASK_LABEL_MAX_CHARS: usize = 72;
+const REQUEST_EXCERPT_MAX_CHARS: usize = 150;
+const ORIGINAL_SUMMARY_MAX_CHARS: usize = 80;
 
 pub(super) fn has_meaningful_reasoning_output(
     token_usage: &Option<TokenUsage>,
@@ -19,4 +25,109 @@ pub(super) fn has_meaningful_reasoning_output(
     .flatten()
     .max()
     .is_some_and(|output_tokens| output_tokens > MEANINGFUL_OUTPUT_TOKENS)
+}
+
+pub(super) fn build_no_op_failure_summary(
+    turn_count: u32,
+    elapsed_secs: i64,
+    tool_name: &str,
+    session_description: Option<&str>,
+    prompt: &str,
+    original_summary: &str,
+) -> String {
+    let skill_name = infer_skill_name(session_description, prompt)
+        .and_then(|skill| sanitize_compact_clip(&skill, TASK_LABEL_MAX_CHARS));
+    let task_label = session_description
+        .filter(|description| !description.trim_start().starts_with("skill:"))
+        .and_then(|description| sanitize_compact_clip(description, TASK_LABEL_MAX_CHARS));
+    let request_excerpt = extract_request_excerpt(prompt)
+        .and_then(|excerpt| sanitize_compact_clip(&excerpt, REQUEST_EXCERPT_MAX_CHARS));
+    let original_summary = sanitize_compact_clip(original_summary, ORIGINAL_SUMMARY_MAX_CHARS);
+
+    let mut summary = format!(
+        "no-op exit detected: turn_count={turn_count}, elapsed={elapsed_secs}s, no tool calls, tool={tool_name}. "
+    );
+
+    match skill_name.as_deref() {
+        Some("commit") => summary.push_str(
+            "commit skill requested task did not run; no local commit was created by this attempt. ",
+        ),
+        Some(skill) => summary.push_str(&format!("skill={skill} requested task did not run. ")),
+        None => summary.push_str("requested task did not run. "),
+    }
+
+    if let Some(label) = task_label {
+        summary.push_str(&format!("task=\"{label}\". "));
+    }
+    if let Some(excerpt) = request_excerpt {
+        summary.push_str(&format!("request=\"{excerpt}\". "));
+    }
+
+    match skill_name.as_deref() {
+        Some("commit") => summary.push_str(
+            "recovery=rerun csa run --skill commit after checking auth/tier or choose another tool/model.",
+        ),
+        Some(skill) => summary.push_str(&format!(
+            "recovery=rerun csa run --skill {skill} after checking auth/tier/tool logs."
+        )),
+        None => summary.push_str("recovery=rerun after checking auth/tier/tool logs."),
+    }
+
+    if let Some(original) = original_summary {
+        summary.push_str(&format!(" original=\"{original}\"."));
+    }
+
+    clip_chars(&summary, SUMMARY_MAX_CHARS)
+}
+
+fn infer_skill_name(session_description: Option<&str>, prompt: &str) -> Option<String> {
+    if let Some(description) = session_description
+        .map(str::trim)
+        .and_then(|description| description.strip_prefix("skill:"))
+        .map(str::trim)
+        .filter(|skill| !skill.is_empty())
+    {
+        return Some(description.to_string());
+    }
+
+    let marker = "<skill-source path=\"";
+    let start = prompt.find(marker)? + marker.len();
+    let path = prompt.get(start..)?.split('"').next()?.trim();
+    let skill = Path::new(path).file_name()?.to_string_lossy();
+    let skill = skill.trim();
+    (!skill.is_empty()).then(|| skill.to_string())
+}
+
+fn extract_request_excerpt(prompt: &str) -> Option<String> {
+    let candidate = prompt
+        .rsplit_once("\n\n---\n\n")
+        .map(|(_, request)| request)
+        .unwrap_or(prompt);
+    let compact = compact_whitespace(candidate);
+    (!compact.is_empty()).then_some(compact)
+}
+
+fn sanitize_compact_clip(text: &str, max_chars: usize) -> Option<String> {
+    let redacted = csa_session::redact_text_content(text);
+    let compact = compact_whitespace(&redacted);
+    if compact.is_empty() {
+        None
+    } else {
+        Some(clip_chars(&compact, max_chars))
+    }
+}
+
+fn compact_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn clip_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    if max_chars <= 3 {
+        return ".".repeat(max_chars);
+    }
+    let clipped: String = text.chars().take(max_chars - 3).collect();
+    format!("{}...", clipped.trim_end())
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_no_op_gate_2181.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_no_op_gate_2181.rs
@@ -1,0 +1,174 @@
+//! Regression coverage for GitHub issue #2181: commit-skill no-op failures
+//! must preserve actionable, bounded, redacted request context.
+
+use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_executor::Executor;
+use csa_session::{SessionResult, create_session, load_result};
+
+fn build_commit_no_op_ctx<'a>(
+    executor: &'a Executor,
+    session_dir: std::path::PathBuf,
+    project_root: &'a std::path::Path,
+    execution_start_time: chrono::DateTime<chrono::Utc>,
+    hooks_config: &'a csa_hooks::HooksConfig,
+    prompt: &'a str,
+) -> PostExecContext<'a> {
+    PostExecContext {
+        executor,
+        prompt,
+        effective_prompt: prompt,
+        task_type: Some("run"),
+        readonly_project_root: false,
+        project_root,
+        config: None,
+        global_config: None,
+        session_dir,
+        sessions_root: "test-root".to_string(),
+        execution_start_time,
+        hooks_config,
+        memory_project_key: None,
+        provider_session_id: None,
+        events_count: 4,
+        transcript_artifacts: vec![],
+        changed_paths: vec![],
+        pre_exec_snapshot: None,
+        has_tool_calls: false,
+        turn_count: 0,
+        output_tokens: None,
+        sa_mode: true,
+    }
+}
+
+fn build_successful_empty_result(summary: &str) -> csa_process::ExecutionResult {
+    csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: String::new(),
+        summary: summary.to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn no_op_gate_for_commit_skill_includes_actionable_redacted_request_context() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    let mut session = create_session(
+        project_root,
+        Some("commit vllm dflash tool parser"),
+        None,
+        Some("openai-compat"),
+    )
+    .expect("create");
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("dir");
+
+    let request = format!(
+        "Commit the current changes with scope: api_key=sk-sup...2345 \
+         enable DFlash vLLM auto tool choice for Hermes and document swap/parser \
+         findings. Do not push or create PR; create only the local commit. {}",
+        "include detailed staged-file analysis ".repeat(20),
+    );
+    let prompt = format!(
+        "<skill-mode>executor</skill-mode>\n\n\
+         <skill-source path=\"{}/patterns/commit/skills/commit\">\n\
+         Resolve relative skill references from this directory.\n\
+         </skill-source>\n\n\
+         # Commit Skill\nCommit with audit metadata.\n\n---\n\n{}",
+        project_root.display(),
+        request,
+    );
+
+    let executor = Executor::OpenaiCompat {
+        model_override: None,
+        thinking_budget: None,
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let start = chrono::Utc::now() - chrono::Duration::seconds(10);
+    let ctx = build_commit_no_op_ctx(
+        &executor,
+        session_dir,
+        project_root,
+        start,
+        &hooks_config,
+        &prompt,
+    );
+    let mut result = build_successful_empty_result("and the required AI Reviewer Metadata block.");
+
+    process_execution_result(ctx, &mut session, &mut result)
+        .await
+        .expect("process_execution_result");
+
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load")
+        .expect("result exists");
+    assert_eq!(persisted.exit_code, 1);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(1));
+    assert_eq!(persisted.summary, result.summary);
+    assert!(
+        persisted.summary.starts_with("no-op exit detected"),
+        "summary should start with no-op diagnostic, got: {}",
+        persisted.summary
+    );
+    assert!(persisted.summary.contains("turn_count=1"));
+    assert!(persisted.summary.contains("no tool calls"));
+    assert!(persisted.summary.contains("tool=openai-compat"));
+    assert!(
+        persisted
+            .summary
+            .contains("commit skill requested task did not run"),
+        "summary must say the commit skill did not run: {}",
+        persisted.summary
+    );
+    assert!(persisted.summary.contains("commit vllm dflash tool parser"));
+    assert!(
+        persisted
+            .summary
+            .contains("enable DFlash vLLM auto tool choice"),
+        "summary must preserve the useful head of the original request, not only the tail: {}",
+        persisted.summary
+    );
+    assert!(
+        persisted.summary.contains("rerun csa run --skill commit"),
+        "summary must include a direct recovery hint: {}",
+        persisted.summary
+    );
+    assert!(
+        persisted.summary.contains("no local commit"),
+        "commit-skill no-op must make fail-closed side effect clear: {}",
+        persisted.summary
+    );
+    assert!(
+        persisted.summary.contains("[REDACTED]"),
+        "request excerpt should be redacted: {}",
+        persisted.summary
+    );
+    assert!(!persisted.summary.contains("sk-sup...2345"));
+    assert!(
+        persisted.summary.chars().count() <= 500,
+        "summary must remain bounded for wait/result surfaces ({} chars): {}",
+        persisted.summary.chars().count(),
+        persisted.summary
+    );
+
+    let json = serde_json::to_value(&result).expect("ExecutionResult should serialize");
+    assert_eq!(json["summary"].as_str(), Some(persisted.summary.as_str()));
+    assert_eq!(json["csa_gate_failure"].as_str(), Some("no-op-exit"));
+    assert!(
+        json["summary"]
+            .as_str()
+            .expect("json summary")
+            .contains("enable DFlash vLLM auto tool choice"),
+        "--format json surface must carry the actionable no-op summary"
+    );
+    assert!(
+        !json["summary"]
+            .as_str()
+            .expect("json summary")
+            .contains("sk-sup...2345"),
+        "--format json summary must be redacted"
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1003"
-weave = "0.1.1003"
+csa = "0.1.1004"
+weave = "0.1.1004"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Make commit-skill no-op failures fail closed with bounded, redacted, actionable context instead of preserving only an unhelpful truncated tail.
- Include the no-op reason, routed tool, commit-task context, original summary excerpt, and retry guidance for commit-skill callers.
- Add #2181 regression coverage in a focused test module and bump the workspace version to `0.1.1004`.

## Validation

- `cargo test -p cli-sub-agent no_op_gate_for_commit_skill_includes_actionable_redacted_request_context -- --nocapture`
- `cargo test -p cli-sub-agent no_op_gate -- --nocapture`
- `cargo test -p cli-sub-agent wait_output_tests -- --nocapture`
- `cargo test -p cli-sub-agent session_cmds_result -- --nocapture`
- `cargo fmt -- --check`
- `git diff --check`
- `git diff --cached --check`
- `just find-monolith-files`
- `just pre-commit-fast`
- hook-enabled `git commit`
- CSA full-diff review PASS/CLEAN: `01KV2JYCSFECRBW33M4KGX4KF2`

Closes #2181
