### PR TITLE
fix(run): admit codex writer memory soft limits early

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1026"
+version = "0.1.1027"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1026"
+version = "0.1.1027"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
@@ -208,9 +208,6 @@ async fn prepare_session_runtime_inner(
     let capture_snapshot = session_exec_audit::capture_git_workspace_snapshot_if_needed;
     let pre_run_workspace =
         capture_snapshot(is_git, input.project_root, require_commit_on_mutation);
-    let tool_state =
-        ensure_tool_state_initialized(session, input.executor, input.resolved_provider_session_id)
-            .await?;
     let result_file_cleared = clear_expected_result_artifacts_for_prompt(
         input.prompt,
         input.session_dir,
@@ -345,7 +342,7 @@ async fn prepare_session_runtime_inner(
             return Err(anyhow::anyhow!(msg));
         }
     };
-    crate::resource_admission_soft_limit::ensure_review_soft_limit_admission(
+    crate::resource_admission_soft_limit::ensure_memory_soft_limit_admission(
         input.task_type,
         input.executor.tool_name(),
         execute_options
@@ -353,6 +350,9 @@ async fn prepare_session_runtime_inner(
             .as_ref()
             .map(|sandbox| &sandbox.isolation_plan),
     )?;
+    let tool_state =
+        ensure_tool_state_initialized(session, input.executor, input.resolved_provider_session_id)
+            .await?;
     crate::pipeline::ensure_tool_runtime_prerequisites(
         input.executor.tool_name(),
         crate::pipeline::resolved_filesystem_capability(&execute_options),

--- a/crates/cli-sub-agent/src/resource_admission_soft_limit.rs
+++ b/crates/cli-sub-agent/src/resource_admission_soft_limit.rs
@@ -1,11 +1,16 @@
 use csa_resource::{IsolationPlan, ResourceCapability, memory_policy};
 
 const REVIEWER_SUB_SESSION_TASK_TYPE: &str = "reviewer_sub_session";
+const WRITER_TASK_TYPE: &str = "run";
 // Codex's default profile is 12288MB because the old 8192MB cap still failed
 // large Rust workspaces. For reviewer sessions, the monitor threshold itself
 // must stay at least at that old cap; otherwise 8192MB at the default 70%
 // soft limit recreates #2254's 5734MB no-verdict kill window.
 const CODEX_REVIEW_MIN_SOFT_LIMIT_MB: u64 = 8192;
+// Writer sessions can mutate the worktree before validation/commit. Keep their
+// soft threshold above the observed 8.6GiB Codex writer kill window from #2277
+// so low caps fail before provider launch instead of after dirty edits.
+const CODEX_WRITER_MIN_SOFT_LIMIT_MB: u64 = 9000;
 pub(crate) const MEMORY_SOFT_LIMIT_ADMISSION_REASON: &str = "memory_soft_limit_admission";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,7 +31,8 @@ impl std::fmt::Display for MemorySoftLimitAdmissionError {
 impl std::error::Error for MemorySoftLimitAdmissionError {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ReviewSoftLimitAdmissionDenial {
+struct SoftLimitAdmissionDenial {
+    session_kind: CodexSoftLimitAdmissionKind,
     memory_max_mb: u64,
     soft_limit_percent: u8,
     threshold_mb: u64,
@@ -34,33 +40,44 @@ struct ReviewSoftLimitAdmissionDenial {
     required_memory_max_mb: u64,
 }
 
-impl ReviewSoftLimitAdmissionDenial {
+impl SoftLimitAdmissionDenial {
     fn message(self, tool_name: &str) -> String {
+        let required_memory_max_mb = self.required_memory_max_mb;
+        let recommendation = match self.session_kind {
+            CodexSoftLimitAdmissionKind::Reviewer => format!(
+                "Raise --memory-max-mb, resources.memory_max_mb, or \
+                 tools.{tool_name}.memory_max_mb to at least {required_memory_max_mb}MB, remove a lower \
+                 memory override so Codex can use its 12288MB default, or raise \
+                 resources.soft_limit_percent only when host RAM makes that safe."
+            ),
+            CodexSoftLimitAdmissionKind::Writer => format!(
+                "Raise --memory-max-mb, resources.memory_max_mb, or \
+                 tools.{tool_name}.memory_max_mb to at least {required_memory_max_mb}MB, or raise \
+                 resources.soft_limit_percent only when host RAM makes that safe."
+            ),
+        };
         format!(
-            "CSA: {reason} denied -- {tool_name} reviewer soft memory threshold is \
+            "CSA: {reason} denied -- {tool_name} {session_kind} soft memory threshold is \
              {threshold}MB, below required={required}MB \
              (memory_max_mb={memory_max}MB, soft_limit_percent={percent}). \
-             This review/fix session is likely to be terminated by CSA's memory monitor before \
-             producing a verdict. Raise --memory-max-mb, resources.memory_max_mb, or \
-             tools.{tool_name}.memory_max_mb to at least {required_memory_max}MB, remove a lower \
-             memory override so Codex can use its 12288MB default, or raise \
-             resources.soft_limit_percent only when host RAM makes that safe.",
+             {risk} {recommendation}",
             reason = MEMORY_SOFT_LIMIT_ADMISSION_REASON,
+            session_kind = self.session_kind.label(),
             threshold = self.threshold_mb,
             required = self.required_threshold_mb,
             memory_max = self.memory_max_mb,
             percent = self.soft_limit_percent,
-            required_memory_max = self.required_memory_max_mb,
+            risk = self.session_kind.risk_message(),
         )
     }
 }
 
-pub(crate) fn ensure_review_soft_limit_admission(
+pub(crate) fn ensure_memory_soft_limit_admission(
     task_type: Option<&str>,
     tool_name: &str,
     isolation_plan: Option<&IsolationPlan>,
 ) -> Result<(), MemorySoftLimitAdmissionError> {
-    let Some(denial) = review_soft_limit_admission_denial(task_type, tool_name, isolation_plan)
+    let Some(denial) = memory_soft_limit_admission_denial(task_type, tool_name, isolation_plan)
     else {
         return Ok(());
     };
@@ -70,14 +87,56 @@ pub(crate) fn ensure_review_soft_limit_admission(
     })
 }
 
-fn review_soft_limit_admission_denial(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexSoftLimitAdmissionKind {
+    Reviewer,
+    Writer,
+}
+
+impl CodexSoftLimitAdmissionKind {
+    fn from_task_type(task_type: Option<&str>) -> Option<Self> {
+        match task_type {
+            Some(REVIEWER_SUB_SESSION_TASK_TYPE) => Some(Self::Reviewer),
+            Some(WRITER_TASK_TYPE) => Some(Self::Writer),
+            _ => None,
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Reviewer => "reviewer",
+            Self::Writer => "writer",
+        }
+    }
+
+    const fn required_threshold_mb(self) -> u64 {
+        match self {
+            Self::Reviewer => CODEX_REVIEW_MIN_SOFT_LIMIT_MB,
+            Self::Writer => CODEX_WRITER_MIN_SOFT_LIMIT_MB,
+        }
+    }
+
+    const fn risk_message(self) -> &'static str {
+        match self {
+            Self::Reviewer => {
+                "This review/fix session is likely to be terminated by CSA's memory monitor before producing a verdict."
+            }
+            Self::Writer => {
+                "This writer session is likely to be terminated by CSA's memory monitor after editing the worktree."
+            }
+        }
+    }
+}
+
+fn memory_soft_limit_admission_denial(
     task_type: Option<&str>,
     tool_name: &str,
     isolation_plan: Option<&IsolationPlan>,
-) -> Option<ReviewSoftLimitAdmissionDenial> {
-    if task_type != Some(REVIEWER_SUB_SESSION_TASK_TYPE) || tool_name != "codex" {
+) -> Option<SoftLimitAdmissionDenial> {
+    if tool_name != "codex" {
         return None;
     }
+    let session_kind = CodexSoftLimitAdmissionKind::from_task_type(task_type)?;
 
     let plan = isolation_plan?;
     if plan.resource != ResourceCapability::CgroupV2 {
@@ -89,17 +148,19 @@ fn review_soft_limit_admission_denial(
         .soft_limit_percent
         .unwrap_or(memory_policy::DEFAULT_SOFT_LIMIT_PERCENT);
     let threshold_mb = memory_policy::soft_limit_threshold_mb(memory_max_mb, soft_limit_percent)?;
-    if threshold_mb >= CODEX_REVIEW_MIN_SOFT_LIMIT_MB {
+    let required_threshold_mb = session_kind.required_threshold_mb();
+    if threshold_mb >= required_threshold_mb {
         return None;
     }
 
-    Some(ReviewSoftLimitAdmissionDenial {
+    Some(SoftLimitAdmissionDenial {
+        session_kind,
         memory_max_mb,
         soft_limit_percent,
         threshold_mb,
-        required_threshold_mb: CODEX_REVIEW_MIN_SOFT_LIMIT_MB,
+        required_threshold_mb,
         required_memory_max_mb: memory_policy::required_memory_max_for_soft_limit_mb(
-            CODEX_REVIEW_MIN_SOFT_LIMIT_MB,
+            required_threshold_mb,
             soft_limit_percent,
         )?,
     })
@@ -136,7 +197,7 @@ mod tests {
     fn codex_review_soft_limit_admission_denies_8192_at_default_percent() {
         let plan = isolation_plan(ResourceCapability::CgroupV2, Some(8192), None);
 
-        let denial = review_soft_limit_admission_denial(
+        let denial = memory_soft_limit_admission_denial(
             Some(REVIEWER_SUB_SESSION_TASK_TYPE),
             "codex",
             Some(&plan),
@@ -146,7 +207,7 @@ mod tests {
         assert_eq!(denial.threshold_mb, 5734);
         assert_eq!(denial.required_threshold_mb, CODEX_REVIEW_MIN_SOFT_LIMIT_MB);
         assert_eq!(denial.required_memory_max_mb, 11_703);
-        let err = ensure_review_soft_limit_admission(
+        let err = ensure_memory_soft_limit_admission(
             Some(REVIEWER_SUB_SESSION_TASK_TYPE),
             "codex",
             Some(&plan),
@@ -158,6 +219,10 @@ mod tests {
         );
         assert!(err.to_string().contains("--memory-max-mb"));
         assert!(err.to_string().contains("tools.codex.memory_max_mb"));
+        assert!(
+            err.to_string()
+                .contains("remove a lower memory override so Codex can use its 12288MB default")
+        );
     }
 
     #[test]
@@ -165,7 +230,7 @@ mod tests {
         let plan = isolation_plan(ResourceCapability::CgroupV2, Some(12_288), None);
 
         assert_eq!(
-            review_soft_limit_admission_denial(
+            memory_soft_limit_admission_denial(
                 Some(REVIEWER_SUB_SESSION_TASK_TYPE),
                 "codex",
                 Some(&plan),
@@ -179,7 +244,7 @@ mod tests {
         let plan = isolation_plan(ResourceCapability::CgroupV2, Some(8192), None);
 
         assert_eq!(
-            review_soft_limit_admission_denial(Some("run"), "codex", Some(&plan)),
+            memory_soft_limit_admission_denial(Some("debate"), "codex", Some(&plan)),
             None
         );
     }
@@ -189,7 +254,7 @@ mod tests {
         let plan = isolation_plan(ResourceCapability::Setrlimit, Some(8192), None);
 
         assert_eq!(
-            review_soft_limit_admission_denial(
+            memory_soft_limit_admission_denial(
                 Some(REVIEWER_SUB_SESSION_TASK_TYPE),
                 "codex",
                 Some(&plan),
@@ -203,11 +268,64 @@ mod tests {
         let plan = isolation_plan(ResourceCapability::CgroupV2, Some(8192), Some(100));
 
         assert_eq!(
-            review_soft_limit_admission_denial(
+            memory_soft_limit_admission_denial(
                 Some(REVIEWER_SUB_SESSION_TASK_TYPE),
                 "codex",
                 Some(&plan),
             ),
+            None
+        );
+    }
+
+    #[test]
+    fn codex_writer_soft_limit_admission_denies_12000_at_default_percent() {
+        let plan = isolation_plan(ResourceCapability::CgroupV2, Some(12_000), None);
+
+        let denial =
+            memory_soft_limit_admission_denial(Some(WRITER_TASK_TYPE), "codex", Some(&plan))
+                .expect("codex writer should be denied");
+
+        assert_eq!(denial.session_kind, CodexSoftLimitAdmissionKind::Writer);
+        assert_eq!(denial.threshold_mb, 8400);
+        assert_eq!(denial.required_threshold_mb, CODEX_WRITER_MIN_SOFT_LIMIT_MB);
+        assert_eq!(denial.required_memory_max_mb, 12_858);
+        let err = ensure_memory_soft_limit_admission(Some(WRITER_TASK_TYPE), "codex", Some(&plan))
+            .expect_err("writer admission should fail");
+        assert!(err.to_string().contains("writer soft memory threshold"));
+        assert!(err.to_string().contains("after editing the worktree"));
+        assert!(err.to_string().contains("tools.codex.memory_max_mb"));
+    }
+
+    #[test]
+    fn codex_writer_soft_limit_admission_denies_issue_2277_memory_max() {
+        let plan = isolation_plan(ResourceCapability::CgroupV2, Some(9000), None);
+
+        let denial =
+            memory_soft_limit_admission_denial(Some(WRITER_TASK_TYPE), "codex", Some(&plan))
+                .expect("#2277 writer cap should be denied before launch");
+
+        assert_eq!(denial.session_kind, CodexSoftLimitAdmissionKind::Writer);
+        assert_eq!(denial.threshold_mb, 6300);
+        assert_eq!(denial.required_threshold_mb, CODEX_WRITER_MIN_SOFT_LIMIT_MB);
+        assert_eq!(denial.required_memory_max_mb, 12_858);
+    }
+
+    #[test]
+    fn codex_writer_soft_limit_admission_allows_required_threshold() {
+        let plan = isolation_plan(ResourceCapability::CgroupV2, Some(12_858), None);
+
+        assert_eq!(
+            memory_soft_limit_admission_denial(Some(WRITER_TASK_TYPE), "codex", Some(&plan)),
+            None
+        );
+    }
+
+    #[test]
+    fn codex_writer_soft_limit_admission_allows_non_codex_tools() {
+        let plan = isolation_plan(ResourceCapability::CgroupV2, Some(8192), None);
+
+        assert_eq!(
+            memory_soft_limit_admission_denial(Some(WRITER_TASK_TYPE), "gemini-cli", Some(&plan)),
             None
         );
     }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1026"
-weave = "0.1.1026"
+csa = "0.1.1027"
+weave = "0.1.1027"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Add Codex writer/run soft-limit admission before provider launch so low-threshold writer sessions fail before dirty worktree edits.
- Preserve existing reviewer-sub-session admission behavior from #2254.
- Add synthetic regression tests for #2277 threshold cases and non-Codex behavior.

## Validation
- `cargo fmt --all -- --check`
- `just find-monolith-files`
- `cargo test -p cli-sub-agent resource_admission_soft_limit -- --nocapture`
- `cargo test -p cli-sub-agent codex_writer_soft_limit_admission -- --nocapture`
- `cargo check -p cli-sub-agent`
- hook-enabled `git commit -F /tmp/commit_2277_msg.txt`
- exact-head Codex review: `01KVCB9TWQ1EQKGXRN5QYNZHC5` PASS
- `target/debug/csa review --check-verdict --sa-mode true --range main...HEAD --cd "$PWD"`
- pre-push review-check/version-check hooks

Closes #2277.
