### PR TITLE
fix(run): keep explicit codex selection from gemini fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1014"
+version = "0.1.1015"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1014"
+version = "0.1.1015"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -12,7 +12,9 @@ use crate::pipeline;
 use crate::run_cmd_caller_fork::resolve_fork_from_caller;
 use crate::run_cmd_fork::try_auto_seed_fork;
 use crate::run_cmd_model_pin::{
-    RunModelPinInput, inherited_model_pin_from_startup, resolve_handle_run_model_pin,
+    RunModelPinInput, explicit_tool_no_failover_from_inherited_pin,
+    inherited_model_pin_from_startup, resolve_handle_run_model_pin,
+    validate_inherited_model_pin_allows_explicit_tool,
 };
 use crate::run_cmd_post::{
     handle_fork_call_resume, mark_seed_and_evict, update_fork_genealogy,
@@ -226,6 +228,7 @@ pub(crate) async fn handle_run(
         &mut global_config,
     )?;
     let pre_session_hook = csa_hooks::load_global_pre_session_hook_invocation();
+    let cli_tool_arg = tool.clone();
     let mut user_explicit_tool = tool.is_some();
     let prompt = resolve_positional_stdin_sentinel(prompt)?.or(prompt_flag);
 
@@ -262,6 +265,18 @@ pub(crate) async fn handle_run(
     auto_route = model_pin_resolution.auto_route;
     force_ignore_tier_setting = model_pin_resolution.force_ignore_tier_setting;
     no_failover = model_pin_resolution.no_failover;
+    if explicit_tool_no_failover_from_inherited_pin(
+        cli_tool_arg.as_ref(),
+        model_pin_resolution.inherited_trusted_pin,
+        allow_fallback,
+    ) {
+        no_failover = true;
+    }
+    validate_inherited_model_pin_allows_explicit_tool(
+        cli_tool_arg.as_ref(),
+        model_pin_resolution.inherited_trusted_pin,
+        model_spec.as_deref(),
+    )?;
     let resolved_skill = skill_res.resolved_skill;
     let gate_prompt_text = skill_res.prompt_text.clone();
     let frontmatter_difficulty = skill_res.frontmatter_difficulty.clone();
@@ -375,6 +390,7 @@ pub(crate) async fn handle_run(
         &merged_aliases,
         user_explicit_tool,
         effective_tier.is_some(),
+        allow_fallback,
     )?;
     let tier_failover_tool_filter = tool_strategy.tier_failover_tool_filter;
     let strategy = tool_strategy.strategy;
@@ -669,6 +685,10 @@ pub(crate) async fn handle_run(
 
     Ok(result.exit_code)
 }
+
+#[cfg(test)]
+#[path = "run_cmd_execute_codex_no_failover_tests.rs"]
+mod codex_no_failover_tests;
 
 #[cfg(test)]
 #[path = "run_cmd_execute_pre_exec_tests.rs"]

--- a/crates/cli-sub-agent/src/run_cmd_execute_codex_no_failover_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_codex_no_failover_tests.rs
@@ -1,0 +1,64 @@
+use super::routing::resolve_run_no_failover;
+use crate::run_cmd_model_pin::{
+    explicit_tool_no_failover_from_inherited_pin, validate_inherited_model_pin_allows_explicit_tool,
+};
+use csa_core::types::{ToolArg, ToolName, ToolSelectionStrategy};
+
+#[test]
+fn run_explicit_tool_with_tier_allow_fallback_keeps_failover_enabled() {
+    assert!(!resolve_run_no_failover(
+        true,
+        true,
+        &ToolSelectionStrategy::Explicit(ToolName::Codex),
+        false,
+        true,
+    ));
+}
+
+#[test]
+fn inherited_gemini_pin_rejects_explicit_codex_tool() {
+    let err = validate_inherited_model_pin_allows_explicit_tool(
+        Some(&ToolArg::Specific(ToolName::Codex)),
+        true,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+    )
+    .expect_err("explicit codex must not inherit a gemini model pin");
+    let msg = err.to_string();
+
+    assert!(msg.contains("explicit --tool codex"), "{msg}");
+    assert!(msg.contains("CSA_MODEL_SPEC"), "{msg}");
+    assert!(msg.contains("gemini-cli"), "{msg}");
+    assert!(
+        msg.contains("refusing to route the explicit codex request through gemini-cli"),
+        "{msg}"
+    );
+}
+
+#[test]
+fn inherited_codex_pin_allows_explicit_codex_tool() {
+    validate_inherited_model_pin_allows_explicit_tool(
+        Some(&ToolArg::Specific(ToolName::Codex)),
+        true,
+        Some("codex/openai/gpt-5.5/xhigh"),
+    )
+    .expect("matching inherited codex pin should be allowed");
+}
+
+#[test]
+fn inherited_pin_keeps_explicit_codex_no_failover_constraint() {
+    assert!(explicit_tool_no_failover_from_inherited_pin(
+        Some(&ToolArg::Specific(ToolName::Codex)),
+        true,
+        false,
+    ));
+    assert!(!explicit_tool_no_failover_from_inherited_pin(
+        Some(&ToolArg::Specific(ToolName::Codex)),
+        true,
+        true,
+    ));
+    assert!(!explicit_tool_no_failover_from_inherited_pin(
+        Some(&ToolArg::Auto),
+        true,
+        false,
+    ));
+}

--- a/crates/cli-sub-agent/src/run_cmd_execute_routing.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_routing.rs
@@ -7,14 +7,13 @@ use weave::parser::AgentConfig;
 
 pub(super) fn resolve_run_no_failover(
     user_explicit_tool: bool,
-    active_tier: bool,
+    _active_tier: bool,
     strategy: &ToolSelectionStrategy,
     no_failover: bool,
     allow_fallback: bool,
 ) -> bool {
     no_failover
         || (user_explicit_tool
-            && !active_tier
             && matches!(strategy, ToolSelectionStrategy::Explicit(_))
             && !allow_fallback)
 }
@@ -22,9 +21,10 @@ pub(super) fn resolve_run_no_failover(
 pub(super) fn resolve_tier_failover_tool_filter(
     user_explicit_tool: bool,
     active_tier: bool,
+    allow_fallback: bool,
     resolved_tool_arg: &ToolArg,
 ) -> Option<ToolName> {
-    if !user_explicit_tool || !active_tier {
+    if !user_explicit_tool || !active_tier || allow_fallback {
         return None;
     }
 
@@ -44,13 +44,18 @@ pub(super) fn resolve_run_tool_strategy(
     tool_aliases: &HashMap<String, String>,
     user_explicit_tool: bool,
     active_tier: bool,
+    allow_fallback: bool,
 ) -> Result<RunToolStrategySelection> {
     let resolved_tool_arg = tool_arg
         .unwrap_or(ToolArg::Auto)
         .resolve_alias(tool_aliases)
         .map_err(anyhow::Error::msg)?;
-    let tier_failover_tool_filter =
-        resolve_tier_failover_tool_filter(user_explicit_tool, active_tier, &resolved_tool_arg);
+    let tier_failover_tool_filter = resolve_tier_failover_tool_filter(
+        user_explicit_tool,
+        active_tier,
+        allow_fallback,
+        &resolved_tool_arg,
+    );
 
     Ok(RunToolStrategySelection {
         strategy: resolved_tool_arg.into_strategy(),

--- a/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
@@ -522,8 +522,8 @@ fn run_explicit_tool_defaults_to_no_failover() {
 }
 
 #[test]
-fn run_explicit_tool_with_tier_keeps_failover_enabled() {
-    assert!(!resolve_run_no_failover(
+fn run_explicit_tool_with_tier_defaults_to_no_failover() {
+    assert!(resolve_run_no_failover(
         true,
         true,
         &ToolSelectionStrategy::Explicit(ToolName::Codex),

--- a/crates/cli-sub-agent/src/run_cmd_execute_tier_failover_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_tier_failover_tests.rs
@@ -118,11 +118,22 @@ fn compound_tier_tool_selector_sets_explicit_tool_failover_filter() {
     let tier_failover_tool_filter = resolve_tier_failover_tool_filter(
         user_explicit_tool,
         effective_tier.is_some(),
+        false,
         &resolved_tool_arg,
     );
 
     assert_eq!(worker.tool, ToolName::Codex);
     assert_eq!(tier_failover_tool_filter, Some(ToolName::Codex));
+    assert_eq!(
+        resolve_tier_failover_tool_filter(
+            user_explicit_tool,
+            effective_tier.is_some(),
+            true,
+            &resolved_tool_arg,
+        ),
+        None,
+        "--allow-fallback must opt explicit tool tier runs back into cross-tool fallback"
+    );
 }
 
 #[test]
@@ -183,6 +194,7 @@ fn explicit_auto_and_any_available_tier_runs_do_not_set_failover_tool_filter() {
         let tier_failover_tool_filter = resolve_tier_failover_tool_filter(
             user_explicit_tool,
             effective_tier.is_some(),
+            false,
             &resolved_tool_arg,
         );
 

--- a/crates/cli-sub-agent/src/run_cmd_model_pin.rs
+++ b/crates/cli-sub-agent/src/run_cmd_model_pin.rs
@@ -12,6 +12,7 @@ pub(crate) use sidecar::sync_subtree_model_pin_sidecar;
 
 use crate::run_cmd_tool_selection::SkillResolution;
 use crate::startup_env::StartupSubtreeEnv;
+use csa_core::types::ToolArg;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct InheritedModelPin {
@@ -355,6 +356,49 @@ pub(crate) fn resolve_handle_run_model_pin(
         inherited_trusted_pin: inherited_pin_active,
         subtree_model_pin_active,
     }
+}
+
+pub(crate) fn explicit_tool_no_failover_from_inherited_pin(
+    explicit_tool: Option<&ToolArg>,
+    inherited_pin_active: bool,
+    allow_fallback: bool,
+) -> bool {
+    inherited_pin_active
+        && explicit_tool.is_some_and(|arg| matches!(arg, ToolArg::Specific(_)))
+        && !allow_fallback
+}
+
+pub(crate) fn validate_inherited_model_pin_allows_explicit_tool(
+    explicit_tool: Option<&ToolArg>,
+    inherited_pin_active: bool,
+    model_spec: Option<&str>,
+) -> anyhow::Result<()> {
+    if !inherited_pin_active {
+        return Ok(());
+    }
+
+    let Some(ToolArg::Specific(requested_tool)) = explicit_tool else {
+        return Ok(());
+    };
+    let Some(model_spec) = model_spec else {
+        return Ok(());
+    };
+
+    let parsed = csa_executor::ModelSpec::parse(model_spec)?;
+    if parsed.tool == requested_tool.as_str() {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "explicit --tool {} conflicts with inherited CSA_MODEL_SPEC {model_spec} \
+         (tool {}); refusing to route the explicit {} request through {}. \
+         Use a matching --model-spec, clear the inherited subtree pin, or choose --tool {}.",
+        requested_tool.as_str(),
+        parsed.tool,
+        requested_tool.as_str(),
+        parsed.tool,
+        parsed.tool
+    )
 }
 
 /// Resolve CSA's authoritative subtree model pin for a spawn (#1741).

--- a/crates/cli-sub-agent/src/run_helpers_executor.rs
+++ b/crates/cli-sub-agent/src/run_helpers_executor.rs
@@ -16,6 +16,14 @@ pub(crate) fn build_executor(
 ) -> Result<Executor> {
     let mut executor = if let Some(spec) = model_spec {
         let parsed = ModelSpec::parse(spec)?;
+        if parsed.tool != tool.as_str() {
+            anyhow::bail!(
+                "tool/model-spec mismatch: selected tool {} cannot execute model spec {spec} \
+                 because it selects tool {}; refusing to dispatch through the wrong provider",
+                tool.as_str(),
+                parsed.tool
+            );
+        }
         Executor::from_spec(&parsed)?
     } else {
         let tool_name = tool.as_str();

--- a/crates/cli-sub-agent/src/run_helpers_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tests.rs
@@ -229,6 +229,28 @@ fn build_executor_model_and_thinking_coexist() {
 }
 
 #[test]
+fn build_executor_rejects_model_spec_tool_mismatch_before_dispatch() {
+    let err = build_executor(
+        &ToolName::Codex,
+        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        None,
+        None,
+        None,
+        false,
+    )
+    .expect_err("codex must not build a gemini executor from mismatched model spec");
+    let msg = err.to_string();
+
+    assert!(msg.contains("selected tool codex"), "{msg}");
+    assert!(msg.contains("model spec"), "{msg}");
+    assert!(msg.contains("gemini-cli"), "{msg}");
+    assert!(
+        msg.contains("refusing to dispatch through the wrong provider"),
+        "{msg}"
+    );
+}
+
+#[test]
 fn build_executor_model_with_thinking_suffix() {
     let result = build_executor(
         &ToolName::GeminiCli,

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1014"
-weave = "0.1.1014"
+csa = "0.1.1015"
+weave = "0.1.1015"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Keep explicit `--tool codex` selection from silently falling through to Gemini auth/execution paths.
- Treat explicit concrete tool selection as no-failover by default; `--allow-fallback` is required to opt back into tier fallback.
- Reject inherited model pins that conflict with explicit tool selection before provider dispatch.
- Add executor-side model-spec/tool mismatch validation so result attribution cannot claim Codex while running Gemini.
- Preserve Gemini auth-error classification when Gemini is actually selected.

Closes #2011

## Test Plan

- `cargo test -p cli-sub-agent run_explicit_tool -- --nocapture`
- `cargo test -p cli-sub-agent inherited_gemini_pin_rejects_explicit_codex_tool -- --nocapture`
- `cargo test -p cli-sub-agent inherited_pin_keeps_explicit_codex_no_failover_constraint -- --nocapture`
- `cargo test -p cli-sub-agent build_executor_rejects_model_spec_tool_mismatch_before_dispatch -- --nocapture`
- `cargo test -p cli-sub-agent compound_tier_tool_selector_sets_explicit_tool_failover_filter -- --nocapture`
- `cargo test -p cli-sub-agent explicit_tool_no_failover_blocks_cross_tool_failover -- --nocapture`
- `cargo test -p cli-sub-agent explicit_tool_no_tier_crash_no_failover -- --nocapture`
- `cargo test -p cli-sub-agent evaluate_error_rate_limit_failover_no_failover_flag_prevents_fallback_chain_entry -- --nocapture`
- `cargo test -p cli-sub-agent gemini_auth -- --nocapture`
- `cargo fmt -- --check`
- `git diff --check`
- `git diff --cached --check`
- `just check-version-bumped`
- `just find-monolith-files`
- `just pre-commit-fast`
- Hook-enabled commit quality gates PASS
- Rebuilt exact-head binary: `target/debug/csa 0.1.1015 (3c924a85)`
- CSA exact-head review no-verdict due `tool_launch_metadata_absent`; same-SHA native exact-head fallback review PASS/CLEAN
