### PR TITLE
fix(review): persist no-result daemon diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "axum",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1004"
+version = "0.1.1005"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1004"
+version = "0.1.1005"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 mod attach;
 #[path = "session_cmds_daemon_completion.rs"]
 mod completion;
+#[path = "session_cmds_daemon_review_diagnostic.rs"]
+mod review_diagnostic;
 
 #[cfg(test)]
 use attach::{

--- a/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
@@ -197,7 +197,6 @@ pub(crate) fn daemon_completion_result(
     packet: &DaemonCompletionPacket,
     completed_at: chrono::DateTime<chrono::Utc>,
 ) -> SessionResult {
-    super::review_diagnostic::persist_review_no_result_diagnostic(session_dir, session, packet);
     let tool_name = session
         .tools
         .iter()
@@ -233,6 +232,12 @@ pub(crate) fn daemon_completion_result(
             .unwrap_or_default()
     );
 
+    let mut artifacts = crate::pipeline_post_exec::collect_fallback_result_artifacts(
+        project_root,
+        &session.meta_session_id,
+    );
+    super::review_diagnostic::append_review_no_result_diagnostic_artifacts(&mut artifacts, session);
+
     SessionResult {
         post_exec_gate: None,
         status: effective.status,
@@ -248,10 +253,7 @@ pub(crate) fn daemon_completion_result(
         started_at: std::cmp::min(session.last_accessed, completed_at),
         completed_at,
         events_count: 0,
-        artifacts: crate::pipeline_post_exec::collect_fallback_result_artifacts(
-            project_root,
-            &session.meta_session_id,
-        ),
+        artifacts,
         raw_process_exit_code: effective.raw_process_exit_code,
         ..Default::default()
     }

--- a/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
@@ -197,6 +197,7 @@ pub(crate) fn daemon_completion_result(
     packet: &DaemonCompletionPacket,
     completed_at: chrono::DateTime<chrono::Utc>,
 ) -> SessionResult {
+    super::review_diagnostic::persist_review_no_result_diagnostic(session_dir, session, packet);
     let tool_name = session
         .tools
         .iter()

--- a/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
@@ -1,0 +1,156 @@
+use std::path::Path;
+
+use csa_core::types::ReviewDecision;
+use csa_session::MetaSessionState;
+use tracing::warn;
+
+use super::completion::DaemonCompletionPacket;
+
+const REVIEW_DAEMON_NO_RESULT_REASON: &str = "daemon_completion_before_result";
+
+pub(crate) fn persist_review_no_result_diagnostic(
+    session_dir: &Path,
+    session: &MetaSessionState,
+    packet: &DaemonCompletionPacket,
+) {
+    if !is_review_daemon_session(session) {
+        return;
+    }
+
+    let tool = review_no_result_tool(session_dir, session);
+    let diagnostic = review_no_result_summary(packet, &tool);
+    persist_review_no_result_meta(session_dir, session, &tool, &diagnostic);
+    persist_review_no_result_verdict(session_dir, session, &tool, &diagnostic);
+}
+
+fn is_review_daemon_session(session: &MetaSessionState) -> bool {
+    session
+        .description
+        .as_deref()
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|description| {
+            description == "review"
+                || description.starts_with("review:")
+                || description == "initializing daemon review"
+        })
+}
+
+fn review_no_result_summary(packet: &DaemonCompletionPacket, tool: &str) -> String {
+    let tool_note = if tool == "unknown" {
+        "; no tool launch metadata was recorded"
+    } else {
+        ""
+    };
+    format!(
+        "review daemon completion recorded status={} exit_code={}{} before result.toml was written{tool_note}",
+        packet.status,
+        packet.exit_code,
+        packet
+            .reason
+            .as_deref()
+            .map(|reason| format!(" reason={reason}"))
+            .unwrap_or_default()
+    )
+}
+
+fn review_no_result_tool(session_dir: &Path, session: &MetaSessionState) -> String {
+    session
+        .tools
+        .iter()
+        .max_by_key(|(_, state)| state.updated_at)
+        .map(|(tool, _)| tool.clone())
+        .or_else(|| {
+            let metadata_path = session_dir.join(csa_session::metadata::METADATA_FILE_NAME);
+            std::fs::read_to_string(metadata_path)
+                .ok()
+                .and_then(|content| {
+                    toml::from_str::<csa_session::metadata::SessionMetadata>(&content).ok()
+                })
+                .map(|metadata| metadata.tool)
+        })
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn persist_review_no_result_meta(
+    session_dir: &Path,
+    session: &MetaSessionState,
+    tool: &str,
+    diagnostic: &str,
+) {
+    let path = session_dir.join("review_meta.json");
+    if path.is_file() {
+        return;
+    }
+
+    let meta = csa_session::ReviewSessionMeta {
+        session_id: session.meta_session_id.clone(),
+        head_sha: session.git_head_at_creation.clone().unwrap_or_default(),
+        decision: ReviewDecision::Unavailable.as_str().to_string(),
+        verdict: "UNAVAILABLE".to_string(),
+        review_mode: None,
+        status_reason: Some(REVIEW_DAEMON_NO_RESULT_REASON.to_string()),
+        routed_to: None,
+        primary_failure: (tool == "unknown").then(|| "tool_launch_metadata_absent".to_string()),
+        failure_reason: Some(diagnostic.to_string()),
+        tool: tool.to_string(),
+        scope: session
+            .description
+            .as_deref()
+            .unwrap_or("unknown")
+            .to_string(),
+        exit_code: crate::verdict_exit_code::exit_code_from_review_decision(
+            ReviewDecision::Unavailable,
+        ),
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+        fix_convergence: None,
+    };
+
+    if let Err(err) = csa_session::write_review_meta(session_dir, &meta) {
+        warn!(
+            session_id = %session.meta_session_id,
+            path = %path.display(),
+            error = %err,
+            "Failed to persist review daemon no-result metadata"
+        );
+    }
+}
+
+fn persist_review_no_result_verdict(
+    session_dir: &Path,
+    session: &MetaSessionState,
+    tool: &str,
+    diagnostic: &str,
+) {
+    let path = session_dir.join("output").join("review-verdict.json");
+    if path.is_file() {
+        return;
+    }
+
+    let mut artifact = csa_session::ReviewVerdictArtifact::from_parts(
+        session.meta_session_id.clone(),
+        ReviewDecision::Unavailable,
+        "UNAVAILABLE",
+        &[],
+        Vec::new(),
+    );
+    artifact.primary_failure = Some(if tool == "unknown" {
+        "tool_launch_metadata_absent".to_string()
+    } else {
+        REVIEW_DAEMON_NO_RESULT_REASON.to_string()
+    });
+    artifact.failure_reason = Some(diagnostic.to_string());
+
+    if let Err(err) = csa_session::write_review_verdict(session_dir, &artifact) {
+        warn!(
+            session_id = %session.meta_session_id,
+            path = %path.display(),
+            error = %err,
+            "Failed to persist review daemon no-result verdict artifact"
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
@@ -82,16 +82,75 @@ pub(crate) fn persist_review_no_result_diagnostic(
 }
 
 fn is_review_daemon_session(session: &MetaSessionState) -> bool {
+    if matches!(
+        session.task_context.task_type.as_deref().map(str::trim),
+        Some("review" | "reviewer_sub_session")
+    ) {
+        return true;
+    }
+
     session
         .description
         .as_deref()
-        .map(str::trim)
-        .map(str::to_ascii_lowercase)
-        .is_some_and(|description| {
-            description == "review"
-                || description.starts_with("review:")
-                || description == "initializing daemon review"
+        .is_some_and(is_legacy_review_description)
+}
+
+fn is_legacy_review_description(description: &str) -> bool {
+    let description = description.trim();
+    description.eq_ignore_ascii_case("review")
+        || description.eq_ignore_ascii_case("initializing daemon review")
+        || has_ascii_prefix_ignore_case(description, "review:")
+        || strip_multi_reviewer_scope(description).is_some()
+        || has_ascii_prefix_ignore_case(description, "code-review:")
+}
+
+fn canonical_review_scope(session: &MetaSessionState) -> String {
+    session
+        .description
+        .as_deref()
+        .and_then(extract_review_scope)
+        .or_else(|| {
+            session
+                .description
+                .as_deref()
+                .map(str::trim)
+                .filter(|description| !description.is_empty())
         })
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn extract_review_scope(description: &str) -> Option<&str> {
+    let description = description.trim();
+    strip_ascii_prefix_ignore_case(description, "review:")
+        .or_else(|| strip_multi_reviewer_scope(description))
+        .or_else(|| strip_ascii_prefix_ignore_case(description, "code-review:"))
+        .map(str::trim)
+        .filter(|scope| !scope.is_empty())
+}
+
+fn strip_multi_reviewer_scope(description: &str) -> Option<&str> {
+    let rest = strip_ascii_prefix_ignore_case(description, "review[")?;
+    let close_bracket = rest.find(']')?;
+    let reviewer_index = &rest[..close_bracket];
+    if reviewer_index.is_empty() || !reviewer_index.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let after_bracket = rest.get(close_bracket + 1..)?.trim_start();
+    after_bracket.strip_prefix(':').map(str::trim)
+}
+
+fn has_ascii_prefix_ignore_case(value: &str, prefix: &str) -> bool {
+    strip_ascii_prefix_ignore_case(value, prefix).is_some()
+}
+
+fn strip_ascii_prefix_ignore_case<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
+    let candidate = value.get(..prefix.len())?;
+    if candidate.eq_ignore_ascii_case(prefix) {
+        value.get(prefix.len()..)
+    } else {
+        None
+    }
 }
 
 fn review_no_result_summary(packet: &DaemonCompletionPacket, tool: &str) -> String {
@@ -152,11 +211,7 @@ fn persist_review_no_result_meta(
         primary_failure: (tool == "unknown").then(|| "tool_launch_metadata_absent".to_string()),
         failure_reason: Some(diagnostic.to_string()),
         tool: tool.to_string(),
-        scope: session
-            .description
-            .as_deref()
-            .unwrap_or("unknown")
-            .to_string(),
+        scope: canonical_review_scope(session),
         exit_code: crate::verdict_exit_code::exit_code_from_review_decision(
             ReviewDecision::Unavailable,
         ),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
@@ -1,12 +1,70 @@
+use std::io::ErrorKind;
 use std::path::Path;
 
 use csa_core::types::ReviewDecision;
-use csa_session::MetaSessionState;
+use csa_session::{MetaSessionState, SessionArtifact};
 use tracing::warn;
 
 use super::completion::DaemonCompletionPacket;
 
 const REVIEW_DAEMON_NO_RESULT_REASON: &str = "daemon_completion_before_result";
+const REVIEW_VERDICT_ARTIFACT_PATH: &str = "output/review-verdict.json";
+
+pub(crate) fn has_review_no_result_diagnostic(session: &MetaSessionState) -> bool {
+    is_review_daemon_session(session)
+}
+
+pub(crate) fn append_review_no_result_diagnostic_artifacts(
+    artifacts: &mut Vec<SessionArtifact>,
+    session: &MetaSessionState,
+) {
+    if !has_review_no_result_diagnostic(session) {
+        return;
+    }
+    if artifacts
+        .iter()
+        .any(|artifact| artifact.path == REVIEW_VERDICT_ARTIFACT_PATH)
+    {
+        return;
+    }
+    artifacts.push(SessionArtifact::new(REVIEW_VERDICT_ARTIFACT_PATH));
+}
+
+impl DaemonCompletionPacket {
+    pub(crate) fn persist_review_diag(
+        &self,
+        result_path: &Path,
+        expected_contents: &[u8],
+        session_dir: &Path,
+        session: &MetaSessionState,
+    ) {
+        if !has_review_no_result_diagnostic(session) {
+            return;
+        }
+
+        match std::fs::read(result_path) {
+            Ok(current_contents) if current_contents == expected_contents => {
+                persist_review_no_result_diagnostic(session_dir, session, self)
+            }
+            Ok(_) => warn!(
+                result_path = %result_path.display(),
+                rollback_cleanup = "late_real_result_preserved",
+                "Skipped review daemon no-result diagnostic sidecars because result.toml changed after synthetic daemon completion publication"
+            ),
+            Err(err) if err.kind() == ErrorKind::NotFound => warn!(
+                result_path = %result_path.display(),
+                rollback_cleanup = "result_missing",
+                "Skipped review daemon no-result diagnostic sidecars because synthetic daemon completion result.toml disappeared before sidecar publication"
+            ),
+            Err(err) => warn!(
+                result_path = %result_path.display(),
+                rollback_cleanup = "read_failed",
+                error = %err,
+                "Skipped review daemon no-result diagnostic sidecars because synthetic daemon completion result.toml could not be verified"
+            ),
+        }
+    }
+}
 
 pub(crate) fn persist_review_no_result_diagnostic(
     session_dir: &Path,

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -580,7 +580,7 @@ where
                 reconciliation_reason = "late_result_write",
                 result_path = %result_path.display(),
                 result_mtime = %format_optional_file_mtime(result_path).unwrap_or_else(|| "unknown".to_string()),
-                "Late result.toml write won during daemon-completion reconciliation"
+                "Late result.toml write won"
             );
             return Ok(if retired {
                 DeadActiveSessionReconciliation::LateResultRetired
@@ -608,13 +608,19 @@ where
             "Failed to transition daemon-completed session to Retired phase during reconciliation for {session_id}"
         ));
     }
+    packet.persist_review_diag(
+        result_path,
+        result_contents.as_bytes(),
+        session_dir,
+        &session,
+    );
     if let Err(err) = persist_session(session_dir, &session) {
         warn!(
             session_id = %session_id,
             trigger = %trigger,
             reconciliation_reason = "daemon_completion",
             error = %err,
-            "Failed to persist retired daemon-completed session state during reconciliation; preserving daemon completion result so callers can recover the terminal outcome"
+            "Failed to persist retired daemon-completed session state during reconciliation"
         );
         return Ok(DeadActiveSessionReconciliation::DaemonCompletionFinalized);
     }
@@ -626,7 +632,7 @@ where
         result_path = %result_path.display(),
         exit_code = packet.exit_code,
         status = %packet.status,
-        "Recovered daemon-completed session from completion packet"
+        "Recovered daemon-completed session"
     );
     Ok(DeadActiveSessionReconciliation::DaemonCompletionFinalized)
 }

--- a/crates/cli-sub-agent/src/session_cmds_result_daemon_completion_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_daemon_completion_tests.rs
@@ -56,3 +56,72 @@ fn handle_session_result_fails_closed_on_success_completion_without_result() {
         Some("daemon_completion_missing_result")
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn handle_session_result_writes_review_no_result_diagnostic_artifacts() {
+    let tmp = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = tmp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", tmp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = tmp.path();
+
+    let session = create_session(project, Some("initializing daemon review"), None, None).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    backdate_tree(&session_dir, 120);
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 1\nstatus = \"failure\"\n",
+    )
+    .unwrap();
+
+    handle_session_result(
+        session_id.clone(),
+        false,
+        Some(project.to_string_lossy().into_owned()),
+        StructuredOutputOpts::default(),
+    )
+    .unwrap();
+
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("session result should synthesize from daemon review completion");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == "output/review-verdict.json"),
+        "result.toml should list the review verdict diagnostic artifact"
+    );
+
+    let review_meta: csa_session::ReviewSessionMeta = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("review_meta.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(review_meta.decision, "unavailable");
+    assert_eq!(review_meta.tool, "unknown");
+    assert_eq!(
+        review_meta.failure_reason.as_deref(),
+        Some(
+            "review daemon completion recorded status=failure exit_code=1 before result.toml was written; no tool launch metadata was recorded"
+        )
+    );
+
+    let verdict: csa_session::ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        verdict.decision,
+        csa_core::types::ReviewDecision::Unavailable
+    );
+    assert_eq!(
+        verdict.failure_reason.as_deref(),
+        review_meta.failure_reason.as_deref()
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2150.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2150.rs
@@ -75,3 +75,67 @@ fn persist_daemon_completion_from_env_writes_review_no_result_diagnostic_artifac
             .contains("no tool launch metadata was recorded")
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn daemon_completion_reconcile_late_real_review_result_does_not_keep_unavailable_diagnostics() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(project, Some("initializing daemon review"), None, None).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 1\nstatus = \"failure\"\n",
+    )
+    .unwrap();
+    let late_result = SessionResult {
+        summary: "late real review result".to_string(),
+        ..make_result("success", 0)
+    };
+
+    let reconciled = ensure_terminal_result_for_dead_active_session_with_before_write(
+        project,
+        &session_id,
+        "session wait",
+        |_| {
+            save_result(project, &session_id, &late_result).expect("persist late real result");
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::LateResultRetired
+    );
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("late real result should remain visible");
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.summary, "late real review result");
+    assert!(
+        !result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == "output/review-verdict.json"),
+        "late real result must not advertise stale unavailable review verdict diagnostics"
+    );
+    assert!(
+        !session_dir.join("review_meta.json").exists(),
+        "late real result must not inherit unavailable review_meta.json"
+    );
+    assert!(
+        !session_dir
+            .join("output")
+            .join("review-verdict.json")
+            .exists(),
+        "late real result must not inherit unavailable review-verdict.json"
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2150.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2150.rs
@@ -78,6 +78,72 @@ fn persist_daemon_completion_from_env_writes_review_no_result_diagnostic_artifac
 
 #[cfg(unix)]
 #[test]
+fn review_daemon_no_result_diagnostic_canonicalizes_review_description_scopes() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    for (description, task_type, expected_scope) in [
+        (
+            "review: range:main...HEAD",
+            Some("review"),
+            "range:main...HEAD",
+        ),
+        (
+            "review[1]: range:main...HEAD",
+            Some("reviewer_sub_session"),
+            "range:main...HEAD",
+        ),
+        ("code-review: range:main...HEAD", None, "range:main...HEAD"),
+    ] {
+        let session = create_session(project, Some(description), None, None).unwrap();
+        let session_id = session.meta_session_id;
+        if let Some(task_type) = task_type {
+            let mut session_state = load_session(project, &session_id).unwrap();
+            session_state.task_context = csa_session::TaskContext {
+                task_type: Some(task_type.to_string()),
+                tier_name: None,
+            };
+            save_session(&session_state).unwrap();
+        }
+        let session_dir = get_session_dir(project, &session_id).unwrap();
+
+        seed_daemon_session_env(&session_id, Some(project.to_string_lossy().as_ref()));
+        persist_daemon_completion_from_env(1);
+
+        let result = load_result(project, &session_id)
+            .unwrap()
+            .unwrap_or_else(|| panic!("{description} should synthesize result.toml"));
+        assert!(
+            result
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.path == "output/review-verdict.json"),
+            "{description} should advertise review verdict diagnostic artifact"
+        );
+        let review_meta: csa_session::ReviewSessionMeta = serde_json::from_str(
+            &std::fs::read_to_string(session_dir.join("review_meta.json"))
+                .unwrap_or_else(|_| panic!("{description} should write review_meta.json")),
+        )
+        .unwrap();
+        assert_eq!(review_meta.decision, "unavailable", "{description}");
+        assert_eq!(review_meta.scope, expected_scope, "{description}");
+        assert!(
+            session_dir
+                .join("output")
+                .join("review-verdict.json")
+                .exists(),
+            "{description} should write review-verdict.json"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
 fn daemon_completion_reconcile_late_real_review_result_does_not_keep_unavailable_diagnostics() {
     let td = tempdir().unwrap();
     let _env_lock = TEST_ENV_LOCK.blocking_lock();

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2150.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2150.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+#[cfg(unix)]
+#[test]
+fn persist_daemon_completion_from_env_writes_review_no_result_diagnostic_artifacts() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(project, Some("initializing daemon review"), None, None).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    seed_daemon_session_env(&session_id, Some(project.to_string_lossy().as_ref()));
+    persist_daemon_completion_from_env(1);
+
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("daemon review completion should synthesize result.toml");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert!(
+        result
+            .summary
+            .contains("no tool launch metadata was recorded"),
+        "summary should include explicit tool metadata absence: {}",
+        result.summary
+    );
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == "output/review-verdict.json"),
+        "synthetic result should advertise the review verdict diagnostic artifact"
+    );
+
+    let review_meta: csa_session::ReviewSessionMeta = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("review_meta.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(review_meta.decision, "unavailable");
+    assert_eq!(review_meta.verdict, "UNAVAILABLE");
+    assert_eq!(review_meta.tool, "unknown");
+    assert_eq!(
+        review_meta.status_reason.as_deref(),
+        Some("daemon_completion_before_result")
+    );
+    assert_eq!(
+        review_meta.primary_failure.as_deref(),
+        Some("tool_launch_metadata_absent")
+    );
+
+    let verdict: csa_session::ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        verdict.decision,
+        csa_core::types::ReviewDecision::Unavailable
+    );
+    assert_eq!(verdict.verdict_legacy, "UNAVAILABLE");
+    assert_eq!(
+        verdict.primary_failure.as_deref(),
+        Some("tool_launch_metadata_absent")
+    );
+    assert!(
+        verdict
+            .failure_reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("no tool launch metadata was recorded")
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_regression.rs
@@ -5,6 +5,9 @@ use crate::session_cmds_daemon::{
 use crate::test_env_lock::TEST_ENV_LOCK;
 use tempfile::tempdir;
 
+#[path = "session_cmds_tests_tail_wait_2150.rs"]
+mod issue_2150;
+
 struct EnvVarGuard {
     key: &'static str,
     original: Option<String>,

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1004"
-weave = "0.1.1004"
+csa = "0.1.1005"
+weave = "0.1.1005"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Persist structured review no-result diagnostics when a review daemon finishes before `result.toml` exists.
- Publish diagnostic sidecars only after the synthetic result wins, so late real results cannot leave stale unavailable metadata.
- Canonicalize review scopes for real review session descriptions (`review: ...`, `review[N]: ...`, `code-review: ...`) so `check-verdict` can see fail-closed unavailable verdicts.

Closes #2150

## Review / Validation

- Hook-enabled commits passed branch protection and quality gates.
- Focused tests passed for direct daemon completion, `session result` finalization, late real result preservation, and canonical review scopes.
- `daemon_completion` focused test suite passed.
- `cargo fmt --all -- --check` passed.
- staged monolith gate passed.
- `just pre-commit-fast` passed.
- exact-head pinned Codex full-diff review PASS/CLEAN:
  - session `01KV2XVW64MSH9ZBG20X65J13Q`
  - head `f1a136f6c6318e4ac2f49fed1060c473cc90251f`
  - verified by both `target/debug/csa review --check-verdict` and global `csa review --check-verdict`.

## Notes

- Several CSA review/implementation sessions hit `unknown_signal` / unavailable review-gate behavior during this work; evidence was added to #2035/#1989 and recurrence #2219 was filed for the `Summary: PASS` but no marker case.
