### PR TITLE
fix(review): fail read-only review mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "axum",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1005"
+version = "0.1.1006"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1005"
+version = "0.1.1006"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main_auto_weave_tests.rs
+++ b/crates/cli-sub-agent/src/main_auto_weave_tests.rs
@@ -79,9 +79,9 @@ fn plan_run_still_attempt_auto_weave_upgrade() {
 }
 
 #[test]
-fn review_still_attempts_auto_weave_upgrade() {
+fn review_skips_auto_weave_upgrade() {
     let cli = Cli::parse_from(["csa", "review", "--sa-mode", "false", "--diff"]);
-    assert!(should_attempt_auto_weave_upgrade(&cli.command));
+    assert!(!should_attempt_auto_weave_upgrade(&cli.command));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/main_bootstrap.rs
+++ b/crates/cli-sub-agent/src/main_bootstrap.rs
@@ -28,15 +28,17 @@ pub(crate) fn resolve_effective_min_timeout() -> u64 {
 }
 
 pub(crate) fn should_attempt_auto_weave_upgrade(command: &Commands) -> bool {
-    // Only execution commands need upgraded weave patterns.
-    // All management/read-only commands stay available even when weave is unhealthy.
+    // Only write-capable execution commands need upgraded weave patterns.
+    // Management/read-only commands stay available even when weave is unhealthy.
     match command {
         Commands::Run { .. }
         | Commands::Hunt(_)
         | Commands::Arch(_)
         | Commands::Triage(_)
         | Commands::Mktsk(_) => true,
-        Commands::Review(args) => !args.check_verdict,
+        // Review is a gate: stale weave.lock should warn, not rewrite the repo
+        // before verdict artifacts are produced.
+        Commands::Review(_) => false,
         Commands::Debate(_) | Commands::Batch { .. } | Commands::Plan { .. } => true,
         Commands::ClaudeSubAgent(_) | Commands::McpServer => true,
         _ => false,

--- a/crates/cli-sub-agent/src/pipeline_post_exec_audit.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_audit.rs
@@ -172,6 +172,10 @@ pub(crate) fn should_audit_repo_tracked_writes(
         return false;
     }
 
+    if matches!(task_type, Some("review" | "reviewer_sub_session")) {
+        return readonly_project_root;
+    }
+
     if !matches!(task_type, Some("run" | "plan" | "plan-step")) {
         return false;
     }

--- a/crates/cli-sub-agent/src/pipeline_tests_post_exec_audit.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_post_exec_audit.rs
@@ -62,12 +62,28 @@ fn should_audit_repo_tracked_writes_for_plan_step_task_type() {
 }
 
 #[test]
-fn should_not_audit_repo_tracked_writes_for_review_or_debate() {
-    assert!(!should_audit_repo_tracked_writes(
+fn should_audit_repo_tracked_writes_for_readonly_review_sessions() {
+    assert!(should_audit_repo_tracked_writes(
         false,
         Some("review"),
         true,
         "Analyze the diff and summarize findings"
+    ));
+    assert!(should_audit_repo_tracked_writes(
+        false,
+        Some("reviewer_sub_session"),
+        true,
+        "Analyze the diff and summarize findings"
+    ));
+}
+
+#[test]
+fn should_not_audit_repo_tracked_writes_for_writable_review_or_debate() {
+    assert!(!should_audit_repo_tracked_writes(
+        false,
+        Some("review"),
+        false,
+        "Fix the diff and summarize findings"
     ));
     assert!(!should_audit_repo_tracked_writes(
         false,

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -54,6 +54,8 @@ mod gate;
 mod mempal;
 #[path = "review_cmd_multi.rs"]
 mod multi;
+#[path = "review_cmd_multi_repo_write_audit.rs"]
+mod multi_repo_write_audit;
 #[path = "review_cmd_parent_artifacts.rs"]
 mod parent_artifacts;
 #[path = "review_cmd_post_review.rs"]

--- a/crates/cli-sub-agent/src/review_cmd_dirty_tree.rs
+++ b/crates/cli-sub-agent/src/review_cmd_dirty_tree.rs
@@ -126,13 +126,7 @@ pub(super) fn append_repo_write_audit_finding(
     project_root: &Path,
     session_id: &str,
 ) -> Vec<Finding> {
-    let Some(result) = csa_session::load_result(project_root, session_id)
-        .ok()
-        .flatten()
-    else {
-        return Vec::new();
-    };
-    let paths = repo_write_audit_paths_from_result(&result);
+    let paths = repo_write_audit_paths(project_root, session_id);
     if paths.is_empty() {
         return Vec::new();
     }
@@ -169,6 +163,26 @@ pub(super) fn append_repo_write_audit_finding(
         format_path_list(&paths)
     );
     vec![legacy_finding]
+}
+
+/// Return the blocking finding(s) implied by a read-only review repo-write audit
+/// without mutating any review sidecars.
+pub(super) fn repo_write_audit_findings(project_root: &Path, session_id: &str) -> Vec<Finding> {
+    let paths = repo_write_audit_paths(project_root, session_id);
+    if paths.is_empty() {
+        return Vec::new();
+    }
+    vec![legacy_worktree_mutation_finding(&paths)]
+}
+
+fn repo_write_audit_paths(project_root: &Path, session_id: &str) -> Vec<String> {
+    let Some(result) = csa_session::load_result(project_root, session_id)
+        .ok()
+        .flatten()
+    else {
+        return Vec::new();
+    };
+    repo_write_audit_paths_from_result(&result)
 }
 
 fn repo_write_audit_paths_from_result(result: &csa_session::SessionResult) -> Vec<String> {

--- a/crates/cli-sub-agent/src/review_cmd_dirty_tree.rs
+++ b/crates/cli-sub-agent/src/review_cmd_dirty_tree.rs
@@ -1,8 +1,14 @@
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::path::Path;
 
-use csa_session::{FindingsFile, get_session_dir};
-use tracing::debug;
+use csa_session::{
+    Finding, FindingsFile, ReviewFinding, ReviewFindingFileRange, Severity, get_session_dir,
+    write_findings_toml,
+};
+use tracing::{debug, warn};
+
+const REVIEW_WORKTREE_MUTATION_FINDING_ID: &str = "CSA-REVIEW-WORKTREE-MUTATION";
+const REVIEW_WORKTREE_MUTATION_RULE_ID: &str = "csa.review.readonly-worktree-mutation";
 
 /// Returns the set of file paths (relative to project root) that have uncommitted
 /// changes in the working tree, according to `git diff --name-only HEAD`.
@@ -109,6 +115,175 @@ fn emit_dirty_tree_hint(dirty_finding_files: &[String]) {
         );
     }
 }
+
+/// Convert a read-only review repo-write audit into a blocking structured finding.
+///
+/// `pipeline_post_exec_audit` records the exact tracked paths that changed during
+/// a read-only session. Review consumers gate on `findings.toml` and
+/// `review-verdict.json`, so a dirty tracked worktree must be surfaced there
+/// rather than remaining a warning-only manager sidecar.
+pub(super) fn append_repo_write_audit_finding(
+    project_root: &Path,
+    session_id: &str,
+) -> Vec<Finding> {
+    let Some(result) = csa_session::load_result(project_root, session_id)
+        .ok()
+        .flatten()
+    else {
+        return Vec::new();
+    };
+    let paths = repo_write_audit_paths_from_result(&result);
+    if paths.is_empty() {
+        return Vec::new();
+    }
+
+    let review_finding = review_worktree_mutation_finding(&paths);
+    let legacy_finding = legacy_worktree_mutation_finding(&paths);
+    if let Ok(session_dir) = get_session_dir(project_root, session_id) {
+        let findings_path = session_dir.join("output").join("findings.toml");
+        let mut findings_file = std::fs::read_to_string(&findings_path)
+            .ok()
+            .and_then(|content| toml::from_str::<FindingsFile>(&content).ok())
+            .unwrap_or_default();
+        findings_file
+            .findings
+            .retain(|finding| finding.id != REVIEW_WORKTREE_MUTATION_FINDING_ID);
+        findings_file.findings.push(review_finding);
+
+        if let Err(error) = write_findings_toml(&session_dir, &findings_file) {
+            warn!(
+                session_id,
+                error = %error,
+                "Failed to persist review worktree-mutation finding"
+            );
+        } else {
+            let synthetic_marker = session_dir
+                .join("output")
+                .join(super::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER);
+            let _ = std::fs::remove_file(synthetic_marker);
+        }
+    }
+
+    eprintln!(
+        "[csa-review] Read-only review mutated repo-tracked file(s): {}",
+        format_path_list(&paths)
+    );
+    vec![legacy_finding]
+}
+
+fn repo_write_audit_paths_from_result(result: &csa_session::SessionResult) -> Vec<String> {
+    let Some(audit) = result
+        .manager_fields
+        .artifacts
+        .as_ref()
+        .and_then(|value| value.get("repo_write_audit"))
+        .and_then(toml::Value::as_table)
+    else {
+        return Vec::new();
+    };
+
+    let mut paths = BTreeSet::new();
+    collect_path_array(audit.get("added"), &mut paths);
+    collect_path_array(audit.get("modified"), &mut paths);
+    collect_path_array(audit.get("deleted"), &mut paths);
+    collect_renamed_paths(audit.get("renamed"), &mut paths);
+    paths.into_iter().collect()
+}
+
+fn collect_path_array(value: Option<&toml::Value>, paths: &mut BTreeSet<String>) {
+    let Some(array) = value.and_then(toml::Value::as_array) else {
+        return;
+    };
+    for item in array {
+        if let Some(path) = item.as_str().map(str::trim).filter(|path| !path.is_empty()) {
+            paths.insert(path.to_string());
+        }
+    }
+}
+
+fn collect_renamed_paths(value: Option<&toml::Value>, paths: &mut BTreeSet<String>) {
+    let Some(array) = value.and_then(toml::Value::as_array) else {
+        return;
+    };
+    for item in array {
+        let Some(table) = item.as_table() else {
+            continue;
+        };
+        collect_path_value(table.get("from"), paths);
+        collect_path_value(table.get("to"), paths);
+    }
+}
+
+fn collect_path_value(value: Option<&toml::Value>, paths: &mut BTreeSet<String>) {
+    if let Some(path) = value
+        .and_then(toml::Value::as_str)
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+    {
+        paths.insert(path.to_string());
+    }
+}
+
+fn review_worktree_mutation_finding(paths: &[String]) -> ReviewFinding {
+    ReviewFinding {
+        id: REVIEW_WORKTREE_MUTATION_FINDING_ID.to_string(),
+        severity: Severity::High,
+        file_ranges: paths
+            .iter()
+            .map(|path| ReviewFindingFileRange {
+                path: path.clone(),
+                start: 1,
+                end: None,
+            })
+            .collect(),
+        is_regression_of_commit: None,
+        suggested_test_scenario: Some(
+            "Run csa review again after restoring or intentionally committing the tracked worktree changes."
+                .to_string(),
+        ),
+        description: format!(
+            "Read-only review mutated repo-tracked file(s): {}. Treat the review as blocking until the worktree is inspected or restored.",
+            format_path_list(paths)
+        ),
+    }
+}
+
+fn legacy_worktree_mutation_finding(paths: &[String]) -> Finding {
+    Finding {
+        severity: Severity::High,
+        fid: REVIEW_WORKTREE_MUTATION_FINDING_ID.to_string(),
+        file: paths
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string()),
+        line: Some(1),
+        rule_id: REVIEW_WORKTREE_MUTATION_RULE_ID.to_string(),
+        summary: format!(
+            "Read-only review mutated repo-tracked file(s): {}",
+            format_path_list(paths)
+        ),
+        engine: "csa-review".to_string(),
+    }
+}
+
+fn format_path_list(paths: &[String]) -> String {
+    const MAX_SHOWN: usize = 8;
+    let shown = paths
+        .iter()
+        .take(MAX_SHOWN)
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    if paths.len() > MAX_SHOWN {
+        format!("{shown}, and {} more", paths.len() - MAX_SHOWN)
+    } else {
+        shown
+    }
+}
+
+#[cfg(test)]
+#[path = "review_cmd_dirty_tree_tests.rs"]
+mod sidecar_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/cli-sub-agent/src/review_cmd_dirty_tree_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_dirty_tree_tests.rs
@@ -1,0 +1,210 @@
+use std::path::Path;
+use std::process::Command;
+
+use csa_core::types::ReviewDecision;
+use csa_core::vcs::{VcsIdentity, VcsKind};
+use csa_session::state::ReviewSessionMeta;
+use csa_session::{FindingsFile, ReviewVerdictArtifact, Severity};
+use tempfile::TempDir;
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn setup_git_repo() -> TempDir {
+    let temp = TempDir::new().expect("create tempdir");
+    run_git(temp.path(), &["init"]);
+    run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+    run_git(temp.path(), &["config", "user.name", "Test User"]);
+    std::fs::write(temp.path().join("tracked.txt"), "baseline\n").expect("write tracked file");
+    run_git(temp.path(), &["add", "tracked.txt"]);
+    run_git(temp.path(), &["commit", "-m", "initial"]);
+    temp
+}
+
+fn create_review_session(
+    project_root: &Path,
+    branch: &str,
+    head_sha: &str,
+) -> (String, std::path::PathBuf) {
+    let mut session = csa_session::create_session_fresh(
+        project_root,
+        Some("review: issue-2135 dirty lockfile"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    session.branch = Some(branch.to_string());
+    session.git_head_at_creation = Some(head_sha.to_string());
+    session.vcs_identity = Some(VcsIdentity {
+        vcs_kind: VcsKind::Git,
+        commit_id: Some(head_sha.to_string()),
+        change_id: None,
+        short_id: Some(head_sha.chars().take(11).collect()),
+        ref_name: Some(branch.to_string()),
+        op_id: None,
+    });
+    csa_session::save_session(&session).expect("save session state");
+
+    let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id)
+        .expect("resolve session dir");
+    std::fs::create_dir_all(session_dir.join("output")).expect("create session output dir");
+    (session.meta_session_id, session_dir)
+}
+
+fn codex_agent_message(text: &str) -> String {
+    serde_json::to_string(&serde_json::json!({
+        "type": "item.completed",
+        "item": {
+            "type": "agent_message",
+            "text": text,
+        }
+    }))
+    .expect("serialize transcript line")
+}
+
+fn review_meta(session_id: &str, head_sha: &str) -> ReviewSessionMeta {
+    ReviewSessionMeta {
+        session_id: session_id.to_string(),
+        head_sha: head_sha.to_string(),
+        decision: ReviewDecision::Pass.as_str().to_string(),
+        verdict: "CLEAN".to_string(),
+        review_mode: None,
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool: "codex".to_string(),
+        scope: "range:main...HEAD".to_string(),
+        exit_code: 0,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+        fix_convergence: None,
+    }
+}
+
+fn save_success_result_with_repo_write_audit(project_root: &Path, session_id: &str) {
+    let mut repo_write_audit = toml::map::Map::new();
+    repo_write_audit.insert(
+        "modified".to_string(),
+        toml::Value::Array(vec![toml::Value::String("weave.lock".to_string())]),
+    );
+    let mut artifacts = toml::map::Map::new();
+    artifacts.insert(
+        "repo_write_audit".to_string(),
+        toml::Value::Table(repo_write_audit),
+    );
+
+    let now = chrono::Utc::now();
+    let result = csa_session::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "No blocking findings remain".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(1),
+        manager_fields: csa_session::SessionManagerFields {
+            artifacts: Some(toml::Value::Table(artifacts)),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    csa_session::save_result(project_root, session_id, &result).expect("save result");
+}
+
+#[test]
+fn readonly_review_repo_write_audit_turns_clean_verdict_into_blocking_finding() {
+    let _guard = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
+    let project_dir = setup_git_repo();
+    let _state_home = crate::test_env_lock::ScopedEnvVarRestore::set(
+        "XDG_STATE_HOME",
+        project_dir.path().join("state"),
+    );
+    let branch = "fix-2135-dirty-lockfile";
+    let head_sha = csa_session::detect_git_head(project_dir.path()).expect("detect HEAD");
+    let (session_id, session_dir) = create_review_session(project_dir.path(), branch, &head_sha);
+
+    let final_pass = concat!(
+        "<!-- CSA:SECTION:summary -->\n",
+        "Verdict: PASS\n",
+        "<!-- CSA:SECTION:summary:END -->\n\n",
+        "<!-- CSA:SECTION:details -->\n",
+        "No blocking findings remain.\n\n",
+        "```findings.toml\n",
+        "findings = []\n",
+        "```\n",
+        "<!-- CSA:SECTION:details:END -->\n",
+    );
+    std::fs::write(
+        session_dir.join("output").join("full.md"),
+        codex_agent_message(final_pass),
+    )
+    .expect("write transcript");
+    csa_session::persist_structured_output(&session_dir, final_pass)
+        .expect("persist final structured output");
+    save_success_result_with_repo_write_audit(project_dir.path(), &session_id);
+
+    let persisted_exit_code = crate::review_cmd::persist_review_sidecars_if_session_exists(
+        project_dir.path(),
+        &review_meta(&session_id, &head_sha),
+        Some(&session_id),
+    );
+
+    assert_eq!(persisted_exit_code, Some(1));
+    let findings: FindingsFile = toml::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("findings.toml")).unwrap(),
+    )
+    .unwrap();
+    let finding = findings
+        .findings
+        .iter()
+        .find(|finding| finding.id == "CSA-REVIEW-WORKTREE-MUTATION")
+        .expect("worktree mutation finding should be persisted");
+    assert_eq!(finding.severity, Severity::High);
+    assert_eq!(finding.file_ranges[0].path, "weave.lock");
+
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json")).unwrap(),
+    )
+    .unwrap();
+    let persisted_meta: ReviewSessionMeta = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("review_meta.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&1));
+    assert_eq!(persisted_meta.decision, ReviewDecision::Fail.as_str());
+    assert_eq!(persisted_meta.verdict, "HAS_ISSUES");
+    assert_eq!(persisted_meta.exit_code, 1);
+
+    let found = crate::review_cmd::check_review_verdict_for_target(
+        project_dir.path(),
+        branch,
+        &head_sha,
+        "range:main...HEAD",
+        None,
+        None,
+    )
+    .unwrap();
+    assert!(
+        found.is_none(),
+        "check-verdict must reject review sessions that mutated tracked worktree files"
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_flow.rs
+++ b/crates/cli-sub-agent/src/review_cmd_flow.rs
@@ -123,7 +123,9 @@ pub(super) fn persist_review_sidecars_if_session_exists_with_diff_size(
     Some(verdict_exit_code)
 }
 
-fn review_meta_with_blocking_worktree_mutation(mut meta: ReviewSessionMeta) -> ReviewSessionMeta {
+pub(super) fn review_meta_with_blocking_worktree_mutation(
+    mut meta: ReviewSessionMeta,
+) -> ReviewSessionMeta {
     let decision = meta
         .decision
         .parse::<ReviewDecision>()

--- a/crates/cli-sub-agent/src/review_cmd_flow.rs
+++ b/crates/cli-sub-agent/src/review_cmd_flow.rs
@@ -2,6 +2,8 @@ use csa_core::types::ReviewDecision;
 use csa_session::ReviewDiffSize;
 use csa_session::state::ReviewSessionMeta;
 
+use crate::review_consensus::HAS_ISSUES;
+
 #[cfg(test)]
 use super::execute;
 use super::findings_toml::persist_review_findings_toml;
@@ -64,19 +66,29 @@ pub(super) fn persist_review_sidecars_if_session_exists_with_diff_size(
         large_diff_warning,
     );
     persist_review_findings_toml(project_root, &effective_meta);
-    let verdict_artifact =
-        persist_review_verdict_artifact(project_root, &effective_meta, &[], Vec::new()).map(
-            |mut artifact| {
-                super::diff_size::persist_review_verdict_diff_report(
-                    project_root,
-                    &effective_meta.session_id,
-                    &mut artifact,
-                    diff_size,
-                    large_diff_warning,
-                );
-                artifact
-            },
+    let worktree_mutation_findings =
+        super::dirty_tree::append_repo_write_audit_finding(project_root, persistable_session_id);
+    let effective_meta = if worktree_mutation_findings.is_empty() {
+        effective_meta
+    } else {
+        review_meta_with_blocking_worktree_mutation(effective_meta)
+    };
+    let verdict_artifact = persist_review_verdict_artifact(
+        project_root,
+        &effective_meta,
+        &worktree_mutation_findings,
+        Vec::new(),
+    )
+    .map(|mut artifact| {
+        super::diff_size::persist_review_verdict_diff_report(
+            project_root,
+            &effective_meta.session_id,
+            &mut artifact,
+            diff_size,
+            large_diff_warning,
         );
+        artifact
+    });
     let final_meta = verdict_artifact
         .as_ref()
         .map(|artifact| review_meta_for_verdict_artifact(&effective_meta, artifact))
@@ -109,6 +121,20 @@ pub(super) fn persist_review_sidecars_if_session_exists_with_diff_size(
         );
     }
     Some(verdict_exit_code)
+}
+
+fn review_meta_with_blocking_worktree_mutation(mut meta: ReviewSessionMeta) -> ReviewSessionMeta {
+    let decision = meta
+        .decision
+        .parse::<ReviewDecision>()
+        .unwrap_or(ReviewDecision::Uncertain);
+    if matches!(decision, ReviewDecision::Pass | ReviewDecision::Skip) {
+        meta.decision = ReviewDecision::Fail.as_str().to_string();
+        meta.verdict = HAS_ISSUES.to_string();
+        meta.exit_code =
+            crate::verdict_exit_code::exit_code_from_review_decision(ReviewDecision::Fail);
+    }
+    meta
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -10,7 +10,7 @@ use crate::failover_trace::FailoverSkipKind;
 use crate::pipeline::resolve_effective_initial_response_timeout_for_tool;
 use crate::review_consensus::{
     CLEAN, UNAVAILABLE, agreement_level, build_multi_reviewer_instruction,
-    consensus_strategy_label, consensus_verdict, parse_consensus_strategy, resolve_consensus,
+    consensus_strategy_label, parse_consensus_strategy, resolve_consensus,
 };
 use crate::review_routing::{
     ReviewRoutingMetadata, persist_review_routing_artifact_with_fallback_chain,
@@ -231,8 +231,13 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
         });
     }
 
-    let outcomes =
+    let mut outcomes =
         collect_reviewer_outcomes(&mut join_set, &reviewer_tool_plan, ctx.args.timeout).await?;
+    let repo_write_audit_blocked =
+        super::multi_repo_write_audit::apply_repo_write_audit_findings_to_multi_outcomes(
+            ctx.project_root,
+            &mut outcomes,
+        );
 
     let review_iterations = outcomes
         .first()
@@ -275,11 +280,11 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
         && outcomes
             .iter()
             .all(|outcome| outcome.verdict == UNAVAILABLE);
-    let final_verdict = if all_reviewers_unavailable {
-        crate::review_consensus::UNAVAILABLE
-    } else {
-        consensus_verdict(&consensus_result)
-    };
+    let final_verdict = super::multi_repo_write_audit::final_verdict_for_multi_review(
+        all_reviewers_unavailable,
+        repo_write_audit_blocked,
+        &consensus_result,
+    );
     let agreement = agreement_level(&consensus_result);
     let consensus_artifacts = super::parent_artifacts::MultiReviewerConsensusArtifacts {
         project_root: ctx.project_root,
@@ -564,9 +569,19 @@ pub(super) fn persist_multi_review_sidecars(
             diff_report.large_diff_warning,
         );
         super::findings_toml::persist_review_findings_toml(project_root, &effective_meta);
-        if let Some(mut artifact) =
-            persist_review_verdict_artifact(project_root, &effective_meta, &[], Vec::new())
-        {
+        let worktree_mutation_findings =
+            super::dirty_tree::append_repo_write_audit_finding(project_root, &outcome.session_id);
+        let effective_meta = if worktree_mutation_findings.is_empty() {
+            effective_meta
+        } else {
+            super::flow::review_meta_with_blocking_worktree_mutation(effective_meta)
+        };
+        if let Some(mut artifact) = persist_review_verdict_artifact(
+            project_root,
+            &effective_meta,
+            &worktree_mutation_findings,
+            Vec::new(),
+        ) {
             super::diff_size::persist_review_verdict_diff_report(
                 project_root,
                 &effective_meta.session_id,
@@ -582,6 +597,12 @@ pub(super) fn persist_multi_review_sidecars(
                 diff_report.large_diff_warning,
             );
         }
+        super::multi_repo_write_audit::persist_multi_reviewer_repo_write_audit_artifact(
+            project_root,
+            outcome,
+            &worktree_mutation_findings,
+            effective_meta.review_mode.as_deref(),
+        );
     }
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -247,6 +247,7 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
     let diff_fingerprint = compute_diff_fingerprint(ctx.project_root, ctx.scope);
     persist_multi_review_sidecars(
         ctx.project_root,
+        parent_startup_env.session_dir().map(Path::new),
         ctx.scope,
         &outcomes,
         &head_sha,
@@ -294,9 +295,7 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
         all_reviewers_unavailable,
         head_sha: &head_sha,
         scope: ctx.scope,
-        // Authoritative run-level mode, mirroring the child-sidecar stamp above so
-        // the parent consensus verdict is mode-tagged independently of whether the
-        // per-reviewer findings artifacts carried a mode (#1817).
+        // Parent consensus uses run-level mode even when reviewer artifacts lack it (#1817).
         run_review_mode: Some(ctx.args.effective_review_mode().as_str()),
         review_iterations,
         diff_fingerprint: diff_fingerprint.clone(),
@@ -514,9 +513,7 @@ pub(super) async fn collect_reviewer_outcomes(
     Ok(outcomes)
 }
 
-/// Per-run review metadata stamped onto every reviewer's [`ReviewSessionMeta`]
-/// when persisting multi-reviewer sidecars. `review_mode` records whether the
-/// run was a standard or red-team review so the merge gate can audit it (#1817).
+/// Per-run metadata stamped onto each reviewer sidecar.
 pub(super) struct ReviewRunMeta<'a> {
     pub(super) review_iterations: u32,
     pub(super) diff_fingerprint: Option<String>,
@@ -525,6 +522,7 @@ pub(super) struct ReviewRunMeta<'a> {
 
 pub(super) fn persist_multi_review_sidecars(
     project_root: &Path,
+    parent_session_dir: Option<&Path>,
     scope: &str,
     outcomes: &[ReviewerOutcome],
     head_sha: &str,
@@ -599,6 +597,7 @@ pub(super) fn persist_multi_review_sidecars(
         }
         super::multi_repo_write_audit::persist_multi_reviewer_repo_write_audit_artifact(
             project_root,
+            parent_session_dir,
             outcome,
             &worktree_mutation_findings,
             effective_meta.review_mode.as_deref(),

--- a/crates/cli-sub-agent/src/review_cmd_multi_repo_write_audit.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi_repo_write_audit.rs
@@ -1,0 +1,101 @@
+use std::{fs, path::Path};
+
+use csa_core::consensus::ConsensusResult;
+use csa_core::types::ReviewDecision;
+use csa_session::{ReviewArtifact, SeveritySummary};
+use tracing::warn;
+
+use crate::review_consensus::{HAS_ISSUES, UNAVAILABLE, consensus_verdict};
+
+use super::output::ReviewerOutcome;
+
+pub(super) fn apply_repo_write_audit_findings_to_multi_outcomes(
+    project_root: &Path,
+    outcomes: &mut [ReviewerOutcome],
+) -> bool {
+    let mut blocked = false;
+    for outcome in outcomes {
+        if super::dirty_tree::repo_write_audit_findings(project_root, &outcome.session_id)
+            .is_empty()
+        {
+            continue;
+        }
+        blocked = true;
+        outcome.verdict = HAS_ISSUES;
+        outcome.exit_code =
+            crate::verdict_exit_code::exit_code_from_review_decision(ReviewDecision::Fail);
+        if !outcome.output.ends_with('\n') {
+            outcome.output.push('\n');
+        }
+        outcome.output.push_str(
+            "[csa-review] Read-only reviewer mutated repo-tracked file(s); \
+             see CSA-REVIEW-WORKTREE-MUTATION finding.\n",
+        );
+    }
+    blocked
+}
+
+pub(super) fn final_verdict_for_multi_review(
+    all_reviewers_unavailable: bool,
+    repo_write_audit_blocked: bool,
+    consensus_result: &ConsensusResult,
+) -> &'static str {
+    if all_reviewers_unavailable {
+        UNAVAILABLE
+    } else if repo_write_audit_blocked {
+        HAS_ISSUES
+    } else {
+        consensus_verdict(consensus_result)
+    }
+}
+
+pub(super) fn persist_multi_reviewer_repo_write_audit_artifact(
+    project_root: &Path,
+    outcome: &ReviewerOutcome,
+    findings: &[csa_session::Finding],
+    review_mode: Option<&str>,
+) {
+    if findings.is_empty() {
+        return;
+    }
+    let Ok(session_dir) = csa_session::get_session_dir(project_root, &outcome.session_id) else {
+        return;
+    };
+    let reviewer_dir = session_dir.join(format!("reviewer-{}", outcome.reviewer_index + 1));
+    if let Err(error) = fs::create_dir_all(&reviewer_dir) {
+        warn!(
+            session_id = %outcome.session_id,
+            error = %error,
+            "Failed to create multi-reviewer repo-write audit artifact directory"
+        );
+        return;
+    }
+    let artifact = ReviewArtifact {
+        findings: findings.to_vec(),
+        severity_summary: SeveritySummary::from_findings(findings),
+        review_mode: review_mode.map(str::to_string),
+        schema_version: "1.0".to_string(),
+        session_id: outcome.session_id.clone(),
+        timestamp: chrono::Utc::now(),
+    };
+    let path = reviewer_dir.join("review-findings.json");
+    let payload = match serde_json::to_vec_pretty(&artifact) {
+        Ok(payload) => payload,
+        Err(error) => {
+            warn!(
+                session_id = %outcome.session_id,
+                error = %error,
+                "Failed to serialize multi-reviewer repo-write audit artifact"
+            );
+            return;
+        }
+    };
+    if let Err(error) = fs::write(&path, payload) {
+        warn!(
+            session_id = %outcome.session_id,
+            path = %path.display(),
+            error = %error,
+            "Failed to write multi-reviewer repo-write audit artifact"
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_multi_repo_write_audit.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi_repo_write_audit.rs
@@ -51,23 +51,12 @@ pub(super) fn final_verdict_for_multi_review(
 
 pub(super) fn persist_multi_reviewer_repo_write_audit_artifact(
     project_root: &Path,
+    parent_session_dir: Option<&Path>,
     outcome: &ReviewerOutcome,
     findings: &[csa_session::Finding],
     review_mode: Option<&str>,
 ) {
     if findings.is_empty() {
-        return;
-    }
-    let Ok(session_dir) = csa_session::get_session_dir(project_root, &outcome.session_id) else {
-        return;
-    };
-    let reviewer_dir = session_dir.join(format!("reviewer-{}", outcome.reviewer_index + 1));
-    if let Err(error) = fs::create_dir_all(&reviewer_dir) {
-        warn!(
-            session_id = %outcome.session_id,
-            error = %error,
-            "Failed to create multi-reviewer repo-write audit artifact directory"
-        );
         return;
     }
     let artifact = ReviewArtifact {
@@ -78,24 +67,84 @@ pub(super) fn persist_multi_reviewer_repo_write_audit_artifact(
         session_id: outcome.session_id.clone(),
         timestamp: chrono::Utc::now(),
     };
-    let path = reviewer_dir.join("review-findings.json");
+    let reviewer_dir_name = format!("reviewer-{}", outcome.reviewer_index + 1);
+    if let Ok(session_dir) = csa_session::get_session_dir(project_root, &outcome.session_id) {
+        write_repo_write_audit_artifact(
+            &session_dir
+                .join(&reviewer_dir_name)
+                .join("review-findings.json"),
+            &artifact,
+        );
+    }
+    if let Some(parent_session_dir) = parent_session_dir {
+        merge_repo_write_audit_artifact(
+            &parent_session_dir
+                .join(reviewer_dir_name)
+                .join("review-findings.json"),
+            &artifact,
+        );
+    }
+}
+
+fn write_repo_write_audit_artifact(path: &Path, artifact: &ReviewArtifact) {
+    if let Some(parent) = path.parent()
+        && let Err(error) = fs::create_dir_all(parent)
+    {
+        warn!(
+            path = %parent.display(),
+            error = %error,
+            "Failed to create multi-reviewer repo-write audit artifact directory"
+        );
+        return;
+    }
     let payload = match serde_json::to_vec_pretty(&artifact) {
         Ok(payload) => payload,
         Err(error) => {
             warn!(
-                session_id = %outcome.session_id,
+                session_id = %artifact.session_id,
                 error = %error,
                 "Failed to serialize multi-reviewer repo-write audit artifact"
             );
             return;
         }
     };
-    if let Err(error) = fs::write(&path, payload) {
+    if let Err(error) = fs::write(path, payload) {
         warn!(
-            session_id = %outcome.session_id,
+            session_id = %artifact.session_id,
             path = %path.display(),
             error = %error,
             "Failed to write multi-reviewer repo-write audit artifact"
         );
     }
+}
+
+fn merge_repo_write_audit_artifact(path: &Path, audit_artifact: &ReviewArtifact) {
+    let artifact = fs::read_to_string(path)
+        .ok()
+        .and_then(|content| match super::parent_artifacts::parse_reviewer_artifact(path, &content) {
+            Ok(mut existing) => {
+                for finding in &audit_artifact.findings {
+                    existing
+                        .findings
+                        .retain(|existing| existing.fid != finding.fid);
+                    existing.findings.push(finding.clone());
+                }
+                existing.severity_summary = SeveritySummary::from_findings(&existing.findings);
+                if existing.review_mode.is_none() {
+                    existing.review_mode = audit_artifact.review_mode.clone();
+                }
+                existing.timestamp = chrono::Utc::now();
+                Some(existing)
+            }
+            Err(error) => {
+                warn!(
+                    path = %path.display(),
+                    error = %error,
+                    "Failed to parse existing parent reviewer artifact; replacing with repo-write audit artifact"
+                );
+                None
+            }
+        })
+        .unwrap_or_else(|| audit_artifact.clone());
+    write_repo_write_audit_artifact(path, &artifact);
 }

--- a/crates/cli-sub-agent/src/review_cmd_multi_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi_tests.rs
@@ -5,7 +5,7 @@ use csa_config::ProjectProfile;
 use csa_core::consensus::ConsensusStrategy;
 use csa_core::env::{CSA_SESSION_DIR_ENV_KEY, CSA_SESSION_ID_ENV_KEY};
 use csa_core::types::ReviewDecision;
-use csa_session::{FindingsFile, ReviewArtifact, ReviewVerdictArtifact, Severity};
+use csa_session::{FindingsFile, ReviewArtifact, ReviewVerdictArtifact, Severity, SeveritySummary};
 use proptest::prelude::*;
 use std::{collections::HashMap, path::Path};
 
@@ -155,8 +155,27 @@ fn repo_write_audit_blocks_clean_multi_reviewer_majority_and_parent_verdict() {
     let final_verdict = final_verdict_for_multi_review(false, blocked, &consensus);
     assert_eq!(final_verdict, HAS_ISSUES);
 
+    let parent_dir = project.path().join("parent-session");
+    std::fs::create_dir_all(parent_dir.join("reviewer-1")).expect("create parent reviewer dir");
+    let parent_session_id = "01PARENTSESSION000000000000";
+    let preexisting_parent_artifact = ReviewArtifact {
+        findings: Vec::new(),
+        severity_summary: SeveritySummary::default(),
+        review_mode: Some("standard".to_string()),
+        schema_version: "1.0".to_string(),
+        session_id: dirty_session_id.clone(),
+        timestamp: chrono::Utc::now(),
+    };
+    std::fs::write(
+        parent_dir.join("reviewer-1").join("review-findings.json"),
+        serde_json::to_vec_pretty(&preexisting_parent_artifact)
+            .expect("preexisting parent artifact should serialize"),
+    )
+    .expect("preexisting parent reviewer artifact should be written");
+
     persist_multi_review_sidecars(
         project.path(),
+        Some(&parent_dir),
         "range:main...HEAD",
         &outcomes,
         "HEADSHA",
@@ -208,9 +227,17 @@ fn repo_write_audit_blocks_clean_multi_reviewer_majority_and_parent_verdict() {
         "CSA-REVIEW-WORKTREE-MUTATION"
     );
 
-    let parent_dir = project.path().join("parent-session");
-    std::fs::create_dir_all(&parent_dir).expect("create parent session dir");
-    let parent_session_id = "01PARENTSESSION000000000000";
+    let parent_reviewer_artifact: ReviewArtifact = serde_json::from_str(
+        &std::fs::read_to_string(parent_dir.join("reviewer-1").join("review-findings.json"))
+            .expect("parent reviewer artifact should exist"),
+    )
+    .expect("parent reviewer artifact should parse");
+    assert_eq!(parent_reviewer_artifact.severity_summary.high, 1);
+    assert_eq!(
+        parent_reviewer_artifact.findings[0].fid,
+        "CSA-REVIEW-WORKTREE-MUTATION"
+    );
+
     super::super::parent_artifacts::write_multi_reviewer_consensus_artifacts(
         super::super::parent_artifacts::MultiReviewerConsensusArtifacts {
             project_root: project.path(),
@@ -229,6 +256,29 @@ fn repo_write_audit_blocks_clean_multi_reviewer_majority_and_parent_verdict() {
         &startup_env_for_parent_session(&parent_dir, parent_session_id),
     )
     .expect("parent consensus artifacts should be written");
+
+    let parent_findings: FindingsFile = toml::from_str(
+        &std::fs::read_to_string(parent_dir.join("output").join("findings.toml"))
+            .expect("parent findings.toml should exist"),
+    )
+    .expect("parent findings.toml should parse");
+    assert_eq!(
+        parent_findings.findings[0].id,
+        "CSA-REVIEW-WORKTREE-MUTATION"
+    );
+
+    let parent_consolidated: ReviewArtifact = serde_json::from_str(
+        &std::fs::read_to_string(
+            parent_dir.join(crate::bug_class::CONSOLIDATED_REVIEW_ARTIFACT_FILE),
+        )
+        .expect("parent consolidated review artifact should exist"),
+    )
+    .expect("parent consolidated review artifact should parse");
+    assert_eq!(parent_consolidated.severity_summary.high, 1);
+    assert_eq!(
+        parent_consolidated.findings[0].fid,
+        "CSA-REVIEW-WORKTREE-MUTATION"
+    );
 
     let parent_verdict: ReviewVerdictArtifact = serde_json::from_str(
         &std::fs::read_to_string(parent_dir.join("output").join("review-verdict.json"))

--- a/crates/cli-sub-agent/src/review_cmd_multi_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi_tests.rs
@@ -1,8 +1,17 @@
 use super::*;
-use crate::review_consensus::HAS_ISSUES;
+use crate::review_consensus::{HAS_ISSUES, consensus_verdict};
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use csa_config::ProjectProfile;
 use csa_core::consensus::ConsensusStrategy;
+use csa_core::env::{CSA_SESSION_DIR_ENV_KEY, CSA_SESSION_ID_ENV_KEY};
+use csa_core::types::ReviewDecision;
+use csa_session::{FindingsFile, ReviewArtifact, ReviewVerdictArtifact, Severity};
 use proptest::prelude::*;
+use std::{collections::HashMap, path::Path};
+
+use super::super::multi_repo_write_audit::{
+    apply_repo_write_audit_findings_to_multi_outcomes, final_verdict_for_multi_review,
+};
 
 #[derive(Clone, Copy, Debug)]
 enum ReviewerState {
@@ -31,15 +40,207 @@ fn outcome_with_tool(
     verdict: &'static str,
     diagnostic: Option<&str>,
 ) -> ReviewerOutcome {
+    outcome_with_session_id(
+        reviewer_index,
+        tool,
+        format!("01TESTREVIEWER{reviewer_index:012}"),
+        verdict,
+        diagnostic,
+    )
+}
+
+fn outcome_with_session_id(
+    reviewer_index: usize,
+    tool: ToolName,
+    session_id: String,
+    verdict: &'static str,
+    diagnostic: Option<&str>,
+) -> ReviewerOutcome {
     ReviewerOutcome {
         reviewer_index,
         tool,
-        session_id: format!("01TESTREVIEWER{reviewer_index:012}"),
+        session_id,
         output: verdict.to_string(),
         exit_code: if verdict == CLEAN { 0 } else { 1 },
         verdict,
         diagnostic: diagnostic.map(str::to_string),
     }
+}
+
+fn create_review_session(project_root: &Path, prompt: &str) -> (String, std::path::PathBuf) {
+    let session =
+        csa_session::create_session_fresh(project_root, Some(prompt), None, Some("codex"))
+            .expect("create review session");
+    csa_session::save_session(&session).expect("save review session");
+    let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id)
+        .expect("resolve review session dir");
+    std::fs::create_dir_all(session_dir.join("output")).expect("create review output dir");
+    (session.meta_session_id, session_dir)
+}
+
+fn save_result_with_repo_write_audit(project_root: &Path, session_id: &str) {
+    let mut repo_write_audit = toml::map::Map::new();
+    repo_write_audit.insert(
+        "modified".to_string(),
+        toml::Value::Array(vec![toml::Value::String("weave.lock".to_string())]),
+    );
+    let mut artifacts = toml::map::Map::new();
+    artifacts.insert(
+        "repo_write_audit".to_string(),
+        toml::Value::Table(repo_write_audit),
+    );
+
+    let now = chrono::Utc::now();
+    let result = csa_session::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "Clean textual verdict".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(1),
+        manager_fields: csa_session::SessionManagerFields {
+            artifacts: Some(toml::Value::Table(artifacts)),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    csa_session::save_result(project_root, session_id, &result).expect("save review result");
+}
+
+fn startup_env_for_parent_session(
+    session_dir: &Path,
+    session_id: &str,
+) -> crate::startup_env::StartupSubtreeEnv {
+    crate::startup_env::StartupSubtreeEnv::from_values(HashMap::from([
+        (CSA_SESSION_DIR_ENV_KEY, session_dir.display().to_string()),
+        (CSA_SESSION_ID_ENV_KEY, session_id.to_string()),
+    ]))
+}
+
+#[test]
+fn repo_write_audit_blocks_clean_multi_reviewer_majority_and_parent_verdict() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let project = tempfile::tempdir().expect("tempdir should be created");
+    let _state_home = ScopedEnvVarRestore::set("XDG_STATE_HOME", project.path().join("state"));
+
+    let (dirty_session_id, dirty_session_dir) =
+        create_review_session(project.path(), "dirty reviewer");
+    save_result_with_repo_write_audit(project.path(), &dirty_session_id);
+    let (clean_session_id_1, _) = create_review_session(project.path(), "clean reviewer 1");
+    let (clean_session_id_2, _) = create_review_session(project.path(), "clean reviewer 2");
+
+    let mut outcomes = vec![
+        outcome_with_session_id(0, ToolName::Codex, dirty_session_id.clone(), CLEAN, None),
+        outcome_with_session_id(1, ToolName::Codex, clean_session_id_1, CLEAN, None),
+        outcome_with_session_id(2, ToolName::Codex, clean_session_id_2, CLEAN, None),
+    ];
+
+    let blocked = apply_repo_write_audit_findings_to_multi_outcomes(project.path(), &mut outcomes);
+
+    assert!(blocked);
+    assert_eq!(outcomes[0].verdict, HAS_ISSUES);
+    assert_eq!(outcomes[0].exit_code, 1);
+    assert!(outcomes[0].output.contains("CSA-REVIEW-WORKTREE-MUTATION"));
+
+    let responses: Vec<AgentResponse> = consensus_outcomes_for_final_verdict(&outcomes)
+        .iter()
+        .map(|outcome| consensus_response_from_outcome(outcome))
+        .collect();
+    let consensus = resolve_consensus(ConsensusStrategy::Majority, &responses);
+    assert_eq!(
+        consensus_verdict(&consensus),
+        CLEAN,
+        "the regression requires an explicit audit override because raw majority would pass"
+    );
+    let final_verdict = final_verdict_for_multi_review(false, blocked, &consensus);
+    assert_eq!(final_verdict, HAS_ISSUES);
+
+    persist_multi_review_sidecars(
+        project.path(),
+        "range:main...HEAD",
+        &outcomes,
+        "HEADSHA",
+        ReviewRunMeta {
+            review_iterations: 1,
+            diff_fingerprint: None,
+            review_mode: Some("standard"),
+        },
+        super::super::diff_size::ReviewDiffReport {
+            diff_size: None,
+            large_diff_warning: None,
+        },
+    );
+
+    let child_findings: FindingsFile = toml::from_str(
+        &std::fs::read_to_string(dirty_session_dir.join("output").join("findings.toml"))
+            .expect("child findings.toml should exist"),
+    )
+    .expect("child findings.toml should parse");
+    let child_finding = child_findings
+        .findings
+        .iter()
+        .find(|finding| finding.id == "CSA-REVIEW-WORKTREE-MUTATION")
+        .expect("child audit finding should be present");
+    assert_eq!(child_finding.severity, Severity::High);
+    assert_eq!(child_finding.file_ranges[0].path, "weave.lock");
+
+    let child_verdict: ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(dirty_session_dir.join("output").join("review-verdict.json"))
+            .expect("child review-verdict.json should exist"),
+    )
+    .expect("child verdict should parse");
+    assert_eq!(child_verdict.decision, ReviewDecision::Fail);
+    assert_eq!(child_verdict.verdict_legacy, HAS_ISSUES);
+    assert_eq!(child_verdict.severity_counts.get(&Severity::High), Some(&1));
+
+    let reviewer_artifact: ReviewArtifact = serde_json::from_str(
+        &std::fs::read_to_string(
+            dirty_session_dir
+                .join("reviewer-1")
+                .join("review-findings.json"),
+        )
+        .expect("fallback reviewer artifact should exist"),
+    )
+    .expect("fallback reviewer artifact should parse");
+    assert_eq!(reviewer_artifact.severity_summary.high, 1);
+    assert_eq!(
+        reviewer_artifact.findings[0].fid,
+        "CSA-REVIEW-WORKTREE-MUTATION"
+    );
+
+    let parent_dir = project.path().join("parent-session");
+    std::fs::create_dir_all(&parent_dir).expect("create parent session dir");
+    let parent_session_id = "01PARENTSESSION000000000000";
+    super::super::parent_artifacts::write_multi_reviewer_consensus_artifacts(
+        super::super::parent_artifacts::MultiReviewerConsensusArtifacts {
+            project_root: project.path(),
+            reviewers: outcomes.len(),
+            outcomes: &outcomes,
+            final_verdict,
+            all_reviewers_unavailable: false,
+            head_sha: "HEADSHA",
+            scope: "range:main...HEAD",
+            run_review_mode: Some("standard"),
+            review_iterations: 1,
+            diff_fingerprint: None,
+            diff_size: None,
+            large_diff_warning: None,
+        },
+        &startup_env_for_parent_session(&parent_dir, parent_session_id),
+    )
+    .expect("parent consensus artifacts should be written");
+
+    let parent_verdict: ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(parent_dir.join("output").join("review-verdict.json"))
+            .expect("parent review-verdict.json should exist"),
+    )
+    .expect("parent verdict should parse");
+    assert_eq!(parent_verdict.decision, ReviewDecision::Fail);
+    assert_eq!(parent_verdict.verdict_legacy, HAS_ISSUES);
+    assert_eq!(
+        parent_verdict.severity_counts.get(&Severity::High),
+        Some(&1)
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -85,7 +85,7 @@ struct ReviewerFindingsContractArtifact {
     summary: Option<String>,
 }
 
-fn parse_reviewer_artifact(path: &Path, content: &str) -> Result<ReviewArtifact> {
+pub(super) fn parse_reviewer_artifact(path: &Path, content: &str) -> Result<ReviewArtifact> {
     if let Ok(artifact) = serde_json::from_str::<ReviewArtifact>(content) {
         return Ok(artifact);
     }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1005"
-weave = "0.1.1005"
+csa = "0.1.1006"
+weave = "0.1.1006"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Detect repo-tracked writes made by read-only review sessions and convert them into blocking review findings.
- Propagate multi-reviewer repo-write audit findings into child, parent, consolidated, and verdict artifacts.
- Prevent `csa review` from auto-upgrading `weave.lock` before review verdict artifacts are produced.
- Add regression coverage for single-review and multi-review dirty-lockfile verdict handling.

Fixes #2135

## Test plan

- [x] `just pre-commit` via hook-enabled commits
- [x] `cargo test -p cli-sub-agent readonly_review_repo_write_audit_turns_clean_verdict_into_blocking_finding`
- [x] `cargo test -p cli-sub-agent repo_write_audit_blocks_clean_multi_reviewer_majority_and_parent_verdict`
- [x] Exact-head CSA review PASS/CLEAN: `01KV3DFTSP0AE2H4S7NJYY5J3C`
- [x] `target/debug/csa review --check-verdict` PASS for `294b802651b`
- [x] `csa review --check-verdict` PASS for `294b802651b`

## Notes

`csa plan run --sa-mode true --pattern pr-bot` failed after pushing the branch because Step 5 referenced an unset `PR_BODY`; this PR is created manually from the already-reviewed exact head.
