### PR TITLE
fix(pr-bot): tolerate missing PR body

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "axum",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1006"
+version = "0.1.1007"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1006"
+version = "0.1.1007"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -259,7 +259,6 @@ if [ -z "${PR_TITLE}" ]; then
   PR_TITLE="$(derive_default_pr_title)"
   echo "INFO: PR_TITLE unset; using derived title: ${PR_TITLE}" >&2
 fi
-
 # --- Early-push detection: warn if branch was already pushed before review ---
 if git ls-remote --heads "${REMOTE_NAME}" "${WORKFLOW_BRANCH}" 2>/dev/null | grep -q .; then
   echo "WARNING: Branch '${WORKFLOW_BRANCH}' was already pushed to remote before this skill ran."
@@ -407,7 +406,7 @@ elif [ "${FIND_RC}" = "1" ]; then
   exit 1
 else
   set +e
-  CREATE_OUTPUT="$(gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}" 2>&1)"
+  CREATE_OUTPUT="$(gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY:-}" 2>&1)"
   CREATE_RC=$?
   set -e
   if [ "${CREATE_RC}" != "0" ]; then
@@ -2123,7 +2122,7 @@ git checkout -b "${CLEAN_BRANCH}"
 CSA_SKIP_REVIEW_CHECK=1 \
 CSA_SKIP_REVIEW_CHECK_REASON="pr-bot push clean branch for PR" \
   git push -u "${REMOTE_NAME}" "${CLEAN_BRANCH}"
-gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${CLEAN_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}"
+gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${CLEAN_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY:-}"
 ```
 
 ## Step 12: Final Merge

--- a/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
+++ b/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
@@ -51,6 +51,7 @@ run_case() {
   local expected_title="${11:-Fix 1171}"
   local pr_title_mode="${12:-set}"
   local git_head_subject="${13-Fix 1171}"
+  local pr_body_mode="${14:-set}"
   local case_dir="${TMP_ROOT}/${case_name}"
   local bin_dir="${case_dir}/bin"
   local stdout_file="${case_dir}/stdout.txt"
@@ -81,7 +82,11 @@ run_case() {
     export WORKFLOW_BRANCH="${workflow_branch}"
     export REPO_SLUG="test-owner/test-repo"
     export DEFAULT_BRANCH="main"
-    export PR_BODY="Body"
+    if [ "${pr_body_mode}" = "unset" ]; then
+      unset PR_BODY
+    else
+      export PR_BODY="Body"
+    fi
     if [ "${pr_title_mode}" = "unset" ]; then
       unset PR_TITLE
     else
@@ -122,6 +127,7 @@ run_case "lookup-hits-merged-noop" "true" "merged" "0" "909" "0"
 run_case "cross-owner-create" "true" "cross-owner" "0" "101" "1"
 run_case "unset-title-derives-head" "true" "create-success" "0" "101" "1" "PR_TITLE unset; using derived title: fix(pr-bot): derive title" "fix/1171" "fix/1171" "test-owner:fix/1171" "fix(pr-bot): derive title" "unset" "fix(pr-bot): derive title"
 run_case "unset-title-falls-back-to-branch" "true" "create-success" "0" "101" "1" "PR_TITLE unset; using derived title: Topic custom title" "topic/custom_title" "topic/custom_title" "test-owner:topic/custom_title" "Topic custom title" "unset" ""
+run_case "unset-body-creates-with-empty-body" "true" "create-success" "0" "101" "1" "" "fix/1171" "fix/1171" "test-owner:fix/1171" "Fix 1171" "set" "Fix 1171" "unset"
 run_case "create-already-exists-reresolve" "true" "missed-already-exists" "0" "303" "1" "PR already exists for test-owner:fix/1171; re-resolving"
 run_case "stale-list-create-race-recovery" "true" "stale-already-exists" "0" "808" "1" "PR already exists for test-owner:fix/1171; re-resolving"
 run_case "ambiguous-fail-closed" "true" "ambiguous" "1" "" "0" "Multiple PRs found for test-owner:fix/1171"

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -747,7 +747,6 @@ if [ -z "${PR_TITLE}" ]; then
   PR_TITLE="$(derive_default_pr_title)"
   echo "INFO: PR_TITLE unset; using derived title: ${PR_TITLE}" >&2
 fi
-
 # --- Early-push detection: warn if branch was already pushed before review ---
 if git ls-remote --heads "${REMOTE_NAME}" "${WORKFLOW_BRANCH}" 2>/dev/null | grep -q .; then
   echo "WARNING: Branch '${WORKFLOW_BRANCH}' was already pushed to remote before this skill ran."
@@ -895,7 +894,7 @@ elif [ "${FIND_RC}" = "1" ]; then
   exit 1
 else
   set +e
-  CREATE_OUTPUT="$(gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}" 2>&1)"
+  CREATE_OUTPUT="$(gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${SOURCE_OWNER}:${WORKFLOW_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY:-}" 2>&1)"
   CREATE_RC=$?
   set -e
   if [ "${CREATE_RC}" != "0" ]; then
@@ -2614,7 +2613,7 @@ git checkout -b "${CLEAN_BRANCH}"
 CSA_SKIP_REVIEW_CHECK=1 \
 CSA_SKIP_REVIEW_CHECK_REASON="pr-bot push clean branch for PR" \
   git push -u "${REMOTE_NAME}" "${CLEAN_BRANCH}"
-gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${CLEAN_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY}"
+gh pr create --repo "${REPO_SLUG}" --base "${DEFAULT_BRANCH}" --head "${CLEAN_BRANCH}" --title "${PR_TITLE}" --body "${PR_BODY:-}"
 ```'''
 on_fail = "abort"
 condition = "(!(${MERGE_COMPLETED})) && ((!(${BOT_UNAVAILABLE}) || (!(${CLOUD_BOT}) || ((${CLOUD_BOT}) && (${BOT_UNAVAILABLE}) && !(${FALLBACK_REVIEW_HAS_ISSUES})))) && (${FIXES_ACCUMULATED} && !(${REBASE_CLEAN_HISTORY_APPLIED})))"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1006"
-weave = "0.1.1006"
+csa = "0.1.1007"
+weave = "0.1.1007"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Allow pr-bot PR creation to proceed when `PR_BODY` is unset under `set -u`.
- Use an empty-body fallback for both pr-bot PR creation paths.
- Keep `PATTERN.md` and `workflow.toml` synchronized.
- Add Step 5 shell regression coverage for the unset-body path.

Fixes #2223

## Test plan

- `patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh`
- `cargo test -p cli-sub-agent pr_bot_step5`
- `just pre-commit-fast`
- Hook-enabled `git commit`
- `target/debug/csa review --sa-mode true --tool codex --tier tier-4-critical --no-failover --range main...HEAD`
- `target/debug/csa review --check-verdict --range main...HEAD`
