### PR TITLE
fix(ci): make version check tests independent of just

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1015"
+version = "0.1.1016"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1015"
+version = "0.1.1016"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/version_check_recipe_tests.rs
+++ b/crates/cli-sub-agent/src/version_check_recipe_tests.rs
@@ -128,7 +128,7 @@ enum CargoInstallRoot {
 }
 
 #[cfg(unix)]
-fn run_check_version_bumped(cargo_install_root: CargoInstallRoot) -> (String, String) {
+fn run_check_version_bumped(cargo_install_root: CargoInstallRoot) -> (PathBuf, PathBuf) {
     let repo = init_version_check_repo();
     let fake_bin = repo.path().join("fake-bin");
     install_fake_cargo(&fake_bin);
@@ -179,24 +179,36 @@ fn run_check_version_bumped(cargo_install_root: CargoInstallRoot) -> (String, St
     );
     let observed_install_root =
         fs::read_to_string(&capture_path).expect("fake cargo should capture install root");
-    (
-        observed_install_root.trim().to_string(),
-        expected_install_root.to_string_lossy().into_owned(),
-    )
+    let observed_install_root = PathBuf::from(observed_install_root.trim());
+    // macOS temp paths may be reported through canonical aliases such as
+    // `/private/var` instead of `/var`, so compare resolved filesystem paths
+    // while the temporary repository still exists.
+    let observed_install_root = observed_install_root
+        .canonicalize()
+        .expect("canonicalize observed install root");
+    let expected_install_root = expected_install_root
+        .canonicalize()
+        .expect("canonicalize expected install root");
+    (observed_install_root, expected_install_root)
+}
+
+#[cfg(unix)]
+fn assert_same_install_root(observed: &Path, expected: &Path) {
+    assert_eq!(observed, expected);
 }
 
 #[test]
 #[cfg(unix)]
 fn check_version_bumped_ignores_read_only_cargo_install_root() {
     let (observed, expected) = run_check_version_bumped(CargoInstallRoot::Value("/usr/local"));
-    assert_eq!(observed, expected);
+    assert_same_install_root(&observed, &expected);
 }
 
 #[test]
 #[cfg(unix)]
 fn check_version_bumped_works_when_cargo_install_root_is_unset() {
     let (observed, expected) = run_check_version_bumped(CargoInstallRoot::Unset);
-    assert_eq!(observed, expected);
+    assert_same_install_root(&observed, &expected);
 }
 
 #[test]
@@ -204,5 +216,5 @@ fn check_version_bumped_works_when_cargo_install_root_is_unset() {
 fn check_version_bumped_preserves_explicit_cargo_install_root() {
     let (observed, expected) =
         run_check_version_bumped(CargoInstallRoot::RepoLocal("explicit-cargo-install-root"));
-    assert_eq!(observed, expected);
+    assert_same_install_root(&observed, &expected);
 }

--- a/crates/cli-sub-agent/src/version_check_recipe_tests.rs
+++ b/crates/cli-sub-agent/src/version_check_recipe_tests.rs
@@ -46,13 +46,24 @@ fn init_version_check_repo() -> TempDir {
 }
 
 #[cfg(unix)]
-fn install_failing_cargo(bin_dir: &Path) {
+fn install_executable(bin_dir: &Path, name: &str, contents: &str) {
     use std::os::unix::fs::PermissionsExt;
 
     fs::create_dir_all(bin_dir).expect("create fake bin dir");
-    let cargo_path = bin_dir.join("cargo");
-    fs::write(
-        &cargo_path,
+    let path = bin_dir.join(name);
+    fs::write(&path, contents).unwrap_or_else(|err| panic!("write fake {name}: {err}"));
+    let mut perms = fs::metadata(&path)
+        .unwrap_or_else(|err| panic!("fake {name} metadata: {err}"))
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).unwrap_or_else(|err| panic!("chmod fake {name}: {err}"));
+}
+
+#[cfg(unix)]
+fn install_fake_cargo(bin_dir: &Path) {
+    install_executable(
+        bin_dir,
+        "cargo",
         r#"#!/usr/bin/env bash
 set -euo pipefail
 if [ "${1:-}" != "metadata" ]; then
@@ -73,13 +84,41 @@ cat <<'JSON'
 {"packages":[{"name":"cli-sub-agent","version":"0.1.1"}]}
 JSON
 "#,
-    )
-    .expect("write fake cargo");
-    let mut perms = fs::metadata(&cargo_path)
-        .expect("fake cargo metadata")
-        .permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(&cargo_path, perms).expect("chmod fake cargo");
+    );
+}
+
+#[cfg(unix)]
+fn install_fake_jq(bin_dir: &Path) {
+    install_executable(
+        bin_dir,
+        "jq",
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+cat >/dev/null
+if [ "${1:-}" != "-r" ]; then
+    echo "fake jq only supports -r; args=$*" >&2
+    exit 45
+fi
+expected='.packages[] | select(.name == "cli-sub-agent") | .version'
+if [ "${2:-}" != "$expected" ]; then
+    echo "fake jq saw unexpected filter: ${2:-<missing>}" >&2
+    exit 46
+fi
+printf '0.1.1\n'
+"#,
+    );
+}
+
+#[cfg(unix)]
+fn install_failing_just(bin_dir: &Path) {
+    install_executable(
+        bin_dir,
+        "just",
+        r#"#!/usr/bin/env bash
+echo "fake just should not be invoked by version_check_recipe_tests" >&2
+exit 127
+"#,
+    );
 }
 
 enum CargoInstallRoot {
@@ -92,7 +131,9 @@ enum CargoInstallRoot {
 fn run_check_version_bumped(cargo_install_root: CargoInstallRoot) -> (String, String) {
     let repo = init_version_check_repo();
     let fake_bin = repo.path().join("fake-bin");
-    install_failing_cargo(&fake_bin);
+    install_fake_cargo(&fake_bin);
+    install_fake_jq(&fake_bin);
+    install_failing_just(&fake_bin);
     let capture_path = repo.path().join("fake-cargo-install-root.txt");
     let default_install_root = repo.path().join("target/cargo-install-root");
 
@@ -101,14 +142,10 @@ fn run_check_version_bumped(cargo_install_root: CargoInstallRoot) -> (String, St
         fake_bin.display(),
         std::env::var("PATH").unwrap_or_default()
     );
-    let mut command = Command::new("just");
+    let mut command = Command::new("bash");
     command
-        .arg("--no-dotenv")
-        .arg("--justfile")
-        .arg(workspace_root().join("justfile"))
-        .arg("--working-directory")
-        .arg(repo.path())
-        .arg("check-version-bumped")
+        .arg(workspace_root().join("scripts/check-version-bumped.sh"))
+        .current_dir(repo.path())
         .env("PATH", path)
         .env("FAKE_CARGO_INSTALL_ROOT_CAPTURE", &capture_path)
         .env_remove("CSA_SKIP_VERSION_CHECK");
@@ -133,10 +170,10 @@ fn run_check_version_bumped(cargo_install_root: CargoInstallRoot) -> (String, St
         }
     };
 
-    let output = command.output().expect("just should execute");
+    let output = command.output().expect("bash should execute");
     assert!(
         output.status.success(),
-        "check-version-bumped should invoke cargo with a writable install root: stdout={}, stderr={}",
+        "check-version-bumped script should invoke cargo with a writable install root without spawning just: stdout={}, stderr={}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );

--- a/justfile
+++ b/justfile
@@ -97,42 +97,7 @@ check-generated-artifacts:
 # Verify workspace version has been bumped relative to main (prevents accidental unversioned PRs).
 # Skipped on main itself and when CSA_SKIP_VERSION_CHECK=1 (e.g., during release automation).
 check-version-bumped:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
-    if [ "$branch" = "main" ] || [ "$branch" = "" ]; then
-        exit 0
-    fi
-    if [ "${CSA_SKIP_VERSION_CHECK:-0}" = "1" ]; then
-        exit 0
-    fi
-    # Extract workspace version from Cargo.toml on current branch vs main.
-    cargo_install_root="${CARGO_INSTALL_ROOT:-}"
-    if [ -z "$cargo_install_root" ] || [ "$cargo_install_root" = "/usr/local" ]; then
-        cargo_install_root="{{_repo_root}}/target/cargo-install-root"
-    fi
-    mkdir -p "$cargo_install_root"
-    current=$(CARGO_INSTALL_ROOT="$cargo_install_root" cargo metadata --no-deps --format-version 1 \
-        | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')
-    main_version=$(git show main:Cargo.toml 2>/dev/null \
-        | grep -A1 '^\[workspace\.package\]' \
-        | grep '^version' | head -1 \
-        | sed 's/.*"\(.*\)".*/\1/' || echo "")
-    if [ -z "$main_version" ]; then
-        echo "WARNING: Could not read main branch version, skipping check."
-        exit 0
-    fi
-    if [ "$current" = "$main_version" ]; then
-        echo ""
-        echo "=========================================="
-        echo "ERROR: Workspace version ($current) matches main."
-        echo "=========================================="
-        echo ""
-        echo "You must bump the version before committing on a feature branch."
-        echo "Run:  just bump-patch"
-        echo ""
-        exit 1
-    fi
+    @bash "{{_repo_root}}/scripts/check-version-bumped.sh" "{{_repo_root}}"
 
 # Fast pre-commit: formatting, linting, static analysis only (no tests).
 # Tests run in pre-push hook instead, avoiding ~58min commit wait (#1383).

--- a/scripts/check-version-bumped.sh
+++ b/scripts/check-version-bumped.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Verify the workspace version differs from main on feature branches.
+# This script backs `just check-version-bumped` and is also invoked directly by
+# Rust tests so workspace tests do not depend on the host having `just` installed.
+set -euo pipefail
+
+repo_root="${1:-}"
+if [ -z "$repo_root" ]; then
+    repo_root="$(git rev-parse --show-superproject-working-tree 2>/dev/null | grep . || git rev-parse --show-toplevel)"
+fi
+
+branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+if [ "$branch" = "main" ] || [ "$branch" = "" ]; then
+    exit 0
+fi
+if [ "${CSA_SKIP_VERSION_CHECK:-0}" = "1" ]; then
+    exit 0
+fi
+
+# Extract workspace version from Cargo.toml on current branch vs main.
+cargo_install_root="${CARGO_INSTALL_ROOT:-}"
+if [ -z "$cargo_install_root" ] || [ "$cargo_install_root" = "/usr/local" ]; then
+    cargo_install_root="$repo_root/target/cargo-install-root"
+fi
+mkdir -p "$cargo_install_root"
+current=$(CARGO_INSTALL_ROOT="$cargo_install_root" cargo metadata --no-deps --format-version 1 \
+    | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')
+main_version=$(git show main:Cargo.toml 2>/dev/null \
+    | grep -A1 '^\[workspace\.package\]' \
+    | grep '^version' | head -1 \
+    | sed 's/.*"\(.*\)".*/\1/' || echo "")
+if [ -z "$main_version" ]; then
+    echo "WARNING: Could not read main branch version, skipping check."
+    exit 0
+fi
+if [ "$current" = "$main_version" ]; then
+    echo ""
+    echo "=========================================="
+    echo "ERROR: Workspace version ($current) matches main."
+    echo "=========================================="
+    echo ""
+    echo "You must bump the version before committing on a feature branch."
+    echo "Run:  just bump-patch"
+    echo ""
+    exit 1
+fi

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1015"
-weave = "0.1.1015"
+csa = "0.1.1016"
+weave = "0.1.1016"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Move the `check-version-bumped` gate body into `scripts/check-version-bumped.sh`.
- Keep `just check-version-bumped` as the hook/local entry point by delegating to the script.
- Update `version_check_recipe_tests` to call the script directly via `bash` with fake `cargo`/`jq`/failing `just`, so CI workspace tests do not require host `just`.
- Canonicalize fake cargo install-root paths while the temporary repo is still alive, making the tests portable across macOS `/var` -> `/private/var` temp path aliases.
- Bump workspace version to `0.1.1016` and update `Cargo.lock` / `weave.lock`.

Fixes #2245.

## Tests

- `cargo test -p cli-sub-agent --bin csa version_check_recipe_tests -- --nocapture`
- `TMPDIR=$PWD/target/tmp-link-2245 cargo test -p cli-sub-agent --bin csa version_check_recipe_tests -- --nocapture`
- `cargo fmt --all -- --check`
- `just check-version-bumped`
- `just pre-commit-fast`
- commit hooks / quality gates: PASS
- exact-head rebuild: `target/debug/csa -> csa 0.1.1016 (e3c7d2f1)`

## Review notes

- CSA exact-head review sessions returned `UNAVAILABLE(tool_launch_metadata_absent)` and did not produce PASS/CLEAN:
  - `01KV5BJ9VRZMHXBHH9T18TR0E1` for `90f4dbad`
  - `01KV5DVGK0RWF1VDXJPD31TM01` for `e3c7d2f1`
- Evidence posted to #2245 and #2234.
- Same-SHA native exact-head fallback review for `e3c7d2f1a9248284202e86aa1b96fb06d4cf7508` returned `PASS/CLEAN`.
