### PR TITLE
fix(review): recover daemon review verdicts before fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1016"
+version = "0.1.1017"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1016"
+version = "0.1.1017"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -110,6 +110,13 @@ use reviewers::resolve_effective_reviewer_selection_for_args;
 #[rustfmt::skip]
 pub(crate) use { fix::persist_fix_final_artifacts_for_tests, output::persist_review_verdict_for_tests };
 
+pub(crate) fn compute_review_diff_fingerprint(
+    project_root: &std::path::Path,
+    scope: &str,
+) -> Option<String> {
+    compute_diff_fingerprint(project_root, scope)
+}
+
 pub(crate) fn validate_session_fix_before_daemon(args: &ReviewArgs) -> Result<()> {
     session_fix::validate_session_fix_before_daemon(args)?;
     fix_finding::validate_fix_finding_before_daemon(args)

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -101,8 +101,7 @@ use resolve::{
     ReviewProjectPromptOptions, build_review_instruction_for_project, derive_scope_for_project,
     resolve_review_effective_tier, resolve_review_model, resolve_review_readonly_configured,
     resolve_review_readonly_project_root, resolve_review_stream_mode, resolve_review_thinking,
-    resolve_review_tier_name, review_scope_allows_auto_discovery,
-    validate_review_direct_tool_tier_restriction, verify_review_skill_available,
+    resolve_review_tier_name, review_scope_allows_auto_discovery, verify_review_skill_available,
 };
 use result_handling::resolve_single_review_result;
 #[rustfmt::skip]
@@ -149,13 +148,12 @@ pub(crate) async fn handle_review(
         effective_tier.as_deref(),
         &project_root,
     )?;
-    validate_review_direct_tool_tier_restriction(
-        selection.direct_tool_requested,
+    prior_rounds::validate_direct_tool_gate(
+        &args,
+        &project_root,
         config.as_ref(),
         effective_tier.as_deref(),
-        args.force_override_user_config,
-        args.force_ignore_tier_setting,
-        args.model_spec.is_some(),
+        selection.direct_tool_requested,
     )?;
     let pre_session_hook = csa_hooks::load_global_pre_session_hook_invocation();
     let review_pattern = verify_review_skill_available(&project_root, args.allow_fallback)?;

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
@@ -640,5 +640,9 @@ fn zero_severity_counts() -> BTreeMap<Severity, u32> {
 }
 
 #[cfg(test)]
+#[path = "review_cmd_check_verdict_daemon_completion_tests.rs"]
+mod daemon_completion_tests;
+
+#[cfg(test)]
 #[path = "review_cmd_check_verdict_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_daemon_completion_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_daemon_completion_tests.rs
@@ -1,0 +1,73 @@
+use super::*;
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+use csa_core::types::ReviewDecision;
+use csa_core::vcs::{VcsIdentity, VcsKind};
+use tempfile::TempDir;
+
+#[test]
+fn daemon_completion_before_result_preserves_exact_head_review_availability() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let temp = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", temp.path().join("state"));
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    let mut session = csa_session::create_session_fresh(
+        &project,
+        Some("review: range:main...HEAD"),
+        None,
+        Some("codex"),
+    )
+    .expect("create daemon review session");
+    session.branch = Some("feature".to_string());
+    session.git_head_at_creation = Some("abcdef1234567890".to_string());
+    session.vcs_identity = Some(VcsIdentity {
+        vcs_kind: VcsKind::Git,
+        commit_id: Some("abcdef1234567890".to_string()),
+        change_id: None,
+        short_id: Some("abcdef123456".to_string()),
+        ref_name: Some("feature".to_string()),
+        op_id: None,
+    });
+    session.task_context = csa_session::TaskContext {
+        task_type: Some("review".to_string()),
+        tier_name: None,
+    };
+    csa_session::save_session(&session).expect("save daemon review session state");
+    let session_id = session.meta_session_id.clone();
+    let session_dir = csa_session::get_session_dir(&project, &session_id).unwrap();
+    csa_session::write_review_verdict(
+        &session_dir,
+        &ReviewVerdictArtifact::from_parts(
+            session_id.clone(),
+            ReviewDecision::Pass,
+            "CLEAN",
+            &[],
+            Vec::new(),
+        ),
+    )
+    .expect("write review verdict before result.toml");
+
+    let _daemon_id = ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_ID", &session_id);
+    let _daemon_dir = ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_DIR", &session_dir);
+    let _daemon_project = ScopedEnvVarRestore::set("CSA_DAEMON_PROJECT_ROOT", &project);
+    crate::session_cmds_daemon::persist_daemon_completion_from_env(1);
+
+    let found = check_review_verdict_for_target(
+        &project,
+        "feature",
+        "abcdef1234567890",
+        REQUIRED_FULL_DIFF_SCOPE,
+        None,
+        None,
+    )
+    .unwrap()
+    .expect("existing review verdict should remain available for exact-head gates");
+    assert_eq!(found.session_id, session_id);
+
+    let result = csa_session::load_result(&project, &session_id)
+        .unwrap()
+        .expect("daemon completion should publish a result from review artifacts");
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+}

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_daemon_completion_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_daemon_completion_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+use chrono::{TimeZone, Utc};
 use csa_core::types::ReviewDecision;
 use csa_core::vcs::{VcsIdentity, VcsKind};
 use std::path::Path;
@@ -43,6 +44,10 @@ fn setup_git_repo_with_feature_diff(project: &Path) -> (String, String) {
     let head_sha = run_git(project, &["rev-parse", "HEAD"]);
     assert_eq!(branch, "feature");
     (branch, head_sha)
+}
+
+fn timestamp(seconds: i64) -> chrono::DateTime<Utc> {
+    Utc.timestamp_opt(seconds, 0).single().unwrap()
 }
 
 #[test]
@@ -128,4 +133,140 @@ fn daemon_completion_before_result_preserves_exact_head_review_availability_for_
         .expect("daemon completion should publish a result from review artifacts");
     assert_eq!(result.status, "success");
     assert_eq!(result.exit_code, 0);
+}
+
+#[test]
+fn recovered_artifact_only_pass_keeps_original_timestamp_so_newer_fail_blocks_gate() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let temp = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", temp.path().join("state"));
+    let project = temp.path().join("project");
+    let (branch, head_sha) = setup_git_repo_with_feature_diff(&project);
+    let expected_diff_fingerprint =
+        crate::review_cmd::compute_review_diff_fingerprint(&project, REQUIRED_FULL_DIFF_SCOPE)
+            .expect("feature branch should have a non-empty main...HEAD diff");
+
+    let mut older_pass_session = csa_session::create_session_fresh(
+        &project,
+        Some("review: range:main...HEAD"),
+        None,
+        Some("codex"),
+    )
+    .expect("create artifact-only daemon review session");
+    older_pass_session.branch = Some(branch.clone());
+    older_pass_session.git_head_at_creation = Some(head_sha.clone());
+    older_pass_session.vcs_identity = Some(VcsIdentity {
+        vcs_kind: VcsKind::Git,
+        commit_id: Some(head_sha.clone()),
+        change_id: None,
+        short_id: Some(head_sha.chars().take(12).collect()),
+        ref_name: Some(branch.clone()),
+        op_id: None,
+    });
+    older_pass_session.task_context = csa_session::TaskContext {
+        task_type: Some("review".to_string()),
+        tier_name: None,
+    };
+    csa_session::save_session(&older_pass_session).expect("save artifact-only session state");
+    let older_pass_id = older_pass_session.meta_session_id.clone();
+    let older_pass_dir = csa_session::get_session_dir(&project, &older_pass_id).unwrap();
+    let older_pass_time = timestamp(1_000);
+    let mut older_pass_verdict = ReviewVerdictArtifact::from_parts(
+        older_pass_id.clone(),
+        ReviewDecision::Pass,
+        "CLEAN",
+        &[],
+        Vec::new(),
+    );
+    older_pass_verdict.timestamp = older_pass_time;
+    csa_session::write_review_verdict(&older_pass_dir, &older_pass_verdict)
+        .expect("write artifact-only pass verdict");
+    assert!(
+        !older_pass_dir.join("review_meta.json").exists(),
+        "regression setup should start with an artifact-only PASS"
+    );
+
+    let mut newer_fail_session = csa_session::create_session_fresh(
+        &project,
+        Some("review: range:main...HEAD"),
+        None,
+        Some("codex"),
+    )
+    .expect("create newer failing review session");
+    newer_fail_session.branch = Some(branch.clone());
+    newer_fail_session.git_head_at_creation = Some(head_sha.clone());
+    newer_fail_session.vcs_identity = Some(VcsIdentity {
+        vcs_kind: VcsKind::Git,
+        commit_id: Some(head_sha.clone()),
+        change_id: None,
+        short_id: Some(head_sha.chars().take(12).collect()),
+        ref_name: Some(branch.clone()),
+        op_id: None,
+    });
+    csa_session::save_session(&newer_fail_session).expect("save newer failing session state");
+    let newer_fail_id = newer_fail_session.meta_session_id.clone();
+    let newer_fail_dir = csa_session::get_session_dir(&project, &newer_fail_id).unwrap();
+    let newer_fail_time = timestamp(2_000);
+    let newer_fail_meta = ReviewSessionMeta {
+        session_id: newer_fail_id.clone(),
+        head_sha: head_sha.clone(),
+        decision: ReviewDecision::Fail.as_str().to_string(),
+        verdict: "HAS_ISSUES".to_string(),
+        review_mode: None,
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool: "codex".to_string(),
+        scope: REQUIRED_FULL_DIFF_SCOPE.to_string(),
+        exit_code: 1,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: newer_fail_time,
+        diff_fingerprint: Some(expected_diff_fingerprint.clone()),
+        fix_convergence: None,
+    };
+    csa_session::state::write_review_meta(&newer_fail_dir, &newer_fail_meta)
+        .expect("write newer failing review meta");
+    let mut newer_fail_verdict = ReviewVerdictArtifact::from_parts(
+        newer_fail_id,
+        ReviewDecision::Fail,
+        "HAS_ISSUES",
+        &[],
+        Vec::new(),
+    );
+    newer_fail_verdict.timestamp = newer_fail_time;
+    csa_session::write_review_verdict(&newer_fail_dir, &newer_fail_verdict)
+        .expect("write newer failing review verdict");
+
+    let _daemon_id = ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_ID", &older_pass_id);
+    let _daemon_dir = ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_DIR", &older_pass_dir);
+    let _daemon_project = ScopedEnvVarRestore::set("CSA_DAEMON_PROJECT_ROOT", &project);
+    crate::session_cmds_daemon::persist_daemon_completion_from_env(1);
+
+    let recovered_meta: ReviewSessionMeta = serde_json::from_str(
+        &std::fs::read_to_string(older_pass_dir.join("review_meta.json"))
+            .expect("daemon completion should recover older PASS review_meta.json"),
+    )
+    .expect("recovered older PASS review_meta.json should parse");
+    assert_eq!(recovered_meta.timestamp, older_pass_time);
+    assert_eq!(
+        recovered_meta.diff_fingerprint.as_deref(),
+        Some(expected_diff_fingerprint.as_str())
+    );
+
+    let found = check_review_verdict_for_target(
+        &project,
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        Some(expected_diff_fingerprint.as_str()),
+        None,
+    )
+    .unwrap();
+    assert!(
+        found.is_none(),
+        "a recovered older PASS must not outrank a newer FAIL for the same branch/head/scope/diff"
+    );
 }

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_daemon_completion_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_daemon_completion_tests.rs
@@ -2,15 +2,59 @@ use super::*;
 use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use csa_core::types::ReviewDecision;
 use csa_core::vcs::{VcsIdentity, VcsKind};
+use std::path::Path;
+use std::process::Command;
 use tempfile::TempDir;
 
+fn run_git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn setup_git_repo_with_feature_diff(project: &Path) -> (String, String) {
+    std::fs::create_dir_all(project).expect("create project dir");
+    run_git(project, &["init"]);
+    run_git(project, &["config", "user.email", "test@example.com"]);
+    run_git(project, &["config", "user.name", "Test User"]);
+
+    std::fs::write(project.join("tracked.txt"), "baseline\n").expect("write baseline");
+    run_git(project, &["add", "tracked.txt"]);
+    run_git(project, &["commit", "-m", "initial"]);
+    run_git(project, &["branch", "-M", "main"]);
+
+    run_git(project, &["checkout", "-b", "feature"]);
+    std::fs::write(project.join("tracked.txt"), "baseline\nfeature change\n")
+        .expect("write feature change");
+    run_git(project, &["add", "tracked.txt"]);
+    run_git(project, &["commit", "-m", "feature change"]);
+
+    let branch = run_git(project, &["branch", "--show-current"]);
+    let head_sha = run_git(project, &["rev-parse", "HEAD"]);
+    assert_eq!(branch, "feature");
+    (branch, head_sha)
+}
+
 #[test]
-fn daemon_completion_before_result_preserves_exact_head_review_availability() {
+fn daemon_completion_before_result_preserves_exact_head_review_availability_for_non_empty_diff() {
     let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
     let temp = TempDir::new().unwrap();
     let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", temp.path().join("state"));
     let project = temp.path().join("project");
-    std::fs::create_dir_all(&project).unwrap();
+    let (branch, head_sha) = setup_git_repo_with_feature_diff(&project);
+    let expected_diff_fingerprint =
+        crate::review_cmd::compute_review_diff_fingerprint(&project, REQUIRED_FULL_DIFF_SCOPE)
+            .expect("feature branch should have a non-empty main...HEAD diff");
 
     let mut session = csa_session::create_session_fresh(
         &project,
@@ -19,14 +63,14 @@ fn daemon_completion_before_result_preserves_exact_head_review_availability() {
         Some("codex"),
     )
     .expect("create daemon review session");
-    session.branch = Some("feature".to_string());
-    session.git_head_at_creation = Some("abcdef1234567890".to_string());
+    session.branch = Some(branch.clone());
+    session.git_head_at_creation = Some(head_sha.clone());
     session.vcs_identity = Some(VcsIdentity {
         vcs_kind: VcsKind::Git,
-        commit_id: Some("abcdef1234567890".to_string()),
+        commit_id: Some(head_sha.clone()),
         change_id: None,
-        short_id: Some("abcdef123456".to_string()),
-        ref_name: Some("feature".to_string()),
+        short_id: Some(head_sha.chars().take(12).collect()),
+        ref_name: Some(branch.clone()),
         op_id: None,
     });
     session.task_context = csa_session::TaskContext {
@@ -36,6 +80,10 @@ fn daemon_completion_before_result_preserves_exact_head_review_availability() {
     csa_session::save_session(&session).expect("save daemon review session state");
     let session_id = session.meta_session_id.clone();
     let session_dir = csa_session::get_session_dir(&project, &session_id).unwrap();
+    assert!(
+        !session_dir.join("review_meta.json").exists(),
+        "regression setup should recover from artifact-only verdict state"
+    );
     csa_session::write_review_verdict(
         &session_dir,
         &ReviewVerdictArtifact::from_parts(
@@ -55,15 +103,25 @@ fn daemon_completion_before_result_preserves_exact_head_review_availability() {
 
     let found = check_review_verdict_for_target(
         &project,
-        "feature",
-        "abcdef1234567890",
+        &branch,
+        &head_sha,
         REQUIRED_FULL_DIFF_SCOPE,
-        None,
+        Some(expected_diff_fingerprint.as_str()),
         None,
     )
     .unwrap()
     .expect("existing review verdict should remain available for exact-head gates");
     assert_eq!(found.session_id, session_id);
+
+    let recovered_meta: ReviewSessionMeta = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("review_meta.json"))
+            .expect("daemon completion should recover review_meta.json"),
+    )
+    .expect("recovered review_meta.json should parse");
+    assert_eq!(
+        recovered_meta.diff_fingerprint.as_deref(),
+        Some(expected_diff_fingerprint.as_str())
+    );
 
     let result = csa_session::load_result(&project, &session_id)
         .unwrap()

--- a/crates/cli-sub-agent/src/review_cmd_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prior_rounds.rs
@@ -1,5 +1,9 @@
 use crate::cli::ReviewArgs;
 use anyhow::Result;
+use csa_config::ProjectConfig;
+use csa_core::types::ReviewDecision;
+use csa_session::{ReviewSessionMeta, ReviewVerdictArtifact, SessionArtifact};
+use tracing::warn;
 
 pub(super) fn load_prior_rounds_section_or_persist_error(
     args: &ReviewArgs,
@@ -57,4 +61,157 @@ pub(super) fn persist_tier_bypass_pre_exec_error(
         tier_name: effective_tier,
         error: err,
     })
+}
+
+pub(super) fn validate_direct_tool_gate(
+    args: &ReviewArgs,
+    project_root: &std::path::Path,
+    project_config: Option<&ProjectConfig>,
+    effective_tier: Option<&str>,
+    direct_tool_requested: bool,
+) -> Result<()> {
+    super::resolve::validate_review_direct_tool_tier_restriction(
+        direct_tool_requested,
+        project_config,
+        effective_tier,
+        args.force_override_user_config,
+        args.force_ignore_tier_setting,
+        args.model_spec.is_some(),
+    )
+    .map_err(|err| persist_daemon_review_pre_exec_error(args, project_root, effective_tier, err))
+}
+
+pub(super) fn persist_daemon_review_pre_exec_error(
+    args: &ReviewArgs,
+    project_root: &std::path::Path,
+    effective_tier: Option<&str>,
+    err: anyhow::Error,
+) -> anyhow::Error {
+    let Some(session_id) = args.session_id.as_deref() else {
+        // Foreground review validation failures intentionally remain ordinary
+        // CLI errors: there is no daemon placeholder session to complete.
+        return err;
+    };
+    let error_message = err.to_string();
+    let primary_failure = primary_failure_for_pre_exec_error(&error_message);
+    let tool_name = explicit_review_tool(args)
+        .map(|tool| tool.as_str().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let err = crate::session_guard::persist_pre_exec_error_result(
+        crate::session_guard::PreExecErrorCtx {
+            project_root,
+            session_id: Some(session_id),
+            description: Some("review"),
+            parent: None,
+            tool_name: Some(tool_name.as_str()),
+            task_type: Some("review"),
+            tier_name: effective_tier,
+            error: err,
+        },
+    );
+    persist_review_pre_exec_unavailable_sidecars(
+        args,
+        project_root,
+        session_id,
+        tool_name.as_str(),
+        primary_failure,
+        &error_message,
+    );
+    err
+}
+
+fn primary_failure_for_pre_exec_error(error_message: &str) -> &'static str {
+    if error_message.contains("Direct --tool is restricted when tiers are configured") {
+        "direct_tool_tier_restricted"
+    } else {
+        "review_pre_exec_error"
+    }
+}
+
+fn persist_review_pre_exec_unavailable_sidecars(
+    args: &ReviewArgs,
+    project_root: &std::path::Path,
+    session_id: &str,
+    tool_name: &str,
+    primary_failure: &str,
+    error_message: &str,
+) {
+    let Ok(session_dir) = csa_session::get_session_dir(project_root, session_id) else {
+        warn!(
+            session_id,
+            "Failed to resolve daemon review session dir for pre-exec sidecars"
+        );
+        return;
+    };
+    let failure_reason = format!("pre-exec: {error_message}");
+    let meta = ReviewSessionMeta {
+        session_id: session_id.to_string(),
+        head_sha: csa_session::detect_git_head(project_root).unwrap_or_default(),
+        decision: ReviewDecision::Unavailable.as_str().to_string(),
+        verdict: crate::review_consensus::UNAVAILABLE.to_string(),
+        review_mode: Some(args.effective_review_mode().as_str().to_string()),
+        status_reason: Some(primary_failure.to_string()),
+        routed_to: None,
+        primary_failure: Some(primary_failure.to_string()),
+        failure_reason: Some(failure_reason.clone()),
+        tool: tool_name.to_string(),
+        scope: super::resolve::derive_scope_for_project(args, project_root),
+        exit_code: crate::verdict_exit_code::exit_code_from_review_decision(
+            ReviewDecision::Unavailable,
+        ),
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+        fix_convergence: None,
+    };
+    if let Err(err) = csa_session::write_review_meta(&session_dir, &meta) {
+        warn!(session_id, error = %err, "Failed to write pre-exec review_meta.json");
+    }
+    let mut artifact = ReviewVerdictArtifact::from_parts(
+        session_id.to_string(),
+        ReviewDecision::Unavailable,
+        crate::review_consensus::UNAVAILABLE,
+        &[],
+        Vec::new(),
+    );
+    artifact.primary_failure = meta.primary_failure.clone();
+    artifact.failure_reason = meta.failure_reason.clone();
+    artifact.review_mode = meta.review_mode.clone();
+    match csa_session::write_review_verdict(&session_dir, &artifact) {
+        Ok(()) => append_review_verdict_artifact_to_pre_exec_result(project_root, session_id),
+        Err(err) => warn!(
+            session_id,
+            error = %err,
+            "Failed to write pre-exec output/review-verdict.json"
+        ),
+    }
+}
+
+fn append_review_verdict_artifact_to_pre_exec_result(
+    project_root: &std::path::Path,
+    session_id: &str,
+) {
+    let Ok(Some(mut result)) = csa_session::load_result(project_root, session_id) else {
+        return;
+    };
+    const REVIEW_VERDICT_ARTIFACT: &str = "output/review-verdict.json";
+    if !result
+        .artifacts
+        .iter()
+        .any(|artifact| artifact.path == REVIEW_VERDICT_ARTIFACT)
+    {
+        result
+            .artifacts
+            .push(SessionArtifact::new(REVIEW_VERDICT_ARTIFACT));
+        if let Err(err) = csa_session::save_result(project_root, session_id, &result) {
+            warn!(
+                session_id,
+                error = %err,
+                "Failed to attach review verdict artifact to pre-exec result"
+            );
+        }
+    }
 }

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -761,6 +761,8 @@ fn has_structured_review_content_requires_non_empty_sections() {
 mod bug_class_tests;
 #[path = "review_cmd_tests_cli_flags.rs"]
 mod cli_flags_tests;
+#[path = "review_cmd_tests_daemon_pre_exec.rs"]
+mod daemon_pre_exec_tests;
 #[path = "review_cmd_tests_explicit_tool_tier_fallback.rs"]
 mod explicit_tool_tier_fallback_tests;
 #[path = "review_cmd_tests/model_spec_tests.rs"]

--- a/crates/cli-sub-agent/src/review_cmd_tests_daemon_pre_exec.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_daemon_pre_exec.rs
@@ -1,0 +1,124 @@
+use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use std::path::Path;
+
+fn write_review_project_config(project_root: &Path, config: &ProjectConfig) {
+    let config_path = ProjectConfig::config_path(project_root);
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(config_path, toml::to_string_pretty(config).unwrap()).unwrap();
+}
+
+fn install_pattern(project_root: &Path, name: &str) {
+    let skill_dir = project_root
+        .join(".csa")
+        .join("patterns")
+        .join(name)
+        .join("skills")
+        .join(name);
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(skill_dir.join("SKILL.md"), "# test pattern\n").unwrap();
+}
+
+#[tokio::test]
+async fn daemon_direct_tool_tier_rejection_persists_pre_exec_result_before_completion() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    config.tiers.insert(
+        "default".to_string(),
+        csa_config::config::TierConfig {
+            description: "Test tier".to_string(),
+            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            strategy: csa_config::TierStrategy::default(),
+            token_budget: None,
+            max_turns: None,
+        },
+    );
+    write_review_project_config(project_dir.path(), &config);
+    install_pattern(project_dir.path(), "csa-review");
+
+    let daemon_session = csa_session::create_session_fresh(
+        project_dir.path(),
+        Some("initializing daemon review"),
+        None,
+        None,
+    )
+    .unwrap();
+    let session_id = daemon_session.meta_session_id.clone();
+    let session_dir = csa_session::get_session_dir(project_dir.path(), &session_id).unwrap();
+    let _daemon_id = ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_ID", &session_id);
+    let _daemon_dir = ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_DIR", &session_dir);
+    let _daemon_project = ScopedEnvVarRestore::set("CSA_DAEMON_PROJECT_ROOT", project_dir.path());
+
+    let cd = project_dir.path().display().to_string();
+    let args = parse_review_args(&[
+        "csa",
+        "review",
+        "--cd",
+        &cd,
+        "--files",
+        "src/lib.rs",
+        "--tool",
+        "codex",
+        "--daemon-child",
+        "--session-id",
+        &session_id,
+    ]);
+
+    let err = handle_review(args, 0, &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV)
+        .await
+        .expect_err("direct --tool tier rejection must fail");
+    assert!(
+        err.chain().any(|cause| cause
+            .to_string()
+            .contains("restricted when tiers are configured")),
+        "unexpected error chain: {err:#}"
+    );
+
+    let result = csa_session::load_result(project_dir.path(), &session_id)
+        .unwrap()
+        .expect("daemon review pre-exec failure should write result.toml before completion");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.tool, "codex");
+    assert!(result.summary.contains("Direct --tool is restricted"));
+    assert!(!result.summary.contains("tool launch metadata"));
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == "output/review-verdict.json"),
+        "pre-exec review result should advertise the unavailable review verdict artifact"
+    );
+
+    let meta: ReviewSessionMeta = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("review_meta.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(meta.tool, "codex");
+    assert_eq!(meta.decision, ReviewDecision::Unavailable.as_str());
+    assert_eq!(
+        meta.primary_failure.as_deref(),
+        Some("direct_tool_tier_restricted")
+    );
+    let artifact: csa_session::ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(artifact.decision, ReviewDecision::Unavailable);
+    assert_eq!(
+        artifact.primary_failure.as_deref(),
+        Some("direct_tool_tier_restricted")
+    );
+
+    crate::session_cmds_daemon::persist_daemon_completion_from_env(1);
+    let result_after_completion = csa_session::load_result(project_dir.path(), &session_id)
+        .unwrap()
+        .expect("daemon completion must preserve pre-exec result");
+    assert_eq!(result_after_completion.summary, result.summary);
+    assert!(
+        !result_after_completion
+            .summary
+            .contains("tool_launch_metadata_absent")
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -613,8 +613,14 @@ pub(crate) fn handle_session_kill(session: String, cd: Option<String>) -> Result
 #[path = "session_cmds_daemon_attach_proptest.rs"]
 mod session_cmds_daemon_attach_proptest;
 #[cfg(test)]
+#[path = "session_cmds_daemon_kill_tests.rs"]
+mod session_cmds_daemon_kill_tests;
+#[cfg(test)]
 #[path = "session_cmds_daemon_routing_proptest.rs"]
 mod session_cmds_daemon_routing_proptest;
+#[cfg(test)]
+#[path = "session_cmds_daemon_test_support.rs"]
+mod session_cmds_daemon_test_support;
 #[cfg(test)]
 #[path = "session_cmds_daemon_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
@@ -197,6 +197,16 @@ pub(crate) fn daemon_completion_result(
     packet: &DaemonCompletionPacket,
     completed_at: chrono::DateTime<chrono::Utc>,
 ) -> SessionResult {
+    if let Some(result) = super::review_diagnostic::review_result_from_existing_artifacts(
+        project_root,
+        session_dir,
+        session,
+        packet,
+        completed_at,
+    ) {
+        return result;
+    }
+
     let tool_name = session
         .tools
         .iter()

--- a/crates/cli-sub-agent/src/session_cmds_daemon_kill_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_kill_tests.rs
@@ -1,0 +1,64 @@
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use super::session_cmds_daemon_test_support::spawn_daemon_like_process;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use super::*;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn handle_session_kill_accepts_legacy_stderr_pid() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = ScopedEnvVarRestore::set("HOME", td.path());
+    let _state_guard = ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session =
+        csa_session::create_session(project, Some("kill-legacy-stderr"), None, Some("opencode"))
+            .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = csa_session::get_session_dir(project, &session_id).expect("session dir");
+
+    let mut child = spawn_daemon_like_process(&session_id);
+    let child_pid = child.id();
+    std::fs::write(
+        session_dir.join("stderr.log"),
+        format!(
+            "<!-- CSA:SESSION_STARTED id={} pid={} dir=\"{}\" wait_cmd=\"\" attach_cmd=\"\" -->\n",
+            session_id,
+            child_pid,
+            session_dir.display()
+        ),
+    )
+    .expect("write legacy stderr pid");
+
+    let daemon_visible = (0..20).any(|_| {
+        if csa_process::ToolLiveness::daemon_pid_for_signal(&session_dir) == Some(child_pid) {
+            true
+        } else {
+            std::thread::sleep(std::time::Duration::from_millis(25));
+            false
+        }
+    });
+    assert!(
+        daemon_visible,
+        "legacy stderr PID fixture must be recognized as a live session process before kill"
+    );
+
+    let reaper = std::thread::spawn(move || child.wait().expect("wait child"));
+
+    handle_session_kill(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+    )
+    .expect("legacy kill should succeed");
+
+    let status = reaper.join().expect("reaper join");
+    assert!(
+        !status.success(),
+        "legacy daemon process should be terminated by session kill"
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
@@ -44,7 +44,8 @@ pub(crate) fn review_result_from_existing_artifacts(
     }
 
     let verdict = recoverable_review_verdict(session_dir)?;
-    let meta = recover_or_persist_review_meta_from_verdict(session_dir, session, &verdict)?;
+    let meta =
+        recover_or_persist_review_meta_from_verdict(project_root, session_dir, session, &verdict)?;
     let exit_code = crate::verdict_exit_code::exit_code_from_review_decision(verdict.decision);
     let mut artifacts = crate::pipeline_post_exec::collect_fallback_result_artifacts(
         project_root,
@@ -279,19 +280,48 @@ fn is_review_no_result_verdict(verdict: &csa_session::ReviewVerdictArtifact) -> 
 }
 
 fn recover_or_persist_review_meta_from_verdict(
+    project_root: &Path,
     session_dir: &Path,
     session: &MetaSessionState,
     verdict: &csa_session::ReviewVerdictArtifact,
 ) -> Option<csa_session::ReviewSessionMeta> {
     let existing_meta = read_review_meta(session_dir);
-    if existing_meta.as_ref().is_some_and(|meta| {
-        !is_review_no_result_meta(meta) && review_meta_matches_verdict(meta, verdict)
-    }) {
-        return existing_meta;
+    if let Some(meta) = existing_meta.as_ref()
+        && !is_review_no_result_meta(meta)
+        && review_meta_matches_verdict(meta, verdict)
+    {
+        let Some(diff_fingerprint) = meta.diff_fingerprint.clone().or_else(|| {
+            crate::review_cmd::compute_review_diff_fingerprint(project_root, &meta.scope)
+        }) else {
+            return existing_meta;
+        };
+        if meta.diff_fingerprint.as_deref() == Some(diff_fingerprint.as_str()) {
+            return existing_meta;
+        }
+
+        let mut recovered_meta = meta.clone();
+        recovered_meta.diff_fingerprint = Some(diff_fingerprint);
+        persist_recovered_review_meta(session_dir, session, &recovered_meta);
+        return Some(recovered_meta);
     }
 
-    let meta = review_meta_from_verdict(session_dir, session, verdict, existing_meta.as_ref());
-    if let Err(err) = csa_session::write_review_meta(session_dir, &meta) {
+    let meta = review_meta_from_verdict(
+        project_root,
+        session_dir,
+        session,
+        verdict,
+        existing_meta.as_ref(),
+    );
+    persist_recovered_review_meta(session_dir, session, &meta);
+    Some(meta)
+}
+
+fn persist_recovered_review_meta(
+    session_dir: &Path,
+    session: &MetaSessionState,
+    meta: &csa_session::ReviewSessionMeta,
+) {
+    if let Err(err) = csa_session::write_review_meta(session_dir, meta) {
         warn!(
             session_id = %session.meta_session_id,
             path = %session_dir.join("review_meta.json").display(),
@@ -299,7 +329,6 @@ fn recover_or_persist_review_meta_from_verdict(
             "Failed to persist recovered review metadata from existing review verdict artifact; using in-memory metadata"
         );
     }
-    Some(meta)
 }
 
 fn review_meta_matches_verdict(
@@ -313,6 +342,7 @@ fn review_meta_matches_verdict(
 }
 
 fn review_meta_from_verdict(
+    project_root: &Path,
     session_dir: &Path,
     session: &MetaSessionState,
     verdict: &csa_session::ReviewVerdictArtifact,
@@ -320,6 +350,13 @@ fn review_meta_from_verdict(
 ) -> csa_session::ReviewSessionMeta {
     let decision = verdict.decision;
     let fallback_tool = review_no_result_tool(session_dir, session);
+    let scope = previous_meta
+        .map(|meta| meta.scope.clone())
+        .filter(|scope| !scope.trim().is_empty())
+        .unwrap_or_else(|| canonical_review_scope(session));
+    let diff_fingerprint = previous_meta
+        .and_then(|meta| meta.diff_fingerprint.clone())
+        .or_else(|| crate::review_cmd::compute_review_diff_fingerprint(project_root, &scope));
     csa_session::ReviewSessionMeta {
         session_id: session.meta_session_id.clone(),
         head_sha: previous_meta
@@ -341,16 +378,13 @@ fn review_meta_from_verdict(
             .map(|meta| meta.tool.clone())
             .filter(|tool| !tool.trim().is_empty() && tool != "unknown")
             .unwrap_or(fallback_tool),
-        scope: previous_meta
-            .map(|meta| meta.scope.clone())
-            .filter(|scope| !scope.trim().is_empty())
-            .unwrap_or_else(|| canonical_review_scope(session)),
+        scope,
         exit_code: crate::verdict_exit_code::exit_code_from_review_decision(decision),
         fix_attempted: previous_meta.is_some_and(|meta| meta.fix_attempted),
         fix_rounds: previous_meta.map_or(0, |meta| meta.fix_rounds),
         review_iterations: previous_meta.map_or(1, |meta| meta.review_iterations),
         timestamp: Utc::now(),
-        diff_fingerprint: previous_meta.and_then(|meta| meta.diff_fingerprint.clone()),
+        diff_fingerprint,
         fix_convergence: previous_meta.and_then(|meta| meta.fix_convergence.clone()),
     }
 }

--- a/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
@@ -45,7 +45,7 @@ pub(crate) fn review_result_from_existing_artifacts(
 
     let verdict = recoverable_review_verdict(session_dir)?;
     let meta = recover_or_persist_review_meta_from_verdict(session_dir, session, &verdict)?;
-    let exit_code = meta.exit_code;
+    let exit_code = crate::verdict_exit_code::exit_code_from_review_decision(verdict.decision);
     let mut artifacts = crate::pipeline_post_exec::collect_fallback_result_artifacts(
         project_root,
         &session.meta_session_id,
@@ -284,9 +284,10 @@ fn recover_or_persist_review_meta_from_verdict(
     verdict: &csa_session::ReviewVerdictArtifact,
 ) -> Option<csa_session::ReviewSessionMeta> {
     let existing_meta = read_review_meta(session_dir);
-    match existing_meta.as_ref() {
-        Some(meta) if !is_review_no_result_meta(meta) => return Some(meta.clone()),
-        _ => {}
+    if existing_meta.as_ref().is_some_and(|meta| {
+        !is_review_no_result_meta(meta) && review_meta_matches_verdict(meta, verdict)
+    }) {
+        return existing_meta;
     }
 
     let meta = review_meta_from_verdict(session_dir, session, verdict, existing_meta.as_ref());
@@ -295,11 +296,20 @@ fn recover_or_persist_review_meta_from_verdict(
             session_id = %session.meta_session_id,
             path = %session_dir.join("review_meta.json").display(),
             error = %err,
-            "Failed to recover review metadata from existing review verdict artifact"
+            "Failed to persist recovered review metadata from existing review verdict artifact; using in-memory metadata"
         );
-        return None;
     }
     Some(meta)
+}
+
+fn review_meta_matches_verdict(
+    meta: &csa_session::ReviewSessionMeta,
+    verdict: &csa_session::ReviewVerdictArtifact,
+) -> bool {
+    meta.decision == verdict.decision.as_str()
+        && meta.verdict == verdict.verdict_legacy
+        && meta.exit_code
+            == crate::verdict_exit_code::exit_code_from_review_decision(verdict.decision)
 }
 
 fn review_meta_from_verdict(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
@@ -383,10 +383,24 @@ fn review_meta_from_verdict(
         fix_attempted: previous_meta.is_some_and(|meta| meta.fix_attempted),
         fix_rounds: previous_meta.map_or(0, |meta| meta.fix_rounds),
         review_iterations: previous_meta.map_or(1, |meta| meta.review_iterations),
-        timestamp: Utc::now(),
+        timestamp: recovered_review_timestamp(verdict, previous_meta),
         diff_fingerprint,
         fix_convergence: previous_meta.and_then(|meta| meta.fix_convergence.clone()),
     }
+}
+
+fn recovered_review_timestamp(
+    verdict: &csa_session::ReviewVerdictArtifact,
+    previous_meta: Option<&csa_session::ReviewSessionMeta>,
+) -> DateTime<Utc> {
+    // Artifact-only recovery may run long after the review completed. Using recovery time here
+    // can make an older recovered PASS outrank a newer FAIL in `review --check-verdict`.
+    // Preserve a real existing metadata timestamp when correcting stale/mismatched metadata;
+    // synthetic no-result metadata is not a review timestamp, so fall back to the verdict time.
+    previous_meta
+        .filter(|meta| !is_review_no_result_meta(meta))
+        .map(|meta| meta.timestamp)
+        .unwrap_or(verdict.timestamp)
 }
 
 fn review_artifact_result_summary(meta: &csa_session::ReviewSessionMeta) -> String {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_review_diagnostic.rs
@@ -1,14 +1,16 @@
 use std::io::ErrorKind;
 use std::path::Path;
 
+use chrono::{DateTime, Utc};
 use csa_core::types::ReviewDecision;
-use csa_session::{MetaSessionState, SessionArtifact};
+use csa_session::{MetaSessionState, SessionArtifact, SessionResult};
 use tracing::warn;
 
 use super::completion::DaemonCompletionPacket;
 
 const REVIEW_DAEMON_NO_RESULT_REASON: &str = "daemon_completion_before_result";
 const REVIEW_VERDICT_ARTIFACT_PATH: &str = "output/review-verdict.json";
+const REVIEW_DAEMON_TOOL_LAUNCH_METADATA_ABSENT: &str = "tool_launch_metadata_absent";
 
 pub(crate) fn has_review_no_result_diagnostic(session: &MetaSessionState) -> bool {
     is_review_daemon_session(session)
@@ -30,6 +32,50 @@ pub(crate) fn append_review_no_result_diagnostic_artifacts(
     artifacts.push(SessionArtifact::new(REVIEW_VERDICT_ARTIFACT_PATH));
 }
 
+pub(crate) fn review_result_from_existing_artifacts(
+    project_root: &Path,
+    session_dir: &Path,
+    session: &MetaSessionState,
+    packet: &DaemonCompletionPacket,
+    completed_at: DateTime<Utc>,
+) -> Option<SessionResult> {
+    if !is_review_daemon_session(session) {
+        return None;
+    }
+
+    let verdict = recoverable_review_verdict(session_dir)?;
+    let meta = recover_or_persist_review_meta_from_verdict(session_dir, session, &verdict)?;
+    let exit_code = meta.exit_code;
+    let mut artifacts = crate::pipeline_post_exec::collect_fallback_result_artifacts(
+        project_root,
+        &session.meta_session_id,
+    );
+    ensure_review_verdict_artifact(&mut artifacts);
+
+    let raw_process_exit_code = (packet.exit_code != exit_code).then_some(packet.exit_code);
+    let warnings = raw_process_exit_code
+        .map(|raw_exit_code| {
+            vec![format!(
+                "daemon completion exit code ({raw_exit_code}) arrived before result.toml; using existing review verdict artifacts"
+            )]
+        })
+        .unwrap_or_default();
+
+    Some(SessionResult {
+        status: SessionResult::status_from_exit_code(exit_code),
+        exit_code,
+        summary: review_artifact_result_summary(&meta),
+        tool: meta.tool.clone(),
+        started_at: session.last_accessed,
+        completed_at,
+        events_count: 0,
+        artifacts,
+        raw_process_exit_code,
+        warnings,
+        ..Default::default()
+    })
+}
+
 impl DaemonCompletionPacket {
     pub(crate) fn persist_review_diag(
         &self,
@@ -39,6 +85,15 @@ impl DaemonCompletionPacket {
         session: &MetaSessionState,
     ) {
         if !has_review_no_result_diagnostic(session) {
+            return;
+        }
+
+        if recoverable_review_verdict(session_dir).is_some() {
+            warn!(
+                result_path = %result_path.display(),
+                rollback_cleanup = "existing_review_artifacts_preserved",
+                "Skipped review daemon no-result diagnostic sidecars because recoverable review artifacts already exist"
+            );
             return;
         }
 
@@ -187,6 +242,133 @@ fn review_no_result_tool(session_dir: &Path, session: &MetaSessionState) -> Stri
                 .map(|metadata| metadata.tool)
         })
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn read_review_meta(session_dir: &Path) -> Option<csa_session::ReviewSessionMeta> {
+    std::fs::read_to_string(session_dir.join("review_meta.json"))
+        .ok()
+        .and_then(|content| serde_json::from_str(&content).ok())
+}
+
+fn read_review_verdict(session_dir: &Path) -> Option<csa_session::ReviewVerdictArtifact> {
+    std::fs::read_to_string(session_dir.join(REVIEW_VERDICT_ARTIFACT_PATH))
+        .ok()
+        .and_then(|content| serde_json::from_str(&content).ok())
+}
+
+fn recoverable_review_verdict(session_dir: &Path) -> Option<csa_session::ReviewVerdictArtifact> {
+    let verdict = read_review_verdict(session_dir)?;
+    (!is_review_no_result_verdict(&verdict)).then_some(verdict)
+}
+
+fn is_review_no_result_meta(meta: &csa_session::ReviewSessionMeta) -> bool {
+    meta.decision == ReviewDecision::Unavailable.as_str()
+        && (meta.status_reason.as_deref() == Some(REVIEW_DAEMON_NO_RESULT_REASON)
+            || matches!(
+                meta.primary_failure.as_deref(),
+                Some(REVIEW_DAEMON_NO_RESULT_REASON | REVIEW_DAEMON_TOOL_LAUNCH_METADATA_ABSENT)
+            ))
+}
+
+fn is_review_no_result_verdict(verdict: &csa_session::ReviewVerdictArtifact) -> bool {
+    verdict.decision == ReviewDecision::Unavailable
+        && matches!(
+            verdict.primary_failure.as_deref(),
+            Some(REVIEW_DAEMON_NO_RESULT_REASON | REVIEW_DAEMON_TOOL_LAUNCH_METADATA_ABSENT)
+        )
+}
+
+fn recover_or_persist_review_meta_from_verdict(
+    session_dir: &Path,
+    session: &MetaSessionState,
+    verdict: &csa_session::ReviewVerdictArtifact,
+) -> Option<csa_session::ReviewSessionMeta> {
+    let existing_meta = read_review_meta(session_dir);
+    match existing_meta.as_ref() {
+        Some(meta) if !is_review_no_result_meta(meta) => return Some(meta.clone()),
+        _ => {}
+    }
+
+    let meta = review_meta_from_verdict(session_dir, session, verdict, existing_meta.as_ref());
+    if let Err(err) = csa_session::write_review_meta(session_dir, &meta) {
+        warn!(
+            session_id = %session.meta_session_id,
+            path = %session_dir.join("review_meta.json").display(),
+            error = %err,
+            "Failed to recover review metadata from existing review verdict artifact"
+        );
+        return None;
+    }
+    Some(meta)
+}
+
+fn review_meta_from_verdict(
+    session_dir: &Path,
+    session: &MetaSessionState,
+    verdict: &csa_session::ReviewVerdictArtifact,
+    previous_meta: Option<&csa_session::ReviewSessionMeta>,
+) -> csa_session::ReviewSessionMeta {
+    let decision = verdict.decision;
+    let fallback_tool = review_no_result_tool(session_dir, session);
+    csa_session::ReviewSessionMeta {
+        session_id: session.meta_session_id.clone(),
+        head_sha: previous_meta
+            .map(|meta| meta.head_sha.clone())
+            .filter(|head| !head.trim().is_empty())
+            .or_else(|| session.git_head_at_creation.clone())
+            .unwrap_or_default(),
+        decision: decision.as_str().to_string(),
+        verdict: verdict.verdict_legacy.clone(),
+        review_mode: verdict
+            .review_mode
+            .clone()
+            .or_else(|| previous_meta.and_then(|meta| meta.review_mode.clone())),
+        status_reason: None,
+        routed_to: verdict.routed_to.clone(),
+        primary_failure: verdict.primary_failure.clone(),
+        failure_reason: verdict.failure_reason.clone(),
+        tool: previous_meta
+            .map(|meta| meta.tool.clone())
+            .filter(|tool| !tool.trim().is_empty() && tool != "unknown")
+            .unwrap_or(fallback_tool),
+        scope: previous_meta
+            .map(|meta| meta.scope.clone())
+            .filter(|scope| !scope.trim().is_empty())
+            .unwrap_or_else(|| canonical_review_scope(session)),
+        exit_code: crate::verdict_exit_code::exit_code_from_review_decision(decision),
+        fix_attempted: previous_meta.is_some_and(|meta| meta.fix_attempted),
+        fix_rounds: previous_meta.map_or(0, |meta| meta.fix_rounds),
+        review_iterations: previous_meta.map_or(1, |meta| meta.review_iterations),
+        timestamp: Utc::now(),
+        diff_fingerprint: previous_meta.and_then(|meta| meta.diff_fingerprint.clone()),
+        fix_convergence: previous_meta.and_then(|meta| meta.fix_convergence.clone()),
+    }
+}
+
+fn review_artifact_result_summary(meta: &csa_session::ReviewSessionMeta) -> String {
+    let verdict = meta.verdict.trim();
+    let decision = meta.decision.trim();
+    if verdict.is_empty() {
+        format!(
+            "review completed with decision {decision}; recovered existing review artifacts before daemon completion result.toml was published"
+        )
+    } else {
+        format!(
+            "review completed with verdict {verdict} ({decision}); recovered existing review artifacts before daemon completion result.toml was published"
+        )
+    }
+}
+
+fn ensure_review_verdict_artifact(artifacts: &mut Vec<SessionArtifact>) {
+    if artifacts
+        .iter()
+        .any(|artifact| artifact.path == REVIEW_VERDICT_ARTIFACT_PATH)
+    {
+        return;
+    }
+    artifacts.push(csa_session::observed_session_artifact(
+        REVIEW_VERDICT_ARTIFACT_PATH,
+    ));
 }
 
 fn persist_review_no_result_meta(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_test_support.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_test_support.rs
@@ -1,0 +1,34 @@
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn spawn_daemon_like_process(session_id: &str) -> std::process::Child {
+    use std::os::unix::process::CommandExt;
+    use std::process::Command;
+
+    let mut cmd = Command::new("sh");
+    // Keep the shell itself as the live session leader and keep the session id in
+    // its command line. macOS legacy PID validation relies on `ps` command-line
+    // context (there is no `/proc` start-time check), so a bare `sleep 60`
+    // fixture can look like an unrelated process there.
+    cmd.arg("-c").arg(format!(
+        "while :; do sleep 60; done # csa-daemon {session_id}"
+    ));
+    // SAFETY: test fixture only; makes the child its own session leader like a daemon.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    cmd.spawn().expect("spawn daemon-like child")
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn attach_test_daemon_pid_record(pid: u32) -> String {
+    format!("{pid}\n")
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn attach_test_daemon_pid_record(pid: u32) -> String {
+    format!("{pid} 0\n")
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
@@ -3,6 +3,10 @@ use crate::cli::{Cli, Commands, SessionCommands};
 use clap::Parser;
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
+use super::session_cmds_daemon_test_support::{
+    attach_test_daemon_pid_record, spawn_daemon_like_process,
+};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use crate::test_env_lock::TEST_ENV_LOCK;
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -527,35 +531,6 @@ fn attach_primary_output_uses_stdout_for_persisted_codex_cli_runtime_binary() {
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-fn spawn_daemon_like_process(session_id: &str) -> std::process::Child {
-    use std::os::unix::process::CommandExt;
-    use std::process::Command;
-
-    let mut cmd = Command::new("sh");
-    cmd.args(["-c", "sleep 60", "csa-daemon", session_id]);
-    // SAFETY: test fixture only; makes the child its own session leader like a daemon.
-    unsafe {
-        cmd.pre_exec(|| {
-            if libc::setsid() == -1 {
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
-    cmd.spawn().expect("spawn daemon-like child")
-}
-
-#[cfg(target_os = "linux")]
-fn attach_test_daemon_pid_record(pid: u32) -> String {
-    format!("{pid}\n")
-}
-
-#[cfg(target_os = "macos")]
-fn attach_test_daemon_pid_record(pid: u32) -> String {
-    format!("{pid} 0\n")
-}
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn handle_session_attach_waits_for_live_daemon_before_consuming_completion_packet() {
     use std::sync::mpsc;
@@ -753,51 +728,6 @@ fn handle_session_kill_uses_lock_file_for_inline_session() {
     assert!(
         !status.success(),
         "inline session process should be terminated by session kill"
-    );
-}
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-#[test]
-fn handle_session_kill_accepts_legacy_stderr_pid() {
-    let td = tempfile::tempdir().expect("tempdir");
-    let _env_lock = TEST_ENV_LOCK.blocking_lock();
-    let state_home = td.path().join("xdg-state");
-    std::fs::create_dir_all(&state_home).expect("create state home");
-    let _home_guard = EnvVarGuard::set("HOME", td.path());
-    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
-    let project = td.path();
-
-    let session =
-        csa_session::create_session(project, Some("kill-legacy-stderr"), None, Some("opencode"))
-            .expect("create session");
-    let session_id = session.meta_session_id;
-    let session_dir = csa_session::get_session_dir(project, &session_id).expect("session dir");
-
-    let mut child = spawn_daemon_like_process(&session_id);
-    let child_pid = child.id();
-    std::fs::write(
-        session_dir.join("stderr.log"),
-        format!(
-            "<!-- CSA:SESSION_STARTED id={} pid={} dir=\"{}\" wait_cmd=\"\" attach_cmd=\"\" -->\n",
-            session_id,
-            child_pid,
-            session_dir.display()
-        ),
-    )
-    .expect("write legacy stderr pid");
-
-    let reaper = std::thread::spawn(move || child.wait().expect("wait child"));
-
-    handle_session_kill(
-        session_id.clone(),
-        Some(project.to_string_lossy().into_owned()),
-    )
-    .expect("legacy kill should succeed");
-
-    let status = reaper.join().expect("reaper join");
-    assert!(
-        !status.success(),
-        "legacy daemon process should be terminated by session kill"
     );
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2150.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2150.rs
@@ -227,6 +227,102 @@ fn daemon_completion_before_result_uses_existing_review_verdict_artifact() {
 
 #[cfg(unix)]
 #[test]
+fn daemon_completion_review_artifact_recovery_prefers_non_pass_verdict_over_stale_pass_meta() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let mut session = create_session(
+        project,
+        Some("review: range:main...HEAD"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    session.git_head_at_creation = Some("abcdef1234567890".to_string());
+    session.task_context = csa_session::TaskContext {
+        task_type: Some("review".to_string()),
+        tier_name: None,
+    };
+    save_session(&session).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+
+    csa_session::write_review_meta(
+        &session_dir,
+        &csa_session::ReviewSessionMeta {
+            session_id: session_id.clone(),
+            head_sha: "abcdef1234567890".to_string(),
+            decision: csa_core::types::ReviewDecision::Pass.as_str().to_string(),
+            verdict: "CLEAN".to_string(),
+            review_mode: Some("standard".to_string()),
+            status_reason: None,
+            routed_to: None,
+            primary_failure: None,
+            failure_reason: None,
+            tool: "codex".to_string(),
+            scope: "range:main...HEAD".to_string(),
+            exit_code: 0,
+            fix_attempted: false,
+            fix_rounds: 0,
+            review_iterations: 1,
+            timestamp: chrono::Utc::now(),
+            diff_fingerprint: Some("sha256:stale-pass-meta".to_string()),
+            fix_convergence: None,
+        },
+    )
+    .unwrap();
+    csa_session::write_review_verdict(
+        &session_dir,
+        &csa_session::ReviewVerdictArtifact::from_parts(
+            session_id.clone(),
+            csa_core::types::ReviewDecision::Fail,
+            "HAS_ISSUES",
+            &[],
+            Vec::new(),
+        ),
+    )
+    .unwrap();
+
+    seed_daemon_session_env(&session_id, Some(project.to_string_lossy().as_ref()));
+    persist_daemon_completion_from_env(0);
+
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("daemon completion should synthesize a result from review artifacts");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.raw_process_exit_code, Some(0));
+    assert!(
+        result.summary.contains("HAS_ISSUES (fail)"),
+        "summary should reflect authoritative non-pass verdict: {}",
+        result.summary
+    );
+
+    let recovered_meta: csa_session::ReviewSessionMeta = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("review_meta.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        recovered_meta.decision,
+        csa_core::types::ReviewDecision::Fail.as_str()
+    );
+    assert_eq!(recovered_meta.verdict, "HAS_ISSUES");
+    assert_eq!(recovered_meta.exit_code, 1);
+    assert_eq!(recovered_meta.head_sha, "abcdef1234567890");
+    assert_eq!(recovered_meta.scope, "range:main...HEAD");
+    assert_eq!(
+        recovered_meta.diff_fingerprint.as_deref(),
+        Some("sha256:stale-pass-meta")
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn daemon_completion_reconcile_late_real_review_result_does_not_keep_unavailable_diagnostics() {
     let td = tempdir().unwrap();
     let _env_lock = TEST_ENV_LOCK.blocking_lock();

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2150.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2150.rs
@@ -144,6 +144,89 @@ fn review_daemon_no_result_diagnostic_canonicalizes_review_description_scopes() 
 
 #[cfg(unix)]
 #[test]
+fn daemon_completion_before_result_uses_existing_review_verdict_artifact() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let mut session = create_session(
+        project,
+        Some("review: range:main...HEAD"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    session.git_head_at_creation = Some("abcdef1234567890".to_string());
+    session.task_context = csa_session::TaskContext {
+        task_type: Some("review".to_string()),
+        tier_name: None,
+    };
+    save_session(&session).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    csa_session::write_review_verdict(
+        &session_dir,
+        &csa_session::ReviewVerdictArtifact::from_parts(
+            session_id.clone(),
+            csa_core::types::ReviewDecision::Pass,
+            "CLEAN",
+            &[],
+            Vec::new(),
+        ),
+    )
+    .unwrap();
+
+    seed_daemon_session_env(&session_id, Some(project.to_string_lossy().as_ref()));
+    persist_daemon_completion_from_env(1);
+
+    let result = load_result(project, &session_id)
+        .unwrap()
+        .expect("daemon completion should synthesize a result from review artifacts");
+    assert_eq!(result.status, "success");
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        !result
+            .summary
+            .contains("no tool launch metadata was recorded"),
+        "existing review artifacts must not be converted into no-result diagnostics: {}",
+        result.summary
+    );
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == "output/review-verdict.json"),
+        "recovered result should advertise the existing review verdict artifact"
+    );
+
+    let review_meta: csa_session::ReviewSessionMeta = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("review_meta.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(review_meta.session_id, session_id);
+    assert_eq!(review_meta.head_sha, "abcdef1234567890");
+    assert_eq!(review_meta.scope, "range:main...HEAD");
+    assert_eq!(review_meta.decision, "pass");
+    assert_eq!(review_meta.verdict, "CLEAN");
+    assert_eq!(review_meta.exit_code, 0);
+    assert_eq!(review_meta.status_reason, None);
+    assert_eq!(review_meta.primary_failure, None);
+
+    let verdict: csa_session::ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(verdict.decision, csa_core::types::ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert_eq!(verdict.primary_failure, None);
+}
+
+#[cfg(unix)]
+#[test]
 fn daemon_completion_reconcile_late_real_review_result_does_not_keep_unavailable_diagnostics() {
     let td = tempdir().unwrap();
     let _env_lock = TEST_ENV_LOCK.blocking_lock();

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2150.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2150.rs
@@ -252,6 +252,7 @@ fn daemon_completion_review_artifact_recovery_prefers_non_pass_verdict_over_stal
     let session_id = session.meta_session_id;
     let session_dir = get_session_dir(project, &session_id).unwrap();
 
+    let stale_meta_timestamp = chrono::DateTime::<chrono::Utc>::from_timestamp(1_000, 0).unwrap();
     csa_session::write_review_meta(
         &session_dir,
         &csa_session::ReviewSessionMeta {
@@ -270,7 +271,7 @@ fn daemon_completion_review_artifact_recovery_prefers_non_pass_verdict_over_stal
             fix_attempted: false,
             fix_rounds: 0,
             review_iterations: 1,
-            timestamp: chrono::Utc::now(),
+            timestamp: stale_meta_timestamp,
             diff_fingerprint: Some("sha256:stale-pass-meta".to_string()),
             fix_convergence: None,
         },
@@ -315,6 +316,7 @@ fn daemon_completion_review_artifact_recovery_prefers_non_pass_verdict_over_stal
     assert_eq!(recovered_meta.exit_code, 1);
     assert_eq!(recovered_meta.head_sha, "abcdef1234567890");
     assert_eq!(recovered_meta.scope, "range:main...HEAD");
+    assert_eq!(recovered_meta.timestamp, stale_meta_timestamp);
     assert_eq!(
         recovered_meta.diff_fingerprint.as_deref(),
         Some("sha256:stale-pass-meta")

--- a/crates/csa-session/src/state.rs
+++ b/crates/csa-session/src/state.rs
@@ -215,7 +215,10 @@ pub struct ReviewSessionMeta {
     /// Number of outer review cycles observed on the same branch/PR.
     #[serde(default = "default_review_iterations")]
     pub review_iterations: u32,
-    /// ISO 8601 timestamp of when this metadata was written.
+    /// ISO 8601 review timestamp used to order candidate verdicts.
+    ///
+    /// Recovered metadata preserves the original review/verdict time rather than
+    /// the recovery write time so stale reviews cannot be reordered as newest.
     pub timestamp: DateTime<Utc>,
     /// Content hash of the diff being reviewed (e.g., "sha256:abc123...").
     /// Enables deduplication: revert-revert scenarios with identical diffs

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1016"
-weave = "0.1.1016"
+csa = "0.1.1017"
+weave = "0.1.1017"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Recover existing review verdict artifacts before daemon-completion fallback synthesizes no-result diagnostics.
- Preserve exact-head review availability when daemon completion arrives before `result.toml` but review verdict artifacts already exist.
- Persist daemon review pre-exec direct-tool tier rejections as durable review results instead of collapsing to `tool_launch_metadata_absent`.
- Add regression coverage for artifact recovery, exact-head check-verdict availability, and daemon pre-exec persistence.
- Bump version to `0.1.1017`.

## Validation

- Focused #2234 regression tests passed in worker validation.
- `cargo fmt --all` / `cargo fmt --check` passed.
- `cargo clippy -p cli-sub-agent --all-targets -- -D warnings` passed.
- `cargo nextest run -p cli-sub-agent --all-features` passed in worker validation.
- `just find-monolith-files` passed.
- `just pre-commit-fast` passed.
- Hook-enabled commits passed branch-protection and quality-gates.
- Exact-head rebuild: `target/debug/csa 0.1.1017 (fd919e1b)`.
- Dogfood direct-tool command now reports `UNAVAILABLE(direct_tool_tier_restricted)` rather than `UNAVAILABLE(tool_launch_metadata_absent)`.
- Compliant tiered CSA/Codex exact-head review was unavailable due CSA memory soft-limit SIGTERM; tracked separately in #2247.
- Same-SHA native fallback exact-head review: `PASS/CLEAN`.

Fixes #2234.
