### PR TITLE
fix(session): keep resumed codex wait sessions live

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1023"
+version = "0.1.1024"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1023"
+version = "0.1.1024"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -445,6 +445,9 @@ fn check_session_stale_before_wait(
                 let now = Utc::now();
                 let elapsed = now.signed_duration_since(session.last_accessed);
 
+                if session_holds_worktree_write_lock(project_root, session_id) {
+                    return Ok(());
+                }
                 if elapsed > chrono::Duration::seconds(stale_threshold_seconds as i64) {
                     if session_has_terminal_process(session_dir) {
                         return Ok(());
@@ -463,6 +466,21 @@ fn check_session_stale_before_wait(
     }
 
     Ok(())
+}
+
+fn session_holds_worktree_write_lock(project_root: &Path, session_id: &str) -> bool {
+    match csa_lock::worktree_write_lock_is_held_by_session(project_root, session_id) {
+        Ok(held) => held,
+        Err(error) => {
+            tracing::debug!(
+                session_id,
+                project_root = %project_root.display(),
+                error = %error,
+                "failed to probe live worktree write lock during stale precheck"
+            );
+            false
+        }
+    }
 }
 
 fn load_session_for_stale_precheck(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -416,6 +416,7 @@ fn check_session_stale_before_wait(
     session_id: &str,
     session_dir: &Path,
     wait_behavior: WaitBehavior,
+    worktree_lock_session_ids: &[&str],
 ) -> anyhow::Result<()> {
     // Load the session to check its phase and last_accessed time.
     // Only flag truly stale sessions (Active phase, no daemon, no recent progress).
@@ -445,7 +446,7 @@ fn check_session_stale_before_wait(
                 let now = Utc::now();
                 let elapsed = now.signed_duration_since(session.last_accessed);
 
-                if session_holds_worktree_write_lock(project_root, session_id) {
+                if any_session_holds_worktree_write_lock(project_root, worktree_lock_session_ids) {
                     return Ok(());
                 }
                 if elapsed > chrono::Duration::seconds(stale_threshold_seconds as i64) {
@@ -466,6 +467,17 @@ fn check_session_stale_before_wait(
     }
 
     Ok(())
+}
+
+fn any_session_holds_worktree_write_lock(project_root: &Path, session_ids: &[&str]) -> bool {
+    session_ids
+        .iter()
+        .copied()
+        .enumerate()
+        .any(|(index, session_id)| {
+            !session_ids[..index].contains(&session_id)
+                && session_holds_worktree_write_lock(project_root, session_id)
+        })
 }
 
 fn session_holds_worktree_write_lock(project_root: &Path, session_id: &str) -> bool {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -174,6 +174,7 @@ pub(crate) fn handle_session_wait_with_emitters(
         result_session_id,
         observed_session_dir,
         wait_options.behavior,
+        &[resolved.session_id.as_str(), result_session_id],
     ) {
         eprintln!("Session {} appears stale: {}", result_session_id, stale_err);
         eprintln!(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -41,6 +41,33 @@ type TerminalOutputEmitter<'a> = Box<
 >;
 type NextStepEmitter<'a> = Box<dyn FnMut(&Path) -> Result<()> + 'a>;
 
+fn session_has_live_execution(
+    project_root: &Path,
+    session_dir: &Path,
+    resolved_session_id: &str,
+    result_session_id: &str,
+) -> bool {
+    session_has_terminal_process(session_dir)
+        || session_holds_worktree_write_lock(project_root, result_session_id)
+        || (resolved_session_id != result_session_id
+            && session_holds_worktree_write_lock(project_root, resolved_session_id))
+}
+
+fn session_holds_worktree_write_lock(project_root: &Path, session_id: &str) -> bool {
+    match csa_lock::worktree_write_lock_is_held_by_session(project_root, session_id) {
+        Ok(held) => held,
+        Err(error) => {
+            tracing::debug!(
+                session_id,
+                project_root = %project_root.display(),
+                error = %error,
+                "failed to probe live worktree write lock for session wait"
+            );
+            false
+        }
+    }
+}
+
 pub(crate) struct WaitEmitters<'a> {
     pub(crate) reconcile_dead_active_session: ReconcileEmitter<'a>,
     pub(crate) emit_completion_signal: CompletionSignalEmitter<'a>,
@@ -157,9 +184,15 @@ pub(crate) fn handle_session_wait_with_emitters(
     }
 
     loop {
-        if let Some(completion) = load_daemon_completion_packet(&session_dir)?
-            && (completion.is_legacy_complete_marker()
-                || !session_has_terminal_process(observed_session_dir))
+        let session_live = session_has_live_execution(
+            effective_root,
+            observed_session_dir,
+            &resolved.session_id,
+            result_session_id,
+        );
+        let completion_packet = load_daemon_completion_packet(&session_dir)?;
+        if let Some(completion) = completion_packet
+            .filter(|completion| completion.is_legacy_complete_marker() || !session_live)
         {
             let refreshed_result = refresh_result_for_wait(
                 effective_root,
@@ -244,9 +277,7 @@ pub(crate) fn handle_session_wait_with_emitters(
                 return Ok(exit_code);
             }
 
-            if session_has_terminal_process(observed_session_dir)
-                || csa_process::ToolLiveness::is_alive(observed_session_dir)
-            {
+            if session_live || csa_process::ToolLiveness::is_alive(observed_session_dir) {
                 tracing::debug!(
                     session_id = %result_session_id,
                     completion_status = %completion.status,
@@ -266,14 +297,17 @@ pub(crate) fn handle_session_wait_with_emitters(
             }
         }
 
-        if !session_has_terminal_process(observed_session_dir)
-            && let Some(result) = load_completed_daemon_result_with_fallback(
+        let completed_result = if session_live {
+            None
+        } else {
+            load_completed_daemon_result_with_fallback(
                 effective_root,
                 result_session_id,
                 &result_session_dir,
                 is_cross_project,
             )?
-        {
+        };
+        if let Some(result) = completed_result {
             let streamed_output = (emitters.emit_terminal_output)(
                 &result_session_dir,
                 result_session_id,
@@ -294,47 +328,52 @@ pub(crate) fn handle_session_wait_with_emitters(
             return Ok(exit_code);
         }
 
-        // Synthesize terminal result for dead Active sessions.
-        let reconciled = (emitters.reconcile_dead_active_session)(
-            effective_root,
-            result_session_id,
-            "session wait",
-        )?;
-        if reconciled.result_became_available
-            && let Some(result) = load_completed_daemon_result_with_fallback(
+        if !session_live {
+            // Synthesize terminal result for dead Active sessions.
+            let reconciled = (emitters.reconcile_dead_active_session)(
                 effective_root,
                 result_session_id,
-                &result_session_dir,
-                is_cross_project,
-            )?
-        {
-            let streamed_output = (emitters.emit_terminal_output)(
-                &result_session_dir,
-                result_session_id,
-                Some(&result),
-                wait_options.output_mode,
+                "session wait",
             )?;
-            (emitters.emit_next_step)(&result_session_dir)?;
-            #[rustfmt::skip]
-            let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, reconciled.synthetic, Some(&result));
-            emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
-            (emitters.emit_completion_signal)(
-                &resolved.session_id,
-                completion_status.as_ref(),
-                exit_code,
-                reconciled.synthetic,
-                !streamed_output,
-            );
-            if reconciled.synthetic && !streamed_output {
-                eprintln!(
-                    "Session {} reached a synthesized terminal result because no live daemon process remained.",
-                    resolved.session_id,
+            let reconciled_result = if reconciled.result_became_available {
+                load_completed_daemon_result_with_fallback(
+                    effective_root,
+                    result_session_id,
+                    &result_session_dir,
+                    is_cross_project,
+                )?
+            } else {
+                None
+            };
+            if let Some(result) = reconciled_result {
+                let streamed_output = (emitters.emit_terminal_output)(
+                    &result_session_dir,
+                    result_session_id,
+                    Some(&result),
+                    wait_options.output_mode,
+                )?;
+                (emitters.emit_next_step)(&result_session_dir)?;
+                #[rustfmt::skip]
+                let (completion_status, exit_code) = resolve_wait_completion_status_and_exit(result.status.as_str(), result.exit_code, reconciled.synthetic, Some(&result));
+                emit_failure_summary_for_empty_output(&session_dir, streamed_output, false);
+                (emitters.emit_completion_signal)(
+                    &resolved.session_id,
+                    completion_status.as_ref(),
+                    exit_code,
+                    reconciled.synthetic,
+                    !streamed_output,
                 );
+                if reconciled.synthetic && !streamed_output {
+                    eprintln!(
+                        "Session {} reached a synthesized terminal result because no live daemon process remained.",
+                        resolved.session_id,
+                    );
+                }
+                return Ok(exit_code);
             }
-            return Ok(exit_code);
         }
 
-        if !session_has_terminal_process(observed_session_dir) {
+        if !session_live {
             if let Some(result) = load_completed_daemon_result_with_fallback(
                 effective_root,
                 result_session_id,
@@ -377,9 +416,13 @@ pub(crate) fn handle_session_wait_with_emitters(
             }
         }
 
-        if let (Some(limit_mb), Some(sample_at)) = (memory_warn_mb, next_memory_sample_at)
-            && std::time::Instant::now() >= sample_at
-        {
+        let memory_sample_limit_mb = match (memory_warn_mb, next_memory_sample_at) {
+            (Some(limit_mb), Some(sample_at)) if std::time::Instant::now() >= sample_at => {
+                Some(limit_mb)
+            }
+            _ => None,
+        };
+        if let Some(limit_mb) = memory_sample_limit_mb {
             match (emitters.sample_session_tree_rss_mb)(effective_root, result_session_id) {
                 Ok(actual_rss_mb) => {
                     if actual_rss_mb > limit_mb {
@@ -416,8 +459,12 @@ pub(crate) fn handle_session_wait_with_emitters(
                 .as_ref()
                 .map(|path| crate::daemon_caller_hints::format_cd_arg(Path::new(path)))
                 .unwrap_or_default();
-            let session_alive = session_has_terminal_process(observed_session_dir)
-                || csa_process::ToolLiveness::is_alive(observed_session_dir);
+            let session_alive = session_has_live_execution(
+                effective_root,
+                observed_session_dir,
+                &resolved.session_id,
+                result_session_id,
+            ) || csa_process::ToolLiveness::is_alive(observed_session_dir);
             if session_alive {
                 let wait_cmd = format!(
                     "csa session wait --session {}{}",

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
@@ -176,3 +176,127 @@ fn handle_session_wait_rejects_duplicate_wait_before_entering_loop() {
         "duplicate wait should not emit a completion signal"
     );
 }
+
+#[test]
+fn handle_session_wait_treats_live_worktree_lock_as_progress_during_stale_precheck() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let mut session = create_session(
+        project,
+        Some("wait-live-lock-not-stale"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    session.last_accessed = chrono::Utc::now() - chrono::Duration::hours(24);
+    let session_id = session.meta_session_id.clone();
+    save_session(&session).expect("save stale active session");
+    let _worktree_lock =
+        csa_lock::acquire_worktree_write_lock(project, &session_id, &[], |_| false)
+            .expect("worktree write lock should be held by session");
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("live worktree lock should keep stale precheck from reconciling")
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should not classify a live worktree lock as stale");
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        emitted_completion, None,
+        "live lock should produce a healthy wait cap, not a stale failure"
+    );
+}
+
+#[test]
+fn handle_session_wait_defers_terminal_result_while_worktree_lock_is_live() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-defers-result-while-worktree-lock-live"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let terminal_result = SessionResult {
+        summary: "provider usage limit".to_string(),
+        ..make_result("failure", 1)
+    };
+    save_result(project, &session_id, &terminal_result).expect("save terminal result");
+    let worktree_lock = csa_lock::acquire_worktree_write_lock(project, &session_id, &[], |_| false)
+        .expect("worktree write lock should be held by session");
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("live worktree lock should keep session nonterminal")
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should defer terminal result while lock is live");
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        emitted_completion, None,
+        "wait must not emit terminal failure while the session still holds the worktree lock"
+    );
+
+    drop(worktree_lock);
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("terminal result after lock release should not need reconciliation")
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should trust terminal result after lock release");
+
+    assert_eq!(exit_code, 1);
+    assert_eq!(
+        emitted_completion,
+        Some((session_id, "failure".to_string(), 1, false))
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs
@@ -174,6 +174,59 @@ fn handle_session_wait_on_resume_wrapper_continues_while_worker_target_alive_wit
 
 #[cfg(unix)]
 #[test]
+fn handle_session_wait_on_resume_wrapper_treats_wrapper_worktree_lock_as_live_in_stale_precheck() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let mut worker = create_session(
+        project,
+        Some("worker-stale-wrapper-lock"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let wrapper = create_session(project, Some("wrapper-holds-lock"), None, None).unwrap();
+    worker.last_accessed = chrono::Utc::now() - chrono::Duration::hours(24);
+    let worker_id = worker.meta_session_id.clone();
+    let wrapper_id = wrapper.meta_session_id;
+    save_session(&worker).unwrap();
+    csa_session::write_resume_target(project, &wrapper_id, &worker_id).unwrap();
+    let _worktree_lock =
+        csa_lock::acquire_worktree_write_lock(project, &wrapper_id, &[], |_| false)
+            .expect("wrapper worktree lock should be held");
+
+    let mut emitted_completion = false;
+    let exit_code = handle_session_wait_with_hooks(
+        wrapper_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("wrapper-held worktree lock should keep stale precheck nonterminal")
+        },
+        |_sid: &str, _status: &str, _exit_code, _synthetic, _mirror_to_stdout| {
+            emitted_completion = true;
+        },
+    )
+    .expect("wrapper-held worktree lock should not fail stale precheck");
+
+    assert_eq!(exit_code, 0);
+    assert!(
+        !emitted_completion,
+        "live wrapper lock should produce a healthy wait cap, not terminal completion"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn handle_session_wait_on_resume_wrapper_memory_warn_samples_worker_target() {
     let td = tempdir().unwrap();
     let _env_lock = TEST_ENV_LOCK.blocking_lock();

--- a/crates/csa-acp/src/transport.rs
+++ b/crates/csa-acp/src/transport.rs
@@ -279,7 +279,7 @@ pub async fn run_prompt_with_io(
         termination_grace_period: options.termination_grace_period,
     })
     .await?;
-    let result = session
+    let result = match session
         .prompt_with_idle_timeout_and_io(
             prompt,
             options.idle_timeout,
@@ -292,7 +292,16 @@ pub async fn run_prompt_with_io(
                 tool_output_compaction: options.io.tool_output_compaction,
             },
         )
-        .await?;
+        .await
+    {
+        Ok(result) => result,
+        Err(error) => {
+            if !has_resume_session {
+                let _ = session.connection().kill().await;
+            }
+            return Err(error);
+        }
+    };
 
     // ACP processes may stay alive across prompts. If the prompt itself succeeded
     // (no error above), a still-running process is normal — default to exit_code=0.

--- a/crates/csa-executor/src/transport_acp_sandbox.rs
+++ b/crates/csa-executor/src/transport_acp_sandbox.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::Path;
 use std::time::Duration;
 
@@ -280,9 +281,10 @@ async fn run_acp_sandboxed_inner(
         )
         .await;
 
-    if sandboxed_prompt_error_should_kill_session(result.is_err(), resume_session_id) {
+    kill_after_fresh_sandboxed_prompt_error(result.is_err(), resume_session_id, || async {
         let _ = connection.kill().await;
-    }
+    })
+    .await;
 
     // Stop memory monitor before capturing peak memory (done by caller).
     if let Some(monitor) = memory_monitor {
@@ -299,9 +301,29 @@ fn sandboxed_prompt_error_should_kill_session(
     prompt_failed && resume_session_id.is_none()
 }
 
+async fn kill_after_fresh_sandboxed_prompt_error<F, Fut>(
+    prompt_failed: bool,
+    resume_session_id: Option<&str>,
+    kill: F,
+) where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    if sandboxed_prompt_error_should_kill_session(prompt_failed, resume_session_id) {
+        kill().await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::sandboxed_prompt_error_should_kill_session;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::{
+        kill_after_fresh_sandboxed_prompt_error, sandboxed_prompt_error_should_kill_session,
+    };
 
     #[test]
     fn kills_fresh_sandboxed_acp_session_after_prompt_error() {
@@ -319,6 +341,61 @@ mod tests {
     #[test]
     fn does_not_kill_successful_sandboxed_acp_prompt() {
         assert!(!sandboxed_prompt_error_should_kill_session(false, None));
+    }
+
+    #[tokio::test]
+    async fn kills_fresh_sandboxed_acp_connection_after_prompt_error() {
+        let kills = Arc::new(AtomicUsize::new(0));
+        let kills_for_closure = Arc::clone(&kills);
+
+        kill_after_fresh_sandboxed_prompt_error(true, None, move || async move {
+            kills_for_closure.fetch_add(1, Ordering::SeqCst);
+        })
+        .await;
+
+        assert_eq!(
+            kills.load(Ordering::SeqCst),
+            1,
+            "fresh sandboxed ACP prompt errors must kill the child connection"
+        );
+    }
+
+    #[tokio::test]
+    async fn preserves_resumed_sandboxed_acp_connection_after_prompt_error() {
+        let kills = Arc::new(AtomicUsize::new(0));
+        let kills_for_closure = Arc::clone(&kills);
+
+        kill_after_fresh_sandboxed_prompt_error(
+            true,
+            Some("provider-session-id"),
+            move || async move {
+                kills_for_closure.fetch_add(1, Ordering::SeqCst);
+            },
+        )
+        .await;
+
+        assert_eq!(
+            kills.load(Ordering::SeqCst),
+            0,
+            "resumed sandboxed ACP prompt errors must leave the child connection alive"
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_kill_successful_sandboxed_acp_connection() {
+        let kills = Arc::new(AtomicUsize::new(0));
+        let kills_for_closure = Arc::clone(&kills);
+
+        kill_after_fresh_sandboxed_prompt_error(false, None, move || async move {
+            kills_for_closure.fetch_add(1, Ordering::SeqCst);
+        })
+        .await;
+
+        assert_eq!(
+            kills.load(Ordering::SeqCst),
+            0,
+            "successful sandboxed ACP prompts must not use the prompt-error kill path"
+        );
     }
 }
 

--- a/crates/csa-executor/src/transport_acp_sandbox.rs
+++ b/crates/csa-executor/src/transport_acp_sandbox.rs
@@ -280,12 +280,46 @@ async fn run_acp_sandboxed_inner(
         )
         .await;
 
+    if sandboxed_prompt_error_should_kill_session(result.is_err(), resume_session_id) {
+        let _ = connection.kill().await;
+    }
+
     // Stop memory monitor before capturing peak memory (done by caller).
     if let Some(monitor) = memory_monitor {
         monitor.stop().await;
     }
 
     result.map(|r| (r, acp_session_id))
+}
+
+fn sandboxed_prompt_error_should_kill_session(
+    prompt_failed: bool,
+    resume_session_id: Option<&str>,
+) -> bool {
+    prompt_failed && resume_session_id.is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sandboxed_prompt_error_should_kill_session;
+
+    #[test]
+    fn kills_fresh_sandboxed_acp_session_after_prompt_error() {
+        assert!(sandboxed_prompt_error_should_kill_session(true, None));
+    }
+
+    #[test]
+    fn preserves_resumed_sandboxed_acp_session_after_prompt_error() {
+        assert!(!sandboxed_prompt_error_should_kill_session(
+            true,
+            Some("provider-session-id")
+        ));
+    }
+
+    #[test]
+    fn does_not_kill_successful_sandboxed_acp_prompt() {
+        assert!(!sandboxed_prompt_error_should_kill_session(false, None));
+    }
 }
 
 pub(super) fn build_summary(stdout: &str, stderr: &str, exit_code: i32) -> String {

--- a/crates/csa-lock/src/lib.rs
+++ b/crates/csa-lock/src/lib.rs
@@ -12,7 +12,9 @@
 pub mod slot;
 mod worktree;
 
-pub use worktree::{WorktreeWriteLock, acquire_worktree_write_lock};
+pub use worktree::{
+    WorktreeWriteLock, acquire_worktree_write_lock, worktree_write_lock_is_held_by_session,
+};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};

--- a/crates/csa-lock/src/worktree.rs
+++ b/crates/csa-lock/src/worktree.rs
@@ -3,8 +3,9 @@ use crate::{
     read_lock_diagnostic,
 };
 use anyhow::Result;
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::io::ErrorKind;
+use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 
 /// Guard for a write-capable CSA session sharing one git worktree.
@@ -116,6 +117,67 @@ impl Drop for WorktreeWriteLock {
             }
         }
     }
+}
+
+/// Return true only when the canonical worktree write lock is actively held by
+/// `session_id`.
+///
+/// This is a non-mutating liveness probe for wait/recovery paths: a stale
+/// diagnostic file without an fd-level flock is not live, and a live flock whose
+/// diagnostic names another session is not treated as this session's lock.
+pub fn worktree_write_lock_is_held_by_session(
+    worktree_root: &Path,
+    session_id: &str,
+) -> Result<bool> {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        anyhow::bail!("session id cannot be empty");
+    }
+
+    let (lock_path, _lock_name, _canonical_root) =
+        project_resource_lock_path(worktree_root, "worktree-write", "exclusive")?;
+    if !lock_path.exists() {
+        return Ok(false);
+    }
+    let diagnostic = match read_lock_diagnostic(&lock_path) {
+        Ok(Some(diagnostic)) => diagnostic,
+        Ok(None) => return Ok(false),
+        Err(error) if !lock_path.exists() => {
+            tracing::debug!(
+                lock_path = %lock_path.display(),
+                error = %error,
+                "worktree lock disappeared during live-holder probe"
+            );
+            return Ok(false);
+        }
+        Err(error) => return Err(error),
+    };
+    if diagnostic.holder_session_id.as_deref() != Some(session_id) {
+        return Ok(false);
+    }
+
+    let file = match OpenOptions::new().read(true).write(true).open(&lock_path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    // SAFETY: `file` owns a valid fd, and LOCK_EX | LOCK_NB is a non-blocking
+    // advisory lock probe. If it succeeds, this process briefly acquired the
+    // stale lock and immediately releases it before returning false.
+    let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if ret == 0 {
+        // SAFETY: same valid fd; release the probe lock before closing `file`.
+        unsafe {
+            libc::flock(file.as_raw_fd(), libc::LOCK_UN);
+        }
+        return Ok(false);
+    }
+
+    let error = std::io::Error::last_os_error();
+    if error.kind() == ErrorKind::WouldBlock {
+        return Ok(true);
+    }
+    Err(error.into())
 }
 
 /// Acquire a fail-fast exclusive write lock for a canonical git worktree root.

--- a/crates/csa-lock/src/worktree_tests.rs
+++ b/crates/csa-lock/src/worktree_tests.rs
@@ -241,6 +241,66 @@ fn worktree_write_lock_keeps_live_holder_blocked() {
 }
 
 #[test]
+fn worktree_write_lock_probe_detects_live_matching_holder() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let _holder = acquire_test_worktree_write_lock(worktree_root.path(), "01LIVE", &[], &[])
+        .expect("holder lock should succeed");
+
+    assert!(
+        worktree_write_lock_is_held_by_session(worktree_root.path(), "01LIVE")
+            .expect("probe live holder"),
+        "live flock plus matching diagnostic should report held"
+    );
+}
+
+#[test]
+fn worktree_write_lock_probe_ignores_stale_matching_diagnostic_without_flock() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let holder = acquire_test_worktree_write_lock(worktree_root.path(), "01STALE", &[], &[])
+        .expect("holder lock should succeed");
+    let lock_path = holder.lock_path().to_path_buf();
+    overwrite_worktree_lock_diagnostic(
+        &lock_path,
+        std::process::id(),
+        crate::process_start_time_ticks(std::process::id()),
+        "01STALE",
+        worktree_root.path(),
+    );
+    drop(holder);
+
+    assert!(
+        !worktree_write_lock_is_held_by_session(worktree_root.path(), "01STALE")
+            .expect("probe stale holder"),
+        "stale diagnostic without live flock must not report held"
+    );
+}
+
+#[test]
+fn worktree_write_lock_probe_ignores_live_different_holder() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let _holder = acquire_test_worktree_write_lock(worktree_root.path(), "01OTHER", &[], &[])
+        .expect("holder lock should succeed");
+
+    assert!(
+        !worktree_write_lock_is_held_by_session(worktree_root.path(), "01WAIT")
+            .expect("probe different holder"),
+        "live flock for another session must not report held for the waited session"
+    );
+}
+
+#[test]
 fn worktree_write_lock_blocks_post_exec_window_with_live_flock() {
     let _env_lock = env_test_lock();
     let state_home = tempdir().expect("state-home tempdir");

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1023"
-weave = "0.1.1023"
+csa = "0.1.1024"
+weave = "0.1.1024"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Keep resumed/wrapper Codex `session wait` paths live when a related session still owns the worktree write lock.
- Ensure fresh sandboxed ACP prompt errors terminate their child connection, while resumed sessions are preserved.
- Add focused regression coverage for the stale-precheck and sandboxed ACP cleanup paths.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p cli-sub-agent session_cmds_tests_tail_wait -- --nocapture`
- `cargo test -p csa-executor --features acp transport_acp_sandbox -- --nocapture`
- Hook-enabled `git commit` pre-commit quality gates passed.
- Exact-head CSA review PASS: `01KVC0GM8C45DQ737NABD8ZBR3` for `main...HEAD` at `715ba839edb`.
- Pre-push review-check passed for `715ba839edb`.

Closes #2047
