### PR TITLE
fix(run): require commit skill to create a commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1019"
+version = "0.1.1020"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1019"
+version = "0.1.1020"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/goal_loop.rs
+++ b/crates/cli-sub-agent/src/goal_loop.rs
@@ -125,6 +125,10 @@ pub(crate) struct GoalRunRequest {
     pub(crate) startup_env: StartupSubtreeEnv,
 }
 
+fn effective_require_commit(require_commit: bool, skill: Option<&str>) -> bool {
+    require_commit || skill == Some("commit")
+}
+
 struct FailureContext {
     iteration: u32,
     exit_code: i32,
@@ -144,6 +148,7 @@ pub(crate) async fn handle_run_or_goal(request: GoalRunRequest) -> Result<i32> {
         return handle_goal_run(request).await;
     }
 
+    let require_commit = effective_require_commit(request.require_commit, request.skill.as_deref());
     crate::run_cmd::handle_run(
         request.tool,
         request.auto_route,
@@ -192,7 +197,7 @@ pub(crate) async fn handle_run_or_goal(request: GoalRunRequest) -> Result<i32> {
         request.no_hook_bypass_scan,
         request.no_preflight,
         request.no_post_exec_gate,
-        request.require_commit,
+        require_commit,
         request.allow_git_push,
         request.extra_writable,
         request.extra_readable,
@@ -358,7 +363,7 @@ async fn run_goal_iteration(
         request.no_hook_bypass_scan,
         request.no_preflight,
         request.no_post_exec_gate,
-        request.require_commit,
+        effective_require_commit(request.require_commit, request.skill.as_deref()),
         request.allow_git_push,
         request.extra_writable.clone(),
         request.extra_readable.clone(),
@@ -465,5 +470,13 @@ mod tests {
             goal_loop.should_continue(),
             GoalDecision::BudgetExhausted("max tokens")
         );
+    }
+
+    #[test]
+    fn commit_skill_implies_require_commit_contract() {
+        assert!(effective_require_commit(false, Some("commit")));
+        assert!(effective_require_commit(true, Some("review")));
+        assert!(!effective_require_commit(false, Some("review")));
+        assert!(!effective_require_commit(false, None));
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -12,7 +12,7 @@ const MAX_UNCOMMITTED_FILES: usize = 20;
 const DIFF_BYTES_PER_TOKEN: usize = 4;
 const DIFF_TOKEN_READ_BUF_BYTES: usize = 16 * 1024;
 const REQUIRE_COMMIT_REASON: &str =
-    "writer session ended with uncommitted changes (--require-commit set)";
+    "writer session ended without required commit (--require-commit set)";
 const REQUIRE_COMMIT_RECOVERY_ACTION: &str = "inspect_changed_paths_then_commit_or_revert";
 const REDACTED_PATH: &str = "[redacted-path]";
 const LARGE_DIFF_WARNING_TEXT: &str = "This CSA session left a large changed surface. Do not proceed directly to a single commit/PR unless this was explicitly intended. First inspect the file list, split into atomic logical units if possible, and run review per unit. If intentionally large, record that rationale in the commit/PR.";
@@ -150,10 +150,9 @@ fn record_writer_uncommitted_changes_with_config(
     if !is_writer_session(record.sa_mode, Some("run")) {
         return None;
     }
-    let session_id = session_id?;
     let token_threshold = tracked_diff_token_threshold(record.large_diff_config);
     let full_changes =
-        collect_uncommitted_changes_with_token_threshold(project_root, token_threshold)?;
+        collect_uncommitted_changes_with_token_threshold(project_root, token_threshold);
     let changes = record
         .changed_paths
         .map(|paths| {
@@ -163,22 +162,43 @@ fn record_writer_uncommitted_changes_with_config(
                 token_threshold,
             )
         })
-        .unwrap_or_else(|| Some(full_changes.clone()))?;
-    let warning = large_diff_warning_report(&changes, record.large_diff_config);
+        .unwrap_or_else(|| full_changes.clone());
+    let warning = changes
+        .as_ref()
+        .and_then(|changes| large_diff_warning_report(changes, record.large_diff_config));
     let require_commit_contract_failure =
         record.require_commit && !record.commit_created.unwrap_or(false);
 
+    if changes.is_none() && !require_commit_contract_failure {
+        return warning;
+    }
+
+    let Some(session_id) = session_id else {
+        if require_commit_contract_failure {
+            mark_require_commit_contract_failure(result);
+        }
+        return warning;
+    };
+
     match csa_session::load_result(project_root, session_id) {
         Ok(Some(mut session_result)) => {
-            let recovery = require_commit_contract_failure
-                .then(|| build_require_commit_recovery_diagnostic(&session_result, &changes));
-            apply_uncommitted_changes_to_result(
-                &mut session_result,
-                changes.clone(),
-                warning.clone(),
-                require_commit_contract_failure,
-                recovery,
-            );
+            let recovery = require_commit_contract_failure.then(|| {
+                build_require_commit_recovery_diagnostic_for_state(
+                    &session_result,
+                    changes.as_ref(),
+                )
+            });
+            if let Some(changes) = changes.clone() {
+                apply_uncommitted_changes_to_result(
+                    &mut session_result,
+                    changes,
+                    warning.clone(),
+                    require_commit_contract_failure,
+                    recovery,
+                );
+            } else if let Some(recovery) = recovery {
+                apply_require_commit_contract_failure_to_result(&mut session_result, recovery);
+            }
             if let Err(err) = csa_session::save_result(project_root, session_id, &session_result) {
                 warn!(
                     session = %session_id,
@@ -203,13 +223,7 @@ fn record_writer_uncommitted_changes_with_config(
     }
 
     if require_commit_contract_failure {
-        result.mark_gate_failure("writer-uncommitted");
-        result.summary = REQUIRE_COMMIT_REASON.to_string();
-        if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
-            result.stderr_output.push('\n');
-        }
-        result.stderr_output.push_str(REQUIRE_COMMIT_REASON);
-        result.stderr_output.push('\n');
+        mark_require_commit_contract_failure(result);
     }
     warning
 }
@@ -225,16 +239,38 @@ pub(crate) fn apply_uncommitted_changes_to_result(
     result.large_diff_warning = large_diff_warning;
     result.require_commit_recovery = recovery;
     if require_commit_contract_failure {
-        remove_incidental_downgrade_warnings(&mut result.warnings);
-        result.exit_code = 1;
-        result.status = csa_session::SessionResult::status_from_exit_code(1);
-        result.summary = REQUIRE_COMMIT_REASON.to_string();
+        let recovery = result.require_commit_recovery.take().unwrap_or_else(|| {
+            build_require_commit_recovery_diagnostic_for_state(
+                result,
+                result.uncommitted_changes.as_ref(),
+            )
+        });
+        apply_require_commit_contract_failure_to_result(result, recovery);
     }
 }
 
+fn apply_require_commit_contract_failure_to_result(
+    result: &mut csa_session::SessionResult,
+    recovery: csa_session::RequireCommitRecoveryDiagnostic,
+) {
+    remove_incidental_downgrade_warnings(&mut result.warnings);
+    result.exit_code = 1;
+    result.status = csa_session::SessionResult::status_from_exit_code(1);
+    result.summary = REQUIRE_COMMIT_REASON.to_string();
+    result.require_commit_recovery = Some(recovery);
+}
+
+#[cfg(test)]
 fn build_require_commit_recovery_diagnostic(
     result: &csa_session::SessionResult,
     changes: &csa_session::UncommittedChanges,
+) -> csa_session::RequireCommitRecoveryDiagnostic {
+    build_require_commit_recovery_diagnostic_for_state(result, Some(changes))
+}
+
+fn build_require_commit_recovery_diagnostic_for_state(
+    result: &csa_session::SessionResult,
+    changes: Option<&csa_session::UncommittedChanges>,
 ) -> csa_session::RequireCommitRecoveryDiagnostic {
     let termination_exit_code = result.raw_process_exit_code.unwrap_or(result.exit_code);
     let termination_status = result
@@ -244,13 +280,17 @@ fn build_require_commit_recovery_diagnostic(
     csa_session::RequireCommitRecoveryDiagnostic {
         require_commit: true,
         commit_created: false,
-        dirty_worktree: true,
+        dirty_worktree: changes.is_some(),
         changed_paths: changes
-            .files
-            .iter()
-            .map(|path| sanitize_diagnostic_path(path))
-            .collect(),
-        changed_paths_truncated: changes.truncated,
+            .map(|changes| {
+                changes
+                    .files
+                    .iter()
+                    .map(|path| sanitize_diagnostic_path(path))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        changed_paths_truncated: changes.map(|changes| changes.truncated).unwrap_or_default(),
         termination_status,
         exit_code: termination_exit_code,
         termination_signal: result
@@ -261,6 +301,16 @@ fn build_require_commit_recovery_diagnostic(
         kill_hint: result.kill_hint.clone(),
         suggested_recovery_action: REQUIRE_COMMIT_RECOVERY_ACTION.to_string(),
     }
+}
+
+fn mark_require_commit_contract_failure(result: &mut csa_process::ExecutionResult) {
+    result.mark_gate_failure("writer-uncommitted");
+    result.summary = REQUIRE_COMMIT_REASON.to_string();
+    if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
+        result.stderr_output.push('\n');
+    }
+    result.stderr_output.push_str(REQUIRE_COMMIT_REASON);
+    result.stderr_output.push('\n');
 }
 
 fn raw_termination_status_from_exit_code(exit_code: i32) -> String {

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_tests.rs
@@ -202,7 +202,7 @@ fn require_commit_with_commit_created_does_not_record_recovery_or_fail_result() 
 }
 
 #[test]
-fn require_commit_with_no_session_dirty_paths_does_not_fail_or_diagnose() {
+fn require_commit_without_created_commit_fails_even_without_session_dirty_paths() {
     let temp = init_repo_with_initial_commit();
     let root = temp.path();
     let session = csa_session::create_session(root, Some("run"), None, Some("codex"))
@@ -233,10 +233,16 @@ fn require_commit_with_no_session_dirty_paths_does_not_fail_or_diagnose() {
     let loaded = csa_session::load_result(root, &session.meta_session_id)
         .expect("load result")
         .expect("result should exist");
-    assert_eq!(execution.exit_code, 0);
-    assert_eq!(loaded.status, "success");
+    assert_eq!(execution.exit_code, 1);
+    assert_eq!(loaded.status, "failure");
     assert!(loaded.uncommitted_changes.is_none());
-    assert!(loaded.require_commit_recovery.is_none());
+    let recovery = loaded
+        .require_commit_recovery
+        .expect("require-commit failure should be machine-readable");
+    assert!(recovery.require_commit);
+    assert!(!recovery.commit_created);
+    assert!(!recovery.dirty_worktree);
+    assert!(recovery.changed_paths.is_empty());
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_recovery_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_recovery_tests.rs
@@ -8,7 +8,7 @@ fn compact_summary_and_json_include_require_commit_recovery() {
     let result = csa_session::SessionResult {
         status: "failure".to_string(),
         exit_code: 1,
-        summary: "writer session ended with uncommitted changes (--require-commit set)".to_string(),
+        summary: "writer session ended without required commit (--require-commit set)".to_string(),
         tool: "codex".to_string(),
         started_at: now,
         completed_at: now + chrono::TimeDelta::seconds(65),

--- a/crates/cli-sub-agent/src/session_cmds_result_require_commit_recovery_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_require_commit_recovery_tests.rs
@@ -7,7 +7,7 @@ fn build_result_json_payload_includes_require_commit_recovery() {
         envelope: SessionResult {
             status: "failure".to_string(),
             exit_code: 1,
-            summary: "writer session ended with uncommitted changes (--require-commit set)"
+            summary: "writer session ended without required commit (--require-commit set)"
                 .to_string(),
             tool: "codex".to_string(),
             started_at: now,

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -200,8 +200,8 @@ impl UncommittedChanges {
     }
 }
 
-/// Machine-readable recovery detail for a `--require-commit` writer run that
-/// ended with session-created dirty worktree changes but no commit.
+/// Machine-readable recovery detail for a writer run that was required to
+/// create a commit but ended without one.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RequireCommitRecoveryDiagnostic {
     /// The run was governed by the require-commit contract.

--- a/crates/csa-session/src/result_tests.rs
+++ b/crates/csa-session/src/result_tests.rs
@@ -102,7 +102,7 @@ fn test_session_result_require_commit_recovery_roundtrip() {
     let result = SessionResult {
         status: "failure".to_string(),
         exit_code: 1,
-        summary: "writer session ended with uncommitted changes (--require-commit set)".to_string(),
+        summary: "writer session ended without required commit (--require-commit set)".to_string(),
         tool: "codex".to_string(),
         started_at: now,
         completed_at: now,

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1019"
-weave = "0.1.1019"
+csa = "0.1.1020"
+weave = "0.1.1020"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Fixes #2061 by enforcing the machine-verifiable commit effect for commit-skill runs.

Changes:

- Treat `--skill commit` as an implicit require-commit contract before dispatching `csa run`.
- Fail require-commit runs when no commit was created, even if the worktree is clean and the session reports no changed paths.
- Emit machine-readable `require_commit_recovery` for missing required commits.
- Bump workspace version to `0.1.1020`.

## Tests

- `cargo test -p cli-sub-agent require_commit -- --nocapture`
- `cargo test -p cli-sub-agent goal_loop::tests::commit_skill_implies_require_commit_contract -- --nocapture`
- `cargo test -p csa-session require_commit_recovery -- --nocapture`
- `cargo check -p cli-sub-agent`
- `cargo clippy -p cli-sub-agent --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `just find-monolith-files`
- `just monolith-test`
- `just pre-commit-fast`

## Review

- Staged native review: PASS/CLEAN
- Exact-head CSA review session `01KV78BDA1840PVQ3210A7MTGQ`: `UNAVAILABLE` due CSA `memory_soft_limit` infra no-verdict; documented on #2249.
- Exact-head `review --check-verdict --sa-mode true --range main...HEAD`: exit 1 because no PASS/CLEAN CSA full-diff review was available.
- Same-SHA native exact-head fallback review for `556e753741ae2b4208c88b8ecc97416cb9c4cdd6`: PASS/CLEAN.

Fixes #2061
