### PR TITLE
fix(review): pass memory overrides to review admission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1022"
+version = "0.1.1023"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1022"
+version = "0.1.1023"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -91,6 +91,14 @@ pub struct ReviewArgs {
     #[arg(long)]
     pub fast_but_more_cost: bool,
 
+    /// Override per-session memory cap/projection for this review invocation.
+    #[arg(long, value_name = "MB", value_parser = clap::value_parser!(u64).range(256..))]
+    pub memory_max_mb: Option<u64>,
+
+    /// Override minimum MemAvailable reserve for this review invocation.
+    #[arg(long, value_name = "MB")]
+    pub min_free_memory_mb: Option<u64>,
+
     /// Cap build (CARGO_BUILD_JOBS) and test (NEXTEST_TEST_THREADS)
     /// parallelism of the validation gate to N. Use on memory-tight hosts
     /// to avoid OOM-kills / spawn flakes. Unset = uncapped (honors an
@@ -490,6 +498,14 @@ pub struct DebateArgs {
     /// Enable Codex fast_mode for faster responses at higher cost. Only affects codex.
     #[arg(long)]
     pub fast_but_more_cost: bool,
+
+    /// Override per-session memory cap/projection for this debate invocation.
+    #[arg(long, value_name = "MB", value_parser = clap::value_parser!(u64).range(256..))]
+    pub memory_max_mb: Option<u64>,
+
+    /// Override minimum MemAvailable reserve for this debate invocation.
+    #[arg(long, value_name = "MB")]
+    pub min_free_memory_mb: Option<u64>,
 
     /// Number of debate rounds (default: 3)
     #[arg(long, default_value_t = 3, value_parser = clap::value_parser!(u32).range(1..))]

--- a/crates/cli-sub-agent/src/debate_cmd.rs
+++ b/crates/cli-sub-agent/src/debate_cmd.rs
@@ -334,6 +334,10 @@ fn resolve_debate_cli_tool(
 mod tests;
 
 #[cfg(test)]
+#[path = "debate_cmd_resource_override_tests.rs"]
+mod resource_override_tests;
+
+#[cfg(test)]
 #[path = "debate_cmd_readonly_tests.rs"]
 mod readonly_tests;
 

--- a/crates/cli-sub-agent/src/debate_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_execute.rs
@@ -9,6 +9,7 @@ use tracing::{debug, error, warn};
 use crate::cli::DebateArgs;
 use crate::debate_cmd_output::DebateOutputHeader;
 use crate::debate_errors::{DebateErrorKind, classify_execution_error, classify_execution_outcome};
+use crate::run_resource_overrides::RunResourceOverrides;
 use crate::startup_env::StartupSubtreeEnv;
 use crate::tier_model_fallback::{self, TierAttemptFailure};
 
@@ -39,6 +40,10 @@ impl DebateArgs {
             self.error_marker_scan,
             self.no_error_marker_scan,
         )
+    }
+
+    pub(crate) fn resource_overrides(&self) -> RunResourceOverrides {
+        RunResourceOverrides::new(self.memory_max_mb, self.min_free_memory_mb)
     }
 }
 
@@ -147,7 +152,7 @@ pub(crate) async fn execute_debate(request: DebateExecutionRequest<'_>) -> Resul
             ensure_debate_wall_clock_within_timeout(wall_clock_start, request.timeout_seconds)?;
 
             let attempt_started_at = Instant::now();
-            let execute_future = crate::pipeline::execute_with_session_and_meta(
+            let execute_future = crate::pipeline::execute_with_session_and_meta_with_parent_source(
                 &executor,
                 attempt_tool,
                 request.prompt,
@@ -160,6 +165,7 @@ pub(crate) async fn execute_debate(request: DebateExecutionRequest<'_>) -> Resul
                 request.config,
                 extra_env,
                 subtree_pin.as_ref(),
+                false,
                 Some("debate"),
                 request.resolved_tier_name,
                 None,
@@ -170,6 +176,9 @@ pub(crate) async fn execute_debate(request: DebateExecutionRequest<'_>) -> Resul
                 None,
                 Some(request.global_config),
                 request.pre_session_hook.clone(),
+                crate::pipeline::ParentSessionSource::ExplicitOrEnv,
+                crate::pipeline::SessionCreationMode::DaemonManaged,
+                request.args.resource_overrides(),
                 request.args.no_fs_sandbox,
                 request.readonly_project_root,
                 &request.args.extra_writable,

--- a/crates/cli-sub-agent/src/debate_cmd_resource_override_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_resource_override_tests.rs
@@ -1,0 +1,38 @@
+use clap::Parser;
+
+use crate::cli::{Cli, Commands, DebateArgs};
+
+fn parse_debate_args(argv: &[&str]) -> DebateArgs {
+    let cli = Cli::try_parse_from(argv).expect("debate CLI args should parse");
+    match cli.command {
+        Commands::Debate(args) => args,
+        _ => panic!("expected debate subcommand"),
+    }
+}
+
+#[test]
+fn debate_cli_accepts_resource_override_flags() {
+    let args = parse_debate_args(&[
+        "csa",
+        "debate",
+        "--memory-max-mb",
+        "6144",
+        "--min-free-memory-mb",
+        "256",
+        "question",
+    ]);
+
+    assert_eq!(args.memory_max_mb, Some(6144));
+    assert_eq!(args.min_free_memory_mb, Some(256));
+}
+
+#[test]
+fn debate_cli_rejects_memory_override_below_config_minimum() {
+    let result = Cli::try_parse_from(["csa", "debate", "--memory-max-mb", "255", "question"]);
+
+    let err = match result {
+        Ok(_) => panic!("memory override below configured minimum should fail"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+}

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -52,9 +52,10 @@ mod session_hooks;
 pub(crate) mod lefthook_auto_install;
 
 // Re-export session execution API so callers keep using `crate::pipeline::*`.
+#[cfg(test)]
+pub(crate) use session_exec::execute_with_session_and_meta;
 pub(crate) use session_exec::{
-    execute_with_session, execute_with_session_and_meta,
-    execute_with_session_and_meta_with_parent_source,
+    execute_with_session, execute_with_session_and_meta_with_parent_source,
 };
 
 pub(crate) const DEFAULT_IDLE_TIMEOUT_SECONDS: u64 = 250;

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -51,7 +51,9 @@ use self::session_exec_pre_exec::{
     check_resources_before_spawn, persist_pipeline_pre_exec_failure,
     write_fatal_error_marker_sidecar,
 };
-pub(crate) use session_exec_api::{execute_with_session, execute_with_session_and_meta};
+pub(crate) use session_exec_api::execute_with_session;
+#[cfg(test)]
+pub(crate) use session_exec_api::execute_with_session_and_meta;
 
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all, fields(tool = %tool, parent_session_source = ?parent_session_source))]

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -111,12 +111,7 @@ use reviewers::resolve_effective_reviewer_selection_for_args;
 #[rustfmt::skip]
 pub(crate) use { fix::persist_fix_final_artifacts_for_tests, output::persist_review_verdict_for_tests };
 
-pub(crate) fn compute_review_diff_fingerprint(
-    project_root: &std::path::Path,
-    scope: &str,
-) -> Option<String> {
-    compute_diff_fingerprint(project_root, scope)
-}
+pub(crate) use execute::compute_diff_fingerprint as compute_review_diff_fingerprint;
 
 pub(crate) fn validate_session_fix_before_daemon(args: &ReviewArgs) -> Result<()> {
     session_fix::validate_session_fix_before_daemon(args)?;
@@ -363,6 +358,7 @@ pub(crate) async fn handle_review(
             &args.extra_writable,
             &args.extra_readable,
             args.error_marker_scan_override(),
+            args.resource_overrides(),
             current_depth,
             startup_env,
         );
@@ -544,6 +540,7 @@ pub(crate) async fn handle_review(
             fast_but_more_cost: args.fast_but_more_cost,
             no_fs_sandbox: args.no_fs_sandbox,
             error_marker_scan_override: args.error_marker_scan_override(),
+            resource_overrides: args.resource_overrides(),
             extra_writable: &args.extra_writable,
             extra_readable: &args.extra_readable,
             timeout: args.timeout,

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -31,6 +31,7 @@ use tracing::{info, warn};
 use crate::review_routing::{
     ReviewRoutingMetadata, persist_review_routing_artifact_with_fallback_chain,
 };
+use crate::run_resource_overrides::RunResourceOverrides;
 use crate::startup_env::StartupSubtreeEnv;
 use crate::tier_model_fallback::{
     TierAttemptFailure, chain_failure_reasons, earliest_backend_reset_window,
@@ -192,6 +193,7 @@ pub(crate) async fn execute_review(
         extra_writable,
         extra_readable,
         error_marker_scan_override,
+        RunResourceOverrides::default(),
         0,
         &startup_env,
     )
@@ -230,6 +232,7 @@ pub(crate) async fn execute_review_with_tier_filter(
     extra_writable: &[PathBuf],
     extra_readable: &[PathBuf],
     error_marker_scan_override: Option<bool>,
+    resource_overrides: RunResourceOverrides,
     current_depth: u32,
     startup_env: &StartupSubtreeEnv,
 ) -> Result<ReviewExecutionOutcome> {
@@ -364,6 +367,7 @@ pub(crate) async fn execute_review_with_tier_filter(
             extra_writable,
             extra_readable,
             error_marker_scan_override,
+            resource_overrides,
             startup_env,
         )
         .await
@@ -534,6 +538,7 @@ pub(crate) async fn execute_review_with_tier_filter(
                     extra_writable,
                     extra_readable,
                     error_marker_scan_override,
+                    resource_overrides,
                     startup_env,
                 )
                 .await
@@ -757,7 +762,7 @@ pub(crate) async fn execute_review_with_tier_filter(
 /// The fingerprint enables diff-level deduplication: if two review
 /// invocations produce the same diff content (e.g., revert-then-revert),
 /// the second can reuse the first review's result.
-pub(super) fn compute_diff_fingerprint(project_root: &Path, scope: &str) -> Option<String> {
+pub(crate) fn compute_diff_fingerprint(project_root: &Path, scope: &str) -> Option<String> {
     use sha2::{Digest, Sha256};
 
     let diff_args: Vec<&str> = if scope == "uncommitted" {

--- a/crates/cli-sub-agent/src/review_cmd_execute_once.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_once.rs
@@ -7,6 +7,7 @@ use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::{OutputFormat, ToolName};
 use csa_executor::Executor;
 
+use crate::run_resource_overrides::RunResourceOverrides;
 use crate::startup_env::StartupSubtreeEnv;
 
 use super::failures::enforce_review_artifact_contract;
@@ -35,6 +36,7 @@ async fn execute_review_once(
     extra_writable: &[PathBuf],
     extra_readable: &[PathBuf],
     error_marker_scan_override: Option<bool>,
+    resource_overrides: RunResourceOverrides,
     startup_env: &StartupSubtreeEnv,
 ) -> Result<crate::pipeline::SessionExecutionResult> {
     crate::pipeline::execute_with_session_and_meta_with_parent_source(
@@ -63,7 +65,7 @@ async fn execute_review_once(
         pre_session_hook,
         crate::pipeline::ParentSessionSource::ExplicitOnly,
         crate::pipeline::SessionCreationMode::DaemonManaged,
-        Default::default(),
+        resource_overrides,
         no_fs_sandbox,
         readonly_project_root,
         extra_writable,
@@ -97,6 +99,7 @@ pub(super) async fn execute_review_once_with_artifact_guard(
     extra_writable: &[PathBuf],
     extra_readable: &[PathBuf],
     error_marker_scan_override: Option<bool>,
+    resource_overrides: RunResourceOverrides,
     startup_env: &StartupSubtreeEnv,
 ) -> Result<crate::pipeline::SessionExecutionResult> {
     let invocation_started_at = Utc::now();
@@ -121,6 +124,7 @@ pub(super) async fn execute_review_once_with_artifact_guard(
         extra_writable,
         extra_readable,
         error_marker_scan_override,
+        resource_overrides,
         startup_env,
     )
     .await

--- a/crates/cli-sub-agent/src/review_cmd_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix.rs
@@ -9,6 +9,7 @@ use tracing::{error, info, warn};
 
 use crate::bug_class::{CONSOLIDATED_REVIEW_ARTIFACT_FILE, SINGLE_REVIEW_ARTIFACT_FILE};
 use crate::review_routing::ReviewRoutingMetadata;
+use crate::run_resource_overrides::RunResourceOverrides;
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::{ReviewDecision, ToolName};
 use csa_session::{
@@ -63,6 +64,7 @@ pub(crate) struct FixLoopContext<'a> {
     pub no_fs_sandbox: bool,
     /// #1652 scan override (#1745, #1847).
     pub error_marker_scan_override: Option<bool>,
+    pub resource_overrides: RunResourceOverrides,
     pub extra_writable: &'a [PathBuf],
     pub extra_readable: &'a [PathBuf],
     pub timeout: Option<u64>,
@@ -161,6 +163,7 @@ pub(crate) async fn run_fix_loop(ctx: FixLoopContext<'_>) -> Result<i32> {
             ctx.extra_writable,
             ctx.extra_readable,
             ctx.error_marker_scan_override,
+            ctx.resource_overrides,
             ctx.current_depth,
             ctx.startup_env,
         );

--- a/crates/cli-sub-agent/src/review_cmd_fix_finding.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_finding.rs
@@ -134,6 +134,7 @@ pub(crate) async fn handle_fix_finding(
         &args.extra_writable,
         &args.extra_readable,
         args.error_marker_scan_override(),
+        args.resource_overrides(),
         current_depth,
         startup_env,
     );

--- a/crates/cli-sub-agent/src/review_cmd_fix_finding_prompt.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_finding_prompt.rs
@@ -106,6 +106,8 @@ mod tests {
             thinking: None,
             no_failover: false,
             fast_but_more_cost: false,
+            memory_max_mb: None,
+            min_free_memory_mb: None,
             build_jobs: None,
             diff: false,
             full_consistency: false,

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -142,6 +142,7 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
         let reviewer_fast_but_more_cost = ctx.args.fast_but_more_cost;
         let reviewer_no_fs_sandbox = ctx.args.no_fs_sandbox;
         let reviewer_error_marker_scan_override = ctx.args.error_marker_scan_override();
+        let reviewer_resource_overrides = ctx.args.resource_overrides();
         let reviewer_extra_writable = ctx.args.extra_writable.clone();
         let reviewer_extra_readable = ctx.args.extra_readable.clone();
         // Keep every reviewer on the resolved tier when possible by binding
@@ -205,6 +206,7 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
                 &reviewer_extra_writable,
                 &reviewer_extra_readable,
                 reviewer_error_marker_scan_override,
+                reviewer_resource_overrides,
                 current_depth,
                 &startup_env,
             )

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -11,6 +11,7 @@ use crate::review_context::{
 };
 use crate::review_prior_rounds::REVIEW_FINDINGS_TOML_INSTRUCTION;
 use crate::review_routing::{ReviewRoutingMetadata, detect_review_routing_metadata};
+use crate::run_resource_overrides::RunResourceOverrides;
 use csa_config::global::{heterogeneous_counterpart, select_heterogeneous_tool};
 use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::ToolName;
@@ -22,6 +23,12 @@ pub(crate) use selection::resolve_review_tool;
 pub(crate) use selection::{
     resolve_review_selection, validate_review_direct_tool_tier_restriction,
 };
+
+impl ReviewArgs {
+    pub(crate) fn resource_overrides(&self) -> RunResourceOverrides {
+        RunResourceOverrides::new(self.memory_max_mb, self.min_free_memory_mb)
+    }
+}
 
 /// Verify the review pattern is installed before attempting execution.
 ///

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -104,6 +104,29 @@ fn parse_or_validate_review_error(argv: &[&str]) -> clap::Error {
     }
 }
 
+#[test]
+fn review_cli_accepts_resource_override_flags() {
+    let args = parse_review_args(&[
+        "csa",
+        "review",
+        "--memory-max-mb",
+        "6144",
+        "--min-free-memory-mb",
+        "256",
+        "--diff",
+    ]);
+
+    assert_eq!(args.memory_max_mb, Some(6144));
+    assert_eq!(args.min_free_memory_mb, Some(256));
+}
+
+#[test]
+fn review_cli_rejects_memory_override_below_config_minimum() {
+    let err = parse_review_error(&["csa", "review", "--memory-max-mb", "255", "--diff"]);
+
+    assert_eq!(err.kind(), ErrorKind::ValueValidation);
+}
+
 fn sample_spec_document(plan_ulid: &str, criterion_id: &str) -> SpecDocument {
     SpecDocument {
         schema_version: 1,

--- a/crates/cli-sub-agent/src/review_cmd_tests_fix_fallback.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_fix_fallback.rs
@@ -142,6 +142,7 @@ async fn handle_review_fix_loop_uses_effective_fallback_tool() {
         fast_but_more_cost: false,
         no_fs_sandbox: true,
         error_marker_scan_override: None,
+        resource_overrides: crate::run_resource_overrides::RunResourceOverrides::default(),
         extra_writable: &[],
         extra_readable: &[],
         timeout: None,

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1022"
-weave = "0.1.1022"
+csa = "0.1.1023"
+weave = "0.1.1023"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Exposes `--memory-max-mb` and `--min-free-memory-mb` on `csa review` and `csa debate`.
- Threads those one-shot memory admission overrides through single review, multi-reviewer, fix-loop, fix-finding, and debate provider-spawn paths.
- Keeps default behavior unchanged when overrides are omitted and preserves the configured minimum memory-cap validation.
- Bumps workspace lock stamps to `0.1.1023`.

Closes #2052

## Test Plan

- `cargo test -p cli-sub-agent resource_override_flags -- --nocapture`
- `cargo test -p cli-sub-agent memory_override_below -- --nocapture`
- `cargo check -p cli-sub-agent`
- `cargo clippy -p cli-sub-agent --all-targets --all-features -- -D warnings`
- `cargo test -p cli-sub-agent --no-run`
- `cargo fmt --all -- --check`
- `git diff --check`
- `just find-monolith-files`
- `just monolith-test`
- staged protected-path/secret scan
- `just pre-commit-fast`
- hook-enabled `git commit`
- exact-head binary check: `csa 0.1.1023 (35e06363)`
- migrations: `Pending migrations: 0`

## Review Evidence

- Exact-head CSA review session `01KV86JN2PVF9TWBWX3VZJTJ74` returned `UNAVAILABLE` due `memory_soft_limit`; evidence recorded on #2254.
- Same-SHA native exact-head fallback review for `35e06363168fe308b763551953448cba634a08bf` returned `PASS/CLEAN`; evidence recorded on #2052 and #2254.
