### PR TITLE
fix(review): recover legacy pass verdict summaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1017"
+version = "0.1.1018"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1017"
+version = "0.1.1018"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -23,6 +23,7 @@ use csa_session::state::ReviewSessionMeta;
 use tracing::{debug, error, warn};
 #[path = "review_cmd_output.rs"]
 mod output;
+pub(crate) use output::clean_detection::detect_bounded_clean_verdict_token;
 use output::{is_worktree_submodule, persist_review_result_exit_code};
 #[path = "review_cmd_artifact_parse.rs"]
 mod artifact_parse;

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
@@ -114,7 +114,9 @@ pub(crate) fn check_review_verdict_for_session(
         return Ok(None);
     }
 
-    let Some(meta) = read_review_meta(&session_dir)? else {
+    let Some(meta) =
+        read_review_meta_after_recovery(project_root, &resolved.session_id, &session_dir)?
+    else {
         debug!(
             session_id = %resolved.session_id,
             session_dir = %session_dir.display(),
@@ -182,16 +184,14 @@ pub(crate) fn check_review_verdict_for_target(
     expected_diff_fingerprint: Option<&str>,
     required_mode: Option<&str>,
 ) -> Result<Option<ReviewVerdictMatch>> {
-    if let Some(found) = check_review_verdict_marker(
+    let marker_candidate = check_review_verdict_marker(
         project_root,
         branch,
         head_sha,
         required_scope,
         expected_diff_fingerprint,
         required_mode,
-    )? {
-        return Ok(Some(found));
-    }
+    )?;
 
     let session_root = csa_session::get_session_root(project_root).with_context(|| {
         format!(
@@ -211,6 +211,9 @@ pub(crate) fn check_review_verdict_for_target(
     );
 
     let mut candidates = Vec::new();
+    if let Some(candidate) = marker_candidate {
+        candidates.push(candidate);
+    }
     for session in sessions {
         let session_branch = session_branch(&session);
         debug!(
@@ -229,7 +232,9 @@ pub(crate) fn check_review_verdict_for_target(
             continue;
         }
         let session_dir = session_root.join("sessions").join(&session.meta_session_id);
-        let Some(meta) = read_review_meta(&session_dir)? else {
+        let Some(meta) =
+            read_review_meta_after_recovery(project_root, &session.meta_session_id, &session_dir)?
+        else {
             debug!(
                 session_id = %session.meta_session_id,
                 session_dir = %session_dir.display(),
@@ -330,7 +335,7 @@ fn check_review_verdict_marker(
     required_scope: &str,
     expected_diff_fingerprint: Option<&str>,
     required_mode: Option<&str>,
-) -> Result<Option<ReviewVerdictMatch>> {
+) -> Result<Option<ReviewVerdictCandidate>> {
     let Some(marker) = crate::review_gate::read_review_gate_marker(project_root, branch, head_sha)
     else {
         return Ok(None);
@@ -438,12 +443,14 @@ fn check_review_verdict_marker(
         session_id = %meta.session_id,
         scope = %meta.scope,
         head_sha = %meta.head_sha,
-        "Review verdict marker matched PASS/CLEAN session"
+        "Review verdict marker matched PASS/CLEAN candidate"
     );
-    Ok(Some(ReviewVerdictMatch {
+    Ok(Some(ReviewVerdictCandidate {
         session_id: meta.session_id,
         scope: meta.scope,
         head_sha: meta.head_sha,
+        timestamp: meta.timestamp,
+        is_pass: true,
         severity_counts: pass_status.severity_counts,
     }))
 }
@@ -526,6 +533,30 @@ fn read_review_meta(session_dir: &Path) -> Result<Option<ReviewSessionMeta>> {
     let meta = serde_json::from_str(&raw)
         .with_context(|| format!("failed to parse {}", path.display()))?;
     Ok(Some(meta))
+}
+
+fn read_review_meta_after_recovery(
+    project_root: &Path,
+    session_id: &str,
+    session_dir: &Path,
+) -> Result<Option<ReviewSessionMeta>> {
+    if let Some(meta) = read_review_meta(session_dir)? {
+        return Ok(Some(meta));
+    }
+    recover_review_sidecars_before_meta(project_root, session_id);
+    read_review_meta(session_dir)
+}
+
+fn recover_review_sidecars_before_meta(project_root: &Path, session_id: &str) {
+    if let Err(error) =
+        crate::session_observability::refresh_and_repair_result(project_root, session_id)
+    {
+        debug!(
+            session_id,
+            error = %error,
+            "Review verdict sidecar recovery failed before metadata lookup"
+        );
+    }
 }
 
 fn diff_fingerprint_matches(
@@ -642,6 +673,22 @@ fn zero_severity_counts() -> BTreeMap<Severity, u32> {
 #[cfg(test)]
 #[path = "review_cmd_check_verdict_daemon_completion_tests.rs"]
 mod daemon_completion_tests;
+
+#[cfg(test)]
+#[path = "review_cmd_check_verdict_2236_tests.rs"]
+mod issue_2236_tests;
+
+#[cfg(test)]
+#[path = "review_cmd_check_verdict_2236_clean_summary_tests.rs"]
+mod issue_2236_clean_summary_tests;
+
+#[cfg(test)]
+#[path = "review_cmd_check_verdict_2236_blocking_legacy_tests.rs"]
+mod issue_2236_blocking_legacy_tests;
+
+#[cfg(test)]
+#[path = "review_cmd_check_verdict_compound_legacy_tests.rs"]
+mod compound_legacy_tests;
 
 #[cfg(test)]
 #[path = "review_cmd_check_verdict_tests.rs"]

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_2236_blocking_legacy_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_2236_blocking_legacy_tests.rs
@@ -1,0 +1,460 @@
+use super::*;
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+use chrono::{DateTime, TimeZone, Utc};
+use csa_core::types::ReviewDecision;
+use csa_core::vcs::{VcsIdentity, VcsKind};
+use csa_session::{ReviewVerdictArtifact, SessionResult};
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn setup_feature_repo() -> (TempDir, String, String) {
+    let temp = TempDir::new().expect("create tempdir");
+    run_git(temp.path(), &["init"]);
+    run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+    run_git(temp.path(), &["config", "user.name", "Test User"]);
+    std::fs::write(temp.path().join("tracked.txt"), "baseline\n").expect("write tracked file");
+    run_git(temp.path(), &["add", "tracked.txt"]);
+    run_git(temp.path(), &["commit", "-m", "initial"]);
+    run_git(temp.path(), &["branch", "-M", "main"]);
+    run_git(temp.path(), &["checkout", "-b", "feature"]);
+    std::fs::write(
+        temp.path().join("tracked.txt"),
+        "baseline\nfeature change\n",
+    )
+    .expect("write feature change");
+    run_git(temp.path(), &["add", "tracked.txt"]);
+    run_git(temp.path(), &["commit", "-m", "feature change"]);
+    let branch = run_git(temp.path(), &["branch", "--show-current"]);
+    let head_sha = csa_session::detect_git_head(temp.path()).unwrap();
+    (temp, branch, head_sha)
+}
+
+fn latest_reflog_timestamp_secs(repo: &Path, ref_name: &str) -> i64 {
+    let reflog_selector = run_git(
+        repo,
+        &[
+            "reflog",
+            "show",
+            "-n",
+            "1",
+            "--date=unix",
+            "--format=%gD",
+            "--end-of-options",
+            ref_name,
+        ],
+    );
+    let reflog_selector = reflog_selector
+        .trim()
+        .strip_suffix('}')
+        .expect("reflog selector should end with }");
+    let (_, timestamp_secs) = reflog_selector
+        .rsplit_once("@{")
+        .expect("reflog selector should contain @{timestamp}");
+    timestamp_secs
+        .trim()
+        .parse()
+        .expect("latest reflog timestamp should parse")
+}
+
+fn utc_timestamp(secs: i64) -> DateTime<Utc> {
+    Utc.timestamp_opt(secs, 0)
+        .single()
+        .expect("valid UTC timestamp")
+}
+
+struct LegacyReviewResultSpec<'a> {
+    branch: &'a str,
+    head_sha: &'a str,
+    summary: &'a str,
+    created_at: DateTime<Utc>,
+    completed_at: DateTime<Utc>,
+    exit_code: i32,
+}
+
+fn write_legacy_review_result(project_root: &Path, spec: LegacyReviewResultSpec<'_>) -> String {
+    let mut session = csa_session::create_session_fresh(
+        project_root,
+        Some("review: range:main...HEAD"),
+        None,
+        Some("codex"),
+    )
+    .expect("create legacy review session");
+    session.created_at = spec.created_at;
+    session.last_accessed = spec.created_at;
+    session.branch = Some(spec.branch.to_string());
+    session.git_head_at_creation = Some(spec.head_sha.to_string());
+    session.vcs_identity = Some(VcsIdentity {
+        vcs_kind: VcsKind::Git,
+        commit_id: Some(spec.head_sha.to_string()),
+        change_id: None,
+        short_id: Some(short_sha(spec.head_sha).to_string()),
+        ref_name: Some(spec.branch.to_string()),
+        op_id: None,
+    });
+    session.task_context = csa_session::TaskContext {
+        task_type: Some("review".to_string()),
+        tier_name: None,
+    };
+    csa_session::save_session(&session).expect("save legacy review state");
+
+    let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id).unwrap();
+    let output_dir = session_dir.join("output");
+    std::fs::create_dir_all(&output_dir).expect("create output dir");
+    std::fs::write(output_dir.join("summary.md"), spec.summary).expect("write summary");
+    csa_session::save_result(
+        project_root,
+        &session.meta_session_id,
+        &SessionResult {
+            status: SessionResult::status_from_exit_code(spec.exit_code),
+            exit_code: spec.exit_code,
+            summary: spec.summary.to_string(),
+            tool: "codex".to_string(),
+            started_at: spec.completed_at,
+            completed_at: spec.completed_at,
+            ..Default::default()
+        },
+    )
+    .expect("save legacy review result");
+    session.meta_session_id
+}
+
+fn assert_newer_legacy_summary_blocks_older_pass(
+    case_name: &str,
+    summary: &str,
+    exit_code: i32,
+    expected_decision: ReviewDecision,
+    expected_verdict: &str,
+) {
+    let (project, branch, head_sha) = setup_feature_repo();
+    let expected_diff_fingerprint = crate::review_cmd::compute_review_diff_fingerprint(
+        project.path(),
+        REQUIRED_FULL_DIFF_SCOPE,
+    )
+    .expect("feature branch should have a main...HEAD diff");
+    let base_reflog_secs = latest_reflog_timestamp_secs(project.path(), "main");
+
+    let older_pass = write_legacy_review_result(
+        project.path(),
+        LegacyReviewResultSpec {
+            branch: &branch,
+            head_sha: &head_sha,
+            summary: "Review result: pass. No serious correctness, concurrency, contract, or security issues found.\n",
+            created_at: utc_timestamp(base_reflog_secs + 1),
+            completed_at: utc_timestamp(1_000),
+            exit_code: 0,
+        },
+    );
+    let found = check_review_verdict_for_target(
+        project.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        Some(expected_diff_fingerprint.as_str()),
+        None,
+    )
+    .unwrap()
+    .expect("older legacy PASS should initially satisfy check-verdict");
+    assert_eq!(found.session_id, older_pass, "{case_name}");
+    crate::review_gate::write_review_gate_marker(
+        project.path(),
+        &branch,
+        &head_sha,
+        &older_pass,
+        REQUIRED_FULL_DIFF_SCOPE,
+        None,
+    );
+
+    let newer_review = write_legacy_review_result(
+        project.path(),
+        LegacyReviewResultSpec {
+            branch: &branch,
+            head_sha: &head_sha,
+            summary,
+            created_at: utc_timestamp(base_reflog_secs + 2),
+            completed_at: utc_timestamp(2_000),
+            exit_code,
+        },
+    );
+    let newer_dir = csa_session::get_session_dir(project.path(), &newer_review).unwrap();
+    assert!(!newer_dir.join("review_meta.json").exists(), "{case_name}");
+
+    let found = check_review_verdict_for_target(
+        project.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        Some(expected_diff_fingerprint.as_str()),
+        None,
+    )
+    .unwrap();
+    assert!(
+        found.is_none(),
+        "{case_name}: newer recovered legacy sidecar must block older PASS sidecar and marker"
+    );
+
+    let newer_meta = read_review_meta(&newer_dir)
+        .unwrap()
+        .expect("newer legacy review should recover fail-closed metadata");
+    assert_eq!(
+        newer_meta.decision,
+        expected_decision.as_str(),
+        "{case_name}"
+    );
+    assert_eq!(newer_meta.verdict, expected_verdict, "{case_name}");
+    assert_eq!(newer_meta.timestamp, utc_timestamp(2_000), "{case_name}");
+    assert_eq!(newer_meta.exit_code, 1, "{case_name}");
+    assert_eq!(
+        newer_meta.diff_fingerprint.as_deref(),
+        Some(expected_diff_fingerprint.as_str()),
+        "{case_name}"
+    );
+
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(newer_dir.join("output").join("review-verdict.json"))
+            .expect("newer legacy review should recover review-verdict.json"),
+    )
+    .expect("recovered newer review-verdict.json should parse");
+    assert_eq!(artifact.decision, expected_decision, "{case_name}");
+    assert_eq!(artifact.verdict_legacy, expected_verdict, "{case_name}");
+}
+
+#[test]
+fn issue_2236_bounded_parser_labels_block_older_pass_candidate() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    let cases = [
+        (
+            "status fail",
+            "Status: FAIL\n",
+            0,
+            ReviewDecision::Fail,
+            "HAS_ISSUES",
+        ),
+        (
+            "result clean-up ambiguous",
+            "Result: clean-up required before merge\n",
+            0,
+            ReviewDecision::Uncertain,
+            "UNCERTAIN",
+        ),
+        (
+            "status pass/fail ambiguous",
+            "Status: pass/fail unclear\n",
+            0,
+            ReviewDecision::Uncertain,
+            "UNCERTAIN",
+        ),
+        (
+            "review pass-through ambiguous",
+            "Review: pass-through behavior still needs validation\n",
+            0,
+            ReviewDecision::Uncertain,
+            "UNCERTAIN",
+        ),
+    ];
+
+    for (case_name, summary, exit_code, expected_decision, expected_verdict) in cases {
+        assert_newer_legacy_summary_blocks_older_pass(
+            case_name,
+            summary,
+            exit_code,
+            expected_decision,
+            expected_verdict,
+        );
+    }
+}
+
+#[test]
+fn issue_2236_newer_blocking_legacy_review_blocks_older_pass_candidate() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    let (project, branch, head_sha) = setup_feature_repo();
+    let expected_diff_fingerprint = crate::review_cmd::compute_review_diff_fingerprint(
+        project.path(),
+        REQUIRED_FULL_DIFF_SCOPE,
+    )
+    .expect("feature branch should have a main...HEAD diff");
+    let base_reflog_secs = latest_reflog_timestamp_secs(project.path(), "main");
+
+    let older_pass = write_legacy_review_result(
+        project.path(),
+        LegacyReviewResultSpec {
+            branch: &branch,
+            head_sha: &head_sha,
+            summary: "Review result: pass. No serious correctness, concurrency, contract, or security issues found.\n",
+            created_at: utc_timestamp(base_reflog_secs + 1),
+            completed_at: utc_timestamp(1_000),
+            exit_code: 0,
+        },
+    );
+    let found = check_review_verdict_for_target(
+        project.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        Some(expected_diff_fingerprint.as_str()),
+        None,
+    )
+    .unwrap()
+    .expect("older legacy PASS should initially satisfy check-verdict");
+    assert_eq!(found.session_id, older_pass);
+    crate::review_gate::write_review_gate_marker(
+        project.path(),
+        &branch,
+        &head_sha,
+        &older_pass,
+        REQUIRED_FULL_DIFF_SCOPE,
+        None,
+    );
+
+    let newer_blocking = write_legacy_review_result(
+        project.path(),
+        LegacyReviewResultSpec {
+            branch: &branch,
+            head_sha: &head_sha,
+            summary: "Review result: pass\nHigh severity findings: 1\n",
+            created_at: utc_timestamp(base_reflog_secs + 2),
+            completed_at: utc_timestamp(2_000),
+            exit_code: 1,
+        },
+    );
+    let newer_dir = csa_session::get_session_dir(project.path(), &newer_blocking).unwrap();
+    assert!(!newer_dir.join("review_meta.json").exists());
+
+    let found = check_review_verdict_for_target(
+        project.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        Some(expected_diff_fingerprint.as_str()),
+        None,
+    )
+    .unwrap();
+    assert!(
+        found.is_none(),
+        "newer recovered failed legacy sidecar must block older PASS sidecar and marker"
+    );
+
+    let newer_meta = read_review_meta(&newer_dir)
+        .unwrap()
+        .expect("blocking legacy review should recover failed metadata");
+    assert_eq!(newer_meta.decision, ReviewDecision::Fail.as_str());
+    assert_eq!(newer_meta.verdict, "HAS_ISSUES");
+    assert_eq!(newer_meta.timestamp, utc_timestamp(2_000));
+    assert_eq!(
+        newer_meta.diff_fingerprint.as_deref(),
+        Some(expected_diff_fingerprint.as_str())
+    );
+}
+
+#[test]
+fn issue_2236_newer_mixed_pass_ambiguous_legacy_review_blocks_older_pass_candidate() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    let (project, branch, head_sha) = setup_feature_repo();
+    let expected_diff_fingerprint = crate::review_cmd::compute_review_diff_fingerprint(
+        project.path(),
+        REQUIRED_FULL_DIFF_SCOPE,
+    )
+    .expect("feature branch should have a main...HEAD diff");
+    let base_reflog_secs = latest_reflog_timestamp_secs(project.path(), "main");
+
+    let older_pass = write_legacy_review_result(
+        project.path(),
+        LegacyReviewResultSpec {
+            branch: &branch,
+            head_sha: &head_sha,
+            summary: "Review result: pass. No serious correctness, concurrency, contract, or security issues found.\n",
+            created_at: utc_timestamp(base_reflog_secs + 1),
+            completed_at: utc_timestamp(1_000),
+            exit_code: 0,
+        },
+    );
+    let found = check_review_verdict_for_target(
+        project.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        Some(expected_diff_fingerprint.as_str()),
+        None,
+    )
+    .unwrap()
+    .expect("older legacy PASS should initially satisfy check-verdict");
+    assert_eq!(found.session_id, older_pass);
+    crate::review_gate::write_review_gate_marker(
+        project.path(),
+        &branch,
+        &head_sha,
+        &older_pass,
+        REQUIRED_FULL_DIFF_SCOPE,
+        None,
+    );
+
+    let newer_ambiguous = write_legacy_review_result(
+        project.path(),
+        LegacyReviewResultSpec {
+            branch: &branch,
+            head_sha: &head_sha,
+            summary: "Review result: pass\nFinal verdict: pass/fail unclear\n",
+            created_at: utc_timestamp(base_reflog_secs + 2),
+            completed_at: utc_timestamp(2_000),
+            exit_code: 0,
+        },
+    );
+    let newer_dir = csa_session::get_session_dir(project.path(), &newer_ambiguous).unwrap();
+    assert!(!newer_dir.join("review_meta.json").exists());
+
+    let found = check_review_verdict_for_target(
+        project.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        Some(expected_diff_fingerprint.as_str()),
+        None,
+    )
+    .unwrap();
+    assert!(
+        found.is_none(),
+        "newer ambiguous recovered legacy sidecar must block older PASS sidecar and marker"
+    );
+
+    let newer_meta = read_review_meta(&newer_dir)
+        .unwrap()
+        .expect("ambiguous legacy review should recover fail-closed metadata");
+    assert_eq!(newer_meta.decision, ReviewDecision::Uncertain.as_str());
+    assert_eq!(newer_meta.verdict, "UNCERTAIN");
+    assert_eq!(newer_meta.timestamp, utc_timestamp(2_000));
+    assert_eq!(newer_meta.exit_code, 1);
+    assert_eq!(
+        newer_meta.diff_fingerprint.as_deref(),
+        Some(expected_diff_fingerprint.as_str())
+    );
+
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(newer_dir.join("output").join("review-verdict.json"))
+            .expect("ambiguous legacy review should recover review-verdict.json"),
+    )
+    .expect("recovered ambiguous review-verdict.json should parse");
+    assert_eq!(artifact.decision, ReviewDecision::Uncertain);
+    assert_eq!(artifact.verdict_legacy, "UNCERTAIN");
+}

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_2236_clean_summary_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_2236_clean_summary_tests.rs
@@ -1,0 +1,242 @@
+use super::*;
+use crate::cli::{Cli, Commands, ReviewArgs, validate_review_args};
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+use chrono::{DateTime, TimeZone, Utc};
+use clap::Parser;
+use csa_core::types::ReviewDecision;
+use csa_core::vcs::{VcsIdentity, VcsKind};
+use csa_session::SessionResult;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn parse_review_args(argv: &[&str]) -> ReviewArgs {
+    let cli = Cli::try_parse_from(argv).expect("review CLI args should parse");
+    match cli.command {
+        Commands::Review(args) => {
+            validate_review_args(&args).expect("review CLI args should validate");
+            args
+        }
+        _ => panic!("expected review subcommand"),
+    }
+}
+
+fn setup_feature_repo() -> (TempDir, String, String) {
+    let temp = TempDir::new().expect("create tempdir");
+    run_git(temp.path(), &["init"]);
+    run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+    run_git(temp.path(), &["config", "user.name", "Test User"]);
+    std::fs::write(temp.path().join("tracked.txt"), "baseline\n").expect("write tracked file");
+    run_git(temp.path(), &["add", "tracked.txt"]);
+    run_git(temp.path(), &["commit", "-m", "initial"]);
+    run_git(temp.path(), &["branch", "-M", "main"]);
+    run_git(temp.path(), &["checkout", "-b", "feature"]);
+    std::fs::write(
+        temp.path().join("tracked.txt"),
+        "baseline\nfeature change\n",
+    )
+    .expect("write feature change");
+    run_git(temp.path(), &["add", "tracked.txt"]);
+    run_git(temp.path(), &["commit", "-m", "feature change"]);
+    let branch = run_git(temp.path(), &["branch", "--show-current"]);
+    let head_sha = csa_session::detect_git_head(temp.path()).unwrap();
+    (temp, branch, head_sha)
+}
+
+fn latest_reflog_timestamp_secs(repo: &Path, ref_name: &str) -> i64 {
+    let reflog_selector = run_git(
+        repo,
+        &[
+            "reflog",
+            "show",
+            "-n",
+            "1",
+            "--date=unix",
+            "--format=%gD",
+            "--end-of-options",
+            ref_name,
+        ],
+    );
+    let reflog_selector = reflog_selector
+        .trim()
+        .strip_suffix('}')
+        .expect("reflog selector should end with }");
+    let (_, timestamp_secs) = reflog_selector
+        .rsplit_once("@{")
+        .expect("reflog selector should contain @{timestamp}");
+    timestamp_secs
+        .trim()
+        .parse()
+        .expect("latest reflog timestamp should parse")
+}
+
+fn utc_timestamp(secs: i64) -> DateTime<Utc> {
+    Utc.timestamp_opt(secs, 0)
+        .single()
+        .expect("valid UTC timestamp")
+}
+
+fn write_legacy_success_result_with_created_at(
+    project_root: &Path,
+    branch: &str,
+    head_sha: &str,
+    summary: &str,
+    created_at: DateTime<Utc>,
+) -> String {
+    let mut session = csa_session::create_session_fresh(
+        project_root,
+        Some("review: range:main...HEAD"),
+        None,
+        Some("codex"),
+    )
+    .expect("create legacy result session");
+    session.created_at = created_at;
+    session.last_accessed = created_at;
+    session.branch = Some(branch.to_string());
+    session.git_head_at_creation = Some(head_sha.to_string());
+    session.vcs_identity = Some(VcsIdentity {
+        vcs_kind: VcsKind::Git,
+        commit_id: Some(head_sha.to_string()),
+        change_id: None,
+        short_id: Some(short_sha(head_sha).to_string()),
+        ref_name: Some(branch.to_string()),
+        op_id: None,
+    });
+    session.task_context = csa_session::TaskContext {
+        task_type: Some("review".to_string()),
+        tier_name: None,
+    };
+    csa_session::save_session(&session).expect("save legacy result session state");
+    let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id).unwrap();
+    let output_dir = session_dir.join("output");
+    std::fs::create_dir_all(&output_dir).expect("create output dir");
+    std::fs::write(output_dir.join("summary.md"), summary).expect("write summary");
+
+    let completed_at = utc_timestamp(1_000);
+    csa_session::save_result(
+        project_root,
+        &session.meta_session_id,
+        &SessionResult {
+            status: SessionResult::status_from_exit_code(0),
+            exit_code: 0,
+            summary: summary.to_string(),
+            tool: "codex".to_string(),
+            started_at: completed_at,
+            completed_at,
+            ..Default::default()
+        },
+    )
+    .expect("save legacy success result");
+
+    session.meta_session_id
+}
+
+#[test]
+fn issue_2236_check_verdict_recovers_bounded_clean_verdict_summary_shapes() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    let cases = [
+        ("standalone PASS", "PASS\n"),
+        ("standalone CLEAN", "CLEAN\n"),
+        (
+            "emphasized standalone PASS",
+            "**PASS** — no blocking findings\n",
+        ),
+        ("emphasized standalone CLEAN", "__CLEAN__\n"),
+        (
+            "labeled separator explanation",
+            "Verdict: PASS - all tests passed\n",
+        ),
+        (
+            "status separator explanation",
+            "Status: CLEAN - all tests passed\n",
+        ),
+        (
+            "labeled emphasized verdict",
+            "Verdict: __PASS__ - all tests passed\n",
+        ),
+    ];
+
+    for (case_name, summary) in cases {
+        let (project, branch, head_sha) = setup_feature_repo();
+        let expected_diff_fingerprint = crate::review_cmd::compute_review_diff_fingerprint(
+            project.path(),
+            REQUIRED_FULL_DIFF_SCOPE,
+        )
+        .expect("feature branch should have a main...HEAD diff");
+        let session_created_at =
+            utc_timestamp(latest_reflog_timestamp_secs(project.path(), "main") + 1);
+        let session_id = write_legacy_success_result_with_created_at(
+            project.path(),
+            &branch,
+            &head_sha,
+            summary,
+            session_created_at,
+        );
+        let session_dir = csa_session::get_session_dir(project.path(), &session_id).unwrap();
+        assert!(!session_dir.join("review_meta.json").exists());
+        assert!(
+            !session_dir
+                .join("output")
+                .join("review-verdict.json")
+                .exists()
+        );
+
+        let args = parse_review_args(&["csa", "review", "--check-verdict"]);
+        let exit = handle_check_verdict(project.path(), &args).unwrap();
+        assert_eq!(
+            exit, 0,
+            "{case_name}: legacy clean summary should satisfy exact-head check-verdict"
+        );
+
+        let found = check_review_verdict_for_target(
+            project.path(),
+            &branch,
+            &head_sha,
+            REQUIRED_FULL_DIFF_SCOPE,
+            Some(expected_diff_fingerprint.as_str()),
+            None,
+        )
+        .unwrap()
+        .expect("legacy clean summary should recover a checkable PASS verdict");
+        assert_eq!(found.session_id, session_id, "{case_name}");
+
+        let meta = read_review_meta(&session_dir)
+            .unwrap()
+            .expect("review_meta.json should be recovered");
+        assert_eq!(meta.decision, ReviewDecision::Pass.as_str(), "{case_name}");
+        assert_eq!(meta.verdict, "CLEAN", "{case_name}");
+        assert_eq!(meta.head_sha, head_sha, "{case_name}");
+        assert_eq!(meta.scope, REQUIRED_FULL_DIFF_SCOPE, "{case_name}");
+        assert_eq!(
+            meta.diff_fingerprint.as_deref(),
+            Some(expected_diff_fingerprint.as_str()),
+            "{case_name}"
+        );
+
+        let artifact: ReviewVerdictArtifact = serde_json::from_str(
+            &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json"))
+                .expect("review-verdict.json should be recovered"),
+        )
+        .expect("recovered review-verdict.json should parse");
+        assert_eq!(artifact.decision, ReviewDecision::Pass, "{case_name}");
+        assert_eq!(artifact.verdict_legacy, "CLEAN", "{case_name}");
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_2236_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_2236_tests.rs
@@ -1,0 +1,615 @@
+use super::*;
+use crate::cli::{Cli, Commands, ReviewArgs, validate_review_args};
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+use chrono::{DateTime, TimeZone, Utc};
+use clap::Parser;
+use csa_core::types::ReviewDecision;
+use csa_core::vcs::{VcsIdentity, VcsKind};
+use csa_session::SessionResult;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn run_git_with_env(repo: &Path, args: &[&str], envs: &[(&str, String)]) -> String {
+    let mut command = Command::new("git");
+    command.arg("-C").arg(repo).args(args);
+    for (name, value) in envs {
+        command.env(name, value);
+    }
+    let output = command.output().expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn parse_review_args(argv: &[&str]) -> ReviewArgs {
+    let cli = Cli::try_parse_from(argv).expect("review CLI args should parse");
+    match cli.command {
+        Commands::Review(args) => {
+            validate_review_args(&args).expect("review CLI args should validate");
+            args
+        }
+        _ => panic!("expected review subcommand"),
+    }
+}
+
+fn setup_git_repo() -> TempDir {
+    let temp = TempDir::new().expect("create tempdir");
+    run_git(temp.path(), &["init"]);
+    run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+    run_git(temp.path(), &["config", "user.name", "Test User"]);
+    std::fs::write(temp.path().join("tracked.txt"), "baseline\n").expect("write tracked file");
+    run_git(temp.path(), &["add", "tracked.txt"]);
+    run_git(temp.path(), &["commit", "-m", "initial"]);
+    temp
+}
+
+fn setup_feature_repo() -> (TempDir, String, String) {
+    let temp = setup_git_repo();
+    run_git(temp.path(), &["branch", "-M", "main"]);
+    run_git(temp.path(), &["checkout", "-b", "feature"]);
+    std::fs::write(
+        temp.path().join("tracked.txt"),
+        "baseline\nfeature change\n",
+    )
+    .expect("write feature change");
+    run_git(temp.path(), &["add", "tracked.txt"]);
+    run_git(temp.path(), &["commit", "-m", "feature change"]);
+    let branch = run_git(temp.path(), &["branch", "--show-current"]);
+    let head_sha = csa_session::detect_git_head(temp.path()).unwrap();
+    (temp, branch, head_sha)
+}
+
+fn latest_reflog_timestamp_secs(repo: &Path, ref_name: &str) -> i64 {
+    let reflog_selector = run_git(
+        repo,
+        &[
+            "reflog",
+            "show",
+            "-n",
+            "1",
+            "--date=unix",
+            "--format=%gD",
+            "--end-of-options",
+            ref_name,
+        ],
+    );
+    parse_unix_reflog_selector_timestamp_secs(&reflog_selector)
+}
+
+fn parse_unix_reflog_selector_timestamp_secs(reflog_selector: &str) -> i64 {
+    let reflog_selector = reflog_selector.trim();
+    let reflog_selector = reflog_selector
+        .strip_suffix('}')
+        .expect("reflog selector should end with }");
+    let (_, timestamp_secs) = reflog_selector
+        .rsplit_once("@{")
+        .expect("reflog selector should contain @{timestamp}");
+    timestamp_secs
+        .trim()
+        .parse()
+        .expect("latest reflog timestamp should parse")
+}
+
+fn utc_timestamp(secs: i64, nanos: u32) -> DateTime<Utc> {
+    Utc.timestamp_opt(secs, nanos)
+        .single()
+        .expect("valid UTC timestamp")
+}
+
+fn git_date(secs: i64) -> String {
+    utc_timestamp(secs, 0).to_rfc3339()
+}
+
+fn commit_timestamp_secs(repo: &Path, rev: &str) -> i64 {
+    run_git(
+        repo,
+        &["show", "-s", "--format=%ct", "--end-of-options", rev],
+    )
+    .parse()
+    .expect("commit timestamp should parse")
+}
+
+fn commit_on_main_at(repo: &Path, branch: &str, commit_secs: i64) {
+    run_git(repo, &["checkout", "main"]);
+    std::fs::write(
+        repo.join("base.txt"),
+        format!("base advanced at {commit_secs}\n"),
+    )
+    .expect("write base-only change");
+    run_git(repo, &["add", "base.txt"]);
+    let commit_date = git_date(commit_secs);
+    run_git_with_env(
+        repo,
+        &["commit", "-m", "advance main"],
+        &[
+            ("GIT_AUTHOR_DATE", commit_date.clone()),
+            ("GIT_COMMITTER_DATE", commit_date),
+        ],
+    );
+    run_git(repo, &["checkout", branch]);
+}
+
+fn write_legacy_success_result(
+    project_root: &Path,
+    branch: &str,
+    head_sha: &str,
+    description: &str,
+    task_type: Option<&str>,
+    summary: &str,
+) -> String {
+    write_legacy_success_result_with_created_at(
+        project_root,
+        branch,
+        head_sha,
+        description,
+        task_type,
+        summary,
+        None,
+    )
+}
+
+fn write_legacy_success_result_with_created_at(
+    project_root: &Path,
+    branch: &str,
+    head_sha: &str,
+    description: &str,
+    task_type: Option<&str>,
+    summary: &str,
+    created_at: Option<DateTime<Utc>>,
+) -> String {
+    let mut session =
+        csa_session::create_session_fresh(project_root, Some(description), None, Some("codex"))
+            .expect("create legacy result session");
+    if let Some(created_at) = created_at {
+        session.created_at = created_at;
+        session.last_accessed = created_at;
+    }
+    session.branch = Some(branch.to_string());
+    session.git_head_at_creation = Some(head_sha.to_string());
+    session.vcs_identity = Some(VcsIdentity {
+        vcs_kind: VcsKind::Git,
+        commit_id: Some(head_sha.to_string()),
+        change_id: None,
+        short_id: Some(short_sha(head_sha).to_string()),
+        ref_name: Some(branch.to_string()),
+        op_id: None,
+    });
+    session.task_context = csa_session::TaskContext {
+        task_type: task_type.map(str::to_string),
+        tier_name: None,
+    };
+    csa_session::save_session(&session).expect("save legacy result session state");
+    let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id).unwrap();
+    let output_dir = session_dir.join("output");
+    std::fs::create_dir_all(&output_dir).expect("create output dir");
+    std::fs::write(output_dir.join("summary.md"), summary).expect("write summary");
+
+    let completed_at = Utc.timestamp_opt(1_000, 0).single().unwrap();
+    csa_session::save_result(
+        project_root,
+        &session.meta_session_id,
+        &SessionResult {
+            status: SessionResult::status_from_exit_code(0),
+            exit_code: 0,
+            summary: summary.to_string(),
+            tool: "codex".to_string(),
+            started_at: completed_at,
+            completed_at,
+            ..Default::default()
+        },
+    )
+    .expect("save legacy success result");
+
+    session.meta_session_id
+}
+
+#[test]
+fn issue_2236_check_verdict_rejects_plain_pass_after_base_resets_to_older_commit() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    let project = setup_git_repo();
+    run_git(project.path(), &["branch", "-M", "main"]);
+    let old_base_sha = csa_session::detect_git_head(project.path()).unwrap();
+
+    let reviewed_base_update_secs = latest_reflog_timestamp_secs(project.path(), "main") + 1;
+    std::fs::write(
+        project.path().join("base.txt"),
+        format!("reviewed base at {reviewed_base_update_secs}\n"),
+    )
+    .expect("write reviewed base change");
+    run_git(project.path(), &["add", "base.txt"]);
+    let reviewed_base_date = git_date(reviewed_base_update_secs);
+    run_git_with_env(
+        project.path(),
+        &["commit", "-m", "advance main before review"],
+        &[
+            ("GIT_AUTHOR_DATE", reviewed_base_date.clone()),
+            ("GIT_COMMITTER_DATE", reviewed_base_date),
+        ],
+    );
+    let reviewed_base_sha = csa_session::detect_git_head(project.path()).unwrap();
+    assert_ne!(
+        reviewed_base_sha, old_base_sha,
+        "reviewed base must differ from the older reset target"
+    );
+
+    run_git(project.path(), &["checkout", "-b", "feature"]);
+    std::fs::write(
+        project.path().join("tracked.txt"),
+        "baseline\nfeature change\n",
+    )
+    .expect("write feature change");
+    run_git(project.path(), &["add", "tracked.txt"]);
+    let feature_commit_date = git_date(reviewed_base_update_secs + 1);
+    run_git_with_env(
+        project.path(),
+        &["commit", "-m", "feature change"],
+        &[
+            ("GIT_AUTHOR_DATE", feature_commit_date.clone()),
+            ("GIT_COMMITTER_DATE", feature_commit_date),
+        ],
+    );
+    let branch = run_git(project.path(), &["branch", "--show-current"]);
+    let head_sha = csa_session::detect_git_head(project.path()).unwrap();
+
+    let session_created_at = utc_timestamp(reviewed_base_update_secs + 2, 0);
+    assert!(
+        commit_timestamp_secs(project.path(), &old_base_sha) < session_created_at.timestamp(),
+        "regression setup requires the reset target to have an older committer timestamp"
+    );
+    let session_id = write_legacy_success_result_with_created_at(
+        project.path(),
+        &branch,
+        &head_sha,
+        "review: range:main...HEAD",
+        Some("review"),
+        "Review result: pass. Scope main...HEAD changes only src/main.rs. No serious correctness, concurrency, contract, or security issues found.\n",
+        Some(session_created_at),
+    );
+    let session_dir = csa_session::get_session_dir(project.path(), &session_id).unwrap();
+    assert!(!session_dir.join("review_meta.json").exists());
+
+    // After the review session exists, move main back to a pre-existing older
+    // commit whose committer timestamp predates session creation. Recovery must
+    // use the reflog update timestamp, not that commit timestamp, or it would
+    // stamp the current (now changed) main...HEAD fingerprint onto a stale PASS.
+    let post_session_base_update_secs = session_created_at.timestamp() + 1;
+    run_git_with_env(
+        project.path(),
+        &["branch", "-f", "main", &old_base_sha],
+        &[(
+            "GIT_COMMITTER_DATE",
+            git_date(post_session_base_update_secs),
+        )],
+    );
+    assert_eq!(
+        run_git(project.path(), &["rev-parse", "main"]),
+        old_base_sha,
+        "main should now point at the older pre-existing commit"
+    );
+    assert_eq!(
+        latest_reflog_timestamp_secs(project.path(), "main"),
+        post_session_base_update_secs,
+        "regression setup must exercise a post-session base-ref update"
+    );
+    assert!(
+        commit_timestamp_secs(project.path(), "main") < session_created_at.timestamp(),
+        "updated-to commit must look old if the proof accidentally uses %ct"
+    );
+
+    let current_diff_fingerprint = crate::review_cmd::compute_review_diff_fingerprint(
+        project.path(),
+        REQUIRED_FULL_DIFF_SCOPE,
+    )
+    .expect("feature branch should still have a main...HEAD diff");
+
+    let args = parse_review_args(&["csa", "review", "--check-verdict"]);
+    let exit = handle_check_verdict(project.path(), &args).unwrap();
+    assert_eq!(
+        exit, 1,
+        "stale legacy PASS summary must not satisfy current main...HEAD check-verdict after base reset"
+    );
+
+    let found = check_review_verdict_for_target(
+        project.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        Some(current_diff_fingerprint.as_str()),
+        None,
+    )
+    .unwrap();
+    assert!(
+        found.is_none(),
+        "recovered stale legacy PASS must not match the current diff fingerprint"
+    );
+
+    let meta = read_review_meta(&session_dir)
+        .unwrap()
+        .expect("legacy recovery should still write review metadata");
+    assert_eq!(meta.decision, ReviewDecision::Pass.as_str());
+    assert!(
+        meta.diff_fingerprint.is_none(),
+        "stale legacy recovery must not stamp the current diff fingerprint"
+    );
+}
+
+#[test]
+fn issue_2236_check_verdict_recovers_plain_pass_summary_review_session() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    let (project, branch, head_sha) = setup_feature_repo();
+    let expected_diff_fingerprint = crate::review_cmd::compute_review_diff_fingerprint(
+        project.path(),
+        REQUIRED_FULL_DIFF_SCOPE,
+    )
+    .expect("feature branch should have a main...HEAD diff");
+
+    let robust_session_created_at =
+        utc_timestamp(latest_reflog_timestamp_secs(project.path(), "main") + 1, 0);
+    let session_id = write_legacy_success_result_with_created_at(
+        project.path(),
+        &branch,
+        &head_sha,
+        "review: range:main...HEAD",
+        Some("review"),
+        "Review result: pass. Scope main...HEAD changes only src/main.rs. No serious correctness, concurrency, contract, or security issues found.\n",
+        Some(robust_session_created_at),
+    );
+    let session_dir = csa_session::get_session_dir(project.path(), &session_id).unwrap();
+    assert!(!session_dir.join("review_meta.json").exists());
+    assert!(
+        !session_dir
+            .join("output")
+            .join("review-verdict.json")
+            .exists()
+    );
+
+    let found = check_review_verdict_for_target(
+        project.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        Some(expected_diff_fingerprint.as_str()),
+        None,
+    )
+    .unwrap()
+    .expect("legacy plain pass summary should recover a checkable PASS verdict");
+    assert_eq!(found.session_id, session_id);
+
+    let meta = read_review_meta(&session_dir)
+        .unwrap()
+        .expect("review_meta.json should be recovered");
+    assert_eq!(meta.decision, ReviewDecision::Pass.as_str());
+    assert_eq!(meta.verdict, "CLEAN");
+    assert_eq!(meta.head_sha, head_sha);
+    assert_eq!(meta.scope, REQUIRED_FULL_DIFF_SCOPE);
+    assert_eq!(
+        meta.diff_fingerprint.as_deref(),
+        Some(expected_diff_fingerprint.as_str())
+    );
+
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json"))
+            .expect("review-verdict.json should be recovered"),
+    )
+    .expect("recovered review-verdict.json should parse");
+    assert_eq!(artifact.decision, ReviewDecision::Pass);
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+}
+
+#[test]
+fn issue_2236_labeled_pass_with_blocking_human_findings_does_not_recover_pass_sidecars() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    let (project, branch, head_sha) = setup_feature_repo();
+    let expected_diff_fingerprint = crate::review_cmd::compute_review_diff_fingerprint(
+        project.path(),
+        REQUIRED_FULL_DIFF_SCOPE,
+    )
+    .expect("feature branch should have a main...HEAD diff");
+    let robust_session_created_at =
+        utc_timestamp(latest_reflog_timestamp_secs(project.path(), "main") + 1, 0);
+    let summary = "Review result: pass\nP1 findings: 1\nHigh severity findings: 1\nCritical severity findings: 1\n";
+    let session_id = write_legacy_success_result_with_created_at(
+        project.path(),
+        &branch,
+        &head_sha,
+        "review: range:main...HEAD",
+        Some("review"),
+        summary,
+        Some(robust_session_created_at),
+    );
+    let session_dir = csa_session::get_session_dir(project.path(), &session_id).unwrap();
+    assert!(!session_dir.join("review_meta.json").exists());
+    assert!(
+        !session_dir
+            .join("output")
+            .join("review-verdict.json")
+            .exists()
+    );
+
+    let args = parse_review_args(&["csa", "review", "--check-verdict"]);
+    let exit = handle_check_verdict(project.path(), &args).unwrap();
+    assert_eq!(
+        exit, 1,
+        "blocking human-review findings must prevent legacy PASS recovery from satisfying the gate"
+    );
+
+    let explicit = check_review_verdict_for_session(
+        project.path(),
+        &session_id,
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        Some(expected_diff_fingerprint.as_str()),
+        None,
+    )
+    .unwrap();
+    assert!(
+        explicit.is_none(),
+        "explicit-session check must also reject the recovered blocking legacy summary"
+    );
+
+    let meta = read_review_meta(&session_dir)
+        .unwrap()
+        .expect("blocking legacy summary should recover failed review metadata");
+    assert_eq!(meta.decision, ReviewDecision::Fail.as_str());
+    assert_eq!(meta.verdict, "HAS_ISSUES");
+    assert_eq!(meta.exit_code, 1);
+    assert_eq!(
+        meta.diff_fingerprint.as_deref(),
+        Some(expected_diff_fingerprint.as_str())
+    );
+
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json"))
+            .expect("blocking legacy summary should recover failed review-verdict.json"),
+    )
+    .expect("recovered failed review-verdict.json should parse");
+    assert_eq!(artifact.decision, ReviewDecision::Fail);
+    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
+
+    let repaired = csa_session::load_result(project.path(), &session_id)
+        .unwrap()
+        .expect("result should remain loadable after failed recovery");
+    assert_eq!(
+        repaired.exit_code, 1,
+        "blocking human-review summary should still force the observable result to failed"
+    );
+}
+
+#[test]
+fn issue_2236_check_verdict_rejects_same_second_plain_pass_recovery_after_base_advances() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    let (project, branch, head_sha) = setup_feature_repo();
+    let ambiguous_second = latest_reflog_timestamp_secs(project.path(), "main") + 1;
+    let session_created_at = utc_timestamp(ambiguous_second, 250_000_000);
+
+    let session_id = write_legacy_success_result_with_created_at(
+        project.path(),
+        &branch,
+        &head_sha,
+        "review: range:main...HEAD",
+        Some("review"),
+        "Review result: pass. Scope main...HEAD changes only src/main.rs. No serious correctness, concurrency, contract, or security issues found.\n",
+        Some(session_created_at),
+    );
+    let session_dir = csa_session::get_session_dir(project.path(), &session_id).unwrap();
+    assert!(!session_dir.join("review_meta.json").exists());
+
+    // Advance main after the legacy review session is written, but give the ref
+    // update the same second as session creation. Reflog selectors cannot prove
+    // whether this second-granularity update happened before or after the
+    // nanosecond-granularity session timestamp, so recovery must fail closed.
+    commit_on_main_at(project.path(), &branch, ambiguous_second);
+    assert_eq!(
+        latest_reflog_timestamp_secs(project.path(), "main"),
+        ambiguous_second,
+        "regression setup must exercise same-second base-ref advancement"
+    );
+    assert_eq!(
+        csa_session::detect_git_head(project.path()).as_deref(),
+        Some(head_sha.as_str())
+    );
+
+    let current_diff_fingerprint = crate::review_cmd::compute_review_diff_fingerprint(
+        project.path(),
+        REQUIRED_FULL_DIFF_SCOPE,
+    )
+    .expect("feature branch should still have a main...HEAD diff");
+
+    let args = parse_review_args(&["csa", "review", "--check-verdict"]);
+    let exit = handle_check_verdict(project.path(), &args).unwrap();
+    assert_eq!(
+        exit, 1,
+        "stale legacy PASS summary must not satisfy current main...HEAD check-verdict"
+    );
+
+    let found = check_review_verdict_for_target(
+        project.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        Some(current_diff_fingerprint.as_str()),
+        None,
+    )
+    .unwrap();
+    assert!(
+        found.is_none(),
+        "recovered stale legacy PASS must not match the current diff fingerprint"
+    );
+
+    let meta = read_review_meta(&session_dir)
+        .unwrap()
+        .expect("legacy recovery should still write review metadata");
+    assert_eq!(meta.decision, ReviewDecision::Pass.as_str());
+    assert!(
+        meta.diff_fingerprint.is_none(),
+        "stale legacy recovery must not stamp the current diff fingerprint"
+    );
+}
+
+#[test]
+fn issue_2236_non_review_success_summary_does_not_recover_pass() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    let (project, branch, head_sha) = setup_feature_repo();
+    let session_id = write_legacy_success_result(
+        project.path(),
+        &branch,
+        &head_sha,
+        "run: not review",
+        None,
+        "Review result: pass. This is ordinary run output, not a review session.\n",
+    );
+    let session_dir = csa_session::get_session_dir(project.path(), &session_id).unwrap();
+
+    let found = check_review_verdict_for_target(
+        project.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        None,
+        None,
+    )
+    .unwrap();
+    assert!(
+        found.is_none(),
+        "ordinary successful sessions must not satisfy the review gate"
+    );
+    assert!(!session_dir.join("review_meta.json").exists());
+    assert!(
+        !session_dir
+            .join("output")
+            .join("review-verdict.json")
+            .exists()
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_compound_legacy_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_compound_legacy_tests.rs
@@ -1,0 +1,266 @@
+use super::*;
+use crate::cli::{Cli, Commands, ReviewArgs, validate_review_args};
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+use chrono::{DateTime, TimeZone, Utc};
+use clap::Parser;
+use csa_core::types::ReviewDecision;
+use csa_core::vcs::{VcsIdentity, VcsKind};
+use csa_session::SessionResult;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn run_git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn parse_review_args(argv: &[&str]) -> ReviewArgs {
+    let cli = Cli::try_parse_from(argv).expect("review CLI args should parse");
+    match cli.command {
+        Commands::Review(args) => {
+            validate_review_args(&args).expect("review CLI args should validate");
+            args
+        }
+        _ => panic!("expected review subcommand"),
+    }
+}
+
+fn setup_git_repo() -> TempDir {
+    let temp = TempDir::new().expect("create tempdir");
+    run_git(temp.path(), &["init"]);
+    run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+    run_git(temp.path(), &["config", "user.name", "Test User"]);
+    std::fs::write(temp.path().join("tracked.txt"), "baseline\n").expect("write tracked file");
+    run_git(temp.path(), &["add", "tracked.txt"]);
+    run_git(temp.path(), &["commit", "-m", "initial"]);
+    temp
+}
+
+fn setup_feature_repo() -> (TempDir, String, String) {
+    let temp = setup_git_repo();
+    run_git(temp.path(), &["branch", "-M", "main"]);
+    run_git(temp.path(), &["checkout", "-b", "feature"]);
+    std::fs::write(
+        temp.path().join("tracked.txt"),
+        "baseline\nfeature change\n",
+    )
+    .expect("write feature change");
+    run_git(temp.path(), &["add", "tracked.txt"]);
+    run_git(temp.path(), &["commit", "-m", "feature change"]);
+    let branch = run_git(temp.path(), &["branch", "--show-current"]);
+    let head_sha = csa_session::detect_git_head(temp.path()).unwrap();
+    (temp, branch, head_sha)
+}
+
+fn latest_reflog_timestamp_secs(repo: &Path, ref_name: &str) -> i64 {
+    let reflog_selector = run_git(
+        repo,
+        &[
+            "reflog",
+            "show",
+            "-n",
+            "1",
+            "--date=unix",
+            "--format=%gD",
+            "--end-of-options",
+            ref_name,
+        ],
+    );
+    parse_unix_reflog_selector_timestamp_secs(&reflog_selector)
+}
+
+fn parse_unix_reflog_selector_timestamp_secs(reflog_selector: &str) -> i64 {
+    let reflog_selector = reflog_selector.trim();
+    let reflog_selector = reflog_selector
+        .strip_suffix('}')
+        .expect("reflog selector should end with }");
+    let (_, timestamp_secs) = reflog_selector
+        .rsplit_once("@{")
+        .expect("reflog selector should contain @{timestamp}");
+    timestamp_secs
+        .trim()
+        .parse()
+        .expect("latest reflog timestamp should parse")
+}
+
+fn utc_timestamp(secs: i64, nanos: u32) -> DateTime<Utc> {
+    Utc.timestamp_opt(secs, nanos)
+        .single()
+        .expect("valid UTC timestamp")
+}
+
+fn write_legacy_success_result_with_created_at(
+    project_root: &Path,
+    branch: &str,
+    head_sha: &str,
+    description: &str,
+    task_type: Option<&str>,
+    summary: &str,
+    created_at: DateTime<Utc>,
+) -> String {
+    let mut session =
+        csa_session::create_session_fresh(project_root, Some(description), None, Some("codex"))
+            .expect("create legacy result session");
+    session.created_at = created_at;
+    session.last_accessed = created_at;
+    session.branch = Some(branch.to_string());
+    session.git_head_at_creation = Some(head_sha.to_string());
+    session.vcs_identity = Some(VcsIdentity {
+        vcs_kind: VcsKind::Git,
+        commit_id: Some(head_sha.to_string()),
+        change_id: None,
+        short_id: Some(short_sha(head_sha).to_string()),
+        ref_name: Some(branch.to_string()),
+        op_id: None,
+    });
+    session.task_context = csa_session::TaskContext {
+        task_type: task_type.map(str::to_string),
+        tier_name: None,
+    };
+    csa_session::save_session(&session).expect("save legacy result session state");
+    let session_dir = csa_session::get_session_dir(project_root, &session.meta_session_id).unwrap();
+    let output_dir = session_dir.join("output");
+    std::fs::create_dir_all(&output_dir).expect("create output dir");
+    std::fs::write(output_dir.join("summary.md"), summary).expect("write summary");
+
+    let completed_at = Utc.timestamp_opt(1_000, 0).single().unwrap();
+    csa_session::save_result(
+        project_root,
+        &session.meta_session_id,
+        &SessionResult {
+            status: SessionResult::status_from_exit_code(0),
+            exit_code: 0,
+            summary: summary.to_string(),
+            tool: "codex".to_string(),
+            started_at: completed_at,
+            completed_at,
+            ..Default::default()
+        },
+    )
+    .expect("save legacy success result");
+
+    session.meta_session_id
+}
+
+#[test]
+fn issue_2236_check_verdict_rejects_compound_legacy_pass_labels() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    let cases = [
+        (
+            "clean-up compound",
+            "Decision: clean-up required before merge\n",
+        ),
+        (
+            "clean word compound",
+            "Decision: clean up required before merge\n",
+        ),
+        (
+            "pass-through compound",
+            "Review result: pass-through behavior still needs validation\n",
+        ),
+        (
+            "pass word compound",
+            "Review result: pass through behavior still needs validation\n",
+        ),
+        ("pass/fail ambiguous", "Final verdict: pass/fail unclear\n"),
+        (
+            "pass spaced dash ambiguous",
+            "Final verdict: pass - fail unclear\n",
+        ),
+        (
+            "pass plus ambiguous final verdict",
+            "Review result: pass\nFinal verdict: pass/fail unclear\n",
+        ),
+        (
+            "pass plus spaced dash ambiguous final verdict",
+            "Review result: pass\nFinal verdict: pass - fail unclear\n",
+        ),
+    ];
+
+    for (case_name, summary) in cases {
+        let (project, branch, head_sha) = setup_feature_repo();
+        let expected_diff_fingerprint = crate::review_cmd::compute_review_diff_fingerprint(
+            project.path(),
+            REQUIRED_FULL_DIFF_SCOPE,
+        )
+        .expect("feature branch should have a main...HEAD diff");
+        let session_created_at =
+            utc_timestamp(latest_reflog_timestamp_secs(project.path(), "main") + 1, 0);
+        let session_id = write_legacy_success_result_with_created_at(
+            project.path(),
+            &branch,
+            &head_sha,
+            "review: range:main...HEAD",
+            Some("review"),
+            summary,
+            session_created_at,
+        );
+        let session_dir = csa_session::get_session_dir(project.path(), &session_id).unwrap();
+        assert!(!session_dir.join("review_meta.json").exists());
+        assert!(
+            !session_dir
+                .join("output")
+                .join("review-verdict.json")
+                .exists()
+        );
+
+        let args = parse_review_args(&["csa", "review", "--check-verdict"]);
+        let exit = handle_check_verdict(project.path(), &args).unwrap();
+        assert_eq!(
+            exit, 1,
+            "{case_name}: compound legacy label must not satisfy check-verdict"
+        );
+
+        let found = check_review_verdict_for_target(
+            project.path(),
+            &branch,
+            &head_sha,
+            REQUIRED_FULL_DIFF_SCOPE,
+            Some(expected_diff_fingerprint.as_str()),
+            None,
+        )
+        .unwrap();
+        assert!(
+            found.is_none(),
+            "{case_name}: compound legacy label must not produce an accepted PASS sidecar"
+        );
+        let meta = read_review_meta(&session_dir)
+            .unwrap()
+            .expect("compound legacy label should recover fail-closed metadata");
+        assert_eq!(
+            meta.decision,
+            ReviewDecision::Uncertain.as_str(),
+            "{case_name}"
+        );
+        assert_eq!(meta.verdict, "UNCERTAIN", "{case_name}");
+        assert_eq!(meta.exit_code, 1, "{case_name}");
+        assert_eq!(
+            meta.diff_fingerprint.as_deref(),
+            Some(expected_diff_fingerprint.as_str()),
+            "{case_name}"
+        );
+
+        let verdict_path = session_dir.join("output").join("review-verdict.json");
+        let artifact: ReviewVerdictArtifact = serde_json::from_str(
+            &std::fs::read_to_string(&verdict_path)
+                .expect("compound legacy label should recover review-verdict.json"),
+        )
+        .expect("compound legacy recovered review-verdict.json should parse");
+        assert_eq!(artifact.decision, ReviewDecision::Uncertain, "{case_name}");
+        assert_eq!(artifact.verdict_legacy, "UNCERTAIN", "{case_name}");
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -10,7 +10,7 @@ use tracing::{debug, warn};
 #[path = "review_cmd_output_artifacts.rs"]
 mod artifacts;
 #[path = "review_cmd_output_clean.rs"]
-mod clean_detection;
+pub(super) mod clean_detection;
 #[path = "review_cmd_output_consistency.rs"]
 mod consistency;
 #[path = "review_cmd_output_diagnostics.rs"]

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -74,6 +74,10 @@ fn verdict_token_pass_or_clean(text: &str) -> bool {
     verdict_token_matches(text, PASS_VERDICT_TOKENS, MatchCase::Sensitive)
 }
 
+pub(crate) fn detect_bounded_clean_verdict_token(text: &str) -> bool {
+    verdict_token_pass_or_clean(text)
+}
+
 /// Detect an affirmative FAIL verdict token (`FAIL`/`HAS_ISSUES`/`REJECT`),
 /// mirroring [`verdict_token_pass_or_clean`]. Matches ONLY bounded verdict tokens
 /// (bare line, `Verdict:`-labeled, or `**`/`__`-emphasized) — never the substring

--- a/crates/cli-sub-agent/src/session_observability.rs
+++ b/crates/cli-sub-agent/src/session_observability.rs
@@ -3,11 +3,15 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::Result;
-use csa_session::{ReviewVerdictArtifact, SessionArtifact, SessionResult};
+use csa_session::{SessionArtifact, SessionResult};
 use tracing::debug;
 
 #[path = "session_observability_gate.rs"]
 mod gate;
+#[path = "session_observability_legacy_review_pass.rs"]
+mod legacy_review_pass;
+#[path = "session_observability_review_verdict.rs"]
+mod review_verdict;
 
 const SUMMARY_MAX_CHARS: usize = 200;
 const REVIEW_SUMMARY_FAIL_TOKENS: &[&str] = &["FAIL", "HAS_ISSUES", "REJECT"];
@@ -60,7 +64,19 @@ pub(crate) fn refresh_and_repair_result_from_dir(
         result.events_count = events_count;
         changed = true;
     }
-    if sync_review_verdict_exit_code(session_dir, &mut result)? {
+    if legacy_review_pass::recover_legacy_plain_pass_review_sidecars_from_dir(
+        session_dir,
+        &mut result,
+    )? {
+        changed = true;
+    }
+    let force_review_failure =
+        human_review_summary_requires_failed_gate(session_dir, &result.summary);
+    if review_verdict::sync_review_verdict_exit_code(
+        session_dir,
+        &mut result,
+        force_review_failure,
+    )? {
         changed = true;
     }
     if gate::infer_post_exec_gate_failure_from_log(session_dir, &result_path, &mut result)? {
@@ -99,7 +115,18 @@ pub(crate) fn enrich_result_from_session_dir(
         changed = true;
     }
 
-    if sync_review_verdict_exit_code(session_dir, result)? {
+    if legacy_review_pass::recover_legacy_plain_pass_review_sidecars(
+        project_root,
+        session_id,
+        session_dir,
+        result,
+    )? {
+        changed = true;
+    }
+
+    let force_review_failure =
+        human_review_summary_requires_failed_gate(session_dir, &result.summary);
+    if review_verdict::sync_review_verdict_exit_code(session_dir, result, force_review_failure)? {
         changed = true;
     }
 
@@ -116,18 +143,6 @@ pub(crate) fn enrich_result_from_session_dir(
     Ok(changed)
 }
 
-fn sync_review_verdict_exit_code(session_dir: &Path, result: &mut SessionResult) -> Result<bool> {
-    let exit_code = if human_review_summary_requires_failed_gate(session_dir, &result.summary) {
-        Some(1)
-    } else {
-        read_review_verdict_exit_code(session_dir)?
-    };
-    let Some(exit_code) = exit_code else {
-        return Ok(false);
-    };
-    Ok(sync_result_exit_code(result, exit_code))
-}
-
 pub(crate) fn human_review_summary_requires_failed_gate(
     session_dir: &Path,
     raw_summary: &str,
@@ -135,10 +150,15 @@ pub(crate) fn human_review_summary_requires_failed_gate(
     crate::session_summary_text::human_session_summary(session_dir, raw_summary).is_some_and(
         |summary| {
             review_summary_has_fail_verdict(&summary)
-                || session_dir.join("review_meta.json").is_file()
+                || human_review_summary_can_apply_blocking_outcomes(session_dir)
                     && review_summary_has_blocking_outcome(&summary)
         },
     )
+}
+
+fn human_review_summary_can_apply_blocking_outcomes(session_dir: &Path) -> bool {
+    session_dir.join("review_meta.json").is_file()
+        || legacy_review_pass::is_review_session_dir(session_dir)
 }
 
 fn review_summary_has_fail_verdict(summary: &str) -> bool {
@@ -382,30 +402,6 @@ fn summary_verdict_token_is_bounded(rest: &str) -> bool {
             .is_none_or(|next| !next.is_ascii_alphanumeric() && next != '_'),
         _ => true,
     }
-}
-
-fn sync_result_exit_code(result: &mut SessionResult, exit_code: i32) -> bool {
-    let status = SessionResult::status_from_exit_code(exit_code);
-    if result.exit_code == exit_code && result.status == status {
-        return false;
-    }
-
-    result.exit_code = exit_code;
-    result.status = status;
-    true
-}
-
-fn read_review_verdict_exit_code(session_dir: &Path) -> Result<Option<i32>> {
-    let verdict_path = session_dir.join("output").join("review-verdict.json");
-    if !verdict_path.is_file() {
-        return Ok(None);
-    }
-
-    let raw = fs::read_to_string(&verdict_path)?;
-    let artifact: ReviewVerdictArtifact = serde_json::from_str(&raw)?;
-    Ok(Some(
-        crate::verdict_exit_code::exit_code_from_review_decision(artifact.decision),
-    ))
 }
 
 pub(crate) fn build_missing_result_diagnostic(

--- a/crates/cli-sub-agent/src/session_observability_legacy_review_pass.rs
+++ b/crates/cli-sub-agent/src/session_observability_legacy_review_pass.rs
@@ -1,0 +1,675 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::review_cmd::detect_bounded_clean_verdict_token;
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use csa_core::types::ReviewDecision;
+use csa_session::{ReviewVerdictArtifact, SessionResult};
+
+pub(super) fn recover_legacy_plain_pass_review_sidecars_from_dir(
+    session_dir: &Path,
+    result: &mut SessionResult,
+) -> Result<bool> {
+    if review_sidecar_exists(session_dir) {
+        return Ok(false);
+    }
+    let Some(session) = read_session_state(session_dir)? else {
+        return Ok(false);
+    };
+    let project_root = PathBuf::from(&session.project_path);
+    recover_legacy_plain_pass_review_sidecars_for_session(
+        &project_root,
+        session_dir,
+        result,
+        &session,
+    )
+}
+
+pub(super) fn recover_legacy_plain_pass_review_sidecars(
+    project_root: &Path,
+    session_id: &str,
+    session_dir: &Path,
+    result: &mut SessionResult,
+) -> Result<bool> {
+    if review_sidecar_exists(session_dir) {
+        return Ok(false);
+    }
+    let session = csa_session::load_session(project_root, session_id)?;
+    recover_legacy_plain_pass_review_sidecars_for_session(
+        project_root,
+        session_dir,
+        result,
+        &session,
+    )
+}
+
+fn recover_legacy_plain_pass_review_sidecars_for_session(
+    project_root: &Path,
+    session_dir: &Path,
+    result: &mut SessionResult,
+    session: &csa_session::MetaSessionState,
+) -> Result<bool> {
+    if review_sidecar_exists(session_dir) || !is_review_session(session) {
+        return Ok(false);
+    }
+
+    let Some(summary) = legacy_review_summary_text(session_dir, result) else {
+        return Ok(false);
+    };
+    let blocking_summary = super::human_review_summary_requires_failed_gate(session_dir, &summary);
+    let summary_decision = legacy_plain_review_summary_decision(&summary);
+    let Some(decision) =
+        recovered_legacy_review_sidecar_decision(summary_decision, blocking_summary)
+    else {
+        return Ok(false);
+    };
+    if decision == ReviewDecision::Pass && result.exit_code != 0 {
+        return Ok(false);
+    }
+
+    let scope = canonical_review_scope(session);
+    let head_sha = session
+        .vcs_identity
+        .as_ref()
+        .and_then(|identity| identity.commit_id.clone())
+        .or_else(|| session.git_head_at_creation.clone())
+        .unwrap_or_default();
+    let tool = non_empty(result.tool.as_str())
+        .map(ToOwned::to_owned)
+        .or_else(|| latest_session_tool(session))
+        .unwrap_or_else(|| "unknown".to_string());
+    let timestamp = result.completed_at;
+    let diff_fingerprint =
+        trusted_legacy_plain_review_diff_fingerprint(project_root, &scope, session);
+
+    let legacy_verdict = legacy_verdict_for_review_decision(decision);
+    let mut verdict = ReviewVerdictArtifact::from_parts(
+        session.meta_session_id.clone(),
+        decision,
+        legacy_verdict,
+        &[],
+        Vec::new(),
+    );
+    verdict.timestamp = timestamp;
+    csa_session::write_review_verdict(session_dir, &verdict)?;
+
+    let meta = csa_session::ReviewSessionMeta {
+        session_id: session.meta_session_id.clone(),
+        head_sha,
+        decision: decision.as_str().to_string(),
+        verdict: legacy_verdict.to_string(),
+        review_mode: None,
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool,
+        scope,
+        exit_code: crate::verdict_exit_code::exit_code_from_review_decision(decision),
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp,
+        diff_fingerprint,
+        fix_convergence: None,
+    };
+    csa_session::write_review_meta(session_dir, &meta)?;
+
+    Ok(true)
+}
+
+fn recovered_legacy_review_sidecar_decision(
+    summary_decision: Option<LegacyPlainReviewSummaryDecision>,
+    blocking_summary: bool,
+) -> Option<ReviewDecision> {
+    if blocking_summary {
+        return Some(ReviewDecision::Fail);
+    }
+
+    match summary_decision {
+        Some(LegacyPlainReviewSummaryDecision::Decision(decision)) => Some(decision),
+        Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel) => {
+            // A recognized-but-ambiguous legacy decision is still a review
+            // candidate. Persist it as fail-closed metadata so its timestamp
+            // can supersede older PASS evidence in check-verdict ordering.
+            Some(ReviewDecision::Uncertain)
+        }
+        None => None,
+    }
+}
+
+fn legacy_verdict_for_review_decision(decision: ReviewDecision) -> &'static str {
+    match decision {
+        ReviewDecision::Pass => "CLEAN",
+        ReviewDecision::Fail => "HAS_ISSUES",
+        ReviewDecision::Skip => "SKIP",
+        ReviewDecision::Uncertain => "UNCERTAIN",
+        ReviewDecision::Unavailable => "UNAVAILABLE",
+    }
+}
+
+fn review_sidecar_exists(session_dir: &Path) -> bool {
+    session_dir.join("review_meta.json").is_file()
+        || session_dir
+            .join("output")
+            .join("review-verdict.json")
+            .is_file()
+}
+
+fn read_session_state(session_dir: &Path) -> Result<Option<csa_session::MetaSessionState>> {
+    let path = session_dir.join("state.toml");
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(&path)?;
+    Ok(Some(toml::from_str(&raw)?))
+}
+
+pub(super) fn is_review_session_dir(session_dir: &Path) -> bool {
+    read_session_state(session_dir)
+        .ok()
+        .flatten()
+        .is_some_and(|session| is_review_session(&session))
+}
+
+pub(super) fn is_review_session(session: &csa_session::MetaSessionState) -> bool {
+    if matches!(
+        session.task_context.task_type.as_deref().map(str::trim),
+        Some("review" | "reviewer_sub_session")
+    ) {
+        return true;
+    }
+
+    session
+        .description
+        .as_deref()
+        .is_some_and(is_legacy_review_description)
+}
+
+fn is_legacy_review_description(description: &str) -> bool {
+    let description = description.trim();
+    description.eq_ignore_ascii_case("review")
+        || description.eq_ignore_ascii_case("initializing daemon review")
+        || has_ascii_prefix_ignore_case(description, "review:")
+        || strip_multi_reviewer_scope(description).is_some()
+        || has_ascii_prefix_ignore_case(description, "code-review:")
+}
+
+fn canonical_review_scope(session: &csa_session::MetaSessionState) -> String {
+    session
+        .description
+        .as_deref()
+        .and_then(extract_review_scope)
+        .or_else(|| {
+            session
+                .description
+                .as_deref()
+                .map(str::trim)
+                .filter(|description| !description.is_empty())
+        })
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn extract_review_scope(description: &str) -> Option<&str> {
+    let description = description.trim();
+    strip_ascii_prefix_ignore_case(description, "review:")
+        .or_else(|| strip_multi_reviewer_scope(description))
+        .or_else(|| strip_ascii_prefix_ignore_case(description, "code-review:"))
+        .map(str::trim)
+        .filter(|scope| !scope.is_empty())
+}
+
+fn strip_multi_reviewer_scope(description: &str) -> Option<&str> {
+    let rest = strip_ascii_prefix_ignore_case(description, "review[")?;
+    let close_bracket = rest.find(']')?;
+    let reviewer_index = &rest[..close_bracket];
+    if reviewer_index.is_empty() || !reviewer_index.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let after_bracket = rest.get(close_bracket + 1..)?.trim_start();
+    after_bracket.strip_prefix(':').map(str::trim)
+}
+
+fn has_ascii_prefix_ignore_case(value: &str, prefix: &str) -> bool {
+    strip_ascii_prefix_ignore_case(value, prefix).is_some()
+}
+
+fn strip_ascii_prefix_ignore_case<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
+    let candidate = value.get(..prefix.len())?;
+    if candidate.eq_ignore_ascii_case(prefix) {
+        value.get(prefix.len()..)
+    } else {
+        None
+    }
+}
+
+fn latest_session_tool(session: &csa_session::MetaSessionState) -> Option<String> {
+    session
+        .tools
+        .iter()
+        .max_by_key(|(_, state)| state.updated_at)
+        .map(|(tool, _)| tool.clone())
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+fn legacy_review_summary_text(session_dir: &Path, result: &SessionResult) -> Option<String> {
+    fs::read_to_string(session_dir.join("output").join("summary.md"))
+        .ok()
+        .filter(|summary| !summary.trim().is_empty())
+        .or_else(|| non_empty(result.summary.as_str()).map(ToOwned::to_owned))
+}
+
+/// Plain legacy review summaries do not carry machine-readable diff identity.
+/// Never stamp the current `main...HEAD` fingerprint onto them unless the
+/// persisted session identity plus git reflog prove the checked-out HEAD and the
+/// base ref still match what the session saw at creation time. Without this
+/// proof, an old legacy verdict could be recovered after `main` advanced and
+/// falsely affect the current check-verdict fingerprint guard.
+fn trusted_legacy_plain_review_diff_fingerprint(
+    project_root: &Path,
+    scope: &str,
+    session: &csa_session::MetaSessionState,
+) -> Option<String> {
+    let session_head = session_head_sha(session)?;
+    let current_head = csa_session::detect_git_head(project_root)?;
+    if session_head != current_head {
+        return None;
+    }
+
+    let base_ref = review_scope_base_ref(scope)?;
+    let base_ref_proven = base_ref_unchanged_since_before_session_creation(
+        project_root,
+        base_ref,
+        session.created_at,
+    );
+    if !base_ref_proven {
+        return None;
+    }
+
+    crate::review_cmd::compute_review_diff_fingerprint(project_root, scope)
+}
+
+fn session_head_sha(session: &csa_session::MetaSessionState) -> Option<String> {
+    session
+        .vcs_identity
+        .as_ref()
+        .and_then(|identity| identity.commit_id.as_deref().and_then(non_empty))
+        .or_else(|| session.git_head_at_creation.as_deref().and_then(non_empty))
+        .map(ToOwned::to_owned)
+}
+
+fn review_scope_base_ref(scope: &str) -> Option<&str> {
+    let scope = scope.trim();
+    let range = scope.strip_prefix("range:")?;
+    range_base_ref(range)
+}
+
+fn range_base_ref(range: &str) -> Option<&str> {
+    let range = range.trim();
+    let (base, head) = range.split_once("...").or_else(|| range.split_once(".."))?;
+    let base = base.trim();
+    let head = head.trim();
+    (!base.is_empty() && head == "HEAD").then_some(base)
+}
+
+fn base_ref_unchanged_since_before_session_creation(
+    project_root: &Path,
+    base_ref: &str,
+    session_created_at: DateTime<Utc>,
+) -> bool {
+    let Some(current_base) = git_commit_at(project_root, base_ref) else {
+        return false;
+    };
+    let Some(latest_reflog_entry) = latest_ref_reflog_entry(project_root, base_ref) else {
+        return false;
+    };
+
+    // Git reflog selectors and entries have second-granularity update timestamps.
+    // A ref update in the same second as session creation may have happened
+    // before or after the review session was created, so equality is ambiguous.
+    // Only trust legacy PASS backfill when the latest base-ref update is strictly
+    // before the session's creation second and therefore could not be a
+    // same-second advance.
+    latest_reflog_entry.commit == current_base
+        && latest_reflog_entry.timestamp_secs < session_created_at.timestamp()
+}
+
+struct ReflogEntry {
+    commit: String,
+    timestamp_secs: i64,
+}
+
+fn latest_ref_reflog_entry(project_root: &Path, ref_name: &str) -> Option<ReflogEntry> {
+    let output = Command::new("git")
+        .args([
+            "reflog",
+            "show",
+            "-n",
+            "1",
+            "--date=unix",
+            "--format=%H%x00%gD",
+            "--end-of-options",
+            ref_name,
+        ])
+        .current_dir(project_root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let line = stdout.trim_end_matches(&['\r', '\n'][..]);
+    let (commit, reflog_selector) = line.split_once('\0')?;
+    let commit = non_empty(commit)?.to_owned();
+    let timestamp_secs = parse_unix_reflog_selector_timestamp_secs(reflog_selector)?;
+    Some(ReflogEntry {
+        commit,
+        timestamp_secs,
+    })
+}
+
+fn parse_unix_reflog_selector_timestamp_secs(reflog_selector: &str) -> Option<i64> {
+    let reflog_selector = reflog_selector.trim();
+    let reflog_selector = reflog_selector.strip_suffix('}')?;
+    let (_, timestamp_secs) = reflog_selector.rsplit_once("@{")?;
+    timestamp_secs.trim().parse().ok()
+}
+
+fn git_commit_at(project_root: &Path, rev: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args([
+            "rev-parse",
+            "--verify",
+            "--end-of-options",
+            &format!("{rev}^{{commit}}"),
+        ])
+        .current_dir(project_root)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    non_empty(stdout.as_str()).map(ToOwned::to_owned)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LegacyPlainReviewSummaryDecision {
+    Decision(ReviewDecision),
+    InvalidRecognizedLabel,
+}
+
+fn legacy_plain_review_summary_decision(summary: &str) -> Option<LegacyPlainReviewSummaryDecision> {
+    let mut pass = false;
+    for line in summary
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+    {
+        let Some(decision) = labeled_review_decision(line) else {
+            if detect_bounded_clean_verdict_token(line) {
+                if has_ambiguous_or_compound_clean_verdict_phrase(line) {
+                    return Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel);
+                }
+                pass = true;
+            }
+            continue;
+        };
+        match decision {
+            LegacyPlainReviewSummaryDecision::Decision(ReviewDecision::Pass) => pass = true,
+            LegacyPlainReviewSummaryDecision::Decision(decision) => {
+                return Some(LegacyPlainReviewSummaryDecision::Decision(decision));
+            }
+            LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel => {
+                return Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel);
+            }
+        }
+    }
+    pass.then_some(LegacyPlainReviewSummaryDecision::Decision(
+        ReviewDecision::Pass,
+    ))
+}
+
+fn labeled_review_decision(line: &str) -> Option<LegacyPlainReviewSummaryDecision> {
+    // Keep the generic labels aligned with the bounded verdict-token parser
+    // (`Verdict:`, `Decision:`, `Status:`, `Result:`, `Review:`), while still
+    // accepting older more-specific legacy labels.
+    const LABELS: &[&str] = &[
+        "review result",
+        "review verdict",
+        "review decision",
+        "final verdict",
+        "final decision",
+        "verdict",
+        "decision",
+        "status",
+        "result",
+        "review",
+    ];
+
+    let line = line
+        .trim_start_matches(|ch: char| ch == '#' || ch == '*' || ch == '-' || ch.is_whitespace())
+        .trim_start();
+    let lower = line.to_ascii_lowercase();
+    for label in LABELS {
+        let Some(rest) = lower.strip_prefix(label) else {
+            continue;
+        };
+        let Some(original_rest) = line.get(label.len()..) else {
+            continue;
+        };
+        let trimmed = rest.trim_start();
+        if !(trimmed.starts_with(':') || trimmed.starts_with('=')) {
+            continue;
+        }
+        let value = original_rest
+            .trim_start()
+            .trim_start_matches(&[':', '='][..])
+            .trim_start();
+        let parsed_decision =
+            review_decision_value(value).map(LegacyPlainReviewSummaryDecision::Decision);
+        if matches!(
+            parsed_decision,
+            Some(LegacyPlainReviewSummaryDecision::Decision(
+                ReviewDecision::Pass
+            ))
+        ) && has_ambiguous_or_compound_clean_verdict_phrase(line)
+        {
+            return Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel);
+        }
+        let parsed_decision = parsed_decision.or_else(|| {
+            (detect_bounded_clean_verdict_token(line)
+                && !has_ambiguous_or_compound_clean_verdict_phrase(line))
+            .then_some(LegacyPlainReviewSummaryDecision::Decision(
+                ReviewDecision::Pass,
+            ))
+        });
+        return Some(
+            parsed_decision.unwrap_or(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel),
+        );
+    }
+    None
+}
+
+fn has_ambiguous_or_compound_clean_verdict_phrase(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    ["clean-up", "clean up", "pass-through", "pass through"]
+        .iter()
+        .any(|phrase| lower.contains(phrase))
+        || contains_pass_fail_separator_phrase(&lower)
+}
+
+fn contains_pass_fail_separator_phrase(lower: &str) -> bool {
+    for (index, _) in lower.match_indices("pass") {
+        let Some(after_pass) = lower.get(index + "pass".len()..) else {
+            continue;
+        };
+        let after_pass = after_pass.trim_start();
+        let mut chars = after_pass.chars();
+        let Some(separator) = chars.next() else {
+            continue;
+        };
+        if !is_compound_decision_separator(separator) {
+            continue;
+        }
+        let Some(after_separator) = after_pass.get(separator.len_utf8()..) else {
+            continue;
+        };
+        if after_separator.trim_start().starts_with("fail") {
+            return true;
+        }
+    }
+    false
+}
+
+fn review_decision_value(value: &str) -> Option<ReviewDecision> {
+    let value = value
+        .trim_end()
+        .trim_start_matches(is_legacy_decision_prefix_char);
+    let token_end = value
+        .char_indices()
+        .find_map(|(index, ch)| (!is_review_decision_token_char(ch)).then_some(index))
+        .unwrap_or(value.len());
+    let token = value.get(..token_end).filter(|token| !token.is_empty())?;
+    let rest = value.get(token_end..).unwrap_or_default();
+    let decision = review_decision_token(token)?;
+    if !has_standalone_decision_suffix(rest) {
+        return None;
+    }
+
+    Some(decision)
+}
+
+fn review_decision_token(token: &str) -> Option<ReviewDecision> {
+    if token.eq_ignore_ascii_case("pass") || token.eq_ignore_ascii_case("clean") {
+        Some(ReviewDecision::Pass)
+    } else if token.eq_ignore_ascii_case("fail") || token.eq_ignore_ascii_case("has_issues") {
+        Some(ReviewDecision::Fail)
+    } else if token.eq_ignore_ascii_case("uncertain") {
+        Some(ReviewDecision::Uncertain)
+    } else if token.eq_ignore_ascii_case("unavailable") {
+        Some(ReviewDecision::Unavailable)
+    } else if token.eq_ignore_ascii_case("skip") {
+        Some(ReviewDecision::Skip)
+    } else {
+        None
+    }
+}
+
+fn is_legacy_decision_prefix_char(ch: char) -> bool {
+    ch.is_whitespace() || matches!(ch, '*' | '`' | '"' | '\'' | '(' | '[' | '{')
+}
+
+fn is_review_decision_token_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_'
+}
+
+fn has_standalone_decision_suffix(rest: &str) -> bool {
+    if rest.trim().is_empty() {
+        return true;
+    }
+    if has_attached_compound_decision_suffix(rest) {
+        return false;
+    }
+    if has_explanatory_separator_decision_suffix(rest) {
+        return true;
+    }
+    if rest.chars().next().is_some_and(|ch| ch.is_whitespace()) {
+        return false;
+    }
+    rest.chars()
+        .next()
+        .is_some_and(is_legacy_standalone_decision_terminator)
+}
+
+fn has_attached_compound_decision_suffix(rest: &str) -> bool {
+    let mut chars = rest.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    is_compound_decision_separator(first) && chars.next().is_some_and(is_review_decision_token_char)
+}
+
+fn has_explanatory_separator_decision_suffix(rest: &str) -> bool {
+    let trimmed = rest.trim_start();
+    let mut chars = trimmed.chars();
+    let Some(separator) = chars.next() else {
+        return false;
+    };
+    if !is_compound_decision_separator(separator) {
+        return false;
+    }
+    let after_separator = &trimmed[separator.len_utf8()..];
+    if after_separator
+        .chars()
+        .next()
+        .is_some_and(is_review_decision_token_char)
+    {
+        return false;
+    }
+    !starts_with_non_passing_review_decision(after_separator)
+}
+
+fn starts_with_non_passing_review_decision(value: &str) -> bool {
+    let value = value.trim_start_matches(is_legacy_decision_prefix_char);
+    let token_end = value
+        .char_indices()
+        .find_map(|(index, ch)| (!is_review_decision_token_char(ch)).then_some(index))
+        .unwrap_or(value.len());
+    let Some(token) = value.get(..token_end).filter(|token| !token.is_empty()) else {
+        return false;
+    };
+    let rest = value.get(token_end..).unwrap_or_default();
+    if pass_like_decision_has_compound_word_suffix(token, rest) {
+        return true;
+    }
+    !matches!(
+        review_decision_token(token),
+        Some(ReviewDecision::Pass) | None
+    )
+}
+
+fn pass_like_decision_has_compound_word_suffix(token: &str, rest: &str) -> bool {
+    (token.eq_ignore_ascii_case("clean") && rest_starts_with_word(rest, "up"))
+        || (token.eq_ignore_ascii_case("pass") && rest_starts_with_word(rest, "through"))
+}
+
+fn rest_starts_with_word(rest: &str, word: &str) -> bool {
+    let rest = rest.trim_start();
+    let Some(head) = rest.get(..word.len()) else {
+        return false;
+    };
+    if !head.eq_ignore_ascii_case(word) {
+        return false;
+    }
+    let after_word = rest.get(word.len()..).unwrap_or_default();
+    after_word
+        .chars()
+        .next()
+        .is_none_or(|ch| !is_review_decision_token_char(ch))
+}
+
+fn is_compound_decision_separator(ch: char) -> bool {
+    matches!(
+        ch,
+        '-' | '/' | '\\' | '\u{2010}' | '\u{2011}' | '\u{2012}' | '\u{2013}' | '\u{2014}'
+    )
+}
+
+fn is_legacy_standalone_decision_terminator(ch: char) -> bool {
+    matches!(
+        ch,
+        '.' | '!' | '?' | '*' | '`' | '"' | '\'' | ')' | ']' | '}'
+    )
+}
+
+#[cfg(test)]
+#[path = "session_observability_legacy_review_pass_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/session_observability_legacy_review_pass_tests.rs
+++ b/crates/cli-sub-agent/src/session_observability_legacy_review_pass_tests.rs
@@ -1,0 +1,168 @@
+use super::*;
+
+#[test]
+fn review_decision_value_accepts_clear_standalone_legacy_pass_decisions() {
+    assert_eq!(
+        review_decision_value("pass. Scope main...HEAD has no blocking issues"),
+        Some(ReviewDecision::Pass)
+    );
+    assert_eq!(review_decision_value("CLEAN"), Some(ReviewDecision::Pass));
+    assert_eq!(
+        review_decision_value("**PASS** no findings"),
+        Some(ReviewDecision::Pass)
+    );
+    assert_eq!(
+        review_decision_value("PASS - all tests passed"),
+        Some(ReviewDecision::Pass)
+    );
+    assert_eq!(
+        review_decision_value("CLEAN/ no blocking findings"),
+        Some(ReviewDecision::Pass)
+    );
+}
+
+#[test]
+fn legacy_plain_review_summary_decision_accepts_bounded_clean_verdict_shapes() {
+    assert_eq!(
+        legacy_plain_review_summary_decision("PASS\n"),
+        Some(LegacyPlainReviewSummaryDecision::Decision(
+            ReviewDecision::Pass
+        ))
+    );
+    assert_eq!(
+        legacy_plain_review_summary_decision("**CLEAN** — no blocking findings\n"),
+        Some(LegacyPlainReviewSummaryDecision::Decision(
+            ReviewDecision::Pass
+        ))
+    );
+    assert_eq!(
+        legacy_plain_review_summary_decision("Verdict: PASS - all tests passed\n"),
+        Some(LegacyPlainReviewSummaryDecision::Decision(
+            ReviewDecision::Pass
+        ))
+    );
+    assert_eq!(
+        legacy_plain_review_summary_decision("Status: CLEAN - all tests passed\n"),
+        Some(LegacyPlainReviewSummaryDecision::Decision(
+            ReviewDecision::Pass
+        ))
+    );
+    assert_eq!(
+        legacy_plain_review_summary_decision("Verdict: __PASS__ - all tests passed\n"),
+        Some(LegacyPlainReviewSummaryDecision::Decision(
+            ReviewDecision::Pass
+        ))
+    );
+}
+
+#[test]
+fn legacy_plain_review_summary_decision_recognizes_bounded_parser_labels_fail_closed() {
+    assert_eq!(
+        legacy_plain_review_summary_decision("Status: FAIL\n"),
+        Some(LegacyPlainReviewSummaryDecision::Decision(
+            ReviewDecision::Fail
+        ))
+    );
+    assert_eq!(
+        legacy_plain_review_summary_decision("Result: clean-up required before merge\n"),
+        Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel)
+    );
+    assert_eq!(
+        legacy_plain_review_summary_decision("Status: pass/fail unclear\n"),
+        Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel)
+    );
+    assert_eq!(
+        legacy_plain_review_summary_decision(
+            "Review: pass-through behavior still needs validation\n"
+        ),
+        Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel)
+    );
+}
+
+#[test]
+fn legacy_plain_review_summary_decision_rejects_ambiguous_label_after_bounded_pass() {
+    assert_eq!(
+        legacy_plain_review_summary_decision("PASS\nFinal verdict: pass/fail unclear\n"),
+        Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel)
+    );
+    assert_eq!(
+        legacy_plain_review_summary_decision("**CLEAN**\nFinal verdict: pass - fail unclear\n"),
+        Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel)
+    );
+    assert_eq!(
+        legacy_plain_review_summary_decision(
+            "Status: PASS through behavior still needs validation\n"
+        ),
+        Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel)
+    );
+    assert_eq!(
+        legacy_plain_review_summary_decision("Status: CLEAN up required before merge\n"),
+        Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel)
+    );
+    assert_eq!(
+        legacy_plain_review_summary_decision("Status: PASS - fail unclear\n"),
+        Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel)
+    );
+}
+
+#[test]
+fn review_decision_value_rejects_compound_pass_like_values() {
+    assert_eq!(
+        review_decision_value("clean-up required before merge"),
+        None
+    );
+    assert_eq!(
+        review_decision_value("clean up required before merge"),
+        None
+    );
+    assert_eq!(
+        review_decision_value("pass-through behavior still needs validation"),
+        None
+    );
+    assert_eq!(
+        review_decision_value("pass through behavior still needs validation"),
+        None
+    );
+    assert_eq!(review_decision_value("pass/fail unclear"), None);
+    assert_eq!(review_decision_value("pass / fail unclear"), None);
+    assert_eq!(review_decision_value("pass - fail unclear"), None);
+    assert_eq!(review_decision_value("pass - clean up required"), None);
+}
+
+#[test]
+fn legacy_plain_review_summary_decision_rejects_ambiguous_label_after_pass() {
+    assert_eq!(
+        legacy_plain_review_summary_decision(
+            "Review result: pass\nFinal verdict: pass/fail unclear\n"
+        ),
+        Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel)
+    );
+    assert_eq!(
+        legacy_plain_review_summary_decision(
+            "Review result: pass\nFinal verdict: pass - fail unclear\n"
+        ),
+        Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel)
+    );
+}
+
+#[test]
+fn recovered_legacy_sidecar_decision_fails_closed_for_invalid_recognized_label() {
+    assert_eq!(
+        recovered_legacy_review_sidecar_decision(
+            Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel),
+            false,
+        ),
+        Some(ReviewDecision::Uncertain)
+    );
+}
+
+#[test]
+fn recovered_legacy_sidecar_decision_does_not_invent_no_decision_sidecar() {
+    assert_eq!(
+        legacy_plain_review_summary_decision(
+            "Reviewer notes only: inspected the implementation and test plan.\n"
+        ),
+        None
+    );
+    assert_eq!(recovered_legacy_review_sidecar_decision(None, false), None);
+}

--- a/crates/cli-sub-agent/src/session_observability_review_verdict.rs
+++ b/crates/cli-sub-agent/src/session_observability_review_verdict.rs
@@ -1,0 +1,45 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+use csa_session::{ReviewVerdictArtifact, SessionResult};
+
+pub(super) fn sync_review_verdict_exit_code(
+    session_dir: &Path,
+    result: &mut SessionResult,
+    force_review_failure: bool,
+) -> Result<bool> {
+    let exit_code = if force_review_failure {
+        Some(1)
+    } else {
+        read_review_verdict_exit_code(session_dir)?
+    };
+    let Some(exit_code) = exit_code else {
+        return Ok(false);
+    };
+    Ok(sync_result_exit_code(result, exit_code))
+}
+
+fn sync_result_exit_code(result: &mut SessionResult, exit_code: i32) -> bool {
+    let status = SessionResult::status_from_exit_code(exit_code);
+    if result.exit_code == exit_code && result.status == status {
+        return false;
+    }
+
+    result.exit_code = exit_code;
+    result.status = status;
+    true
+}
+
+fn read_review_verdict_exit_code(session_dir: &Path) -> Result<Option<i32>> {
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    if !verdict_path.is_file() {
+        return Ok(None);
+    }
+
+    let raw = fs::read_to_string(&verdict_path)?;
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(&raw)?;
+    Ok(Some(
+        crate::verdict_exit_code::exit_code_from_review_decision(artifact.decision),
+    ))
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1017"
-weave = "0.1.1017"
+csa = "0.1.1018"
+weave = "0.1.1018"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Fixes #2236 by recovering durable review verdict artifacts for legacy successful review sessions that only persisted a plain PASS/CLEAN summary, while keeping `review --check-verdict` fail-closed for stale or ambiguous evidence.

Key behaviors:

- recover legacy/plain PASS/CLEAN review summaries into `review_meta.json` and `output/review-verdict.json` only for qualified review/reviewer sessions
- preserve existing structured verdict artifacts as authoritative
- align legacy clean summary recognition with the existing bounded verdict parser, including `Verdict`, `Decision`, `Status`, `Result`, and `Review` labels
- persist ambiguous/compound recognized labels as non-pass/UNCERTAIN candidates so newer ambiguous reviews block older PASS evidence
- recover blocking human-review summaries as failed review candidates so newer blocking reviews supersede older PASS markers/sidecars
- treat explicit PASS markers as ordered candidates, not unconditional pass evidence
- avoid stamping current diff fingerprints unless reviewed HEAD and base identity are proven with reflog update timestamps
- fail closed for stale base, same-second base reflog ambiguity, and base reset/update-to-older-commit cases
- remove the temporary `#[allow(clippy::too_many_arguments)]` by refactoring the helper into a semantic spec struct
- bump workspace version to `0.1.1018`

## Verification

Local/worker gates that passed during the review-fix loop:

- `cargo test -p cli-sub-agent issue_2236 -- --nocapture`
- `cargo test -p cli-sub-agent check_verdict -- --nocapture`
- `cargo test -p cli-sub-agent session_observability -- --nocapture`
- `cargo test -p cli-sub-agent artifact_only -- --nocapture`
- `cargo test -p cli-sub-agent legacy_plain_review_summary_decision`
- `cargo test -p cli-sub-agent legacy_review_pass`
- `cargo test -p cli-sub-agent issue_2236 --all-features`
- `cargo test -p cli-sub-agent issue_2236_check_verdict_recovers_bounded_clean_verdict_summary_shapes -- --nocapture`
- `cargo test -p cli-sub-agent verdict_token -- --nocapture`
- `cargo nextest run -p cli-sub-agent --all-features -E 'test(issue_2236) or test(check_verdict) or test(session_observability)'`
- `cargo clippy -p cli-sub-agent --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- `git diff --cached --check`
- `just find-monolith-files`
- `just monolith-test`
- `just pre-commit-fast`
- hook-enabled amend quality gates

Exact-head evidence:

- HEAD: `bb4f9f5d9cc383c8dac41a264ff567b2b6ecdc40`
- binary: `target/debug/csa 0.1.1018 (bb4f9f5d)`
- target: `/mnt/ssd/mirror-rootfs/.../target`
- migrations: pending `0`

CSA exact-head review was attempted but ended as infra/no-verdict due CSA memory soft-limit:

- session: `01KV70A166YY064EMENQNPNZ84`
- command: `target/debug/csa review --sa-mode true --range main...HEAD --tool codex --tier tier-4-critical --no-failover`
- result: `signal` / exit `143`
- kill hint: `memory_soft_limit`
- details posted to #2247: https://github.com/RyderFreeman4Logos/cli-sub-agent/issues/2247#issuecomment-4714002641

Same-SHA native exact-head fallback review for `main...HEAD` passed clean:

- documented on #2236: https://github.com/RyderFreeman4Logos/cli-sub-agent/issues/2236#issuecomment-4714043772

Because CSA exact-head review was unavailable and the same-SHA native fallback passed, push used a narrow `CSA_SKIP_REVIEW_CHECK=1` bypass with reason bound to session `01KV70A166YY064EMENQNPNZ84` and reviewed SHA `bb4f9f5d`.

Closes #2236.
