### PR TITLE
fix(version): use writable install root for checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "axum",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1007"
+version = "0.1.1008"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1007"
+version = "0.1.1008"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -128,6 +128,8 @@ mod triage_cmd;
 mod untracked_size;
 mod verdict_exit_code;
 mod verify_cmd;
+#[cfg(test)]
+mod version_check_recipe_tests;
 mod xurl_cmd;
 #[cfg(test)]
 include!("review_cmd_exact_tests.rs");

--- a/crates/cli-sub-agent/src/version_check_recipe_tests.rs
+++ b/crates/cli-sub-agent/src/version_check_recipe_tests.rs
@@ -1,0 +1,171 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
+}
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("git should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn write_workspace_version(repo: &Path, version: &str) {
+    fs::write(
+        repo.join("Cargo.toml"),
+        format!("[workspace.package]\nversion = \"{version}\"\n"),
+    )
+    .expect("write Cargo.toml");
+}
+
+fn init_version_check_repo() -> TempDir {
+    let td = TempDir::new().expect("create tempdir");
+    run_git(td.path(), &["init", "-b", "main"]);
+    run_git(td.path(), &["config", "user.email", "test@example.com"]);
+    run_git(td.path(), &["config", "user.name", "Test User"]);
+
+    write_workspace_version(td.path(), "0.1.0");
+    run_git(td.path(), &["add", "Cargo.toml"]);
+    run_git(td.path(), &["commit", "-m", "initial"]);
+    run_git(td.path(), &["checkout", "-b", "feature/version-bumped"]);
+    write_workspace_version(td.path(), "0.1.1");
+
+    td
+}
+
+#[cfg(unix)]
+fn install_failing_cargo(bin_dir: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::create_dir_all(bin_dir).expect("create fake bin dir");
+    let cargo_path = bin_dir.join("cargo");
+    fs::write(
+        &cargo_path,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" != "metadata" ]; then
+    echo "fake cargo only supports metadata; args=$*" >&2
+    exit 43
+fi
+install_root="${CARGO_INSTALL_ROOT:-}"
+printf '%s\n' "$install_root" >"${FAKE_CARGO_INSTALL_ROOT_CAPTURE:?}"
+if [ -z "$install_root" ] || [ "$install_root" = "/usr/local" ]; then
+    echo "fake cargo saw non-writable CARGO_INSTALL_ROOT=${install_root:-<unset>}" >&2
+    exit 42
+fi
+if [ ! -d "$install_root" ]; then
+    echo "fake cargo expected install root directory to exist: $install_root" >&2
+    exit 44
+fi
+cat <<'JSON'
+{"packages":[{"name":"cli-sub-agent","version":"0.1.1"}]}
+JSON
+"#,
+    )
+    .expect("write fake cargo");
+    let mut perms = fs::metadata(&cargo_path)
+        .expect("fake cargo metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&cargo_path, perms).expect("chmod fake cargo");
+}
+
+enum CargoInstallRoot {
+    Unset,
+    Value(&'static str),
+    RepoLocal(&'static str),
+}
+
+#[cfg(unix)]
+fn run_check_version_bumped(cargo_install_root: CargoInstallRoot) -> (String, String) {
+    let repo = init_version_check_repo();
+    let fake_bin = repo.path().join("fake-bin");
+    install_failing_cargo(&fake_bin);
+    let capture_path = repo.path().join("fake-cargo-install-root.txt");
+    let default_install_root = repo.path().join("target/cargo-install-root");
+
+    let path = format!(
+        "{}:{}",
+        fake_bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let mut command = Command::new("just");
+    command
+        .arg("--no-dotenv")
+        .arg("--justfile")
+        .arg(workspace_root().join("justfile"))
+        .arg("--working-directory")
+        .arg(repo.path())
+        .arg("check-version-bumped")
+        .env("PATH", path)
+        .env("FAKE_CARGO_INSTALL_ROOT_CAPTURE", &capture_path)
+        .env_remove("CSA_SKIP_VERSION_CHECK");
+
+    let expected_install_root = match cargo_install_root {
+        CargoInstallRoot::Unset => {
+            command.env_remove("CARGO_INSTALL_ROOT");
+            default_install_root
+        }
+        CargoInstallRoot::Value(value) => {
+            command.env("CARGO_INSTALL_ROOT", value);
+            if value == "/usr/local" {
+                default_install_root
+            } else {
+                PathBuf::from(value)
+            }
+        }
+        CargoInstallRoot::RepoLocal(name) => {
+            let path = repo.path().join(name);
+            command.env("CARGO_INSTALL_ROOT", &path);
+            path
+        }
+    };
+
+    let output = command.output().expect("just should execute");
+    assert!(
+        output.status.success(),
+        "check-version-bumped should invoke cargo with a writable install root: stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let observed_install_root =
+        fs::read_to_string(&capture_path).expect("fake cargo should capture install root");
+    (
+        observed_install_root.trim().to_string(),
+        expected_install_root.to_string_lossy().into_owned(),
+    )
+}
+
+#[test]
+#[cfg(unix)]
+fn check_version_bumped_ignores_read_only_cargo_install_root() {
+    let (observed, expected) = run_check_version_bumped(CargoInstallRoot::Value("/usr/local"));
+    assert_eq!(observed, expected);
+}
+
+#[test]
+#[cfg(unix)]
+fn check_version_bumped_works_when_cargo_install_root_is_unset() {
+    let (observed, expected) = run_check_version_bumped(CargoInstallRoot::Unset);
+    assert_eq!(observed, expected);
+}
+
+#[test]
+#[cfg(unix)]
+fn check_version_bumped_preserves_explicit_cargo_install_root() {
+    let (observed, expected) =
+        run_check_version_bumped(CargoInstallRoot::RepoLocal("explicit-cargo-install-root"));
+    assert_eq!(observed, expected);
+}

--- a/justfile
+++ b/justfile
@@ -107,7 +107,12 @@ check-version-bumped:
         exit 0
     fi
     # Extract workspace version from Cargo.toml on current branch vs main.
-    current=$(cargo metadata --no-deps --format-version 1 \
+    cargo_install_root="${CARGO_INSTALL_ROOT:-}"
+    if [ -z "$cargo_install_root" ] || [ "$cargo_install_root" = "/usr/local" ]; then
+        cargo_install_root="{{_repo_root}}/target/cargo-install-root"
+    fi
+    mkdir -p "$cargo_install_root"
+    current=$(CARGO_INSTALL_ROOT="$cargo_install_root" cargo metadata --no-deps --format-version 1 \
         | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')
     main_version=$(git show main:Cargo.toml 2>/dev/null \
         | grep -A1 '^\[workspace\.package\]' \

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1007"
-weave = "0.1.1007"
+csa = "0.1.1008"
+weave = "0.1.1008"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Make `check-version-bumped` use a writable repo-local Cargo install root when the inherited install root is unset or points at `/usr/local`.
- Preserve explicit non-default `CARGO_INSTALL_ROOT` values.
- Add regression coverage for unset, `/usr/local`, and explicit repo-local install roots.
- Bump the workspace version to `0.1.1008` for this fix branch.

Fixes #2222

## Local validation

- `cargo test -p cli-sub-agent version_check_recipe_tests -- --nocapture` — PASS (`3 passed, 0 failed`) via cleanup CSA session `01KV3KRAFBXRSKG3KM7487MR0K`.
- `git diff --cached --check` — PASS via cleanup CSA session `01KV3KRAFBXRSKG3KM7487MR0K`.
- Hook-enabled commit quality gates — PASS (`proc_786f8607d85d`).
- `target/debug/csa review --sa-mode true --tool codex --tier tier-4-critical --no-failover --range main...HEAD` — PASS/CLEAN, session `01KV3MTMZD3ZWCJ5MYM2RQAPQF`.
- `target/debug/csa review --check-verdict --sa-mode true --range main...HEAD` — PASS.
- `csa review --check-verdict --sa-mode true --range main...HEAD` — PASS.

## Notes

GitHub Actions were not used as the primary agent-side gate; this repo is using local hooks plus exact-head CSA review for this workflow.
