### PR TITLE
fix(session): resolve wait worktree lock root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1024"
+version = "0.1.1025"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1024"
+version = "0.1.1025"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -132,6 +132,7 @@ mod verdict_exit_code;
 mod verify_cmd;
 #[cfg(test)]
 mod version_check_recipe_tests;
+mod worktree_lock_root;
 mod xurl_cmd;
 #[cfg(test)]
 include!("review_cmd_exact_tests.rs");

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -4,8 +4,7 @@ use anyhow::{Context, Result};
 use csa_lock::WorktreeWriteLock;
 use csa_session::{MetaSessionState, SessionPhase};
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::Path;
 
 pub(super) fn acquire_or_persist_failure(
     project_root: &Path,
@@ -35,7 +34,7 @@ pub(super) fn acquire_if_needed(
         return Ok(None);
     }
 
-    let worktree_root = resolve_worktree_lock_root(project_root)?;
+    let worktree_root = crate::worktree_lock_root::resolve_worktree_lock_root(project_root)?;
     let ancestor_session_ids = collect_lineage_session_ids(project_root, session)?;
     csa_lock::acquire_worktree_write_lock(
         &worktree_root,
@@ -61,48 +60,6 @@ pub(super) fn acquire_if_needed(
 /// acquires no lock and never contends.
 fn session_mutates_worktree(readonly_project_root: bool) -> bool {
     !readonly_project_root
-}
-
-fn resolve_worktree_lock_root(project_root: &Path) -> Result<PathBuf> {
-    if let Some(toplevel) = git_rev_parse_path(project_root, "--show-toplevel") {
-        return canonicalize_lock_root(&toplevel, "git worktree toplevel");
-    }
-
-    if let Some(common_dir) = git_rev_parse_path(project_root, "--git-common-dir") {
-        return canonicalize_lock_root(&common_dir, "git common dir");
-    }
-
-    canonicalize_lock_root(project_root, "project root")
-}
-
-fn canonicalize_lock_root(path: &Path, label: &str) -> Result<PathBuf> {
-    path.canonicalize()
-        .with_context(|| format!("failed to canonicalize {label} '{}'", path.display()))
-}
-
-fn git_rev_parse_path(project_root: &Path, arg: &str) -> Option<PathBuf> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(project_root)
-        .arg("rev-parse")
-        .arg(arg)
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if raw.is_empty() {
-        return None;
-    }
-
-    let path = PathBuf::from(raw);
-    if path.is_absolute() {
-        Some(path)
-    } else {
-        Some(project_root.join(path))
-    }
 }
 
 fn collect_lineage_session_ids(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -2,6 +2,7 @@ use super::*;
 use chrono::Utc;
 use csa_config::GlobalConfig;
 use std::cell::RefCell;
+use std::path::PathBuf;
 use std::time::{Duration, Instant, SystemTime};
 
 #[path = "session_cmds_daemon_wait_completion.rs"]
@@ -255,6 +256,20 @@ fn append_mcp_wait_line(text: &mut String, line: impl AsRef<str>) {
     }
 }
 
+fn resolve_session_wait_worktree_lock_root(project_root: &Path) -> Option<PathBuf> {
+    match crate::worktree_lock_root::resolve_worktree_lock_root(project_root) {
+        Ok(root) => Some(root),
+        Err(error) => {
+            tracing::debug!(
+                project_root = %project_root.display(),
+                error = %error,
+                "failed to resolve worktree lock root for session wait"
+            );
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn handle_session_wait_with_hooks<R, E>(
     session: String,
@@ -416,6 +431,7 @@ fn check_session_stale_before_wait(
     session_id: &str,
     session_dir: &Path,
     wait_behavior: WaitBehavior,
+    worktree_lock_root: Option<&Path>,
     worktree_lock_session_ids: &[&str],
 ) -> anyhow::Result<()> {
     // Load the session to check its phase and last_accessed time.
@@ -446,7 +462,10 @@ fn check_session_stale_before_wait(
                 let now = Utc::now();
                 let elapsed = now.signed_duration_since(session.last_accessed);
 
-                if any_session_holds_worktree_write_lock(project_root, worktree_lock_session_ids) {
+                if any_session_holds_worktree_write_lock(
+                    worktree_lock_root,
+                    worktree_lock_session_ids,
+                ) {
                     return Ok(());
                 }
                 if elapsed > chrono::Duration::seconds(stale_threshold_seconds as i64) {
@@ -469,24 +488,31 @@ fn check_session_stale_before_wait(
     Ok(())
 }
 
-fn any_session_holds_worktree_write_lock(project_root: &Path, session_ids: &[&str]) -> bool {
+fn any_session_holds_worktree_write_lock(
+    worktree_lock_root: Option<&Path>,
+    session_ids: &[&str],
+) -> bool {
     session_ids
         .iter()
         .copied()
         .enumerate()
         .any(|(index, session_id)| {
             !session_ids[..index].contains(&session_id)
-                && session_holds_worktree_write_lock(project_root, session_id)
+                && session_holds_worktree_write_lock(worktree_lock_root, session_id)
         })
 }
 
-fn session_holds_worktree_write_lock(project_root: &Path, session_id: &str) -> bool {
-    match csa_lock::worktree_write_lock_is_held_by_session(project_root, session_id) {
+fn session_holds_worktree_write_lock(worktree_lock_root: Option<&Path>, session_id: &str) -> bool {
+    let Some(worktree_lock_root) = worktree_lock_root else {
+        return false;
+    };
+
+    match csa_lock::worktree_write_lock_is_held_by_session(worktree_lock_root, session_id) {
         Ok(held) => held,
         Err(error) => {
             tracing::debug!(
                 session_id,
-                project_root = %project_root.display(),
+                worktree_lock_root = %worktree_lock_root.display(),
                 error = %error,
                 "failed to probe live worktree write lock during stale precheck"
             );

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -42,24 +42,28 @@ type TerminalOutputEmitter<'a> = Box<
 type NextStepEmitter<'a> = Box<dyn FnMut(&Path) -> Result<()> + 'a>;
 
 fn session_has_live_execution(
-    project_root: &Path,
+    worktree_lock_root: Option<&Path>,
     session_dir: &Path,
     resolved_session_id: &str,
     result_session_id: &str,
 ) -> bool {
     session_has_terminal_process(session_dir)
-        || session_holds_worktree_write_lock(project_root, result_session_id)
+        || session_holds_worktree_write_lock(worktree_lock_root, result_session_id)
         || (resolved_session_id != result_session_id
-            && session_holds_worktree_write_lock(project_root, resolved_session_id))
+            && session_holds_worktree_write_lock(worktree_lock_root, resolved_session_id))
 }
 
-fn session_holds_worktree_write_lock(project_root: &Path, session_id: &str) -> bool {
-    match csa_lock::worktree_write_lock_is_held_by_session(project_root, session_id) {
+fn session_holds_worktree_write_lock(worktree_lock_root: Option<&Path>, session_id: &str) -> bool {
+    let Some(worktree_lock_root) = worktree_lock_root else {
+        return false;
+    };
+
+    match csa_lock::worktree_write_lock_is_held_by_session(worktree_lock_root, session_id) {
         Ok(held) => held,
         Err(error) => {
             tracing::debug!(
                 session_id,
-                project_root = %project_root.display(),
+                worktree_lock_root = %worktree_lock_root.display(),
                 error = %error,
                 "failed to probe live worktree write lock for session wait"
             );
@@ -128,6 +132,7 @@ pub(crate) fn handle_session_wait_with_emitters(
         .unwrap_or(&project_root);
     let is_cross_project = resolved.foreign_project_root.is_some();
     let resume_target = csa_session::resolve_resume_target_from_dir(effective_root, &session_dir)?;
+    let worktree_lock_root = super::resolve_session_wait_worktree_lock_root(effective_root);
     let result_session_id = resume_target
         .as_ref()
         .map(|target| target.session_id.as_str())
@@ -174,6 +179,7 @@ pub(crate) fn handle_session_wait_with_emitters(
         result_session_id,
         observed_session_dir,
         wait_options.behavior,
+        worktree_lock_root.as_deref(),
         &[resolved.session_id.as_str(), result_session_id],
     ) {
         eprintln!("Session {} appears stale: {}", result_session_id, stale_err);
@@ -186,7 +192,7 @@ pub(crate) fn handle_session_wait_with_emitters(
 
     loop {
         let session_live = session_has_live_execution(
-            effective_root,
+            worktree_lock_root.as_deref(),
             observed_session_dir,
             &resolved.session_id,
             result_session_id,
@@ -461,7 +467,7 @@ pub(crate) fn handle_session_wait_with_emitters(
                 .map(|path| crate::daemon_caller_hints::format_cd_arg(Path::new(path)))
                 .unwrap_or_default();
             let session_alive = session_has_live_execution(
-                effective_root,
+                worktree_lock_root.as_deref(),
                 observed_session_dir,
                 &resolved.session_id,
                 result_session_id,

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
@@ -7,6 +7,8 @@ use crate::test_env_lock::TEST_ENV_LOCK;
 use std::io::Write;
 use std::os::fd::AsRawFd;
 use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+use std::process::Command;
 use tempfile::tempdir;
 
 struct EnvVarGuard {
@@ -125,6 +127,19 @@ fn exited_child_pid() -> u32 {
     pid
 }
 
+fn init_git_repo(path: &Path) {
+    let output = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(path)
+        .output()
+        .expect("git init should run");
+    assert!(
+        output.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn handle_session_wait_rejects_duplicate_wait_before_entering_loop() {
     let td = tempdir().expect("tempdir");
@@ -223,6 +238,68 @@ fn handle_session_wait_treats_live_worktree_lock_as_progress_during_stale_preche
     assert_eq!(
         emitted_completion, None,
         "live lock should produce a healthy wait cap, not a stale failure"
+    );
+}
+
+#[test]
+fn handle_session_wait_sees_git_toplevel_worktree_lock_from_subdirectory() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let repo_root = td.path().join("repo");
+    let project = repo_root.join("nested");
+    std::fs::create_dir_all(&project).expect("create nested project dir");
+    init_git_repo(&repo_root);
+
+    let mut session = create_session(
+        &project,
+        Some("wait-subdir-live-lock-not-stale"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    session.last_accessed = chrono::Utc::now() - chrono::Duration::hours(24);
+    let session_id = session.meta_session_id.clone();
+    save_session(&session).expect("save stale active session");
+    let _worktree_lock =
+        csa_lock::acquire_worktree_write_lock(&repo_root, &session_id, &[], |_| false)
+            .expect("writer lock should be held at git toplevel");
+    assert!(
+        csa_lock::worktree_write_lock_is_held_by_session(&repo_root, &session_id)
+            .expect("probe repo-root worktree lock"),
+        "test setup requires a live git-toplevel worktree lock"
+    );
+    assert!(
+        !csa_lock::worktree_write_lock_is_held_by_session(&project, &session_id)
+            .expect("probe nested worktree lock"),
+        "direct nested-root probe must miss the git-toplevel lock to prove the root mismatch"
+    );
+
+    let mut emitted_completion: Option<(String, String, i32, bool)> = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("live git-toplevel worktree lock should keep session nonterminal")
+        },
+        |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("wait should see the git-toplevel worktree lock from a subdirectory");
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        emitted_completion, None,
+        "subdirectory wait must return the healthy wait-cap path, not stale failure or completion"
     );
 }
 

--- a/crates/cli-sub-agent/src/worktree_lock_root.rs
+++ b/crates/cli-sub-agent/src/worktree_lock_root.rs
@@ -1,0 +1,45 @@
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub(crate) fn resolve_worktree_lock_root(project_root: &Path) -> Result<PathBuf> {
+    if let Some(toplevel) = git_rev_parse_path(project_root, "--show-toplevel") {
+        return canonicalize_lock_root(&toplevel, "git worktree toplevel");
+    }
+
+    if let Some(common_dir) = git_rev_parse_path(project_root, "--git-common-dir") {
+        return canonicalize_lock_root(&common_dir, "git common dir");
+    }
+
+    canonicalize_lock_root(project_root, "project root")
+}
+
+fn canonicalize_lock_root(path: &Path, label: &str) -> Result<PathBuf> {
+    path.canonicalize()
+        .with_context(|| format!("failed to canonicalize {label} '{}'", path.display()))
+}
+
+fn git_rev_parse_path(project_root: &Path, arg: &str) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .arg("rev-parse")
+        .arg(arg)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        Some(path)
+    } else {
+        Some(project_root.join(path))
+    }
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1024"
-weave = "0.1.1024"
+csa = "0.1.1025"
+weave = "0.1.1025"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Centralize Git-aware worktree lock root resolution for writer and wait paths.
- Make daemon wait-loop and stale-precheck liveness probes use the same canonical lock root as writer acquisition.
- Add a regression covering nested `--cd` / repository-root mismatch so live writer locks remain visible.
- Bump workspace version to `0.1.1025` and update `weave.lock` version stamps.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check --cached`
- `cargo test -p cli-sub-agent session_cmds_tests_tail_wait_lock -- --nocapture`
- Hook-enabled `git commit` pre-commit quality gates passed.
- Exact-head CSA review PASS: `01KVC42HA8ZGBW42CSKJR0J3B2` for `main...HEAD` at `b7c3307e21c`.
- Pre-push review-check passed for `b7c3307e21c`.

Closes #2270
