### PR TITLE
fix(review): admit codex memory soft-limit reviews early

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1025"
+version = "0.1.1026"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1025"
+version = "0.1.1026"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -64,6 +64,7 @@ mod push_cmd;
 mod recall_cmd;
 mod require_commit_recovery_display;
 mod resource_admission;
+mod resource_admission_soft_limit;
 mod review_cmd;
 mod review_consensus;
 mod review_context;

--- a/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
@@ -102,13 +102,18 @@ pub(super) async fn prepare_session_runtime(
     prepare_session_runtime_inner(input, session)
         .await
         .map_err(|err| {
+            let termination_reason = err
+                .downcast_ref::<crate::resource_admission_soft_limit::MemorySoftLimitAdmissionError>()
+                .map(|_| {
+                    crate::resource_admission_soft_limit::MemorySoftLimitAdmissionError::TERMINATION_REASON
+                });
             persist_pipeline_pre_exec_failure(
                 project_root,
                 session,
                 &tool_name,
                 err,
                 cleanup_guard,
-                None,
+                termination_reason,
             )
         })
 }
@@ -340,6 +345,14 @@ async fn prepare_session_runtime_inner(
             return Err(anyhow::anyhow!(msg));
         }
     };
+    crate::resource_admission_soft_limit::ensure_review_soft_limit_admission(
+        input.task_type,
+        input.executor.tool_name(),
+        execute_options
+            .sandbox
+            .as_ref()
+            .map(|sandbox| &sandbox.isolation_plan),
+    )?;
     crate::pipeline::ensure_tool_runtime_prerequisites(
         input.executor.tool_name(),
         crate::pipeline::resolved_filesystem_capability(&execute_options),

--- a/crates/cli-sub-agent/src/resource_admission_soft_limit.rs
+++ b/crates/cli-sub-agent/src/resource_admission_soft_limit.rs
@@ -1,0 +1,214 @@
+use csa_resource::{IsolationPlan, ResourceCapability, memory_policy};
+
+const REVIEWER_SUB_SESSION_TASK_TYPE: &str = "reviewer_sub_session";
+// Codex's default profile is 12288MB because the old 8192MB cap still failed
+// large Rust workspaces. For reviewer sessions, the monitor threshold itself
+// must stay at least at that old cap; otherwise 8192MB at the default 70%
+// soft limit recreates #2254's 5734MB no-verdict kill window.
+const CODEX_REVIEW_MIN_SOFT_LIMIT_MB: u64 = 8192;
+pub(crate) const MEMORY_SOFT_LIMIT_ADMISSION_REASON: &str = "memory_soft_limit_admission";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MemorySoftLimitAdmissionError {
+    message: String,
+}
+
+impl MemorySoftLimitAdmissionError {
+    pub(crate) const TERMINATION_REASON: &'static str = MEMORY_SOFT_LIMIT_ADMISSION_REASON;
+}
+
+impl std::fmt::Display for MemorySoftLimitAdmissionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for MemorySoftLimitAdmissionError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReviewSoftLimitAdmissionDenial {
+    memory_max_mb: u64,
+    soft_limit_percent: u8,
+    threshold_mb: u64,
+    required_threshold_mb: u64,
+    required_memory_max_mb: u64,
+}
+
+impl ReviewSoftLimitAdmissionDenial {
+    fn message(self, tool_name: &str) -> String {
+        format!(
+            "CSA: {reason} denied -- {tool_name} reviewer soft memory threshold is \
+             {threshold}MB, below required={required}MB \
+             (memory_max_mb={memory_max}MB, soft_limit_percent={percent}). \
+             This review/fix session is likely to be terminated by CSA's memory monitor before \
+             producing a verdict. Raise --memory-max-mb, resources.memory_max_mb, or \
+             tools.{tool_name}.memory_max_mb to at least {required_memory_max}MB, remove a lower \
+             memory override so Codex can use its 12288MB default, or raise \
+             resources.soft_limit_percent only when host RAM makes that safe.",
+            reason = MEMORY_SOFT_LIMIT_ADMISSION_REASON,
+            threshold = self.threshold_mb,
+            required = self.required_threshold_mb,
+            memory_max = self.memory_max_mb,
+            percent = self.soft_limit_percent,
+            required_memory_max = self.required_memory_max_mb,
+        )
+    }
+}
+
+pub(crate) fn ensure_review_soft_limit_admission(
+    task_type: Option<&str>,
+    tool_name: &str,
+    isolation_plan: Option<&IsolationPlan>,
+) -> Result<(), MemorySoftLimitAdmissionError> {
+    let Some(denial) = review_soft_limit_admission_denial(task_type, tool_name, isolation_plan)
+    else {
+        return Ok(());
+    };
+
+    Err(MemorySoftLimitAdmissionError {
+        message: denial.message(tool_name),
+    })
+}
+
+fn review_soft_limit_admission_denial(
+    task_type: Option<&str>,
+    tool_name: &str,
+    isolation_plan: Option<&IsolationPlan>,
+) -> Option<ReviewSoftLimitAdmissionDenial> {
+    if task_type != Some(REVIEWER_SUB_SESSION_TASK_TYPE) || tool_name != "codex" {
+        return None;
+    }
+
+    let plan = isolation_plan?;
+    if plan.resource != ResourceCapability::CgroupV2 {
+        return None;
+    }
+
+    let memory_max_mb = plan.memory_max_mb?;
+    let soft_limit_percent = plan
+        .soft_limit_percent
+        .unwrap_or(memory_policy::DEFAULT_SOFT_LIMIT_PERCENT);
+    let threshold_mb = memory_policy::soft_limit_threshold_mb(memory_max_mb, soft_limit_percent)?;
+    if threshold_mb >= CODEX_REVIEW_MIN_SOFT_LIMIT_MB {
+        return None;
+    }
+
+    Some(ReviewSoftLimitAdmissionDenial {
+        memory_max_mb,
+        soft_limit_percent,
+        threshold_mb,
+        required_threshold_mb: CODEX_REVIEW_MIN_SOFT_LIMIT_MB,
+        required_memory_max_mb: memory_policy::required_memory_max_for_soft_limit_mb(
+            CODEX_REVIEW_MIN_SOFT_LIMIT_MB,
+            soft_limit_percent,
+        )?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use csa_resource::FilesystemCapability;
+
+    fn isolation_plan(
+        tool_resource: ResourceCapability,
+        memory_max_mb: Option<u64>,
+        soft_limit_percent: Option<u8>,
+    ) -> IsolationPlan {
+        IsolationPlan {
+            resource: tool_resource,
+            filesystem: FilesystemCapability::Bwrap,
+            writable_paths: Vec::new(),
+            readable_paths: Vec::new(),
+            env_overrides: std::collections::HashMap::new(),
+            degraded_reasons: Vec::new(),
+            memory_max_mb,
+            memory_swap_max_mb: None,
+            pids_max: None,
+            readonly_project_root: true,
+            project_root: None,
+            soft_limit_percent,
+            memory_monitor_interval_seconds: None,
+        }
+    }
+
+    #[test]
+    fn codex_review_soft_limit_admission_denies_8192_at_default_percent() {
+        let plan = isolation_plan(ResourceCapability::CgroupV2, Some(8192), None);
+
+        let denial = review_soft_limit_admission_denial(
+            Some(REVIEWER_SUB_SESSION_TASK_TYPE),
+            "codex",
+            Some(&plan),
+        )
+        .expect("codex reviewer should be denied");
+
+        assert_eq!(denial.threshold_mb, 5734);
+        assert_eq!(denial.required_threshold_mb, CODEX_REVIEW_MIN_SOFT_LIMIT_MB);
+        assert_eq!(denial.required_memory_max_mb, 11_703);
+        let err = ensure_review_soft_limit_admission(
+            Some(REVIEWER_SUB_SESSION_TASK_TYPE),
+            "codex",
+            Some(&plan),
+        )
+        .expect_err("admission should fail");
+        assert_eq!(
+            MemorySoftLimitAdmissionError::TERMINATION_REASON,
+            MEMORY_SOFT_LIMIT_ADMISSION_REASON
+        );
+        assert!(err.to_string().contains("--memory-max-mb"));
+        assert!(err.to_string().contains("tools.codex.memory_max_mb"));
+    }
+
+    #[test]
+    fn codex_review_soft_limit_admission_allows_codex_default_limit() {
+        let plan = isolation_plan(ResourceCapability::CgroupV2, Some(12_288), None);
+
+        assert_eq!(
+            review_soft_limit_admission_denial(
+                Some(REVIEWER_SUB_SESSION_TASK_TYPE),
+                "codex",
+                Some(&plan),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn codex_review_soft_limit_admission_allows_non_review_tasks() {
+        let plan = isolation_plan(ResourceCapability::CgroupV2, Some(8192), None);
+
+        assert_eq!(
+            review_soft_limit_admission_denial(Some("run"), "codex", Some(&plan)),
+            None
+        );
+    }
+
+    #[test]
+    fn codex_review_soft_limit_admission_allows_non_cgroup_plans() {
+        let plan = isolation_plan(ResourceCapability::Setrlimit, Some(8192), None);
+
+        assert_eq!(
+            review_soft_limit_admission_denial(
+                Some(REVIEWER_SUB_SESSION_TASK_TYPE),
+                "codex",
+                Some(&plan),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn codex_review_soft_limit_admission_honors_custom_soft_limit_percent() {
+        let plan = isolation_plan(ResourceCapability::CgroupV2, Some(8192), Some(100));
+
+        assert_eq!(
+            review_soft_limit_admission_denial(
+                Some(REVIEWER_SUB_SESSION_TASK_TYPE),
+                "codex",
+                Some(&plan),
+            ),
+            None
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_result.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result.rs
@@ -25,6 +25,7 @@ const AUTH_PROMPT_DIAGNOSTIC: &str =
     "gemini-cli auth failure: OAuth browser prompt detected; no review verdict produced";
 const REVIEW_UNAVAILABLE_PREFIX: &str = "Review unavailable: ";
 const REVIEW_UNAVAILABLE_FAILURE_PATTERNS: &[&str] = &[
+    "memory_soft_limit_admission",
     "retrydelayms",
     "rate limit",
     "rate_limit",
@@ -417,3 +418,7 @@ pub(super) fn build_unavailable_reviewer_outcome(
 #[cfg(test)]
 #[path = "review_cmd_result_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "review_cmd_result_memory_soft_limit_tests.rs"]
+mod memory_soft_limit_tests;

--- a/crates/cli-sub-agent/src/review_cmd_result_memory_soft_limit_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_memory_soft_limit_tests.rs
@@ -1,0 +1,14 @@
+use super::*;
+
+#[test]
+fn reviewer_unavailable_error_reason_maps_memory_soft_limit_admission() {
+    let err = anyhow::anyhow!(
+        "CSA: memory_soft_limit_admission denied -- codex reviewer soft memory threshold is 5734MB"
+    );
+
+    let reason = reviewer_unavailable_error_reason(&err, ToolName::Codex)
+        .expect("memory soft-limit admission reason");
+
+    assert!(reason.contains("codex tool failure"));
+    assert!(reason.contains("memory_soft_limit_admission"));
+}

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -60,14 +60,6 @@ const CSA_OWNED_ENV_KEYS: &[&str] = &[
     csa_session::RESULT_TOML_PATH_CONTRACT_ENV,
 ];
 
-/// Default soft memory limit as a percentage of MemoryMax.
-/// Lowered from 80% to 70% in #568 to provide more headroom before the
-/// memory monitor fires SIGTERM, reducing near-system-crash scenarios on
-/// memory-constrained hosts.  Raised from 65% to 70% after R5 review
-/// found that 65% of codex's 12288MB limit (7987MB) was below the old
-/// 8192MB hard cap, effectively negating the #555 increase.
-const DEFAULT_SOFT_LIMIT_PERCENT: u8 = 70;
-
 #[cfg(feature = "acp")]
 impl AcpTransport {
     pub(crate) fn build_system_prompt(session_config: Option<&SessionConfig>) -> Option<String> {
@@ -356,7 +348,7 @@ pub(super) fn start_memory_monitor(
     }
     let soft_pct = isolation_plan
         .soft_limit_percent
-        .unwrap_or(DEFAULT_SOFT_LIMIT_PERCENT);
+        .unwrap_or(csa_resource::memory_policy::DEFAULT_SOFT_LIMIT_PERCENT);
     let interval_secs = isolation_plan.memory_monitor_interval_seconds.unwrap_or(5);
     csa_resource::memory_monitor::start(csa_resource::memory_monitor::MemoryMonitorConfig {
         scope_name: scope_name.to_string(),

--- a/crates/csa-resource/src/lib.rs
+++ b/crates/csa-resource/src/lib.rs
@@ -12,6 +12,7 @@ pub mod landlock;
 pub mod landlock;
 pub mod memory_balloon;
 pub mod memory_monitor;
+pub mod memory_policy;
 pub mod rlimit;
 pub mod sandbox;
 

--- a/crates/csa-resource/src/memory_monitor.rs
+++ b/crates/csa-resource/src/memory_monitor.rs
@@ -134,19 +134,15 @@ pub fn start(mut config: MemoryMonitorConfig) -> Option<MemoryMonitorHandle> {
     // limit must not inherit a previous run's soft-limit kill evidence.
     clear_soft_limit_diagnostic_path(config.diagnostic_path.as_deref());
 
-    if config.memory_max_bytes == 0
-        || config.soft_limit_percent == 0
-        || config.soft_limit_percent > 100
-    {
-        return None;
-    }
+    let threshold_bytes = crate::memory_policy::soft_limit_threshold_bytes(
+        config.memory_max_bytes,
+        config.soft_limit_percent,
+    )?;
 
     // Defense in depth: clamp zero interval to 1 second to prevent busy-polling.
     if config.interval.is_zero() {
         config.interval = Duration::from_secs(1);
     }
-
-    let threshold_bytes = config.memory_max_bytes * u64::from(config.soft_limit_percent) / 100;
 
     info!(
         scope = %config.scope_name,

--- a/crates/csa-resource/src/memory_policy.rs
+++ b/crates/csa-resource/src/memory_policy.rs
@@ -1,0 +1,49 @@
+//! Shared memory-limit policy used before spawn and during runtime monitoring.
+
+/// Default soft memory limit as a percentage of `MemoryMax`.
+///
+/// Lowered from 80% to 70% in #568 to provide headroom before SIGTERM on
+/// memory-constrained hosts. Raised from 65% to 70% after review found that
+/// 65% of Codex's 12288MB limit (7987MB) was below the old 8192MB hard cap,
+/// effectively negating the #555 increase.
+pub const DEFAULT_SOFT_LIMIT_PERCENT: u8 = 70;
+
+/// Return the soft-limit threshold in MB for a configured memory cap.
+pub fn soft_limit_threshold_mb(memory_max_mb: u64, soft_limit_percent: u8) -> Option<u64> {
+    soft_limit_threshold(memory_max_mb, soft_limit_percent)
+}
+
+/// Return the soft-limit threshold in bytes for a configured memory cap.
+pub fn soft_limit_threshold_bytes(memory_max_bytes: u64, soft_limit_percent: u8) -> Option<u64> {
+    soft_limit_threshold(memory_max_bytes, soft_limit_percent)
+}
+
+/// Return the minimum memory cap in MB required to satisfy a soft-limit floor.
+pub fn required_memory_max_for_soft_limit_mb(
+    required_threshold_mb: u64,
+    soft_limit_percent: u8,
+) -> Option<u64> {
+    if !is_valid_soft_limit_percent(soft_limit_percent) {
+        return None;
+    }
+
+    let percent = u64::from(soft_limit_percent);
+    Some(
+        required_threshold_mb
+            .saturating_mul(100)
+            .saturating_add(percent.saturating_sub(1))
+            / percent,
+    )
+}
+
+fn soft_limit_threshold(memory_max: u64, soft_limit_percent: u8) -> Option<u64> {
+    if memory_max == 0 || !is_valid_soft_limit_percent(soft_limit_percent) {
+        return None;
+    }
+
+    Some(memory_max.saturating_mul(u64::from(soft_limit_percent)) / 100)
+}
+
+fn is_valid_soft_limit_percent(soft_limit_percent: u8) -> bool {
+    (1..=100).contains(&soft_limit_percent)
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1025"
-weave = "0.1.1025"
+csa = "0.1.1026"
+weave = "0.1.1026"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Admit Codex reviewer sub-sessions before provider launch when the resolved cgroup soft-limit threshold is below the minimum review memory requirement.
- Surface these denials as `memory_soft_limit_admission` so review/fix flows report actionable infrastructure no-verdicts instead of launching doomed reviewer sessions that CSA later SIGTERMs.
- Extract shared memory soft-limit threshold policy into `csa_resource::memory_policy` and split new tests/helpers to satisfy monolith gates.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check && git diff --check --cached`
- `just find-monolith-files`
- `cargo test -p cli-sub-agent memory_soft_limit_admission -- --nocapture`
- `cargo check -p cli-sub-agent`
- `cargo clippy -p csa-resource -- -D warnings`
- hook-enabled commit quality gates
- exact-head Gemini review PASS: `01KVC79KKBXYMCT12MC295TPTD`
- `target/debug/csa review --check-verdict --sa-mode true --range main...HEAD`

Fixes #2254.
