### PR TITLE
fix(review): explain explicit tool failover exhaustion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "chrono",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "chrono",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "chrono",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "axum",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "chrono",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "chrono",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "chrono",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1009"
+version = "0.1.1010"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1009"
+version = "0.1.1010"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -19,8 +19,6 @@ use csa_config::GlobalConfig;
 #[cfg(test)]
 use csa_config::ProjectConfig;
 use csa_core::types::ReviewDecision;
-#[cfg(test)]
-use csa_core::types::ToolName;
 use csa_session::state::ReviewSessionMeta;
 use tracing::{debug, error, warn};
 #[path = "review_cmd_output.rs"]
@@ -324,6 +322,8 @@ pub(crate) async fn handle_review(
         &global_config,
     );
     let reviewers = reviewer_selection.reviewers;
+    let explicit_tool_with_failover =
+        (selection.direct_tool_requested && tier_active && !execution_no_failover).then_some(tool);
 
     if reviewers == 1 {
         let review_future = execute_review_with_tier_filter(
@@ -348,6 +348,7 @@ pub(crate) async fn handle_review(
             args.force_override_user_config,
             args.force_ignore_tier_setting,
             execution_no_failover,
+            explicit_tool_with_failover,
             args.build_jobs,
             args.fast_but_more_cost,
             true,

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -2,6 +2,8 @@
 
 #[path = "review_cmd_execute_artifact_guard.rs"]
 mod artifact_guard;
+#[path = "review_cmd_execute_once.rs"]
+mod execute_once;
 #[path = "review_cmd_execute_failures.rs"]
 mod failures;
 
@@ -18,9 +20,9 @@ use csa_core::{
         API_KEY_ENV, API_KEY_FALLBACK_ENV_KEY, AUTH_MODE_API_KEY, AUTH_MODE_ENV_KEY,
         AUTH_MODE_OAUTH,
     },
-    types::{OutputFormat, ReviewDecision, ToolName},
+    types::{ReviewDecision, ToolName},
 };
-use csa_executor::{Executor, PeakMemoryContext};
+use csa_executor::PeakMemoryContext;
 use csa_session::{
     SessionResult, get_session_dir, load_result, load_session, save_result, save_session,
 };
@@ -32,7 +34,7 @@ use crate::review_routing::{
 use crate::startup_env::StartupSubtreeEnv;
 use crate::tier_model_fallback::{
     TierAttemptFailure, chain_failure_reasons, earliest_backend_reset_window,
-    fallback_reason_for_result, format_all_models_failed_reason_with_reset,
+    fallback_reason_for_result, format_all_models_failed_reason_with_ux_context,
     ordered_tier_candidates, parse_backend_reset_duration, persist_fallback_chain,
     persist_fallback_result_fields,
 };
@@ -43,17 +45,16 @@ use super::output::{
     is_review_output_empty,
 };
 use artifact_guard::detect_repo_root_review_artifact_violations;
+use execute_once::execute_review_once_with_artifact_guard;
 #[cfg(test)]
 use failures::read_review_failure_excerpt;
 use failures::{
     build_gemini_api_key_retry_env, classify_review_failover_error,
     classify_review_failover_reason, classify_review_failure_result,
-    enforce_review_artifact_contract, extract_meta_session_id_from_error,
-    maybe_synthesize_missing_review_result, repair_completed_review_restriction_result,
-    retire_tier_failover_session,
+    extract_meta_session_id_from_error, maybe_synthesize_missing_review_result,
+    repair_completed_review_restriction_result, retire_tier_failover_session,
 };
 
-const REVIEWER_SUB_SESSION_TASK_TYPE: &str = "reviewer_sub_session";
 const CSA_READONLY_SESSION_ENV: &str = "CSA_READONLY_SESSION";
 
 fn with_readonly_session_env(
@@ -183,6 +184,7 @@ pub(crate) async fn execute_review(
         force_ignore_tier_setting,
         no_failover,
         None,
+        None,
         false,
         false,
         no_fs_sandbox,
@@ -219,6 +221,7 @@ pub(crate) async fn execute_review_with_tier_filter(
     force_override_user_config: bool,
     force_ignore_tier_setting: bool,
     no_failover: bool,
+    explicit_tool_with_failover: Option<ToolName>,
     build_jobs: Option<u32>,
     fast_but_more_cost: bool,
     warn_no_codex_fast_mode: bool,
@@ -450,10 +453,11 @@ pub(crate) async fn execute_review_with_tier_filter(
                             fallback_chain,
                         );
                     }
-                    let failure_reason = format_all_models_failed_reason_with_reset(
+                    let failure_reason = format_all_models_failed_reason_with_ux_context(
                         tier_name.as_deref(),
                         &failures,
                         earliest_backend_reset_window(&reset_windows),
+                        explicit_tool_with_failover,
                     );
                     return Ok(ReviewExecutionOutcome {
                         execution: crate::pipeline::SessionExecutionResult {
@@ -657,10 +661,11 @@ pub(crate) async fn execute_review_with_tier_filter(
                     forced_decision: Some(ReviewDecision::Unavailable),
                     routed_to: None,
                     primary_failure: chain_failure_reasons(&failures),
-                    failure_reason: format_all_models_failed_reason_with_reset(
+                    failure_reason: format_all_models_failed_reason_with_ux_context(
                         tier_name.as_deref(),
                         &failures,
                         earliest_backend_reset_window(&reset_windows),
+                        explicit_tool_with_failover,
                     ),
                 });
             }
@@ -746,141 +751,6 @@ pub(crate) async fn execute_review_with_tier_filter(
 
     unreachable!("tier candidate list is never empty")
 }
-#[allow(clippy::too_many_arguments)]
-async fn execute_review_once(
-    executor: &Executor,
-    tool: &ToolName,
-    effective_prompt: &str,
-    session: Option<String>,
-    description: String,
-    project_root: &Path,
-    project_config: Option<&ProjectConfig>,
-    extra_env: Option<&HashMap<String, String>>,
-    subtree_pin: Option<&csa_core::env::SubtreeModelPin>,
-    tier_name: Option<&str>,
-    global_config: &GlobalConfig,
-    pre_session_hook: Option<csa_hooks::PreSessionHookInvocation>,
-    stream_mode: csa_process::StreamMode,
-    idle_timeout_seconds: u64,
-    initial_response_timeout_seconds: Option<u64>,
-    no_fs_sandbox: bool,
-    readonly_project_root: bool,
-    extra_writable: &[PathBuf],
-    extra_readable: &[PathBuf],
-    error_marker_scan_override: Option<bool>,
-    startup_env: &StartupSubtreeEnv,
-) -> Result<crate::pipeline::SessionExecutionResult> {
-    crate::pipeline::execute_with_session_and_meta_with_parent_source(
-        executor,
-        tool,
-        effective_prompt,
-        OutputFormat::Json,
-        session,
-        false,
-        Some(description),
-        None,
-        project_root,
-        project_config,
-        extra_env,
-        subtree_pin,
-        false,
-        Some(REVIEWER_SUB_SESSION_TASK_TYPE),
-        tier_name,
-        None,
-        stream_mode,
-        idle_timeout_seconds,
-        initial_response_timeout_seconds,
-        None,
-        None,
-        Some(global_config),
-        pre_session_hook,
-        crate::pipeline::ParentSessionSource::ExplicitOnly,
-        crate::pipeline::SessionCreationMode::DaemonManaged,
-        Default::default(),
-        no_fs_sandbox,
-        readonly_project_root,
-        extra_writable,
-        extra_readable,
-        error_marker_scan_override,
-        false,
-        startup_env,
-    )
-    .await
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn execute_review_once_with_artifact_guard(
-    executor: &Executor,
-    tool: &ToolName,
-    effective_prompt: &str,
-    session: Option<String>,
-    description: String,
-    project_root: &Path,
-    project_config: Option<&ProjectConfig>,
-    extra_env: Option<&HashMap<String, String>>,
-    subtree_pin: Option<&csa_core::env::SubtreeModelPin>,
-    tier_name: Option<&str>,
-    global_config: &GlobalConfig,
-    pre_session_hook: Option<csa_hooks::PreSessionHookInvocation>,
-    stream_mode: csa_process::StreamMode,
-    idle_timeout_seconds: u64,
-    initial_response_timeout_seconds: Option<u64>,
-    no_fs_sandbox: bool,
-    readonly_project_root: bool,
-    extra_writable: &[PathBuf],
-    extra_readable: &[PathBuf],
-    error_marker_scan_override: Option<bool>,
-    startup_env: &StartupSubtreeEnv,
-) -> Result<crate::pipeline::SessionExecutionResult> {
-    let invocation_started_at = Utc::now();
-    match execute_review_once(
-        executor,
-        tool,
-        effective_prompt,
-        session,
-        description,
-        project_root,
-        project_config,
-        extra_env,
-        subtree_pin,
-        tier_name,
-        global_config,
-        pre_session_hook,
-        stream_mode,
-        idle_timeout_seconds,
-        initial_response_timeout_seconds,
-        no_fs_sandbox,
-        readonly_project_root,
-        extra_writable,
-        extra_readable,
-        error_marker_scan_override,
-        startup_env,
-    )
-    .await
-    {
-        Ok(mut execution) => {
-            enforce_review_artifact_contract(
-                project_root,
-                tool,
-                invocation_started_at,
-                Some(&mut execution),
-                None,
-            )?;
-            Ok(execution)
-        }
-        Err(err) => {
-            enforce_review_artifact_contract(
-                project_root,
-                tool,
-                invocation_started_at,
-                None,
-                Some(&err),
-            )?;
-            Err(err)
-        }
-    }
-}
-
 /// Compute a SHA-256 content hash of the diff being reviewed.
 ///
 /// The fingerprint enables diff-level deduplication: if two review

--- a/crates/cli-sub-agent/src/review_cmd_execute_once.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_once.rs
@@ -1,0 +1,149 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use chrono::Utc;
+use csa_config::{GlobalConfig, ProjectConfig};
+use csa_core::types::{OutputFormat, ToolName};
+use csa_executor::Executor;
+
+use crate::startup_env::StartupSubtreeEnv;
+
+use super::failures::enforce_review_artifact_contract;
+
+const REVIEWER_SUB_SESSION_TASK_TYPE: &str = "reviewer_sub_session";
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_review_once(
+    executor: &Executor,
+    tool: &ToolName,
+    effective_prompt: &str,
+    session: Option<String>,
+    description: String,
+    project_root: &Path,
+    project_config: Option<&ProjectConfig>,
+    extra_env: Option<&HashMap<String, String>>,
+    subtree_pin: Option<&csa_core::env::SubtreeModelPin>,
+    tier_name: Option<&str>,
+    global_config: &GlobalConfig,
+    pre_session_hook: Option<csa_hooks::PreSessionHookInvocation>,
+    stream_mode: csa_process::StreamMode,
+    idle_timeout_seconds: u64,
+    initial_response_timeout_seconds: Option<u64>,
+    no_fs_sandbox: bool,
+    readonly_project_root: bool,
+    extra_writable: &[PathBuf],
+    extra_readable: &[PathBuf],
+    error_marker_scan_override: Option<bool>,
+    startup_env: &StartupSubtreeEnv,
+) -> Result<crate::pipeline::SessionExecutionResult> {
+    crate::pipeline::execute_with_session_and_meta_with_parent_source(
+        executor,
+        tool,
+        effective_prompt,
+        OutputFormat::Json,
+        session,
+        false,
+        Some(description),
+        None,
+        project_root,
+        project_config,
+        extra_env,
+        subtree_pin,
+        false,
+        Some(REVIEWER_SUB_SESSION_TASK_TYPE),
+        tier_name,
+        None,
+        stream_mode,
+        idle_timeout_seconds,
+        initial_response_timeout_seconds,
+        None,
+        None,
+        Some(global_config),
+        pre_session_hook,
+        crate::pipeline::ParentSessionSource::ExplicitOnly,
+        crate::pipeline::SessionCreationMode::DaemonManaged,
+        Default::default(),
+        no_fs_sandbox,
+        readonly_project_root,
+        extra_writable,
+        extra_readable,
+        error_marker_scan_override,
+        false,
+        startup_env,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn execute_review_once_with_artifact_guard(
+    executor: &Executor,
+    tool: &ToolName,
+    effective_prompt: &str,
+    session: Option<String>,
+    description: String,
+    project_root: &Path,
+    project_config: Option<&ProjectConfig>,
+    extra_env: Option<&HashMap<String, String>>,
+    subtree_pin: Option<&csa_core::env::SubtreeModelPin>,
+    tier_name: Option<&str>,
+    global_config: &GlobalConfig,
+    pre_session_hook: Option<csa_hooks::PreSessionHookInvocation>,
+    stream_mode: csa_process::StreamMode,
+    idle_timeout_seconds: u64,
+    initial_response_timeout_seconds: Option<u64>,
+    no_fs_sandbox: bool,
+    readonly_project_root: bool,
+    extra_writable: &[PathBuf],
+    extra_readable: &[PathBuf],
+    error_marker_scan_override: Option<bool>,
+    startup_env: &StartupSubtreeEnv,
+) -> Result<crate::pipeline::SessionExecutionResult> {
+    let invocation_started_at = Utc::now();
+    match execute_review_once(
+        executor,
+        tool,
+        effective_prompt,
+        session,
+        description,
+        project_root,
+        project_config,
+        extra_env,
+        subtree_pin,
+        tier_name,
+        global_config,
+        pre_session_hook,
+        stream_mode,
+        idle_timeout_seconds,
+        initial_response_timeout_seconds,
+        no_fs_sandbox,
+        readonly_project_root,
+        extra_writable,
+        extra_readable,
+        error_marker_scan_override,
+        startup_env,
+    )
+    .await
+    {
+        Ok(mut execution) => {
+            enforce_review_artifact_contract(
+                project_root,
+                tool,
+                invocation_started_at,
+                Some(&mut execution),
+                None,
+            )?;
+            Ok(execution)
+        }
+        Err(err) => {
+            enforce_review_artifact_contract(
+                project_root,
+                tool,
+                invocation_started_at,
+                None,
+                Some(&err),
+            )?;
+            Err(err)
+        }
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix.rs
@@ -152,6 +152,7 @@ pub(crate) async fn run_fix_loop(ctx: FixLoopContext<'_>) -> Result<i32> {
             ctx.force_override_user_config,
             ctx.force_ignore_tier_setting,
             ctx.no_failover,
+            None,
             ctx.build_jobs,
             ctx.fast_but_more_cost,
             false,

--- a/crates/cli-sub-agent/src/review_cmd_fix_finding.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_finding.rs
@@ -125,6 +125,7 @@ pub(crate) async fn handle_fix_finding(
         args.force_override_user_config,
         true,
         true,
+        None,
         args.build_jobs,
         args.fast_but_more_cost,
         false,

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -196,6 +196,7 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
                 reviewer_force_override,
                 reviewer_force_ignore_tier,
                 reviewer_no_failover,
+                None,
                 reviewer_build_jobs,
                 reviewer_fast_but_more_cost,
                 false,

--- a/crates/cli-sub-agent/src/review_cmd_tests_barrel.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_barrel.rs
@@ -1,4 +1,5 @@
 pub(in crate::review_cmd::tests) use super::*;
+use csa_core::types::ToolName;
 pub(crate) use review_core::{
     ScopedEnvVarRestore, project_config_with_enabled_tools, setup_git_repo,
 };
@@ -24,6 +25,17 @@ fn review_fix_forces_writable_project_root() {
     assert!(!resolve_review_readonly_project_root(true, None));
     assert!(!resolve_review_readonly_project_root(true, Some(true)));
     assert!(!resolve_review_readonly_project_root(true, Some(false)));
+}
+
+#[test]
+fn explicit_tool_failover_context_requires_explicit_tool_active_tier_and_failover() {
+    let context = |direct_tool_requested: bool, tier_active: bool, no_failover: bool| {
+        (direct_tool_requested && tier_active && !no_failover).then_some(ToolName::Codex)
+    };
+    assert_eq!(context(true, true, false), Some(ToolName::Codex));
+    assert_eq!(context(false, true, false), None);
+    assert_eq!(context(true, false, false), None);
+    assert_eq!(context(true, true, true), None);
 }
 
 fn project_config_with_review_readonly(readonly_sandbox: Option<bool>) -> ProjectConfig {

--- a/crates/cli-sub-agent/src/tier_model_fallback.rs
+++ b/crates/cli-sub-agent/src/tier_model_fallback.rs
@@ -252,6 +252,20 @@ pub(crate) fn format_all_models_failed_reason_with_reset(
     Some(reason)
 }
 
+pub(crate) fn format_all_models_failed_reason_with_ux_context(
+    tier_name: Option<&str>,
+    failures: &[TierAttemptFailure],
+    reset_after: Option<Duration>,
+    explicit_tool_with_failover: Option<ToolName>,
+) -> Option<String> {
+    let mut reason = format_all_models_failed_reason_with_reset(tier_name, failures, reset_after)?;
+    if let Some(tool) = explicit_tool_with_failover {
+        reason.push_str("; explicit_tool_failover=");
+        reason.push_str(tool.as_str());
+    }
+    Some(reason)
+}
+
 pub(crate) fn earliest_backend_reset_window(reset_windows: &[Duration]) -> Option<Duration> {
     reset_windows.iter().copied().min()
 }
@@ -283,6 +297,7 @@ pub(crate) fn opaque_total_exhaustion_message(
     Some(format_opaque_total_exhaustion_message(
         tier_label,
         failure_reason.and_then(parse_backend_reset_duration),
+        failure_reason.and_then(parse_explicit_tool_failover),
     ))
 }
 
@@ -357,13 +372,39 @@ fn is_quota_rate_auth_reason(reason: &str) -> bool {
 fn format_opaque_total_exhaustion_message(
     tier_label: &str,
     reset_after: Option<Duration>,
+    explicit_tool_with_failover: Option<&str>,
 ) -> String {
     let mut message = format!("review unavailable: all {tier_label} backends rate-limited");
     if let Some(reset_after) = reset_after {
         message.push_str("; earliest reset ~");
         message.push_str(&format_reset_duration(reset_after));
     }
+    if let Some(tool) = explicit_tool_with_failover {
+        message.push_str("; explicit --tool ");
+        message.push_str(tool);
+        message.push_str(" kept tier failover enabled (--tool is not a pin); to pin ");
+        message.push_str(tool_display_name(tool));
+        message.push_str(" use: csa review --tool ");
+        message.push_str(tool);
+        message.push_str(" --tier ");
+        message.push_str(tier_label);
+        message.push_str(" --no-failover --single");
+    }
     message
+}
+
+fn parse_explicit_tool_failover(text: &str) -> Option<&str> {
+    let (_, rest) = text.split_once("explicit_tool_failover=")?;
+    let value = rest.split(';').next().unwrap_or(rest).trim();
+    (!value.is_empty()).then_some(value)
+}
+
+fn tool_display_name(tool: &str) -> &str {
+    if tool == ToolName::Codex.as_str() {
+        "Codex"
+    } else {
+        tool
+    }
 }
 
 fn format_reset_duration(duration: Duration) -> String {

--- a/crates/cli-sub-agent/src/tier_model_fallback_tests.rs
+++ b/crates/cli-sub-agent/src/tier_model_fallback_tests.rs
@@ -1,7 +1,7 @@
 use super::{
     TierAttemptFailure, classify_next_model_failure_with_elapsed, earliest_backend_reset_window,
-    format_all_models_failed_reason_with_reset, opaque_total_exhaustion_message,
-    ordered_tier_candidates, parse_backend_reset_duration,
+    format_all_models_failed_reason_with_reset, format_all_models_failed_reason_with_ux_context,
+    opaque_total_exhaustion_message, ordered_tier_candidates, parse_backend_reset_duration,
 };
 use csa_config::{GlobalConfig, ProjectConfig, ToolConfig, global::GlobalToolConfig};
 use csa_core::types::ToolName;
@@ -245,6 +245,39 @@ fn opaque_total_exhaustion_uses_provider_reset_window() {
         Some(
             "review unavailable: all tier-4-critical backends rate-limited; earliest reset ~1h 0m"
         )
+    );
+}
+
+#[test]
+fn opaque_total_exhaustion_explains_explicit_tool_tier_failover() {
+    let failures = vec![
+        TierAttemptFailure {
+            model_spec: "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
+            reason: "auth_unavailable".to_string(),
+            quota_exhausted: Some(false),
+        },
+        TierAttemptFailure {
+            model_spec: "codex/openai/gpt-5.5/xhigh".to_string(),
+            reason: "HTTP 429".to_string(),
+            quota_exhausted: Some(false),
+        },
+    ];
+    let failure_reason = format_all_models_failed_reason_with_ux_context(
+        Some("tier-4-critical"),
+        &failures,
+        Some(Duration::from_secs(3600)),
+        Some(ToolName::Codex),
+    )
+    .expect("failure reason");
+
+    let message =
+        opaque_total_exhaustion_message(Some("auth_unavailable; HTTP 429"), Some(&failure_reason))
+            .expect("opaque message");
+
+    assert!(message.contains("explicit --tool codex kept tier failover enabled"));
+    assert!(message.contains("--tool is not a pin"));
+    assert!(
+        message.contains("csa review --tool codex --tier tier-4-critical --no-failover --single")
     );
 }
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1009"
-weave = "0.1.1009"
+csa = "0.1.1010"
+weave = "0.1.1010"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Improve review tier-exhaustion diagnostics when a concrete `--tool` was explicitly requested but review failover remained enabled.
- Preserve the existing routing contract: `csa review --tool <tool>` still allows tier failover; use `--no-failover` to pin.
- Split review execution code to satisfy the monolith gate without changing behavior.

## Test plan

- `cargo fmt -- --check`
- `git diff --check`
- `just check-version-bumped`
- `just test-f explicit_tool` — 29 passed
- hook-enabled commit quality gates — PASS
- monolith gate — PASS
- Native exact-head review fallback for `3bf9106ff11c33d9df018eda7b0737de60ba7827` — PASS/CLEAN

## CSA review fallback note

Exact-head CSA/Codex review for `main...HEAD` was attempted with `target/debug/csa 0.1.1010 (3bf9106f)` but the review session `01KV3WM4K63FJE1PXBYWTM05H0` exited with `signal/143 unknown_signal` before producing a PASS/CLEAN verdict. Evidence was added to #2035. Because this was infrastructure failure rather than a review finding, I used an independent native exact-head full-diff review fallback for the same SHA; it returned PASS/CLEAN.

Fixes #2126
