### PR TITLE
fix(run): restore failed commit skill workspace drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1020"
+version = "0.1.1021"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1020"
+version = "0.1.1021"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/edit_restriction_guard.rs
+++ b/crates/cli-sub-agent/src/edit_restriction_guard.rs
@@ -1,8 +1,9 @@
 use std::collections::{BTreeSet, HashMap};
 use std::ffi::OsStr;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
 use anyhow::{Context, Result, anyhow};
@@ -16,8 +17,8 @@ fn git_binary() -> &'static Path {
 pub(crate) struct TrackedFileEditGuard {
     project_root: PathBuf,
     pre_dirty_paths: BTreeSet<PathBuf>,
-    pre_staged_paths: BTreeSet<PathBuf>,
     pre_dirty_snapshots: HashMap<PathBuf, PathState>,
+    pre_staged_patches: HashMap<PathBuf, Vec<u8>>,
 }
 
 #[derive(Debug, Clone)]
@@ -293,17 +294,23 @@ impl TrackedFileEditGuard {
             .collect::<BTreeSet<_>>();
 
         let mut pre_dirty_snapshots = HashMap::new();
+        let mut pre_staged_patches = HashMap::new();
         for path in &pre_dirty_paths {
             let snapshot = capture_path_state(&project_root.join(path))
                 .with_context(|| format!("failed to snapshot dirty file '{}'", path.display()))?;
             pre_dirty_snapshots.insert(path.clone(), snapshot);
+            let staged_patch =
+                git_diff_cached_binary_for_path(project_root, path).with_context(|| {
+                    format!("failed to snapshot staged diff for '{}'", path.display())
+                })?;
+            pre_staged_patches.insert(path.clone(), staged_patch);
         }
 
         Ok(Self {
             project_root: project_root.to_path_buf(),
             pre_dirty_paths,
-            pre_staged_paths,
             pre_dirty_snapshots,
+            pre_staged_patches,
         })
     }
 
@@ -331,7 +338,18 @@ impl TrackedFileEditGuard {
             };
             let current_state = capture_path_state(&self.project_root.join(path))
                 .with_context(|| format!("failed to inspect dirty file '{}'", path.display()))?;
-            if &current_state != previous_state {
+            let current_staged_patch = git_diff_cached_binary_for_path(&self.project_root, path)
+                .with_context(|| {
+                    format!("failed to inspect staged diff for '{}'", path.display())
+                })?;
+            let previous_staged_patch = self
+                .pre_staged_patches
+                .get(path)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            if &current_state != previous_state
+                || current_staged_patch.as_slice() != previous_staged_patch
+            {
                 violating_paths.insert(path.clone());
             }
         }
@@ -363,20 +381,17 @@ impl TrackedFileEditGuard {
             let Some(previous_state) = self.pre_dirty_snapshots.get(path) else {
                 continue;
             };
+            let previous_staged_patch = self
+                .pre_staged_patches
+                .get(path)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
 
+            restore_index_state(&self.project_root, path, previous_staged_patch)
+                .with_context(|| format!("failed to restore index for '{}'", path.display()))?;
             restore_path_state(&self.project_root.join(path), previous_state)
                 .with_context(|| format!("failed to restore dirty file '{}'", path.display()))?;
             restored_paths.insert(path.clone());
-
-            if !self.pre_staged_paths.contains(path) && post_staged_paths.contains(path) {
-                git_restore_paths(&self.project_root, std::slice::from_ref(path), true, false)
-                    .with_context(|| {
-                        format!(
-                            "failed to unstage file '{}' after restoring dirty snapshot",
-                            path.display()
-                        )
-                    })?;
-            }
         }
 
         Ok(Some(EditRestrictionViolation {
@@ -476,6 +491,76 @@ fn git_restore_paths(
         ));
     }
 
+    Ok(())
+}
+
+fn git_diff_cached_binary_for_path(project_root: &Path, path: &Path) -> Result<Vec<u8>> {
+    let output = Command::new(git_binary())
+        .current_dir("/")
+        .arg("-C")
+        .arg(project_root)
+        .args(["diff", "--cached", "--binary", "--"])
+        .arg(path)
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run git diff --cached in '{}', path='{}'",
+                project_root.display(),
+                path.display()
+            )
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "git diff --cached failed in '{}': {}",
+            project_root.display(),
+            stderr.trim()
+        ));
+    }
+
+    Ok(output.stdout)
+}
+
+fn restore_index_state(project_root: &Path, path: &PathBuf, staged_patch: &[u8]) -> Result<()> {
+    git_restore_paths(project_root, std::slice::from_ref(path), true, false)
+        .with_context(|| format!("failed to reset index for '{}'", path.display()))?;
+    if staged_patch.is_empty() {
+        return Ok(());
+    }
+    git_apply_cached_patch(project_root, staged_patch)
+}
+
+fn git_apply_cached_patch(project_root: &Path, patch: &[u8]) -> Result<()> {
+    let mut child = Command::new(git_binary())
+        .current_dir("/")
+        .arg("-C")
+        .arg(project_root)
+        .args(["apply", "--cached", "--binary", "--whitespace=nowarn"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to spawn git apply in '{}'", project_root.display()))?;
+
+    child
+        .stdin
+        .take()
+        .context("git apply stdin unavailable")?
+        .write_all(patch)
+        .context("failed to write staged patch to git apply")?;
+
+    let output = child
+        .wait_with_output()
+        .context("failed to wait for git apply")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "git apply --cached failed in '{}': {}",
+            project_root.display(),
+            stderr.trim()
+        ));
+    }
     Ok(())
 }
 
@@ -615,163 +700,8 @@ fn remove_existing_path(path: &Path) -> Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    use std::sync::OnceLock;
-    use tempfile::TempDir;
-
-    fn git_binary() -> &'static Path {
-        static GIT_BINARY: OnceLock<PathBuf> = OnceLock::new();
-        GIT_BINARY.get_or_init(|| which::which("git").unwrap_or_else(|_| PathBuf::from("git")))
-    }
-
-    fn run_git(repo: &Path, args: &[&str]) {
-        let output = Command::new(git_binary())
-            .current_dir("/")
-            .arg("-C")
-            .arg(repo)
-            .args(args)
-            .output()
-            .expect("git command should execute");
-        assert!(
-            output.status.success(),
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    pub(super) fn setup_git_repo() -> TempDir {
-        let temp = TempDir::new().expect("create tempdir");
-        run_git(temp.path(), &["init"]);
-        run_git(temp.path(), &["config", "user.email", "test@example.com"]);
-        run_git(temp.path(), &["config", "user.name", "Test User"]);
-
-        fs::write(temp.path().join("tracked.txt"), "baseline\n").expect("write tracked file");
-        run_git(temp.path(), &["add", "tracked.txt"]);
-        run_git(temp.path(), &["commit", "-m", "initial"]);
-
-        temp
-    }
-
-    pub(super) fn git_status_porcelain(repo: &Path) -> String {
-        let output = Command::new("git")
-            .current_dir("/")
-            .arg("-C")
-            .arg(repo)
-            .args(["status", "--porcelain"])
-            .output()
-            .expect("git status should run");
-        assert!(output.status.success());
-        String::from_utf8_lossy(&output.stdout).to_string()
-    }
-
-    #[test]
-    fn returns_none_for_non_git_directory() {
-        let temp = TempDir::new().expect("create tempdir");
-        let guard = maybe_capture_tracked_file_guard(temp.path()).expect("capture should succeed");
-        assert!(guard.is_none());
-    }
-
-    #[test]
-    fn allows_new_untracked_file_creation() {
-        let repo = setup_git_repo();
-        let guard = maybe_capture_tracked_file_guard(repo.path())
-            .expect("capture should succeed")
-            .expect("git repo should return guard");
-
-        fs::write(repo.path().join("new.md"), "new file\n").expect("write untracked file");
-
-        let violation = guard.enforce_and_restore().expect("enforce should run");
-        assert!(violation.is_none(), "new untracked files should be allowed");
-        assert!(repo.path().join("new.md").exists());
-    }
-
-    #[test]
-    fn restores_newly_modified_tracked_file() {
-        let repo = setup_git_repo();
-        let guard = maybe_capture_tracked_file_guard(repo.path())
-            .expect("capture should succeed")
-            .expect("git repo should return guard");
-
-        fs::write(repo.path().join("tracked.txt"), "tool mutation\n").expect("mutate tracked file");
-
-        let violation = guard
-            .enforce_and_restore()
-            .expect("enforce should succeed")
-            .expect("should detect violation");
-
-        assert_eq!(
-            fs::read_to_string(repo.path().join("tracked.txt")).expect("read restored file"),
-            "baseline\n"
-        );
-        assert!(
-            violation
-                .modified_paths
-                .iter()
-                .any(|path| path == Path::new("tracked.txt"))
-        );
-        assert!(git_status_porcelain(repo.path()).trim().is_empty());
-    }
-
-    #[test]
-    fn restores_dirty_file_to_pre_run_snapshot() {
-        let repo = setup_git_repo();
-
-        fs::write(repo.path().join("tracked.txt"), "pre-existing dirty\n")
-            .expect("create dirty baseline");
-
-        let guard = maybe_capture_tracked_file_guard(repo.path())
-            .expect("capture should succeed")
-            .expect("git repo should return guard");
-
-        fs::write(repo.path().join("tracked.txt"), "tool mutation\n").expect("mutate dirty file");
-
-        let violation = guard
-            .enforce_and_restore()
-            .expect("enforce should succeed")
-            .expect("should detect violation");
-
-        assert_eq!(
-            fs::read_to_string(repo.path().join("tracked.txt")).expect("read restored file"),
-            "pre-existing dirty\n"
-        );
-        assert!(
-            violation
-                .modified_paths
-                .iter()
-                .any(|path| path == Path::new("tracked.txt"))
-        );
-
-        let status = git_status_porcelain(repo.path());
-        assert!(status.contains(" M tracked.txt"));
-    }
-
-    #[test]
-    fn restores_staged_mutation_on_clean_file() {
-        let repo = setup_git_repo();
-        let guard = maybe_capture_tracked_file_guard(repo.path())
-            .expect("capture should succeed")
-            .expect("git repo should return guard");
-
-        fs::write(repo.path().join("tracked.txt"), "tool mutation\n").expect("mutate tracked file");
-        run_git(repo.path(), &["add", "tracked.txt"]);
-
-        let violation = guard
-            .enforce_and_restore()
-            .expect("enforce should succeed")
-            .expect("should detect violation");
-
-        assert!(
-            violation
-                .restored_paths
-                .iter()
-                .any(|path| path == Path::new("tracked.txt"))
-        );
-        assert!(git_status_porcelain(repo.path()).trim().is_empty());
-    }
-}
+#[path = "edit_restriction_guard_tests.rs"]
+mod tests;
 
 #[cfg(test)]
 #[path = "edit_restriction_guard_tests_tail.rs"]

--- a/crates/cli-sub-agent/src/edit_restriction_guard_tests.rs
+++ b/crates/cli-sub-agent/src/edit_restriction_guard_tests.rs
@@ -1,0 +1,155 @@
+use super::*;
+
+use std::sync::OnceLock;
+use tempfile::TempDir;
+
+fn git_binary() -> &'static Path {
+    static GIT_BINARY: OnceLock<PathBuf> = OnceLock::new();
+    GIT_BINARY.get_or_init(|| which::which("git").unwrap_or_else(|_| PathBuf::from("git")))
+}
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let output = Command::new(git_binary())
+        .current_dir("/")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+pub(super) fn setup_git_repo() -> TempDir {
+    let temp = TempDir::new().expect("create tempdir");
+    run_git(temp.path(), &["init"]);
+    run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+    run_git(temp.path(), &["config", "user.name", "Test User"]);
+
+    fs::write(temp.path().join("tracked.txt"), "baseline\n").expect("write tracked file");
+    run_git(temp.path(), &["add", "tracked.txt"]);
+    run_git(temp.path(), &["commit", "-m", "initial"]);
+
+    temp
+}
+
+pub(super) fn git_status_porcelain(repo: &Path) -> String {
+    let output = Command::new("git")
+        .current_dir("/")
+        .arg("-C")
+        .arg(repo)
+        .args(["status", "--porcelain"])
+        .output()
+        .expect("git status should run");
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+#[test]
+fn returns_none_for_non_git_directory() {
+    let temp = TempDir::new().expect("create tempdir");
+    let guard = maybe_capture_tracked_file_guard(temp.path()).expect("capture should succeed");
+    assert!(guard.is_none());
+}
+
+#[test]
+fn allows_new_untracked_file_creation() {
+    let repo = setup_git_repo();
+    let guard = maybe_capture_tracked_file_guard(repo.path())
+        .expect("capture should succeed")
+        .expect("git repo should return guard");
+
+    fs::write(repo.path().join("new.md"), "new file\n").expect("write untracked file");
+
+    let violation = guard.enforce_and_restore().expect("enforce should run");
+    assert!(violation.is_none(), "new untracked files should be allowed");
+    assert!(repo.path().join("new.md").exists());
+}
+
+#[test]
+fn restores_newly_modified_tracked_file() {
+    let repo = setup_git_repo();
+    let guard = maybe_capture_tracked_file_guard(repo.path())
+        .expect("capture should succeed")
+        .expect("git repo should return guard");
+
+    fs::write(repo.path().join("tracked.txt"), "tool mutation\n").expect("mutate tracked file");
+
+    let violation = guard
+        .enforce_and_restore()
+        .expect("enforce should succeed")
+        .expect("should detect violation");
+
+    assert_eq!(
+        fs::read_to_string(repo.path().join("tracked.txt")).expect("read restored file"),
+        "baseline\n"
+    );
+    assert!(
+        violation
+            .modified_paths
+            .iter()
+            .any(|path| path == Path::new("tracked.txt"))
+    );
+    assert!(git_status_porcelain(repo.path()).trim().is_empty());
+}
+
+#[test]
+fn restores_dirty_file_to_pre_run_snapshot() {
+    let repo = setup_git_repo();
+
+    fs::write(repo.path().join("tracked.txt"), "pre-existing dirty\n")
+        .expect("create dirty baseline");
+
+    let guard = maybe_capture_tracked_file_guard(repo.path())
+        .expect("capture should succeed")
+        .expect("git repo should return guard");
+
+    fs::write(repo.path().join("tracked.txt"), "tool mutation\n").expect("mutate dirty file");
+
+    let violation = guard
+        .enforce_and_restore()
+        .expect("enforce should succeed")
+        .expect("should detect violation");
+
+    assert_eq!(
+        fs::read_to_string(repo.path().join("tracked.txt")).expect("read restored file"),
+        "pre-existing dirty\n"
+    );
+    assert!(
+        violation
+            .modified_paths
+            .iter()
+            .any(|path| path == Path::new("tracked.txt"))
+    );
+
+    let status = git_status_porcelain(repo.path());
+    assert!(status.contains(" M tracked.txt"));
+}
+
+#[test]
+fn restores_staged_mutation_on_clean_file() {
+    let repo = setup_git_repo();
+    let guard = maybe_capture_tracked_file_guard(repo.path())
+        .expect("capture should succeed")
+        .expect("git repo should return guard");
+
+    fs::write(repo.path().join("tracked.txt"), "tool mutation\n").expect("mutate tracked file");
+    run_git(repo.path(), &["add", "tracked.txt"]);
+
+    let violation = guard
+        .enforce_and_restore()
+        .expect("enforce should succeed")
+        .expect("should detect violation");
+
+    assert!(
+        violation
+            .restored_paths
+            .iter()
+            .any(|path| path == Path::new("tracked.txt"))
+    );
+    assert!(git_status_porcelain(repo.path()).trim().is_empty());
+}

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use csa_config::{GlobalConfig, ProjectConfig};
-use csa_core::types::ToolSelectionStrategy;
 use std::time::Instant;
 use tracing::warn;
 
@@ -9,8 +8,14 @@ use super::attempt_exec::{
     run_ephemeral_without_timeout, run_persistent_with_timeout, run_persistent_without_timeout,
 };
 use super::attempt_support::{
-    allow_cross_tool_failover, merge_run_loop_changed_paths,
-    persist_fork_timeout_result_if_missing, resolve_attempt_initial_response_timeout_seconds,
+    CommitSkillWorkspaceGuard as Cg, allow_cross_tool_failover,
+    capture_commit_skill_workspace_guard as capture_cg, codex_fast_mode_enabled as codex_fast,
+    merge_run_loop_changed_paths as merge_changed,
+    persist_fork_timeout_result_if_missing as persist_timeout,
+    resolve_attempt_initial_response_timeout_seconds as initial_timeout,
+    resolve_max_failover_attempts as max_failovers,
+    resolve_runtime_fallback_enabled as runtime_fallback,
+    restore_failed_commit_skill_workspace as restore_cg, strategy_is_explicit,
 };
 use super::resume::{emit_run_timeout, resolve_remaining_run_timeout};
 use crate::pipeline;
@@ -19,6 +24,7 @@ use crate::run_cmd_tool_selection::resolve_slot_wait_timeout_seconds;
 
 #[path = "run_cmd_attempt_types.rs"]
 mod types;
+use RunLoopCompletion::Exit;
 pub(crate) use types::{RunLoopCompletion, RunLoopOutcome, RunLoopRequest};
 #[path = "run_cmd_attempt_outcome.rs"]
 mod outcome;
@@ -37,20 +43,16 @@ use prompt::resolve_attempt_subtree_model_pin_spec;
 use prompt::{AttemptPromptRequest, build_attempt_prompt};
 
 pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunLoopCompletion> {
-    let max_failover_attempts = if request.no_failover {
-        1
-    } else {
-        request
-            .config
-            .map(|cfg| {
-                cfg.tiers
-                    .values()
-                    .map(|t| t.models.len())
-                    .sum::<usize>()
-                    .max(1)
-            })
-            .unwrap_or(1)
-    };
+    let mut g = capture_cg(request.project_root, request.skill)?;
+    let o = ri(request, &mut g).await;
+    if matches!(o, Err(_) | Ok(Exit(_))) {
+        restore_cg(&mut g, None, None)?;
+    }
+    o
+}
+
+async fn ri(request: RunLoopRequest<'_>, g: &mut Cg) -> Result<RunLoopCompletion> {
+    let max_failover_attempts = max_failovers(request.no_failover, request.config);
 
     let slots_dir = GlobalConfig::slots_dir()?;
     let mut current_tool = request.initial_tool;
@@ -60,10 +62,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
     let mut tried_specs: Vec<String> = Vec::new();
     let mut fallback_chain: csa_scheduler::FallbackChain = Vec::new();
     let mut attempts = 0;
-    let runtime_fallback_enabled = matches!(
-        request.strategy,
-        ToolSelectionStrategy::HeterogeneousPreferred
-    ) && !request.no_failover;
+    let runtime_fallback_enabled = runtime_fallback(&request.strategy, request.no_failover);
     let mut runtime_fallback_candidates = request.runtime_fallback_candidates;
     let mut runtime_fallback_attempts = 0u8;
     let max_runtime_fallback_attempts = 1u8;
@@ -86,7 +85,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
         !request.force && !request.force_ignore_tier_setting && !request.user_model_spec_explicit;
     let mut accumulated_changed_paths: Vec<String> = Vec::new();
     let mut all_attempt_change_snapshots_available = true;
-    let (result, changed_paths, commit_created) = loop {
+    let (mut result, changed_paths, commit_created) = loop {
         attempts += 1;
         let mut fresh_spawn_preflight_override = false;
 
@@ -101,27 +100,19 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             },
             enforce_tier,
             request.force_override_user_config,
-            matches!(request.strategy, ToolSelectionStrategy::Explicit(_)),
+            strategy_is_explicit(&request.strategy),
         )
         .await?;
-        let fast_mode = request.fast_but_more_cost
-            || request
-                .config
-                .and_then(|c| c.tools.get("codex"))
-                .and_then(|t| t.fast_mode)
-                .unwrap_or(false)
-            || request
-                .global_config
-                .tools
-                .get("codex")
-                .and_then(|t| t.fast_mode)
-                .unwrap_or(false);
-        if fast_mode {
+        if codex_fast(
+            request.fast_but_more_cost,
+            request.config,
+            request.global_config,
+        ) {
             executor.enable_codex_fast_mode();
         }
 
         let tool_name_str = executor.tool_name();
-        let initial_response_timeout_seconds = resolve_attempt_initial_response_timeout_seconds(
+        let initial_response_timeout_seconds = initial_timeout(
             request.config,
             request.cli_initial_response_timeout,
             request.cli_idle_timeout,
@@ -156,7 +147,9 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 }
                 continue;
             }
-            AttemptSlotOutcome::Exit(exit_code) => return Ok(RunLoopCompletion::Exit(exit_code)),
+            AttemptSlotOutcome::Exit(exit_code) => {
+                return Ok(Exit(exit_code));
+            }
         };
 
         if request.fork_call {
@@ -173,7 +166,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 Ok(child_slot) => _slot_guard = Some(child_slot),
                 Err(e) => {
                     eprintln!("{e}");
-                    return Ok(RunLoopCompletion::Exit(1));
+                    return Ok(Exit(1));
                 }
             }
         }
@@ -200,7 +193,9 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                         is_fork = false;
                         session_arg = None;
                     }
-                    Err(e) => return Err(e),
+                    Err(e) => {
+                        return Err(e);
+                    }
                 }
             } else if !is_auto_seed_fork {
                 anyhow::bail!("Fork requested but no source session resolved");
@@ -216,7 +211,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             &request.branch_guard,
             branch_state,
         ) {
-            return Ok(RunLoopCompletion::Exit(exit_code));
+            return Ok(Exit(exit_code));
         }
 
         if let Some(ref fork_res) = fork_resolution {
@@ -262,7 +257,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 .clone()
                 .or_else(|| pre_created_fork_session_id.clone())
                 .or_else(|| effective_session_arg.clone());
-            persist_fork_timeout_result_if_missing(
+            persist_timeout(
                 request.project_root,
                 is_fork,
                 current_tool,
@@ -281,7 +276,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                 request.skill,
                 timeout_resume_session.as_deref(),
             )?;
-            return Ok(RunLoopCompletion::Exit(exit_code));
+            return Ok(Exit(exit_code));
         }
 
         let attempt_started_at = Instant::now();
@@ -397,7 +392,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                     .clone()
                     .or_else(|| pre_created_fork_session_id.clone())
                     .or_else(|| effective_session_arg.clone());
-                persist_fork_timeout_result_if_missing(
+                persist_timeout(
                     request.project_root,
                     is_fork,
                     current_tool,
@@ -416,9 +411,11 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                     request.skill,
                     timeout_resume_session.as_deref(),
                 )?;
-                return Ok(RunLoopCompletion::Exit(exit_code));
+                return Ok(Exit(exit_code));
             }
-            AttemptExecution::Exit(exit_code) => return Ok(RunLoopCompletion::Exit(exit_code)),
+            AttemptExecution::Exit(exit_code) => {
+                return Ok(Exit(exit_code));
+            }
             AttemptExecution::Finished {
                 result,
                 changed_paths: attempt_changed_paths,
@@ -463,9 +460,11 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
                     },
                 )? {
                     AttemptErrorAction::Exit(exit_code) => {
-                        return Ok(RunLoopCompletion::Exit(exit_code));
+                        return Ok(Exit(exit_code));
                     }
-                    AttemptErrorAction::Error(error) => return Err(error),
+                    AttemptErrorAction::Error(error) => {
+                        return Err(error);
+                    }
                     AttemptErrorAction::Retry(action) => {
                         AttemptRetryState {
                             failover_context: &mut failover_context_addendum,
@@ -536,7 +535,8 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
             }
         }
     };
-    let changed_paths = merge_run_loop_changed_paths(
+    restore_cg(g, commit_created, Some(&mut result))?;
+    let changed_paths = merge_changed(
         accumulated_changed_paths,
         all_attempt_change_snapshots_available,
         changed_paths,

--- a/crates/cli-sub-agent/src/run_cmd_attempt_support.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_support.rs
@@ -1,9 +1,25 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
-use csa_config::ProjectConfig;
+use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::{ToolName, ToolSelectionStrategy};
 
+use crate::edit_restriction_guard::{TrackedFileEditGuard, maybe_capture_tracked_file_guard};
 use crate::pipeline;
+
+pub(crate) type CommitSkillWorkspaceGuard = Option<CommitSkillWorkspaceSnapshot>;
+
+pub(crate) struct CommitSkillWorkspaceSnapshot {
+    project_root: PathBuf,
+    pre_head_oid: Option<String>,
+    tracked_guard: TrackedFileEditGuard,
+}
+
+impl CommitSkillWorkspaceSnapshot {
+    fn head_changed(&self) -> anyhow::Result<bool> {
+        Ok(git_head_oid(&self.project_root)? != self.pre_head_oid)
+    }
+}
 
 pub(crate) fn allow_cross_tool_failover(
     strategy: ToolSelectionStrategy,
@@ -20,6 +36,53 @@ pub(crate) fn allow_cross_tool_failover(
     // different tool (#1440). Active tier failover is handled by the scheduler
     // using the resolved tier model specs, not by this generic slot fallback.
     !matches!(strategy, ToolSelectionStrategy::Explicit(_))
+}
+
+pub(crate) fn resolve_max_failover_attempts(
+    no_failover: bool,
+    config: Option<&ProjectConfig>,
+) -> usize {
+    if no_failover {
+        1
+    } else {
+        config
+            .map(|cfg| {
+                cfg.tiers
+                    .values()
+                    .map(|tier| tier.models.len())
+                    .sum::<usize>()
+                    .max(1)
+            })
+            .unwrap_or(1)
+    }
+}
+
+pub(crate) fn resolve_runtime_fallback_enabled(
+    strategy: &ToolSelectionStrategy,
+    no_failover: bool,
+) -> bool {
+    matches!(strategy, ToolSelectionStrategy::HeterogeneousPreferred) && !no_failover
+}
+
+pub(crate) fn strategy_is_explicit(strategy: &ToolSelectionStrategy) -> bool {
+    matches!(strategy, ToolSelectionStrategy::Explicit(_))
+}
+
+pub(crate) fn codex_fast_mode_enabled(
+    cli_fast_mode: bool,
+    config: Option<&ProjectConfig>,
+    global_config: &GlobalConfig,
+) -> bool {
+    cli_fast_mode
+        || config
+            .and_then(|cfg| cfg.tools.get("codex"))
+            .and_then(|tool| tool.fast_mode)
+            .unwrap_or(false)
+        || global_config
+            .tools
+            .get("codex")
+            .and_then(|tool| tool.fast_mode)
+            .unwrap_or(false)
 }
 
 pub(crate) fn resolve_attempt_initial_response_timeout_seconds(
@@ -100,6 +163,72 @@ pub(crate) fn merge_run_loop_changed_paths(
     Some(accumulated_changed_paths)
 }
 
+pub(crate) fn capture_commit_skill_workspace_guard(
+    project_root: &Path,
+    skill: Option<&str>,
+) -> anyhow::Result<CommitSkillWorkspaceGuard> {
+    if skill != Some("commit") {
+        return Ok(None);
+    }
+    let Some(tracked_guard) = maybe_capture_tracked_file_guard(project_root)? else {
+        return Ok(None);
+    };
+    Ok(Some(CommitSkillWorkspaceSnapshot {
+        project_root: project_root.to_path_buf(),
+        pre_head_oid: git_head_oid(project_root)?,
+        tracked_guard,
+    }))
+}
+
+pub(crate) fn restore_failed_commit_skill_workspace(
+    guard: &mut CommitSkillWorkspaceGuard,
+    commit_created: Option<bool>,
+    result: Option<&mut csa_process::ExecutionResult>,
+) -> anyhow::Result<()> {
+    if commit_created.unwrap_or(false) {
+        return Ok(());
+    }
+
+    let Some(snapshot) = guard.take() else {
+        return Ok(());
+    };
+    if snapshot.head_changed()? {
+        return Ok(());
+    }
+    let Some(violation) = snapshot.tracked_guard.enforce_and_restore()? else {
+        return Ok(());
+    };
+
+    let Some(result) = result else {
+        return Ok(());
+    };
+    if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
+        result.stderr_output.push('\n');
+    }
+    result
+        .stderr_output
+        .push_str("Commit skill workspace guard restored tracked drift after missing commit.\n");
+    result.stderr_output.push_str(&violation.detail_message());
+    if !result.stderr_output.ends_with('\n') {
+        result.stderr_output.push('\n');
+    }
+    Ok(())
+}
+
+fn git_head_oid(project_root: &Path) -> anyhow::Result<Option<String>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["rev-parse", "--verify", "HEAD"])
+        .output()?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    Ok(Some(
+        String::from_utf8_lossy(&output.stdout).trim().to_string(),
+    ))
+}
+
 pub(crate) fn persist_fork_timeout_result_if_missing(
     project_root: &Path,
     is_fork: bool,
@@ -129,7 +258,129 @@ pub(crate) fn persist_fork_timeout_result_if_missing(
 
 #[cfg(test)]
 mod tests {
-    use super::merge_run_loop_changed_paths;
+    use std::path::Path;
+    use std::process::Command;
+
+    use super::{
+        capture_commit_skill_workspace_guard, merge_run_loop_changed_paths,
+        restore_failed_commit_skill_workspace,
+    };
+
+    fn run_git(project_root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(args)
+            .output()
+            .expect("git command should run");
+        assert!(
+            output.status.success(),
+            "git {} failed\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_status(project_root: &Path) -> String {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(["status", "--porcelain"])
+            .output()
+            .expect("git status should run");
+        assert!(output.status.success());
+        String::from_utf8_lossy(&output.stdout).to_string()
+    }
+
+    fn git_diff_cached(project_root: &Path) -> String {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(["diff", "--cached"])
+            .output()
+            .expect("git diff --cached should run");
+        assert!(output.status.success());
+        String::from_utf8_lossy(&output.stdout).to_string()
+    }
+
+    #[test]
+    fn failed_commit_skill_restores_tracked_drift_without_unstaging_existing_diff() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        run_git(repo.path(), &["init", "-q"]);
+        run_git(
+            repo.path(),
+            &["config", "user.email", "csa@example.invalid"],
+        );
+        run_git(repo.path(), &["config", "user.name", "CSA Test"]);
+        std::fs::write(repo.path().join("README.md"), "before\n").expect("seed readme");
+        std::fs::write(repo.path().join("weave.lock"), "lock\n").expect("seed lockfile");
+        run_git(repo.path(), &["add", "README.md"]);
+        run_git(repo.path(), &["add", "-f", "weave.lock"]);
+        run_git(repo.path(), &["commit", "-m", "seed"]);
+
+        std::fs::write(repo.path().join("README.md"), "after\n").expect("stage readme");
+        run_git(repo.path(), &["add", "README.md"]);
+        assert_eq!(git_status(repo.path()), "M  README.md\n");
+        let expected_cached_diff = git_diff_cached(repo.path());
+
+        let mut guard = capture_commit_skill_workspace_guard(repo.path(), Some("commit"))
+            .expect("guard capture should succeed");
+        std::fs::write(repo.path().join("README.md"), "tool rewrite\n")
+            .expect("simulate staged rewrite");
+        run_git(repo.path(), &["add", "README.md"]);
+        std::fs::remove_file(repo.path().join("weave.lock")).expect("simulate stray lock deletion");
+        assert_eq!(git_status(repo.path()), "M  README.md\n D weave.lock\n");
+
+        let mut result = csa_process::ExecutionResult::default();
+        restore_failed_commit_skill_workspace(&mut guard, Some(false), Some(&mut result))
+            .expect("restore should succeed");
+
+        assert_eq!(git_status(repo.path()), "M  README.md\n");
+        assert_eq!(git_diff_cached(repo.path()), expected_cached_diff);
+        assert_eq!(
+            std::fs::read_to_string(repo.path().join("weave.lock")).expect("lock restored"),
+            "lock\n"
+        );
+        assert!(
+            result
+                .stderr_output
+                .contains("Commit skill workspace guard restored tracked drift")
+        );
+    }
+
+    #[test]
+    fn unknown_commit_state_restores_only_when_head_is_unchanged() {
+        let repo = tempfile::tempdir().expect("repo tempdir");
+        run_git(repo.path(), &["init", "-q"]);
+        run_git(
+            repo.path(),
+            &["config", "user.email", "csa@example.invalid"],
+        );
+        run_git(repo.path(), &["config", "user.name", "CSA Test"]);
+        std::fs::write(repo.path().join("README.md"), "before\n").expect("seed readme");
+        std::fs::write(repo.path().join("weave.lock"), "lock\n").expect("seed lockfile");
+        run_git(repo.path(), &["add", "README.md"]);
+        run_git(repo.path(), &["add", "-f", "weave.lock"]);
+        run_git(repo.path(), &["commit", "-m", "seed"]);
+
+        let mut guard = capture_commit_skill_workspace_guard(repo.path(), Some("commit"))
+            .expect("guard capture should succeed");
+        std::fs::remove_file(repo.path().join("weave.lock")).expect("simulate stray lock deletion");
+        restore_failed_commit_skill_workspace(&mut guard, None, None)
+            .expect("restore should succeed");
+        assert!(git_status(repo.path()).trim().is_empty());
+
+        let mut guard = capture_commit_skill_workspace_guard(repo.path(), Some("commit"))
+            .expect("guard capture should succeed");
+        std::fs::write(repo.path().join("README.md"), "committed\n").expect("session edit");
+        run_git(repo.path(), &["add", "README.md"]);
+        run_git(repo.path(), &["commit", "-m", "session commit"]);
+        std::fs::remove_file(repo.path().join("weave.lock")).expect("simulate post-commit drift");
+        restore_failed_commit_skill_workspace(&mut guard, None, None)
+            .expect("restore should skip after HEAD changes");
+        assert_eq!(git_status(repo.path()), " D weave.lock\n");
+    }
 
     #[test]
     fn merge_run_loop_changed_paths_preserves_known_empty_delta() {

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1020"
-weave = "0.1.1020"
+csa = "0.1.1021"
+weave = "0.1.1021"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Restore session-introduced tracked workspace drift when `--skill commit` exits without creating a commit.
- Preserve any pre-existing staged tracked diff by snapshotting/restoring cached binary patches alongside worktree content.
- Add HEAD-aware restore semantics so unknown/no-commit exits restore only when HEAD is unchanged, and ensure error/early-exit paths cannot bypass cleanup.
- Bump workspace version to `0.1.1021`.

## Validation
- `cargo test -p cli-sub-agent run_cmd::attempt_support -- --nocapture`
- `cargo test -p cli-sub-agent require_commit -- --nocapture`
- `cargo test -p cli-sub-agent edit_restriction_guard -- --nocapture`
- `cargo check -p cli-sub-agent`
- `cargo clippy -p cli-sub-agent --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `just find-monolith-files`
- `just monolith-test`
- `just pre-commit-fast`
- Hook-enabled commit/amend gates passed.

## Review gate
- Exact head: `cc02c21628eac0d16adb477d52a35894b5a8bf14`.
- Exact-head binary proof: `target/debug/csa --version` => `csa 0.1.1021 (cc02c216)`.
- Migration status: pending migrations `0`.
- CSA/Codex exact-head review was unavailable due `memory_soft_limit` in session `01KV7EYHX9QV4PCMB12QW8YKCY`; diagnostic issue filed: #2254.
- Same-SHA native exact-head full-diff fallback review for `main...HEAD` returned `PASS/CLEAN`.
- Push used the documented narrow `CSA_SKIP_REVIEW_CHECK=1` review-check override only; branch-protection/version-check hooks still passed.

Closes #2231
