### PR TITLE
fix(review): resolve cgroup memory-events diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1018"
+version = "0.1.1019"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1018"
+version = "0.1.1019"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_kill_diagnostics.rs
+++ b/crates/cli-sub-agent/src/session_kill_diagnostics.rs
@@ -1,7 +1,7 @@
 //! Best-effort diagnostics for signal exits that often mean host OOM pressure
 //! or a bounded in-turn child command timing out.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 use csa_resource::memory_monitor::{MEMORY_SOFT_LIMIT_KILL_HINT, MemorySoftLimitKillDiagnostic};
@@ -13,7 +13,13 @@ use csa_session::{
 #[path = "session_kill_diagnostics_memory.rs"]
 mod memory;
 
+#[cfg(target_os = "linux")]
+#[path = "session_kill_diagnostics_cgroup.rs"]
+mod cgroup;
+
 mod child_timeout;
+#[cfg(target_os = "linux")]
+use cgroup::read_session_cgroup_memory_events;
 use child_timeout::{
     ChildTimeoutKind, ChildTimeoutProvenance, detect_child_timeout_provenance, redact_command_text,
     truncate_one_line,
@@ -576,24 +582,6 @@ pub(crate) fn parse_meminfo(content: &str) -> Option<MemInfo> {
     })
 }
 
-fn parse_memory_events(content: &str) -> CgroupMemoryEvents {
-    let mut events = CgroupMemoryEvents {
-        oom: 0,
-        oom_kill: 0,
-    };
-    for line in content.lines() {
-        let mut fields = line.split_whitespace();
-        let key = fields.next();
-        let value = fields.next().and_then(|raw| raw.parse::<u64>().ok());
-        match (key, value) {
-            (Some("oom"), Some(value)) => events.oom = value,
-            (Some("oom_kill"), Some(value)) => events.oom_kill = value,
-            _ => {}
-        }
-    }
-    events
-}
-
 #[cfg(target_os = "linux")]
 fn read_meminfo_from_path(path: &Path) -> Option<MemInfo> {
     std::fs::read_to_string(path)
@@ -616,54 +604,6 @@ fn earlyoom_running() -> bool {
         }
         std::fs::read_to_string(entry.path().join("comm"))
             .is_ok_and(|comm| comm.trim() == "earlyoom")
-    })
-}
-
-#[cfg(target_os = "linux")]
-fn read_session_cgroup_memory_events(
-    tool_name: &str,
-    session_id: &str,
-) -> Option<CgroupMemoryEvents> {
-    let scope = csa_resource::cgroup::scope_unit_name(tool_name, session_id);
-    let mut first_readable = None;
-    for path in cgroup_memory_event_candidates(&scope) {
-        let Ok(content) = std::fs::read_to_string(path) else {
-            continue;
-        };
-        let events = parse_memory_events(&content);
-        if events.has_oom_event() {
-            return Some(events);
-        }
-        first_readable.get_or_insert(events);
-    }
-    first_readable
-}
-
-#[cfg(target_os = "linux")]
-fn cgroup_memory_event_candidates(scope: &str) -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
-    if let Some(uid) = effective_uid_from_proc_status() {
-        candidates.push(PathBuf::from(format!(
-            "/sys/fs/cgroup/user.slice/user-{uid}.slice/user@{uid}.service/app.slice/{scope}/memory.events"
-        )));
-        candidates.push(PathBuf::from(format!(
-            "/sys/fs/cgroup/user.slice/user-{uid}.slice/user@{uid}.service/{scope}/memory.events"
-        )));
-    }
-    candidates.push(PathBuf::from(format!(
-        "/sys/fs/cgroup/system.slice/{scope}/memory.events"
-    )));
-    candidates
-}
-
-#[cfg(target_os = "linux")]
-fn effective_uid_from_proc_status() -> Option<u32> {
-    let content = std::fs::read_to_string("/proc/self/status").ok()?;
-    content.lines().find_map(|line| {
-        let rest = line.strip_prefix("Uid:")?;
-        rest.split_whitespace()
-            .next()
-            .and_then(|value| value.parse().ok())
     })
 }
 

--- a/crates/cli-sub-agent/src/session_kill_diagnostics_cgroup.rs
+++ b/crates/cli-sub-agent/src/session_kill_diagnostics_cgroup.rs
@@ -1,0 +1,152 @@
+use std::path::PathBuf;
+
+use super::CgroupMemoryEvents;
+
+pub(super) fn read_session_cgroup_memory_events(
+    tool_name: &str,
+    session_id: &str,
+) -> Option<CgroupMemoryEvents> {
+    let scope = csa_resource::cgroup::scope_unit_name(tool_name, session_id);
+    let mut first_readable = None;
+    for path in cgroup_memory_event_candidates(&scope) {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let events = parse_memory_events(&content);
+        if events.has_oom_event() {
+            return Some(events);
+        }
+        first_readable.get_or_insert(events);
+    }
+    first_readable
+}
+
+fn parse_memory_events(content: &str) -> CgroupMemoryEvents {
+    let mut events = CgroupMemoryEvents {
+        oom: 0,
+        oom_kill: 0,
+    };
+    for line in content.lines() {
+        let mut fields = line.split_whitespace();
+        let key = fields.next();
+        let value = fields.next().and_then(|raw| raw.parse::<u64>().ok());
+        match (key, value) {
+            (Some("oom"), Some(value)) => events.oom = value,
+            (Some("oom_kill"), Some(value)) => events.oom_kill = value,
+            _ => {}
+        }
+    }
+    events
+}
+
+fn cgroup_memory_event_candidates(scope: &str) -> Vec<PathBuf> {
+    let control_group = query_systemd_control_group(scope);
+    cgroup_memory_event_candidates_from_parts(
+        scope,
+        effective_uid_from_proc_status(),
+        control_group.as_deref(),
+    )
+}
+
+fn cgroup_memory_event_candidates_from_parts(
+    scope: &str,
+    uid: Option<u32>,
+    control_group: Option<&str>,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(path) = control_group.and_then(systemd_control_group_memory_events_path) {
+        push_unique_path(&mut candidates, path);
+    }
+    if let Some(uid) = uid {
+        push_unique_path(
+            &mut candidates,
+            PathBuf::from(format!(
+                "/sys/fs/cgroup/user.slice/user-{uid}.slice/user@{uid}.service/app.slice/{scope}/memory.events"
+            )),
+        );
+        push_unique_path(
+            &mut candidates,
+            PathBuf::from(format!(
+                "/sys/fs/cgroup/user.slice/user-{uid}.slice/user@{uid}.service/{scope}/memory.events"
+            )),
+        );
+    }
+    push_unique_path(
+        &mut candidates,
+        PathBuf::from(format!("/sys/fs/cgroup/system.slice/{scope}/memory.events")),
+    );
+    candidates
+}
+
+fn query_systemd_control_group(scope: &str) -> Option<String> {
+    let output = std::process::Command::new("systemctl")
+        .args([
+            "--user",
+            "show",
+            scope,
+            "--property=ControlGroup",
+            "--value",
+        ])
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    systemd_control_group_value(&stdout).map(ToOwned::to_owned)
+}
+
+fn systemd_control_group_memory_events_path(raw: &str) -> Option<PathBuf> {
+    let control_group = systemd_control_group_value(raw)?;
+    let relative = control_group.strip_prefix('/').unwrap_or(control_group);
+    if relative.is_empty() {
+        return None;
+    }
+
+    let mut path = PathBuf::from("/sys/fs/cgroup");
+    for segment in relative.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return None;
+        }
+        path.push(segment);
+    }
+    path.push("memory.events");
+    Some(path)
+}
+
+fn systemd_control_group_value(raw: &str) -> Option<&str> {
+    raw.lines().find_map(|line| {
+        let trimmed = line.trim();
+        let value = trimmed
+            .strip_prefix("ControlGroup=")
+            .unwrap_or(trimmed)
+            .trim();
+        if value.is_empty() || value == "/" {
+            None
+        } else {
+            Some(value)
+        }
+    })
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.contains(&path) {
+        paths.push(path);
+    }
+}
+
+fn effective_uid_from_proc_status() -> Option<u32> {
+    let content = std::fs::read_to_string("/proc/self/status").ok()?;
+    content.lines().find_map(|line| {
+        let rest = line.strip_prefix("Uid:")?;
+        rest.split_whitespace()
+            .next()
+            .and_then(|value| value.parse().ok())
+    })
+}
+
+#[cfg(test)]
+#[path = "session_kill_diagnostics_cgroup_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/session_kill_diagnostics_cgroup_tests.rs
+++ b/crates/cli-sub-agent/src/session_kill_diagnostics_cgroup_tests.rs
@@ -1,0 +1,45 @@
+use super::*;
+use std::path::PathBuf;
+
+#[test]
+fn parses_cgroup_memory_events() {
+    let events = parse_memory_events("low 2\nhigh 3\nmax 4\noom 1\noom_kill 1\n");
+
+    assert_eq!(events.oom, 1);
+    assert_eq!(events.oom_kill, 1);
+    assert!(events.has_oom_event());
+    assert!(events.has_oom_kill_event());
+}
+
+#[test]
+fn cgroup_candidates_include_systemd_control_group_memory_events_path_first() {
+    let scope = "csa-codex-01KV4HXVYPG7N5Z9VHG7JYWSBT.scope";
+    let control_group = "/user.slice/user-1000.slice/user@1000.service/app.slice/app-csa.slice/\
+         csa-codex-01KV4HXVYPG7N5Z9VHG7JYWSBT.scope";
+
+    let candidates =
+        cgroup_memory_event_candidates_from_parts(scope, Some(1000), Some(control_group));
+
+    assert_eq!(
+        candidates.first(),
+        Some(&PathBuf::from(
+            "/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/\
+             app-csa.slice/csa-codex-01KV4HXVYPG7N5Z9VHG7JYWSBT.scope/memory.events"
+        ))
+    );
+    assert!(candidates.iter().any(|path| path
+        == &PathBuf::from(
+            "/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice/\
+         csa-codex-01KV4HXVYPG7N5Z9VHG7JYWSBT.scope/memory.events"
+        )));
+}
+
+#[test]
+fn systemd_control_group_memory_events_path_rejects_empty_root_and_traversal() {
+    for raw in ["", "\n", "/", "../evil.scope", "/user.slice/../evil.scope"] {
+        assert!(
+            systemd_control_group_memory_events_path(raw).is_none(),
+            "invalid ControlGroup must not produce a host path: {raw:?}"
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/session_kill_diagnostics_tests.rs
+++ b/crates/cli-sub-agent/src/session_kill_diagnostics_tests.rs
@@ -653,13 +653,3 @@ fn non_signal_exits_do_not_collect_observations() {
         assert!(!called.get(), "exit {exit_code} should not trigger checks");
     }
 }
-
-#[test]
-fn parses_cgroup_memory_events() {
-    let events = parse_memory_events("low 2\nhigh 3\nmax 4\noom 1\noom_kill 1\n");
-
-    assert_eq!(events.oom, 1);
-    assert_eq!(events.oom_kill, 1);
-    assert!(events.has_oom_event());
-    assert!(events.has_oom_kill_event());
-}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1018"
-weave = "0.1.1018"
+csa = "0.1.1019"
+weave = "0.1.1019"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Fixes #2238 by making signal-kill diagnostics read cgroup `memory.events` from the actual systemd ControlGroup for the CSA scope before falling back to guessed user/system slice paths.

Changes:
- Query `systemctl --user show <scope> --property=ControlGroup --value` as best-effort diagnostic input.
- Derive `/sys/fs/cgroup/.../memory.events` from the reported ControlGroup with empty/root/traversal guards.
- Preserve existing hard-coded fallback candidates for environments where systemd lookup fails or the scope has already disappeared.
- Split Linux cgroup memory-events helpers/tests into dedicated modules to keep monolith gates green.
- Bump workspace/weave versions to `0.1.1019`.

## Validation

Local gates:
- `cargo check -p cli-sub-agent`
- `cargo test -p cli-sub-agent session_kill_diagnostics -- --nocapture` (28 passed)
- `cargo clippy -p cli-sub-agent --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check && git diff --cached --check`
- `just find-monolith-files`
- `just monolith-test`
- `just pre-commit-fast`
- staged secret scan: PASS
- native staged-diff review: PASS/CLEAN

Exact-head review gate:
- Reviewed SHA: `c9504131209b6ee7293dadf127b430436dea20ae`
- Binary: `target/debug/csa 0.1.1019 (c9504131)`
- `target/debug/csa migrate --status`: pending migrations `0`
- CSA review session: `01KV7470GZF14NRRD6DHFBTKHN`
- Verdict: PASS
- `target/debug/csa review --check-verdict --sa-mode true --range main...HEAD`: passed

Closes #2238
