### PR TITLE
fix(session): persist require-commit recovery diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1013"
+version = "0.1.1014"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1013"
+version = "0.1.1014"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
@@ -156,6 +156,7 @@ fn finalize_seeded_debate(
             meta_session_id: session_id.to_string(),
             provider_session_id: None,
             changed_paths: None,
+            commit_created: None,
         }),
         debate_cmd::DebateFinalizeContext {
             all_tier_models_failed: false,
@@ -658,6 +659,7 @@ Verdict: APPROVE
             meta_session_id: session.meta_session_id.clone(),
             provider_session_id: None,
             changed_paths: None,
+            commit_created: None,
         }),
         debate_cmd::DebateFinalizeContext {
             all_tier_models_failed: false,
@@ -749,6 +751,7 @@ Verdict: APPROVE
             meta_session_id: session.meta_session_id.clone(),
             provider_session_id: None,
             changed_paths: None,
+            commit_created: None,
         }),
         debate_cmd::DebateFinalizeContext {
             all_tier_models_failed: false,
@@ -841,6 +844,7 @@ Verdict: APPROVE
             meta_session_id: session.meta_session_id.clone(),
             provider_session_id: None,
             changed_paths: None,
+            commit_created: None,
         }),
         debate_cmd::DebateFinalizeContext {
             all_tier_models_failed: false,
@@ -948,6 +952,7 @@ Summary: Needs changes from terminal non-success verdict.
             meta_session_id: session.meta_session_id.clone(),
             provider_session_id: None,
             changed_paths: None,
+            commit_created: None,
         }),
         debate_cmd::DebateFinalizeContext {
             all_tier_models_failed: false,

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -62,6 +62,7 @@ mod process_exit;
 mod process_tree;
 mod push_cmd;
 mod recall_cmd;
+mod require_commit_recovery_display;
 mod resource_admission;
 mod review_cmd;
 mod review_consensus;

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -497,6 +497,8 @@ pub(crate) struct SessionExecutionResult {
     pub provider_session_id: Option<String>,
     /// Paths changed by this session when git snapshots were available.
     pub changed_paths: Option<Vec<String>>,
+    /// Whether post-run commit policy observed HEAD advancing for this run.
+    pub commit_created: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -120,11 +120,13 @@ pub(super) async fn complete_session_execution(
         post_fingerprints.as_ref(),
     );
     let snapshots_available = pre_run_workspace.is_some() && post_run_workspace.is_some();
+    let mut commit_created = None;
     if commit_guard_enabled {
         let commit_guard = crate::run_cmd::evaluate_post_run_commit_guard(
             pre_run_workspace.as_ref(),
             post_run_workspace.as_ref(),
         );
+        commit_created = commit_guard.as_ref().map(|guard| guard.head_changed);
         let policy_evaluation_failed = require_commit_on_mutation
             && (!inside_git_worktree
                 || pre_run_workspace.is_none()
@@ -186,6 +188,7 @@ pub(super) async fn complete_session_execution(
         meta_session_id: session.meta_session_id.clone(),
         provider_session_id,
         changed_paths: snapshots_available.then_some(changed_paths),
+        commit_created,
     })
 }
 

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -348,6 +348,7 @@ mod tests {
                 raw_process_exit_code: None,
                 uncommitted_changes: None,
                 large_diff_warning: None,
+                require_commit_recovery: None,
                 post_exec_gate: None,
                 manager_fields: Default::default(),
             },

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -504,6 +504,7 @@ async fn state_dir_cap_failure_overwrites_stale_result_for_resume() {
             raw_process_exit_code: None,
             uncommitted_changes: None,
             large_diff_warning: None,
+            require_commit_recovery: None,
             manager_fields: csa_session::SessionManagerFields {
                 report: Some(
                     toml::toml! {

--- a/crates/cli-sub-agent/src/require_commit_recovery_display.rs
+++ b/crates/cli-sub-agent/src/require_commit_recovery_display.rs
@@ -1,0 +1,82 @@
+pub(crate) fn format_require_commit_recovery_lines(
+    diagnostic: &csa_session::RequireCommitRecoveryDiagnostic,
+) -> Vec<String> {
+    vec![
+        format!(
+            "Require-commit recovery: CONTRACT FAILURE; dirty_worktree={} commit_created={} changed_paths={}{}",
+            diagnostic.dirty_worktree,
+            diagnostic.commit_created,
+            diagnostic.changed_paths.len(),
+            format_termination_suffix(diagnostic)
+        ),
+        format!(
+            "Changed paths: {}",
+            format_changed_paths(
+                &diagnostic.changed_paths,
+                diagnostic.changed_paths_truncated
+            )
+        ),
+        format!("Recovery action: {}", diagnostic.suggested_recovery_action),
+    ]
+}
+
+fn format_termination_suffix(diagnostic: &csa_session::RequireCommitRecoveryDiagnostic) -> String {
+    let mut parts = vec![
+        format!("status={}", diagnostic.termination_status),
+        format!("exit_code={}", diagnostic.exit_code),
+    ];
+    if let Some(signal) = diagnostic.termination_signal {
+        parts.push(format!("signal={signal}"));
+    }
+    if let Some(kill_hint) = diagnostic
+        .kill_hint
+        .as_deref()
+        .filter(|hint| !hint.is_empty())
+    {
+        parts.push(format!("kill_hint={kill_hint}"));
+    }
+    format!(" ({})", parts.join(", "))
+}
+
+fn format_changed_paths(paths: &[String], truncated: usize) -> String {
+    if paths.is_empty() {
+        return "<none recorded>".to_string();
+    }
+    let mut rendered = paths.join(", ");
+    if truncated > 0 {
+        rendered.push_str(&format!(" (+{truncated} more)"));
+    }
+    rendered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovery_lines_include_contract_state_and_paths_only() {
+        let lines =
+            format_require_commit_recovery_lines(&csa_session::RequireCommitRecoveryDiagnostic {
+                require_commit: true,
+                commit_created: false,
+                dirty_worktree: true,
+                changed_paths: vec!["src/lib.rs".to_string(), "README.md".to_string()],
+                changed_paths_truncated: 1,
+                termination_status: "signal".to_string(),
+                exit_code: 143,
+                termination_signal: Some(15),
+                kill_hint: Some("memory_pressure".to_string()),
+                suggested_recovery_action: "inspect_changed_paths_then_commit_or_revert"
+                    .to_string(),
+            });
+
+        let rendered = lines.join("\n");
+        assert!(rendered.contains("CONTRACT FAILURE"));
+        assert!(rendered.contains("dirty_worktree=true"));
+        assert!(rendered.contains("commit_created=false"));
+        assert!(rendered.contains("status=signal"));
+        assert!(rendered.contains("signal=15"));
+        assert!(rendered.contains("src/lib.rs, README.md (+1 more)"));
+        assert!(!rendered.contains("file contents"));
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -473,6 +473,7 @@ pub(crate) async fn execute_review_with_tier_filter(
                                 .unwrap_or_else(|| "unknown".to_string()),
                             provider_session_id: None,
                             changed_paths: None,
+                            commit_created: None,
                         },
                         persistable_session_id: extract_meta_session_id_from_error(&err),
                         executed_tool: *attempt_tool,

--- a/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
@@ -18,6 +18,7 @@ fn execution_with(
         meta_session_id: "01TESTREVIEWFAILOVER".to_string(),
         provider_session_id: None,
         changed_paths: None,
+        commit_created: None,
     }
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_result_terminal_error_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_terminal_error_tests.rs
@@ -20,6 +20,7 @@ fn outcome(output: &str, exit_code: i32) -> ReviewExecutionOutcome {
             meta_session_id: "01TESTRESULT".to_string(),
             provider_session_id: None,
             changed_paths: None,
+            commit_created: None,
         },
         persistable_session_id: Some("01TESTRESULT".to_string()),
         executed_tool: ToolName::Codex,

--- a/crates/cli-sub-agent/src/review_cmd_result_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_tests.rs
@@ -18,6 +18,7 @@ fn outcome(output: &str, exit_code: i32) -> ReviewExecutionOutcome {
             meta_session_id: "01TESTRESULT".to_string(),
             provider_session_id: None,
             changed_paths: None,
+            commit_created: None,
         },
         persistable_session_id: Some("01TESTRESULT".to_string()),
         executed_tool: ToolName::Codex,

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -37,8 +37,6 @@ use prompt::resolve_attempt_subtree_model_pin_spec;
 use prompt::{AttemptPromptRequest, build_attempt_prompt};
 
 pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunLoopCompletion> {
-    // Compute max failover attempts: count total models across ALL tiers to
-    // allow cross-tier failover when the primary tier is exhausted (#493).
     let max_failover_attempts = if request.no_failover {
         1
     } else {
@@ -88,7 +86,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
         !request.force && !request.force_ignore_tier_setting && !request.user_model_spec_explicit;
     let mut accumulated_changed_paths: Vec<String> = Vec::new();
     let mut all_attempt_change_snapshots_available = true;
-    let (result, changed_paths) = loop {
+    let (result, changed_paths, commit_created) = loop {
         attempts += 1;
         let mut fresh_spawn_preflight_override = false;
 
@@ -393,7 +391,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             .await
         }?;
 
-        let (mut exec_result, exec_changed_paths) = match attempt_execution {
+        let (mut exec_result, exec_changed_paths, exec_commit_created) = match attempt_execution {
             AttemptExecution::TimedOut => {
                 let timeout_resume_session = executed_session_id
                     .clone()
@@ -424,8 +422,9 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             AttemptExecution::Finished {
                 result,
                 changed_paths: attempt_changed_paths,
+                commit_created: attempt_commit_created,
             } => match *result {
-                Ok(result) => (result, attempt_changed_paths),
+                Ok(result) => (result, attempt_changed_paths, attempt_commit_created),
                 Err(e) => match handle_attempt_error(
                     e,
                     AttemptErrorRequest {
@@ -532,7 +531,9 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 .apply(action);
                 continue;
             }
-            PostAttemptAction::Break(changed_paths) => break (exec_result, changed_paths),
+            PostAttemptAction::Break(changed_paths) => {
+                break (exec_result, changed_paths, exec_commit_created);
+            }
         }
     };
     let changed_paths = merge_run_loop_changed_paths(
@@ -545,6 +546,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
         current_tool,
         executed_session_id,
         changed_paths,
+        commit_created,
         fork_resolution,
         fallback_chain,
     })))

--- a/crates/cli-sub-agent/src/run_cmd_attempt_exec.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_exec.rs
@@ -21,6 +21,7 @@ pub(super) enum AttemptExecution {
     Finished {
         result: Box<Result<csa_process::ExecutionResult, anyhow::Error>>,
         changed_paths: Option<Vec<String>>,
+        commit_created: Option<bool>,
     },
     Exit(i32),
     TimedOut,
@@ -71,6 +72,7 @@ pub(super) async fn run_ephemeral_with_timeout(
         Ok(result) => AttemptExecution::Finished {
             result: Box::new(result),
             changed_paths: None,
+            commit_created: None,
         },
         Err(_) => AttemptExecution::TimedOut,
     };
@@ -103,6 +105,7 @@ pub(super) async fn run_ephemeral_without_timeout(
                 .await,
         ),
         changed_paths: None,
+        commit_created: None,
     })
 }
 
@@ -357,6 +360,7 @@ async fn execute_persistent(
             AttemptExecution::Finished {
                 result: Box::new(Ok(session_result.execution)),
                 changed_paths: session_result.changed_paths,
+                commit_created: session_result.commit_created,
             }
         }
         Err(e) => {
@@ -377,6 +381,7 @@ async fn execute_persistent(
                 AttemptExecution::Finished {
                     result: Box::new(Err(e)),
                     changed_paths: None,
+                    commit_created: None,
                 }
             }
         }

--- a/crates/cli-sub-agent/src/run_cmd_attempt_types.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_types.rs
@@ -92,6 +92,7 @@ pub(crate) struct RunLoopOutcome {
     pub(crate) current_tool: ToolName,
     pub(crate) executed_session_id: Option<String>,
     pub(crate) changed_paths: Option<Vec<String>>,
+    pub(crate) commit_created: Option<bool>,
     pub(crate) fork_resolution: Option<ForkResolution>,
     /// Ordered list of tools skipped due to rate-limit/quota failover before this result.
     pub(crate) fallback_chain: csa_scheduler::FallbackChain,

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -598,6 +598,7 @@ pub(crate) async fn handle_run(
         session_id,
         &mut result,
         loop_outcome.changed_paths.as_deref(),
+        loop_outcome.commit_created,
         require_commit,
         config.as_ref(),
     );

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -13,6 +13,8 @@ const DIFF_BYTES_PER_TOKEN: usize = 4;
 const DIFF_TOKEN_READ_BUF_BYTES: usize = 16 * 1024;
 const REQUIRE_COMMIT_REASON: &str =
     "writer session ended with uncommitted changes (--require-commit set)";
+const REQUIRE_COMMIT_RECOVERY_ACTION: &str = "inspect_changed_paths_then_commit_or_revert";
+const REDACTED_PATH: &str = "[redacted-path]";
 const LARGE_DIFF_WARNING_TEXT: &str = "This CSA session left a large changed surface. Do not proceed directly to a single commit/PR unless this was explicitly intended. First inspect the file list, split into atomic logical units if possible, and run review per unit. If intentionally large, record that rationale in the commit/PR.";
 
 pub(crate) fn is_writer_session(sa_mode: bool, task_type: Option<&str>) -> bool {
@@ -106,6 +108,7 @@ pub(crate) fn record_run_dirty(
     session_id: Option<&str>,
     result: &mut csa_process::ExecutionResult,
     changed_paths: Option<&[String]>,
+    commit_created: Option<bool>,
     cli_require_commit: bool,
     config: Option<&csa_config::ProjectConfig>,
 ) -> Option<csa_session::LargeDiffWarningReport> {
@@ -120,29 +123,39 @@ pub(crate) fn record_run_dirty(
         project_root,
         session_id,
         result,
-        sa_mode,
-        effective_writer_must_commit(cli_require_commit, config),
-        changed_paths,
-        &large_diff_config,
+        WriterUncommittedRecord {
+            sa_mode,
+            require_commit: effective_writer_must_commit(cli_require_commit, config),
+            changed_paths,
+            commit_created,
+            large_diff_config: &large_diff_config,
+        },
     )
+}
+
+struct WriterUncommittedRecord<'a> {
+    sa_mode: bool,
+    require_commit: bool,
+    changed_paths: Option<&'a [String]>,
+    commit_created: Option<bool>,
+    large_diff_config: &'a RunLargeDiffWarningConfig,
 }
 
 fn record_writer_uncommitted_changes_with_config(
     project_root: &Path,
     session_id: Option<&str>,
     result: &mut csa_process::ExecutionResult,
-    sa_mode: bool,
-    require_commit: bool,
-    changed_paths: Option<&[String]>,
-    large_diff_config: &RunLargeDiffWarningConfig,
+    record: WriterUncommittedRecord<'_>,
 ) -> Option<csa_session::LargeDiffWarningReport> {
-    if !is_writer_session(sa_mode, Some("run")) {
+    if !is_writer_session(record.sa_mode, Some("run")) {
         return None;
     }
     let session_id = session_id?;
-    let token_threshold = tracked_diff_token_threshold(large_diff_config);
-    let changes = collect_uncommitted_changes_with_token_threshold(project_root, token_threshold)?;
-    let warning_changes = changed_paths
+    let token_threshold = tracked_diff_token_threshold(record.large_diff_config);
+    let full_changes =
+        collect_uncommitted_changes_with_token_threshold(project_root, token_threshold)?;
+    let changes = record
+        .changed_paths
         .map(|paths| {
             collect_uncommitted_changes_for_changed_paths_with_token_threshold(
                 project_root,
@@ -150,18 +163,21 @@ fn record_writer_uncommitted_changes_with_config(
                 token_threshold,
             )
         })
-        .unwrap_or_else(|| Some(changes.clone()));
-    let warning = warning_changes
-        .as_ref()
-        .and_then(|changes| large_diff_warning_report(changes, large_diff_config));
+        .unwrap_or_else(|| Some(full_changes.clone()))?;
+    let warning = large_diff_warning_report(&changes, record.large_diff_config);
+    let require_commit_contract_failure =
+        record.require_commit && !record.commit_created.unwrap_or(false);
 
     match csa_session::load_result(project_root, session_id) {
         Ok(Some(mut session_result)) => {
+            let recovery = require_commit_contract_failure
+                .then(|| build_require_commit_recovery_diagnostic(&session_result, &changes));
             apply_uncommitted_changes_to_result(
                 &mut session_result,
                 changes.clone(),
                 warning.clone(),
-                require_commit,
+                require_commit_contract_failure,
+                recovery,
             );
             if let Err(err) = csa_session::save_result(project_root, session_id, &session_result) {
                 warn!(
@@ -186,7 +202,7 @@ fn record_writer_uncommitted_changes_with_config(
         }
     }
 
-    if require_commit {
+    if require_commit_contract_failure {
         result.mark_gate_failure("writer-uncommitted");
         result.summary = REQUIRE_COMMIT_REASON.to_string();
         if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
@@ -202,15 +218,85 @@ pub(crate) fn apply_uncommitted_changes_to_result(
     result: &mut csa_session::SessionResult,
     changes: csa_session::UncommittedChanges,
     large_diff_warning: Option<csa_session::LargeDiffWarningReport>,
-    require_commit: bool,
+    require_commit_contract_failure: bool,
+    recovery: Option<csa_session::RequireCommitRecoveryDiagnostic>,
 ) {
     result.uncommitted_changes = Some(changes);
     result.large_diff_warning = large_diff_warning;
-    if require_commit {
+    result.require_commit_recovery = recovery;
+    if require_commit_contract_failure {
+        remove_incidental_downgrade_warnings(&mut result.warnings);
         result.exit_code = 1;
         result.status = csa_session::SessionResult::status_from_exit_code(1);
         result.summary = REQUIRE_COMMIT_REASON.to_string();
     }
+}
+
+fn build_require_commit_recovery_diagnostic(
+    result: &csa_session::SessionResult,
+    changes: &csa_session::UncommittedChanges,
+) -> csa_session::RequireCommitRecoveryDiagnostic {
+    let termination_exit_code = result.raw_process_exit_code.unwrap_or(result.exit_code);
+    let termination_status = result
+        .raw_process_exit_code
+        .map(raw_termination_status_from_exit_code)
+        .unwrap_or_else(|| result.status.clone());
+    csa_session::RequireCommitRecoveryDiagnostic {
+        require_commit: true,
+        commit_created: false,
+        dirty_worktree: true,
+        changed_paths: changes
+            .files
+            .iter()
+            .map(|path| sanitize_diagnostic_path(path))
+            .collect(),
+        changed_paths_truncated: changes.truncated,
+        termination_status,
+        exit_code: termination_exit_code,
+        termination_signal: result
+            .kill_diagnostics
+            .as_ref()
+            .and_then(|diagnostics| diagnostics.signal)
+            .or_else(|| infer_signal_from_exit_code(termination_exit_code)),
+        kill_hint: result.kill_hint.clone(),
+        suggested_recovery_action: REQUIRE_COMMIT_RECOVERY_ACTION.to_string(),
+    }
+}
+
+fn raw_termination_status_from_exit_code(exit_code: i32) -> String {
+    match exit_code {
+        0 => "success".to_string(),
+        124 => "timeout".to_string(),
+        137 | 143 => "signal".to_string(),
+        _ => "failure".to_string(),
+    }
+}
+
+fn remove_incidental_downgrade_warnings(warnings: &mut Vec<String>) {
+    warnings.retain(|warning| !is_incidental_downgrade_warning(warning));
+}
+
+fn is_incidental_downgrade_warning(warning: &str) -> bool {
+    warning.contains("incidental nonzero exit") && warning.contains("treated as success")
+}
+
+fn infer_signal_from_exit_code(exit_code: i32) -> Option<i32> {
+    (129..=255).contains(&exit_code).then_some(exit_code - 128)
+}
+
+fn sanitize_diagnostic_path(path: &str) -> String {
+    let path = path.strip_prefix("./").unwrap_or(path);
+    if path.is_empty() || path.starts_with('/') || has_unsafe_path_component(path) {
+        return REDACTED_PATH.to_string();
+    }
+
+    path.chars()
+        .map(|ch| if ch.is_control() { '�' } else { ch })
+        .collect()
+}
+
+fn has_unsafe_path_component(path: &str) -> bool {
+    path.split('/').any(|part| matches!(part, ".." | ".git"))
 }
 
 pub(crate) fn format_uncommitted_warning(changes: &csa_session::UncommittedChanges) -> String {
@@ -558,6 +644,10 @@ fn parse_numstat_totals(numstat: &str) -> (u64, u64) {
 
     (insertions, deletions)
 }
+
+#[cfg(test)]
+#[path = "run_cmd_uncommitted_incidental_tests.rs"]
+mod incidental_tests;
 
 #[cfg(test)]
 #[path = "run_cmd_uncommitted_tests.rs"]

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_incidental_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_incidental_tests.rs
@@ -1,0 +1,150 @@
+use std::path::Path;
+use std::process::Command;
+
+use super::*;
+
+#[tokio::test]
+async fn require_commit_recovery_uses_raw_exit_after_incidental_downgrade() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    let mut session = csa_session::create_session(root, Some("run"), None, Some("codex"))
+        .expect("session should be created");
+    let session_dir = csa_session::get_session_dir(root, &session.meta_session_id)
+        .expect("session dir should exist");
+    let changed_paths = vec!["src.rs".to_string()];
+    std::fs::write(root.join("src.rs"), "dirty\n").expect("dirty file");
+
+    let executor = csa_executor::Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: csa_executor::CodexRuntimeMetadata::current(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let post_exec_ctx = crate::pipeline_post_exec::PostExecContext {
+        executor: &executor,
+        prompt: "write src.rs",
+        effective_prompt: "write src.rs",
+        task_type: Some("run"),
+        readonly_project_root: false,
+        project_root: root,
+        config: None,
+        global_config: None,
+        session_dir,
+        sessions_root: "test-root".to_string(),
+        execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(5),
+        hooks_config: &hooks_config,
+        memory_project_key: None,
+        provider_session_id: None,
+        events_count: 1,
+        transcript_artifacts: Vec::new(),
+        changed_paths: changed_paths.clone(),
+        pre_exec_snapshot: None,
+        has_tool_calls: true,
+        turn_count: 1,
+        output_tokens: None,
+        sa_mode: false,
+    };
+    let mut execution = csa_process::ExecutionResult {
+        output: String::new(),
+        stderr_output: String::new(),
+        summary: "completed with dirty changes".to_string(),
+        exit_code: 2,
+        raw_process_exit_code: Some(2),
+        model_completed: Some(true),
+        terminal_reason: Some("end_turn".to_string()),
+        ..Default::default()
+    };
+
+    crate::pipeline_post_exec::process_execution_result(
+        post_exec_ctx,
+        &mut session,
+        &mut execution,
+    )
+    .await
+    .expect("post-exec should downgrade the incidental raw exit");
+
+    let downgraded = csa_session::load_result(root, &session.meta_session_id)
+        .expect("load downgraded result")
+        .expect("downgraded result should exist");
+    assert_eq!(execution.exit_code, 0);
+    assert_eq!(downgraded.status, "success");
+    assert_eq!(downgraded.exit_code, 0);
+    assert_eq!(downgraded.raw_process_exit_code, Some(2));
+    assert!(
+        downgraded
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("incidental nonzero exit (2)")),
+        "downgrade warning should record the raw exit: {:?}",
+        downgraded.warnings
+    );
+
+    record_writer_uncommitted_changes_with_config(
+        root,
+        Some(&session.meta_session_id),
+        &mut execution,
+        WriterUncommittedRecord {
+            sa_mode: false,
+            require_commit: true,
+            changed_paths: Some(&changed_paths),
+            commit_created: Some(false),
+            large_diff_config: &RunLargeDiffWarningConfig::default(),
+        },
+    );
+
+    let loaded = csa_session::load_result(root, &session.meta_session_id)
+        .expect("load require-commit result")
+        .expect("require-commit result should exist");
+    assert_eq!(execution.exit_code, 1);
+    assert_eq!(
+        execution.csa_gate_failure.as_deref(),
+        Some("writer-uncommitted")
+    );
+    assert_eq!(loaded.status, "failure");
+    assert_eq!(loaded.exit_code, 1);
+    assert!(
+        loaded.warnings.is_empty(),
+        "fatal contract result must not keep success warnings: {:?}",
+        loaded.warnings
+    );
+    assert_eq!(loaded.raw_process_exit_code, Some(2));
+    let recovery = loaded
+        .require_commit_recovery
+        .expect("require-commit recovery should be recorded");
+    assert_eq!(recovery.termination_status, "failure");
+    assert_eq!(recovery.exit_code, 2);
+    assert_eq!(recovery.termination_signal, None);
+    assert_eq!(recovery.changed_paths, vec!["src.rs".to_string()]);
+}
+
+fn init_repo_with_initial_commit() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    run_git(root, &["init", "-q"]);
+    run_git(root, &["config", "user.email", "test@example.com"]);
+    run_git(root, &["config", "user.name", "Test User"]);
+    run_git(root, &["config", "commit.gpgsign", "false"]);
+    run_git(
+        root,
+        &["config", "core.hooksPath", "/nonexistent-csa-hooks"],
+    );
+    std::fs::write(root.join("seed.txt"), "seed\n").expect("write seed");
+    run_git(root, &["add", "seed.txt"]);
+    run_git(root, &["commit", "-q", "-m", "initial"]);
+    temp
+}
+
+fn run_git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
@@ -68,7 +68,7 @@ fn apply_uncommitted_changes_warn_only_preserves_success() {
         truncated: 0,
     };
 
-    apply_uncommitted_changes_to_result(&mut result, changes, None, false);
+    apply_uncommitted_changes_to_result(&mut result, changes, None, false, None);
 
     assert_eq!(result.status, "success");
     assert_eq!(result.exit_code, 0);
@@ -89,12 +89,154 @@ fn apply_uncommitted_changes_require_commit_flips_to_failure() {
         truncated: 0,
     };
 
-    apply_uncommitted_changes_to_result(&mut result, changes, None, true);
+    apply_uncommitted_changes_to_result(&mut result, changes, None, true, None);
 
     assert_eq!(result.status, "failure");
     assert_eq!(result.exit_code, 1);
     assert_eq!(result.summary, REQUIRE_COMMIT_REASON);
     assert!(result.uncommitted_changes.is_some());
+}
+
+#[test]
+fn require_commit_recovery_diagnostic_preserves_signal_exit_and_sanitized_paths() {
+    let mut result = session_result("signal", 143);
+    result.kill_hint = Some("memory_pressure".to_string());
+    let changes = csa_session::UncommittedChanges {
+        file_count: 4,
+        insertions: 8,
+        deletions: 1,
+        approx_diff_tokens: 64,
+        files: vec![
+            "src/lib.rs".to_string(),
+            "secret\nname.txt".to_string(),
+            "../outside.txt".to_string(),
+        ],
+        truncated: 1,
+    };
+    let recovery = build_require_commit_recovery_diagnostic(&result, &changes);
+
+    apply_uncommitted_changes_to_result(&mut result, changes, None, true, Some(recovery.clone()));
+
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    let persisted = result
+        .require_commit_recovery
+        .expect("recovery diagnostic should be attached");
+    assert!(persisted.require_commit);
+    assert!(!persisted.commit_created);
+    assert!(persisted.dirty_worktree);
+    assert_eq!(persisted.termination_status, "signal");
+    assert_eq!(persisted.exit_code, 143);
+    assert_eq!(persisted.termination_signal, Some(15));
+    assert_eq!(persisted.kill_hint.as_deref(), Some("memory_pressure"));
+    assert_eq!(
+        persisted.changed_paths,
+        vec![
+            "src/lib.rs".to_string(),
+            "secret�name.txt".to_string(),
+            REDACTED_PATH.to_string(),
+        ]
+    );
+    assert_eq!(persisted.changed_paths_truncated, 1);
+    assert_eq!(
+        persisted.suggested_recovery_action,
+        REQUIRE_COMMIT_RECOVERY_ACTION
+    );
+}
+
+#[test]
+fn require_commit_recovery_diagnostic_covers_generic_nonzero_exit() {
+    let result = session_result("failure", 2);
+    let changes = csa_session::UncommittedChanges {
+        file_count: 1,
+        insertions: 1,
+        deletions: 0,
+        approx_diff_tokens: 4,
+        files: vec!["src/main.rs".to_string()],
+        truncated: 0,
+    };
+
+    let recovery = build_require_commit_recovery_diagnostic(&result, &changes);
+
+    assert_eq!(recovery.termination_status, "failure");
+    assert_eq!(recovery.exit_code, 2);
+    assert_eq!(recovery.termination_signal, None);
+    assert_eq!(recovery.changed_paths, vec!["src/main.rs".to_string()]);
+}
+
+#[test]
+fn require_commit_with_commit_created_does_not_record_recovery_or_fail_result() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    let session = csa_session::create_session(root, Some("run"), None, Some("codex"))
+        .expect("session should be created");
+    let mut session_result = session_result("success", 0);
+    csa_session::save_result(root, &session.meta_session_id, &session_result)
+        .expect("result should be saved");
+    std::fs::write(root.join("src.rs"), "dirty\n").expect("dirty file");
+    let mut execution = csa_process::ExecutionResult {
+        exit_code: 0,
+        summary: "done".to_string(),
+        ..Default::default()
+    };
+
+    record_writer_uncommitted_changes_with_config(
+        root,
+        Some(&session.meta_session_id),
+        &mut execution,
+        WriterUncommittedRecord {
+            sa_mode: false,
+            require_commit: true,
+            changed_paths: Some(&["src.rs".to_string()]),
+            commit_created: Some(true),
+            large_diff_config: &RunLargeDiffWarningConfig::default(),
+        },
+    );
+
+    session_result = csa_session::load_result(root, &session.meta_session_id)
+        .expect("load result")
+        .expect("result should exist");
+    assert_eq!(execution.exit_code, 0);
+    assert_eq!(session_result.status, "success");
+    assert!(session_result.require_commit_recovery.is_none());
+}
+
+#[test]
+fn require_commit_with_no_session_dirty_paths_does_not_fail_or_diagnose() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    let session = csa_session::create_session(root, Some("run"), None, Some("codex"))
+        .expect("session should be created");
+    let session_result = session_result("success", 0);
+    csa_session::save_result(root, &session.meta_session_id, &session_result)
+        .expect("result should be saved");
+    std::fs::write(root.join("preexisting.txt"), "dirty\n").expect("dirty file");
+    let mut execution = csa_process::ExecutionResult {
+        exit_code: 0,
+        summary: "done".to_string(),
+        ..Default::default()
+    };
+
+    record_writer_uncommitted_changes_with_config(
+        root,
+        Some(&session.meta_session_id),
+        &mut execution,
+        WriterUncommittedRecord {
+            sa_mode: false,
+            require_commit: true,
+            changed_paths: Some(&[]),
+            commit_created: Some(false),
+            large_diff_config: &RunLargeDiffWarningConfig::default(),
+        },
+    );
+
+    let loaded = csa_session::load_result(root, &session.meta_session_id)
+        .expect("load result")
+        .expect("result should exist");
+    assert_eq!(execution.exit_code, 0);
+    assert_eq!(loaded.status, "success");
+    assert!(loaded.uncommitted_changes.is_none());
+    assert!(loaded.require_commit_recovery.is_none());
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -130,6 +130,12 @@ pub(crate) fn render_wait_result_summary(
         lines.push(kill_hint);
     }
 
+    if let Some(recovery) = result.require_commit_recovery.as_ref() {
+        lines.extend(
+            crate::require_commit_recovery_display::format_require_commit_recovery_lines(recovery),
+        );
+    }
+
     if let Some(changes) = result.uncommitted_changes.as_ref() {
         lines.push(crate::run_cmd::format_uncommitted_warning(changes));
     }
@@ -225,6 +231,7 @@ fn render_wait_result_json(
         "failover": format_failover_chain_label(session_dir, result),
         "kill_hint": result.kill_hint.as_deref(),
         "kill_diagnostics": result.kill_diagnostics.as_ref(),
+        "require_commit_recovery": result.require_commit_recovery.as_ref(),
         "post_exec_gate": result.post_exec_gate.as_ref(),
         "large_diff_warning": result.large_diff_warning.as_ref(),
         "warnings": result.warnings,

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_recovery_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_recovery_tests.rs
@@ -1,0 +1,78 @@
+use super::{render_wait_result_json, render_wait_result_summary};
+use chrono::Utc;
+
+#[test]
+fn compact_summary_and_json_include_require_commit_recovery() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "writer session ended with uncommitted changes (--require-commit set)".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        require_commit_recovery: Some(csa_session::RequireCommitRecoveryDiagnostic {
+            require_commit: true,
+            commit_created: false,
+            dirty_worktree: true,
+            changed_paths: vec!["src/lib.rs".to_string(), "README.md".to_string()],
+            changed_paths_truncated: 0,
+            termination_status: "signal".to_string(),
+            exit_code: 143,
+            termination_signal: Some(15),
+            kill_hint: Some("memory_pressure".to_string()),
+            suggested_recovery_action: "inspect_changed_paths_then_commit_or_revert".to_string(),
+        }),
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITRECOVER", &result);
+
+    assert!(summary.contains("Status: failure"));
+    assert!(summary.contains("Require-commit recovery: CONTRACT FAILURE"));
+    assert!(summary.contains("dirty_worktree=true"));
+    assert!(summary.contains("commit_created=false"));
+    assert!(summary.contains("status=signal"));
+    assert!(summary.contains("signal=15"));
+    assert!(summary.contains("Changed paths: src/lib.rs, README.md"));
+    assert!(summary.contains("Recovery action: inspect_changed_paths_then_commit_or_revert"));
+    assert!(!summary.contains("Review verdict: PASS"));
+
+    let json: serde_json::Value = serde_json::from_str(
+        &render_wait_result_json(temp.path(), "01TESTWAITRECOVER", &result)
+            .expect("wait JSON should render"),
+    )
+    .expect("wait JSON should parse");
+    let recovery = &json["require_commit_recovery"];
+    assert_eq!(recovery["require_commit"], serde_json::json!(true));
+    assert_eq!(recovery["commit_created"], serde_json::json!(false));
+    assert_eq!(recovery["dirty_worktree"], serde_json::json!(true));
+    assert_eq!(
+        recovery["changed_paths"][0],
+        serde_json::json!("src/lib.rs")
+    );
+    assert_eq!(recovery["termination_status"], serde_json::json!("signal"));
+    assert_eq!(recovery["exit_code"], serde_json::json!(143));
+    assert_eq!(recovery["termination_signal"], serde_json::json!(15));
+}
+
+#[test]
+fn compact_summary_omits_require_commit_recovery_when_absent() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "done".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(1),
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITNORECOVER", &result);
+
+    assert!(!summary.contains("Require-commit recovery"));
+    assert!(!summary.contains("CONTRACT FAILURE"));
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -7,6 +7,8 @@ use super::{
 
 #[path = "session_cmds_daemon_wait_summary_kill_tests.rs"]
 mod kill_diagnostics;
+#[path = "session_cmds_daemon_wait_summary_recovery_tests.rs"]
+mod recovery;
 
 #[test]
 fn read_wait_output_log_tails_large_stdout_without_loading_prefix() {
@@ -295,6 +297,7 @@ fn compact_summary_labels_fix_loop_noop_from_review_meta() {
         raw_process_exit_code: None,
         uncommitted_changes: None,
         large_diff_warning: None,
+        require_commit_recovery: None,
         manager_fields: Default::default(),
     };
 
@@ -427,6 +430,7 @@ fn compact_summary_includes_writer_uncommitted_warning() {
             truncated: 6,
         }),
         large_diff_warning: None,
+        require_commit_recovery: None,
         manager_fields: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/session_cmds_result_display.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_display.rs
@@ -48,6 +48,13 @@ pub(super) fn display_result_text(
     if let Some(diagnostics) = envelope.kill_diagnostics.as_ref() {
         println!("Kill diagnostics: {}", format_kill_diagnostics(diagnostics));
     }
+    if let Some(recovery) = envelope.require_commit_recovery.as_ref() {
+        for line in
+            crate::require_commit_recovery_display::format_require_commit_recovery_lines(recovery)
+        {
+            println!("{line}");
+        }
+    }
     if !envelope.artifacts.is_empty() {
         println!("Artifacts:");
         for a in &envelope.artifacts {

--- a/crates/cli-sub-agent/src/session_cmds_result_require_commit_recovery_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_require_commit_recovery_tests.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+#[test]
+fn build_result_json_payload_includes_require_commit_recovery() {
+    let now = chrono::Utc::now();
+    let result = SessionResultView {
+        envelope: SessionResult {
+            status: "failure".to_string(),
+            exit_code: 1,
+            summary: "writer session ended with uncommitted changes (--require-commit set)"
+                .to_string(),
+            tool: "codex".to_string(),
+            started_at: now,
+            completed_at: now,
+            require_commit_recovery: Some(csa_session::RequireCommitRecoveryDiagnostic {
+                require_commit: true,
+                commit_created: false,
+                dirty_worktree: true,
+                changed_paths: vec!["src/lib.rs".to_string()],
+                changed_paths_truncated: 0,
+                termination_status: "failure".to_string(),
+                exit_code: 2,
+                termination_signal: None,
+                kill_hint: None,
+                suggested_recovery_action: "inspect_changed_paths_then_commit_or_revert"
+                    .to_string(),
+            }),
+            ..Default::default()
+        },
+        manager_sidecar: None,
+        legacy_sidecar: None,
+    };
+
+    let payload = build_result_json_payload(&result, None, None, None).unwrap();
+    let recovery = &payload["require_commit_recovery"];
+
+    assert_eq!(recovery["require_commit"], serde_json::json!(true));
+    assert_eq!(recovery["commit_created"], serde_json::json!(false));
+    assert_eq!(recovery["dirty_worktree"], serde_json::json!(true));
+    assert_eq!(
+        recovery["changed_paths"][0],
+        serde_json::json!("src/lib.rs")
+    );
+    assert_eq!(
+        recovery["suggested_recovery_action"],
+        serde_json::json!("inspect_changed_paths_then_commit_or_revert")
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_result_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tests.rs
@@ -40,6 +40,8 @@ mod daemon_completion;
 mod issue_2016;
 #[path = "session_cmds_result_kill_diagnostics_tests.rs"]
 mod kill_diagnostics;
+#[path = "session_cmds_result_require_commit_recovery_tests.rs"]
+mod require_commit_recovery;
 #[path = "session_cmds_result_resume_wrapper_tests.rs"]
 mod resume_wrapper;
 

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -84,7 +84,10 @@ pub use post_exec_gate_report::{
 };
 pub use process_tree_memory::{SessionTreeMemorySampler, session_tree_rss_mb};
 pub use redact::{redact_event, redact_text_content};
-pub use result::{SessionArtifact, SessionManagerFields, SessionResult, UncommittedChanges};
+pub use result::{
+    RequireCommitRecoveryDiagnostic, SessionArtifact, SessionManagerFields, SessionResult,
+    UncommittedChanges,
+};
 pub use review_artifact::{
     Finding, FindingsFile, REVIEW_VERDICT_SCHEMA_VERSION, ReviewArtifact, ReviewDiffSize,
     ReviewFinding, ReviewFindingFileRange, ReviewVerdictArtifact, Severity, SeveritySummary,

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -12,7 +12,7 @@ pub const RESULT_TOML_PATH_CONTRACT_ENV: &str = "CSA_RESULT_TOML_PATH_CONTRACT";
 pub const CONTRACT_RESULT_ARTIFACT_PATH: &str = "output/result.toml";
 pub const LEGACY_USER_RESULT_ARTIFACT_PATH: &str = "output/user-result.toml";
 const LEGACY_KILL_REASON_KEY: &str = "kill_reason";
-const RUNTIME_RESULT_KEYS: [&str; 23] = [
+const RUNTIME_RESULT_KEYS: [&str; 24] = [
     "status",
     "exit_code",
     "summary",
@@ -32,6 +32,7 @@ const RUNTIME_RESULT_KEYS: [&str; 23] = [
     "raw_process_exit_code",
     "uncommitted_changes",
     "large_diff_warning",
+    "require_commit_recovery",
     "kill_hint",
     "kill_diagnostics",
     LEGACY_KILL_REASON_KEY,
@@ -441,9 +442,11 @@ fn value_matches_runtime_schema(key: &str, value: &toml::Value) -> bool {
         "gate_timeout" => value.is_bool(),
         "warnings" => value.is_array(),
         "artifacts" => artifacts_value_matches_runtime_schema(value),
-        "post_exec_gate" | "uncommitted_changes" | "large_diff_warning" | "kill_diagnostics" => {
-            value.is_table()
-        }
+        "post_exec_gate"
+        | "uncommitted_changes"
+        | "large_diff_warning"
+        | "require_commit_recovery"
+        | "kill_diagnostics" => value.is_table(),
         _ => false,
     }
 }

--- a/crates/csa-session/src/manager_result_spillover.rs
+++ b/crates/csa-session/src/manager_result_spillover.rs
@@ -343,6 +343,7 @@ mod tests {
             raw_process_exit_code: None,
             uncommitted_changes: None,
             large_diff_warning: None,
+            require_commit_recovery: None,
             manager_fields: crate::result::SessionManagerFields {
                 report: Some(
                     toml::toml! {

--- a/crates/csa-session/src/manager_tests_audit.rs
+++ b/crates/csa-session/src/manager_tests_audit.rs
@@ -25,6 +25,7 @@ fn test_save_result_persists_manager_fields_sidecar() {
         raw_process_exit_code: None,
         uncommitted_changes: None,
         large_diff_warning: None,
+        require_commit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             artifacts: Some(
                 toml::toml! {

--- a/crates/csa-session/src/manager_tests_result_view.rs
+++ b/crates/csa-session/src/manager_tests_result_view.rs
@@ -442,6 +442,7 @@ fn test_save_result_with_empty_manager_fields_preserves_existing_sidecar() {
         raw_process_exit_code: None,
         uncommitted_changes: None,
         large_diff_warning: None,
+        require_commit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {
@@ -527,6 +528,7 @@ fn test_clear_manager_sidecar_removes_existing_sidecar() {
         raw_process_exit_code: None,
         uncommitted_changes: None,
         large_diff_warning: None,
+        require_commit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {

--- a/crates/csa-session/src/manager_tests_sidecar_preservation.rs
+++ b/crates/csa-session/src/manager_tests_sidecar_preservation.rs
@@ -84,6 +84,7 @@ fn sidecar_write_failure_leaves_envelope_unchanged() {
         raw_process_exit_code: None,
         uncommitted_changes: None,
         large_diff_warning: None,
+        require_commit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             artifacts: Some(
                 toml::toml! {
@@ -117,6 +118,7 @@ fn sidecar_write_failure_leaves_envelope_unchanged() {
         raw_process_exit_code: None,
         uncommitted_changes: None,
         large_diff_warning: None,
+        require_commit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             artifacts: Some(
                 toml::toml! {
@@ -180,6 +182,7 @@ fn sidecar_clear_failure_or_crash_leaves_envelope_consistent() {
         raw_process_exit_code: None,
         uncommitted_changes: None,
         large_diff_warning: None,
+        require_commit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {
@@ -257,6 +260,7 @@ fn sidecar_clear_happy_path_publishes_envelope_then_unlinks() {
         raw_process_exit_code: None,
         uncommitted_changes: None,
         large_diff_warning: None,
+        require_commit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -200,6 +200,36 @@ impl UncommittedChanges {
     }
 }
 
+/// Machine-readable recovery detail for a `--require-commit` writer run that
+/// ended with session-created dirty worktree changes but no commit.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RequireCommitRecoveryDiagnostic {
+    /// The run was governed by the require-commit contract.
+    pub require_commit: bool,
+    /// Whether CSA observed a commit satisfying the contract.
+    pub commit_created: bool,
+    /// Whether dirty worktree changes remained after the run.
+    pub dirty_worktree: bool,
+    /// Sanitized relative paths still dirty after the run, capped by the caller.
+    pub changed_paths: Vec<String>,
+    /// Number of additional dirty paths omitted from `changed_paths`.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub changed_paths_truncated: usize,
+    /// Original tool termination status before the require-commit contract
+    /// converted the session to a contract failure.
+    pub termination_status: String,
+    /// Original tool exit code before the require-commit contract conversion.
+    pub exit_code: i32,
+    /// Original signal number when the termination was signal-shaped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub termination_signal: Option<i32>,
+    /// CSA's best-effort kill hint, if one was recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kill_hint: Option<String>,
+    /// Stable recovery action code for callers.
+    pub suggested_recovery_action: String,
+}
+
 /// Structured result of a session execution.
 /// Written to `sessions/{id}/result.toml` after each tool invocation.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -276,6 +306,11 @@ pub struct SessionResult {
     /// Omitted when the dirty surface stays below the configured warning thresholds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub large_diff_warning: Option<LargeDiffWarningReport>,
+    /// Structured recovery data for a require-commit contract failure that left
+    /// session-created dirty changes behind. Omitted for clean sessions,
+    /// successful commits, and legacy result files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub require_commit_recovery: Option<RequireCommitRecoveryDiagnostic>,
     /// Structured detail of a failed post-exec verification gate (#1726).
     /// Present ONLY when the gate (e.g. `just pre-commit`) failed, so an SA
     /// orchestrator can diagnose the failing step/test from `result.toml`
@@ -308,312 +343,5 @@ impl SessionResult {
 mod kill_diagnostics_tests;
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use chrono::Utc;
-
-    // ── Serialization round-trip ───────────────────────────────────
-
-    #[test]
-    fn test_session_result_toml_roundtrip() {
-        let now = Utc::now();
-        let result = SessionResult {
-            post_exec_gate: None,
-            status: "success".to_string(),
-            exit_code: 0,
-            summary: "All tests passed".to_string(),
-            tool: "codex".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now,
-            events_count: 4,
-            artifacts: vec![SessionArtifact::new("output/diff.patch")],
-            peak_memory_mb: None,
-            kill_hint: Some("memory_pressure".to_string()),
-            last_item: Some("running tests".to_string()),
-            fallback_chain: None,
-            ..Default::default()
-        };
-
-        let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
-        let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
-
-        assert_eq!(loaded.status, "success");
-        assert_eq!(loaded.exit_code, 0);
-        assert_eq!(loaded.summary, "All tests passed");
-        assert_eq!(loaded.tool, "codex");
-        assert_eq!(loaded.events_count, 4);
-        assert_eq!(loaded.artifacts.len(), 1);
-        assert_eq!(loaded.artifacts[0].path, "output/diff.patch");
-        assert_eq!(loaded.kill_hint.as_deref(), Some("memory_pressure"));
-        assert_eq!(loaded.last_item.as_deref(), Some("running tests"));
-    }
-
-    #[test]
-    fn test_session_result_empty_optional_fields_omitted() {
-        let now = Utc::now();
-        let result = SessionResult {
-            post_exec_gate: None,
-            status: "failure".to_string(),
-            exit_code: 1,
-            summary: "Build failed".to_string(),
-            tool: "gemini-cli".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now,
-            events_count: 0,
-            artifacts: vec![],
-            ..Default::default()
-        };
-
-        let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
-        assert!(
-            !toml_str.contains("artifacts"),
-            "Empty artifacts should be omitted from serialization"
-        );
-        assert!(
-            !toml_str.contains("events_count"),
-            "Zero events_count should be omitted from serialization"
-        );
-        assert!(
-            !toml_str.contains("uncommitted_changes"),
-            "Clean sessions should omit uncommitted_changes"
-        );
-        assert!(
-            !toml_str.contains("kill_hint"),
-            "Missing kill hint should be omitted from serialization"
-        );
-        assert!(
-            !toml_str.contains("kill_diagnostics"),
-            "Missing kill diagnostics should be omitted from serialization"
-        );
-        assert!(
-            !toml_str.contains("last_item"),
-            "Missing last_item should be omitted from serialization"
-        );
-
-        let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
-        assert!(loaded.artifacts.is_empty());
-        assert_eq!(loaded.events_count, 0);
-        assert!(loaded.uncommitted_changes.is_none());
-    }
-
-    #[test]
-    fn test_session_result_uncommitted_changes_roundtrip() {
-        let now = Utc::now();
-        let result = SessionResult {
-            post_exec_gate: None,
-            status: "success".to_string(),
-            exit_code: 0,
-            summary: "Done".to_string(),
-            tool: "codex".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now,
-            events_count: 0,
-            artifacts: vec![],
-            peak_memory_mb: None,
-            kill_hint: None,
-            kill_diagnostics: None,
-            last_item: None,
-            fallback_chain: None,
-            gate_timeout: false,
-            warnings: Vec::new(),
-            raw_process_exit_code: None,
-            uncommitted_changes: Some(UncommittedChanges {
-                file_count: 7,
-                insertions: 240,
-                deletions: 12,
-                approx_diff_tokens: 1_024,
-                files: vec!["src/lib.rs".to_string()],
-                truncated: 6,
-            }),
-            large_diff_warning: Some(LargeDiffWarningReport {
-                changed_files: 7,
-                changed_lines: 252,
-                approx_diff_tokens: 1_024,
-            }),
-            manager_fields: Default::default(),
-        };
-
-        let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
-        assert!(toml_str.contains("[uncommitted_changes]"));
-
-        let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
-        let changes = loaded
-            .uncommitted_changes
-            .expect("uncommitted_changes should roundtrip");
-        assert_eq!(changes.file_count, 7);
-        assert_eq!(changes.insertions, 240);
-        assert_eq!(changes.deletions, 12);
-        assert_eq!(changes.changed_lines(), 252);
-        assert_eq!(changes.approx_diff_tokens, 1_024);
-        assert_eq!(changes.truncated, 6);
-        let warning = loaded
-            .large_diff_warning
-            .expect("large_diff_warning should roundtrip");
-        assert_eq!(warning.changed_files, 7);
-        assert_eq!(warning.changed_lines, 252);
-        assert_eq!(warning.approx_diff_tokens, 1_024);
-    }
-
-    #[test]
-    fn test_session_result_artifacts_support_legacy_path_strings() {
-        let raw = r#"
-status = "success"
-exit_code = 0
-summary = "ok"
-tool = "codex"
-started_at = "2026-01-01T00:00:00Z"
-completed_at = "2026-01-01T00:00:00Z"
-artifacts = ["output/a.txt", "output/b.txt"]
-"#;
-        let loaded: SessionResult = toml::from_str(raw).expect("Deserialize should succeed");
-        assert_eq!(loaded.artifacts.len(), 2);
-        assert_eq!(loaded.artifacts[0].path, "output/a.txt");
-        assert_eq!(loaded.artifacts[1].path, "output/b.txt");
-    }
-
-    #[test]
-    fn test_result_without_post_exec_gate_deserializes_to_none() {
-        // Backward compat (#1726): pre-existing result.toml files have no
-        // [post_exec_gate] table; they must still deserialize, with the field None.
-        let raw = r#"
-status = "success"
-exit_code = 0
-summary = "ok"
-tool = "codex"
-started_at = "2026-01-01T00:00:00Z"
-completed_at = "2026-01-01T00:00:00Z"
-"#;
-        let loaded: SessionResult = toml::from_str(raw).expect("Deserialize should succeed");
-        assert!(loaded.post_exec_gate.is_none());
-    }
-
-    #[test]
-    fn test_successful_result_omits_post_exec_gate_table() {
-        // A successful (post_exec_gate = None) result must serialize WITHOUT a
-        // [post_exec_gate] table, so successful sessions emit no spurious table.
-        let now = Utc::now();
-        let result = SessionResult {
-            post_exec_gate: None,
-            status: "success".to_string(),
-            exit_code: 0,
-            summary: "ok".to_string(),
-            tool: "codex".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now,
-            events_count: 0,
-            artifacts: Vec::new(),
-            ..Default::default()
-        };
-        let toml_str = toml::to_string_pretty(&result).expect("serialize");
-        assert!(
-            !toml_str.contains("post_exec_gate"),
-            "successful result must not serialize a [post_exec_gate] table: {toml_str}"
-        );
-    }
-
-    #[test]
-    fn test_result_with_post_exec_gate_table_roundtrips() {
-        // A failed-gate result round-trips its [post_exec_gate] table intact.
-        let now = Utc::now();
-        let report = crate::post_exec_gate_report::PostExecGateReport::from_redacted_gate_output(
-            "just pre-commit",
-            100,
-            "FAIL [   0.005s] pkg::a\nerror: Recipe `test` failed on line 1 with exit code 100",
-        );
-        let result = SessionResult {
-            post_exec_gate: Some(report.clone()),
-            status: "failure".to_string(),
-            exit_code: 1,
-            summary: "POST-EXEC GATE FAILED (exit=100, step=just test)".to_string(),
-            tool: "codex".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now,
-            events_count: 0,
-            artifacts: Vec::new(),
-            ..Default::default()
-        };
-        let toml_str = toml::to_string_pretty(&result).expect("serialize");
-        let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
-        assert_eq!(loaded.post_exec_gate, Some(report));
-    }
-
-    // ── status_from_exit_code ──────────────────────────────────────
-
-    #[test]
-    fn test_status_from_exit_code_success() {
-        assert_eq!(SessionResult::status_from_exit_code(0), "success");
-    }
-
-    #[test]
-    fn test_status_from_exit_code_failure() {
-        assert_eq!(SessionResult::status_from_exit_code(1), "failure");
-        assert_eq!(SessionResult::status_from_exit_code(2), "failure");
-        assert_eq!(SessionResult::status_from_exit_code(127), "failure");
-    }
-
-    #[test]
-    fn test_status_from_exit_code_signal() {
-        assert_eq!(SessionResult::status_from_exit_code(137), "signal"); // SIGKILL
-        assert_eq!(SessionResult::status_from_exit_code(143), "signal"); // SIGTERM
-    }
-
-    #[test]
-    fn test_status_from_exit_code_negative() {
-        // Negative exit codes should be treated as failure
-        assert_eq!(SessionResult::status_from_exit_code(-1), "failure");
-    }
-
-    // ── File I/O round-trip ────────────────────────────────────────
-
-    #[test]
-    fn test_session_result_file_roundtrip() {
-        let tmp = tempfile::tempdir().expect("Failed to create temp dir");
-        let path = tmp.path().join(RESULT_FILE_NAME);
-
-        let now = Utc::now();
-        let result = SessionResult {
-            post_exec_gate: None,
-            status: "success".to_string(),
-            exit_code: 0,
-            summary: "Done".to_string(),
-            tool: "opencode".to_string(),
-            original_tool: None,
-            fallback_tool: None,
-            fallback_reason: None,
-            started_at: now,
-            completed_at: now,
-            events_count: 2,
-            artifacts: vec![
-                SessionArtifact::new("output/a.txt"),
-                SessionArtifact::with_stats("output/acp-events.jsonl", 10, 256),
-            ],
-            ..Default::default()
-        };
-
-        let contents = toml::to_string_pretty(&result).unwrap();
-        std::fs::write(&path, &contents).expect("Write should succeed");
-
-        let read_back = std::fs::read_to_string(&path).expect("Read should succeed");
-        let loaded: SessionResult = toml::from_str(&read_back).expect("Parse should succeed");
-
-        assert_eq!(loaded.status, result.status);
-        assert_eq!(loaded.exit_code, result.exit_code);
-        assert_eq!(loaded.events_count, 2);
-        assert_eq!(loaded.artifacts.len(), 2);
-    }
-}
+#[path = "result_tests.rs"]
+mod tests;

--- a/crates/csa-session/src/result_tests.rs
+++ b/crates/csa-session/src/result_tests.rs
@@ -1,0 +1,362 @@
+use super::*;
+use chrono::Utc;
+
+// ── Serialization round-trip ───────────────────────────────────
+
+#[test]
+fn test_session_result_toml_roundtrip() {
+    let now = Utc::now();
+    let result = SessionResult {
+        post_exec_gate: None,
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "All tests passed".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 4,
+        artifacts: vec![SessionArtifact::new("output/diff.patch")],
+        peak_memory_mb: None,
+        kill_hint: Some("memory_pressure".to_string()),
+        last_item: Some("running tests".to_string()),
+        fallback_chain: None,
+        ..Default::default()
+    };
+
+    let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
+    let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
+
+    assert_eq!(loaded.status, "success");
+    assert_eq!(loaded.exit_code, 0);
+    assert_eq!(loaded.summary, "All tests passed");
+    assert_eq!(loaded.tool, "codex");
+    assert_eq!(loaded.events_count, 4);
+    assert_eq!(loaded.artifacts.len(), 1);
+    assert_eq!(loaded.artifacts[0].path, "output/diff.patch");
+    assert_eq!(loaded.kill_hint.as_deref(), Some("memory_pressure"));
+    assert_eq!(loaded.last_item.as_deref(), Some("running tests"));
+}
+
+#[test]
+fn test_session_result_empty_optional_fields_omitted() {
+    let now = Utc::now();
+    let result = SessionResult {
+        post_exec_gate: None,
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "Build failed".to_string(),
+        tool: "gemini-cli".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: vec![],
+        ..Default::default()
+    };
+
+    let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
+    assert!(
+        !toml_str.contains("artifacts"),
+        "Empty artifacts should be omitted from serialization"
+    );
+    assert!(
+        !toml_str.contains("events_count"),
+        "Zero events_count should be omitted from serialization"
+    );
+    assert!(
+        !toml_str.contains("uncommitted_changes"),
+        "Clean sessions should omit uncommitted_changes"
+    );
+    assert!(
+        !toml_str.contains("require_commit_recovery"),
+        "Clean sessions should omit require_commit_recovery"
+    );
+    assert!(
+        !toml_str.contains("kill_hint"),
+        "Missing kill hint should be omitted from serialization"
+    );
+    assert!(
+        !toml_str.contains("kill_diagnostics"),
+        "Missing kill diagnostics should be omitted from serialization"
+    );
+    assert!(
+        !toml_str.contains("last_item"),
+        "Missing last_item should be omitted from serialization"
+    );
+
+    let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
+    assert!(loaded.artifacts.is_empty());
+    assert_eq!(loaded.events_count, 0);
+    assert!(loaded.uncommitted_changes.is_none());
+    assert!(loaded.require_commit_recovery.is_none());
+}
+
+#[test]
+fn test_session_result_require_commit_recovery_roundtrip() {
+    let now = Utc::now();
+    let result = SessionResult {
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "writer session ended with uncommitted changes (--require-commit set)".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        require_commit_recovery: Some(RequireCommitRecoveryDiagnostic {
+            require_commit: true,
+            commit_created: false,
+            dirty_worktree: true,
+            changed_paths: vec!["src/lib.rs".to_string(), "README.md".to_string()],
+            changed_paths_truncated: 2,
+            termination_status: "signal".to_string(),
+            exit_code: 143,
+            termination_signal: Some(15),
+            kill_hint: Some("memory_pressure".to_string()),
+            suggested_recovery_action: "inspect_changed_paths_then_commit_or_revert".to_string(),
+        }),
+        ..Default::default()
+    };
+
+    let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
+    assert!(toml_str.contains("[require_commit_recovery]"));
+    assert!(toml_str.contains("require_commit = true"));
+    assert!(toml_str.contains("commit_created = false"));
+    assert!(!toml_str.contains("file contents"));
+
+    let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
+    let recovery = loaded
+        .require_commit_recovery
+        .expect("recovery diagnostic should roundtrip");
+    assert!(recovery.require_commit);
+    assert!(!recovery.commit_created);
+    assert!(recovery.dirty_worktree);
+    assert_eq!(
+        recovery.changed_paths,
+        vec!["src/lib.rs".to_string(), "README.md".to_string()]
+    );
+    assert_eq!(recovery.changed_paths_truncated, 2);
+    assert_eq!(recovery.termination_status, "signal");
+    assert_eq!(recovery.exit_code, 143);
+    assert_eq!(recovery.termination_signal, Some(15));
+    assert_eq!(recovery.kill_hint.as_deref(), Some("memory_pressure"));
+}
+
+#[test]
+fn test_session_result_uncommitted_changes_roundtrip() {
+    let now = Utc::now();
+    let result = SessionResult {
+        post_exec_gate: None,
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "Done".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: vec![],
+        peak_memory_mb: None,
+        kill_hint: None,
+        kill_diagnostics: None,
+        last_item: None,
+        fallback_chain: None,
+        gate_timeout: false,
+        warnings: Vec::new(),
+        raw_process_exit_code: None,
+        uncommitted_changes: Some(UncommittedChanges {
+            file_count: 7,
+            insertions: 240,
+            deletions: 12,
+            approx_diff_tokens: 1_024,
+            files: vec!["src/lib.rs".to_string()],
+            truncated: 6,
+        }),
+        large_diff_warning: Some(LargeDiffWarningReport {
+            changed_files: 7,
+            changed_lines: 252,
+            approx_diff_tokens: 1_024,
+        }),
+        require_commit_recovery: None,
+        manager_fields: Default::default(),
+    };
+
+    let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
+    assert!(toml_str.contains("[uncommitted_changes]"));
+
+    let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
+    let changes = loaded
+        .uncommitted_changes
+        .expect("uncommitted_changes should roundtrip");
+    assert_eq!(changes.file_count, 7);
+    assert_eq!(changes.insertions, 240);
+    assert_eq!(changes.deletions, 12);
+    assert_eq!(changes.changed_lines(), 252);
+    assert_eq!(changes.approx_diff_tokens, 1_024);
+    assert_eq!(changes.truncated, 6);
+    let warning = loaded
+        .large_diff_warning
+        .expect("large_diff_warning should roundtrip");
+    assert_eq!(warning.changed_files, 7);
+    assert_eq!(warning.changed_lines, 252);
+    assert_eq!(warning.approx_diff_tokens, 1_024);
+}
+
+#[test]
+fn test_session_result_artifacts_support_legacy_path_strings() {
+    let raw = r#"
+status = "success"
+exit_code = 0
+summary = "ok"
+tool = "codex"
+started_at = "2026-01-01T00:00:00Z"
+completed_at = "2026-01-01T00:00:00Z"
+artifacts = ["output/a.txt", "output/b.txt"]
+"#;
+    let loaded: SessionResult = toml::from_str(raw).expect("Deserialize should succeed");
+    assert_eq!(loaded.artifacts.len(), 2);
+    assert_eq!(loaded.artifacts[0].path, "output/a.txt");
+    assert_eq!(loaded.artifacts[1].path, "output/b.txt");
+}
+
+#[test]
+fn test_result_without_post_exec_gate_deserializes_to_none() {
+    // Backward compat (#1726): pre-existing result.toml files have no
+    // [post_exec_gate] table; they must still deserialize, with the field None.
+    let raw = r#"
+status = "success"
+exit_code = 0
+summary = "ok"
+tool = "codex"
+started_at = "2026-01-01T00:00:00Z"
+completed_at = "2026-01-01T00:00:00Z"
+"#;
+    let loaded: SessionResult = toml::from_str(raw).expect("Deserialize should succeed");
+    assert!(loaded.post_exec_gate.is_none());
+}
+
+#[test]
+fn test_successful_result_omits_post_exec_gate_table() {
+    // A successful (post_exec_gate = None) result must serialize WITHOUT a
+    // [post_exec_gate] table, so successful sessions emit no spurious table.
+    let now = Utc::now();
+    let result = SessionResult {
+        post_exec_gate: None,
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "ok".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    };
+    let toml_str = toml::to_string_pretty(&result).expect("serialize");
+    assert!(
+        !toml_str.contains("post_exec_gate"),
+        "successful result must not serialize a [post_exec_gate] table: {toml_str}"
+    );
+}
+
+#[test]
+fn test_result_with_post_exec_gate_table_roundtrips() {
+    // A failed-gate result round-trips its [post_exec_gate] table intact.
+    let now = Utc::now();
+    let report = crate::post_exec_gate_report::PostExecGateReport::from_redacted_gate_output(
+        "just pre-commit",
+        100,
+        "FAIL [   0.005s] pkg::a\nerror: Recipe `test` failed on line 1 with exit code 100",
+    );
+    let result = SessionResult {
+        post_exec_gate: Some(report.clone()),
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "POST-EXEC GATE FAILED (exit=100, step=just test)".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    };
+    let toml_str = toml::to_string_pretty(&result).expect("serialize");
+    let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
+    assert_eq!(loaded.post_exec_gate, Some(report));
+}
+
+// ── status_from_exit_code ──────────────────────────────────────
+
+#[test]
+fn test_status_from_exit_code_success() {
+    assert_eq!(SessionResult::status_from_exit_code(0), "success");
+}
+
+#[test]
+fn test_status_from_exit_code_failure() {
+    assert_eq!(SessionResult::status_from_exit_code(1), "failure");
+    assert_eq!(SessionResult::status_from_exit_code(2), "failure");
+    assert_eq!(SessionResult::status_from_exit_code(127), "failure");
+}
+
+#[test]
+fn test_status_from_exit_code_signal() {
+    assert_eq!(SessionResult::status_from_exit_code(137), "signal"); // SIGKILL
+    assert_eq!(SessionResult::status_from_exit_code(143), "signal"); // SIGTERM
+}
+
+#[test]
+fn test_status_from_exit_code_negative() {
+    // Negative exit codes should be treated as failure
+    assert_eq!(SessionResult::status_from_exit_code(-1), "failure");
+}
+
+// ── File I/O round-trip ────────────────────────────────────────
+
+#[test]
+fn test_session_result_file_roundtrip() {
+    let tmp = tempfile::tempdir().expect("Failed to create temp dir");
+    let path = tmp.path().join(RESULT_FILE_NAME);
+
+    let now = Utc::now();
+    let result = SessionResult {
+        post_exec_gate: None,
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "Done".to_string(),
+        tool: "opencode".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 2,
+        artifacts: vec![
+            SessionArtifact::new("output/a.txt"),
+            SessionArtifact::with_stats("output/acp-events.jsonl", 10, 256),
+        ],
+        ..Default::default()
+    };
+
+    let contents = toml::to_string_pretty(&result).unwrap();
+    std::fs::write(&path, &contents).expect("Write should succeed");
+
+    let read_back = std::fs::read_to_string(&path).expect("Read should succeed");
+    let loaded: SessionResult = toml::from_str(&read_back).expect("Parse should succeed");
+
+    assert_eq!(loaded.status, result.status);
+    assert_eq!(loaded.exit_code, result.exit_code);
+    assert_eq!(loaded.events_count, 2);
+    assert_eq!(loaded.artifacts.len(), 2);
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1013"
-weave = "0.1.1013"
+csa = "0.1.1014"
+weave = "0.1.1014"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Persist structured recovery metadata when a `--require-commit` writer exits without creating a commit and leaves dirty workspace mutations.
- Surface the recovery contract failure in result/wait display and JSON, including sanitized changed paths, termination status/exit/signal, `kill_hint`, and suggested recovery action.
- Preserve raw/original nonzero exits when incidental downgrade would otherwise make the effective result success/0.
- Keep diagnostics path/status-only; no file contents or secrets.
- Split tests to satisfy monolith gates without updating baselines.

Closes #1989

## Test Plan

- `cargo test -p csa-session result::tests::test_session_result_require_commit_recovery_roundtrip --quiet`
- `cargo test -p cli-sub-agent require_commit_recovery --quiet`
- `cargo test -p cli-sub-agent run_cmd::uncommitted --quiet`
- `cargo test -p cli-sub-agent session_cmds_result --quiet`
- `cargo test -p csa-session result --quiet`
- `cargo test -p cli-sub-agent require_commit_recovery_uses_raw_exit_after_incidental_downgrade -- --nocapture`
- `cargo test -p cli-sub-agent require_commit -- --nocapture`
- `cargo fmt -- --check`
- `git diff --check`
- `git diff --cached --check`
- `just check-version-bumped`
- `just find-monolith-files`
- `just pre-commit-fast`
- Hook-enabled commit / amend quality gates PASS
- Rebuilt exact-head binary: `target/debug/csa 0.1.1014 (ca76bc80)`
- CSA exact-head review no-verdict due `memory_soft_limit`; same-SHA native exact-head fallback review PASS/CLEAN
