### PR TITLE
fix(session): mark no-pid active sessions stale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "axum",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1008"
+version = "0.1.1009"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1008"
+version = "0.1.1009"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_list.rs
+++ b/crates/cli-sub-agent/src/session_cmds_list.rs
@@ -5,9 +5,13 @@ use std::path::Path;
 use csa_config::GlobalConfig;
 #[cfg(test)]
 use csa_session::decode_session_created_at;
-use csa_session::{MetaSessionState, SessionPhase, SessionResult, list_sessions, load_result};
+use csa_session::{
+    MetaSessionState, SessionPhase, SessionResult, get_session_dir, list_sessions, load_result,
+};
 
 use super::{ensure_terminal_result_for_dead_active_session, retire_if_dead_with_result};
+
+const NO_LIVE_PID_STATUS: &str = "NoLivePID";
 
 /// Threshold (seconds) after which an `Active`-phase session whose `last_accessed`
 /// has not advanced is considered stale (#1118 part D). The threshold is `2 *
@@ -151,6 +155,31 @@ pub(super) fn status_from_phase_and_result(
     }
 }
 
+fn active_status_with_liveness(project_root: &Path, sid: &str, status: &'static str) -> String {
+    if status == "Active" && active_session_has_no_live_pid(project_root, sid) {
+        NO_LIVE_PID_STATUS.to_string()
+    } else {
+        status.to_string()
+    }
+}
+
+fn active_session_has_no_live_pid(project_root: &Path, sid: &str) -> bool {
+    let session_dir = match get_session_dir(project_root, sid) {
+        Ok(session_dir) => session_dir,
+        Err(err) => {
+            tracing::warn!(
+                session_id = %sid,
+                error = %err,
+                "Failed to resolve session directory for liveness-derived list status"
+            );
+            return false;
+        }
+    };
+
+    !csa_process::ToolLiveness::has_live_process(&session_dir)
+        && !csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir)
+}
+
 pub(super) fn resolve_session_status(session: &MetaSessionState) -> String {
     // Use the session's own project_path so cross-project sessions resolve correctly.
     let project_root = Path::new(&session.project_path);
@@ -164,7 +193,11 @@ pub(super) fn resolve_session_status(session: &MetaSessionState) -> String {
                 return status_from_phase_and_result(&SessionPhase::Retired, Some(&result))
                     .to_string();
             }
-            status_from_phase_and_result(&session.phase, Some(&result)).to_string()
+            active_status_with_liveness(
+                project_root,
+                sid,
+                status_from_phase_and_result(&session.phase, Some(&result)),
+            )
         }
         Ok(None) => {
             let reconciled =
@@ -187,7 +220,7 @@ pub(super) fn resolve_session_status(session: &MetaSessionState) -> String {
             if is_session_stale(session, stale_threshold_seconds(), Utc::now()) {
                 return "Stale".to_string();
             }
-            phase_label(&session.phase).to_string()
+            active_status_with_liveness(project_root, sid, phase_label(&session.phase))
         }
         Err(err) => {
             tracing::warn!(session_id = %sid, error = %err, "Failed to load result.toml");

--- a/crates/cli-sub-agent/src/session_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests.rs
@@ -822,17 +822,6 @@ fn session_logs_cli_events_defaults_to_false() {
     }
 }
 
-#[test]
-fn print_content_with_tail_no_panic_on_empty() {
-    print_content_with_tail("", None);
-    print_content_with_tail("", Some(5));
-}
-
-#[test]
-fn print_content_with_tail_no_panic_on_large_tail() {
-    print_content_with_tail("line1\nline2\n", Some(100));
-}
-
 include!("session_cmds_tests_fork_tail.rs");
 
 #[path = "session_cmds_tests_daemon_pid_tail.rs"]
@@ -841,6 +830,10 @@ mod daemon_pid_tail_tests;
 mod kv_warm_tests;
 #[path = "session_cmds_tests_list_format.rs"]
 mod list_format_tests;
+#[path = "session_cmds_tests_list_no_live_pid.rs"]
+mod list_no_live_pid_tests;
+#[path = "session_cmds_tests_print_tail.rs"]
+mod print_tail_tests;
 #[path = "session_cmds_tests_result_cli.rs"]
 mod result_cli_tests;
 #[path = "session_cmds_tests_tail.rs"]

--- a/crates/cli-sub-agent/src/session_cmds_tests_list_no_live_pid.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_list_no_live_pid.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+#[cfg(unix)]
+#[test]
+fn session_to_json_reports_no_live_pid_for_active_session_when_progress_blocks_reconcile() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let _daemon_project_guard = EnvVarGuard::set("CSA_DAEMON_PROJECT_ROOT", "");
+    let _daemon_dir_guard = EnvVarGuard::set("CSA_DAEMON_SESSION_DIR", "");
+    let project = td.path();
+
+    let created = create_session(project, Some("json-no-live-pid"), None, None).unwrap();
+    let session_id = created.meta_session_id.clone();
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    std::fs::write(session_dir.join("output.log"), "fresh output bytes\n").unwrap();
+    assert!(
+        !csa_process::ToolLiveness::has_live_process(&session_dir),
+        "fixture must not have a live tool lock PID"
+    );
+    assert!(
+        !csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir),
+        "fixture must not have a live daemon PID"
+    );
+
+    let session = load_session(project, &session_id).unwrap();
+    let value = session_to_json(&session);
+
+    assert_eq!(
+        value.get("status").and_then(|v| v.as_str()),
+        Some("NoLivePID")
+    );
+    assert!(
+        load_result(project, &session_id).unwrap().is_none(),
+        "fresh output should still block synthetic result creation"
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_print_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_print_tail.rs
@@ -1,0 +1,12 @@
+use super::*;
+
+#[test]
+fn print_content_with_tail_no_panic_on_empty() {
+    print_content_with_tail("", None);
+    print_content_with_tail("", Some(5));
+}
+
+#[test]
+fn print_content_with_tail_no_panic_on_large_tail() {
+    print_content_with_tail("line1\nline2\n", Some(100));
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1008"
-weave = "0.1.1008"
+csa = "0.1.1009"
+weave = "0.1.1009"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Mark otherwise-active sessions without a live daemon/tool PID as `NoLivePID` in session list output instead of continuing to show them as `Active`.
- Preserve existing result-backed terminal status reconciliation and recent-progress stale-session behavior.
- Split the new/no-live-PID and print-tail tests into sibling modules so the staged monolith ratchet stays green.

## Validation

- Hook-enabled commit passed branch-protection and quality-gates.
- `target/debug/csa --version` => `csa 0.1.1009 (d8883e66)`.
- Exact-head CSA review PASS/CLEAN: `01KV3R63TZYBVG85STW83SEHZR`.
- `target/debug/csa review --check-verdict --sa-mode true --range main...HEAD` passed for `d8883e66d5d`.
- CSA follow-up reported:
  - `cargo fmt -- --check` PASS
  - #2127 focused regression PASS
  - adjacent reconcile regression PASS
  - moved print-tail test PASS
  - `just find-monolith-files` PASS

Fixes #2127
