### PR TITLE
fix(plan): verify dev2merge publish side effects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1027"
+version = "0.1.1028"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1027"
+version = "0.1.1028"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -41,6 +41,9 @@ mod plan_cmd_flow;
 #[path = "plan_cmd_failure.rs"]
 pub(crate) mod plan_cmd_failure;
 
+#[path = "plan_cmd_completion.rs"]
+pub(crate) mod plan_cmd_completion;
+
 #[path = "plan_cmd_assignment.rs"]
 mod plan_cmd_assignment;
 
@@ -185,6 +188,11 @@ pub(crate) struct PlanRunArgs {
     pub startup_env: StartupSubtreeEnv,
 }
 
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PlanRunOutcome {
+    pub(crate) completion_summary: Option<String>,
+}
+
 /// Handle `csa plan run <file>` or `csa plan run --pattern <name>`.
 ///
 /// Foreground entry point: runs the workflow synchronously in the calling
@@ -192,7 +200,7 @@ pub(crate) struct PlanRunArgs {
 /// `--resume`, the daemon-child path (after env priming), and any nested
 /// invocation detected by [`plan_cmd_daemon::dispatch`] (depth>0 / parent
 /// session env), which depend on the synchronous exit-code contract.
-pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
+pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<PlanRunOutcome> {
     let PlanRunArgs {
         file,
         pattern,
@@ -301,9 +309,11 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
     // 6. Dry-run: print plan and exit
     if dry_run {
         print_plan(&plan, &cli_variables, config.as_ref());
-        return Ok(());
+        return Ok(PlanRunOutcome::default());
     }
 
+    let completion_snapshot =
+        plan_cmd_completion::PlanCompletionSnapshot::capture(&plan.name, &project_root);
     let current_repo_fingerprint = detect_repo_fingerprint(&project_root);
     let resume_context = load_plan_resume_context(
         &plan,
@@ -386,7 +396,7 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
                 r.exit_code
             );
         }
-        return Ok(());
+        return Ok(PlanRunOutcome::default());
     }
 
     // 8. Print summary
@@ -400,7 +410,7 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
             plan.name,
             journal_path.display()
         );
-        return Ok(());
+        return Ok(PlanRunOutcome::default());
     }
 
     if journal.status == "awaiting-user" {
@@ -410,7 +420,7 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
             "Workflow '{}' is awaiting user action. Re-run the workflow from the beginning after the requested remediation is complete.",
             plan.name
         );
-        return Ok(());
+        return Ok(PlanRunOutcome::default());
     }
 
     // 9. Warn about unsupported skips (loop_var)
@@ -456,12 +466,34 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<()> {
         );
     }
 
+    let completion_summary = match plan_cmd_completion::verify_plan_completion(
+        plan_cmd_completion::PlanCompletionInput {
+            workflow_name: &plan.name,
+            workflow_path: &workflow_path,
+            project_root: &project_root,
+            results: &results,
+            completed_steps: &journal.completed_steps,
+            vars: &journal.vars,
+            snapshot: &completion_snapshot,
+        },
+    ) {
+        Ok(summary) => summary,
+        Err(err) => {
+            let failure_summary = err.to_string();
+            journal.status = "failed".to_string();
+            journal.last_error = Some(failure_summary.clone());
+            apply_repo_fingerprint(&mut journal, &detect_repo_fingerprint(&project_root));
+            persist_plan_journal(&journal_path, &journal)?;
+            return Err(err.into());
+        }
+    };
+
     journal.status = "completed".to_string();
     journal.last_error = None;
     apply_repo_fingerprint(&mut journal, &detect_repo_fingerprint(&project_root));
     persist_plan_journal(&journal_path, &journal)?;
 
-    Ok(())
+    Ok(PlanRunOutcome { completion_summary })
 }
 
 fn enforce_plan_run_tier_bypass_gate(

--- a/crates/cli-sub-agent/src/plan_cmd_completion.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_completion.rs
@@ -1,0 +1,406 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+use super::StepResult;
+use super::plan_cmd_failure::{PlanFailureError, PlanFailureReport};
+
+const DEV2MERGE_WORKFLOW_NAME: &str = "dev2merge";
+const DEV2MERGE_VERIFY_STEP_ID: usize = 18;
+const DEV2MERGE_PUBLISH_STEPS: [usize; 5] = [13, 14, 15, 16, 17];
+
+pub(crate) struct PlanCompletionInput<'a> {
+    pub(crate) workflow_name: &'a str,
+    pub(crate) workflow_path: &'a Path,
+    pub(crate) project_root: &'a Path,
+    pub(crate) results: &'a [StepResult],
+    pub(crate) completed_steps: &'a [usize],
+    pub(crate) vars: &'a HashMap<String, String>,
+    pub(crate) snapshot: &'a PlanCompletionSnapshot,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PlanCompletionSnapshot {
+    initial_branch: Option<String>,
+}
+
+impl PlanCompletionSnapshot {
+    pub(crate) fn capture(workflow_name: &str, project_root: &Path) -> Self {
+        if workflow_name != DEV2MERGE_WORKFLOW_NAME {
+            return Self::default();
+        }
+        Self {
+            initial_branch: git_stdout(project_root, &["branch", "--show-current"])
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty() && value != "HEAD"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PlanSuccessReport {
+    workflow_label: String,
+    completion_summary: Option<String>,
+}
+
+impl PlanSuccessReport {
+    pub(crate) fn new(workflow_label: &str, completion_summary: Option<String>) -> Self {
+        Self {
+            workflow_label: workflow_label.to_string(),
+            completion_summary,
+        }
+    }
+
+    fn render_summary_section(&self) -> String {
+        let mut lines = vec![format!("Plan complete: {}", self.workflow_label)];
+        if let Some(summary) = &self.completion_summary {
+            lines.push(format!("Completion verification: {summary}"));
+        }
+        lines.join("\n")
+    }
+
+    fn render_details_section(&self) -> String {
+        let mut details = String::new();
+        details.push_str("# Plan Completion Report\n\n");
+        details.push_str(&format!("- Workflow: `{}`\n", self.workflow_label));
+        details.push_str("- Status: `success`\n");
+        if let Some(summary) = &self.completion_summary {
+            details.push_str(&format!("- Completion verification: {summary}\n"));
+        }
+        details
+    }
+}
+
+pub(crate) fn persist_plan_success_output(
+    session_dir: &Path,
+    report: &PlanSuccessReport,
+) -> Result<()> {
+    if csa_session::read_section(session_dir, "summary")?.is_some() {
+        return Ok(());
+    }
+
+    let summary = report.render_summary_section();
+    let details = report.render_details_section();
+    let marked = format!(
+        "<!-- CSA:SECTION:summary -->\n{summary}\n<!-- CSA:SECTION:summary:END -->\n\n\
+         <!-- CSA:SECTION:details -->\n{details}\n<!-- CSA:SECTION:details:END -->\n"
+    );
+    let marked = csa_session::redact_text_content(&marked);
+
+    std::fs::create_dir_all(session_dir)
+        .with_context(|| format!("Failed to create session dir: {}", session_dir.display()))?;
+    csa_session::persist_structured_output(session_dir, &marked).with_context(|| {
+        format!(
+            "Failed to persist plan success output for {}",
+            session_dir.display()
+        )
+    })?;
+    Ok(())
+}
+
+pub(crate) fn persist_success_report_for_session(
+    project_root: &Path,
+    session_id: &str,
+    report: &PlanSuccessReport,
+) -> Result<()> {
+    let session_dir = csa_session::get_session_dir(project_root, session_id)?;
+    persist_plan_success_output(&session_dir, report)
+}
+
+pub(crate) fn verify_plan_completion(
+    input: PlanCompletionInput<'_>,
+) -> std::result::Result<Option<String>, Box<PlanFailureError>> {
+    if input.workflow_name != DEV2MERGE_WORKFLOW_NAME {
+        return Ok(None);
+    }
+    let facts = Dev2MergeCompletionFacts::from_input(&input);
+    if !facts.publish_started {
+        return Ok(None);
+    }
+
+    let observed = observe_dev2merge_state(input.project_root, &facts);
+    let failures = evaluate_dev2merge_completion(&facts, &observed);
+    if failures.is_empty() {
+        let pr = facts
+            .pr_number
+            .as_deref()
+            .map(|value| format!("PR #{value} is MERGED"))
+            .unwrap_or_else(|| "publish side effects are complete".to_string());
+        let branch = facts
+            .branch
+            .as_deref()
+            .map(|value| format!(" for branch {value}"))
+            .unwrap_or_default();
+        return Ok(Some(format!("dev2merge{branch}: {pr}")));
+    }
+
+    Err(Box::new(dev2merge_completion_failure_report(
+        input.workflow_name,
+        input.workflow_path,
+        failures,
+    )))
+}
+
+#[derive(Debug, Clone, Default)]
+struct Dev2MergeCompletionFacts {
+    publish_started: bool,
+    push_gate_completed: bool,
+    review_verdict_completed: bool,
+    pr_completed: bool,
+    pr_bot_completed: bool,
+    post_merge_sync_completed: bool,
+    branch: Option<String>,
+    pr_number: Option<String>,
+    pr_bot_done_marker: Option<PathBuf>,
+}
+
+impl Dev2MergeCompletionFacts {
+    fn from_input(input: &PlanCompletionInput<'_>) -> Self {
+        let dev2merge_skip = truthy(input.vars.get("DEV2MERGE_SKIP"));
+        let step_completed = |step_id| {
+            step_completed_successfully(
+                input.results,
+                input.completed_steps,
+                dev2merge_skip,
+                step_id,
+            )
+        };
+        let publish_started = DEV2MERGE_PUBLISH_STEPS.into_iter().any(&step_completed);
+        let branch = input
+            .snapshot
+            .initial_branch
+            .clone()
+            .or_else(|| non_empty_var(input.vars, "WORKFLOW_BRANCH"))
+            .or_else(|| non_empty_var(input.vars, "BRANCH"));
+        let pr_number = non_empty_var(input.vars, "PR_NUMBER")
+            .filter(|value| value.chars().all(|ch| ch.is_ascii_digit()));
+        let pr_bot_done_marker = non_empty_var(input.vars, "PR_BOT_DONE_MARKER").map(PathBuf::from);
+
+        Self {
+            publish_started,
+            push_gate_completed: step_completed(13),
+            review_verdict_completed: step_completed(14),
+            pr_completed: step_completed(15),
+            pr_bot_completed: step_completed(16),
+            post_merge_sync_completed: step_completed(17),
+            branch,
+            pr_number,
+            pr_bot_done_marker,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct Dev2MergeObservedState {
+    pr_bot_marker_exists: Option<bool>,
+    pr_state: Option<String>,
+    pr_state_error: Option<String>,
+}
+
+fn observe_dev2merge_state(
+    project_root: &Path,
+    facts: &Dev2MergeCompletionFacts,
+) -> Dev2MergeObservedState {
+    let pr_bot_marker_exists = facts
+        .pr_bot_done_marker
+        .as_ref()
+        .map(|path| resolve_observed_path(project_root, path).is_file());
+    let (pr_state, pr_state_error) = match facts.pr_number.as_deref() {
+        Some(pr_number) => match command_stdout(
+            project_root,
+            "gh",
+            &["pr", "view", pr_number, "--json", "state", "-q", ".state"],
+        ) {
+            Ok(value) => (Some(value.trim().to_string()), None),
+            Err(error) => (None, Some(error)),
+        },
+        None => (None, None),
+    };
+
+    Dev2MergeObservedState {
+        pr_bot_marker_exists,
+        pr_state,
+        pr_state_error,
+    }
+}
+
+fn evaluate_dev2merge_completion(
+    facts: &Dev2MergeCompletionFacts,
+    observed: &Dev2MergeObservedState,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    if !facts.push_gate_completed {
+        failures.push(
+            "ERROR: Push Gate (Step 13) did not complete; branch publication is incomplete."
+                .to_string(),
+        );
+    }
+    if !facts.review_verdict_completed {
+        failures.push("ERROR: Pre-PR Review Verdict Check (Step 14) did not complete.".to_string());
+    }
+    if !facts.pr_completed {
+        failures
+            .push("ERROR: Create or Reuse Pull Request (Step 15) did not complete.".to_string());
+    }
+    if !facts.pr_bot_completed {
+        failures.push("ERROR: pr-bot Review & Merge Gate (Step 16) did not complete.".to_string());
+    }
+    if !facts.post_merge_sync_completed {
+        failures.push("ERROR: Post-Merge Local Sync (Step 17) did not complete.".to_string());
+    }
+
+    match facts.pr_number.as_deref() {
+        Some(_) => {}
+        None => failures.push(
+            "ERROR: PR_NUMBER was not captured; PR creation/reuse is incomplete.".to_string(),
+        ),
+    }
+    match (&facts.pr_bot_done_marker, observed.pr_bot_marker_exists) {
+        (Some(path), Some(true)) => {
+            let _ = path;
+        }
+        (Some(path), Some(false)) => failures.push(format!(
+            "ERROR: pr-bot completion marker is missing: {}.",
+            path.display()
+        )),
+        (None, _) => failures.push(
+            "ERROR: PR_BOT_DONE_MARKER was not captured; pr-bot completion is unverified."
+                .to_string(),
+        ),
+        (Some(path), None) => failures.push(format!(
+            "ERROR: pr-bot completion marker could not be inspected: {}.",
+            path.display()
+        )),
+    }
+    if let Some(error) = &observed.pr_state_error {
+        failures.push(format!(
+            "ERROR: failed to inspect PR state via gh: {error}."
+        ));
+    } else if facts.pr_number.is_some() {
+        match observed.pr_state.as_deref() {
+            Some("MERGED") => {}
+            Some("") => {
+                failures.push("ERROR: PR state is empty; expected MERGED after pr-bot.".to_string())
+            }
+            Some(state) => failures.push(format!(
+                "ERROR: PR state is {state}; expected MERGED after pr-bot."
+            )),
+            None => failures.push(
+                "ERROR: PR state was not observed; expected MERGED after pr-bot.".to_string(),
+            ),
+        }
+    }
+
+    failures
+}
+
+fn dev2merge_completion_failure_report(
+    workflow_name: &str,
+    workflow_path: &Path,
+    failures: Vec<String>,
+) -> PlanFailureError {
+    let summary = "dev2merge publish side-effect verification failed".to_string();
+    let mut error = vec![
+        "ERROR: dev2merge publish side-effect verification failed after workflow steps reported success."
+            .to_string(),
+    ];
+    error.extend(failures);
+    error.push(
+        "Retry after resolving the named incomplete side effect; callers should use this structured result instead of hidden session transcripts."
+            .to_string(),
+    );
+    let error = error.join("\n");
+    let synthetic_result = StepResult {
+        step_id: DEV2MERGE_VERIFY_STEP_ID,
+        title: "Dev2merge Publish Side-Effect Verification".to_string(),
+        exit_code: 1,
+        duration_secs: 0.0,
+        skipped: false,
+        error: Some(error.clone()),
+        output: None,
+        session_id: None,
+        command: Some(
+            "post-run verifier: check Step 13-17 completion, PR_NUMBER, PR_BOT_DONE_MARKER, and gh PR state"
+                .to_string(),
+        ),
+        stderr: Some(error),
+    };
+    let report = PlanFailureReport::from_results(
+        workflow_name,
+        workflow_path,
+        summary.clone(),
+        &[synthetic_result],
+        None,
+    );
+    PlanFailureError::new(summary, report)
+}
+
+fn step_completed_successfully(
+    results: &[StepResult],
+    completed_steps: &[usize],
+    dev2merge_skip: bool,
+    step_id: usize,
+) -> bool {
+    if let Some(result) = results.iter().find(|result| result.step_id == step_id) {
+        return !result.skipped && result.exit_code == 0;
+    }
+    !dev2merge_skip && completed_steps.contains(&step_id)
+}
+
+fn truthy(value: Option<&String>) -> bool {
+    value
+        .map(|value| {
+            let lower = value.trim().to_ascii_lowercase();
+            !lower.is_empty() && lower != "false" && lower != "0"
+        })
+        .unwrap_or(false)
+}
+
+fn non_empty_var(vars: &HashMap<String, String>, key: &str) -> Option<String> {
+    vars.get(key)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn resolve_observed_path(project_root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        project_root.join(path)
+    }
+}
+
+fn git_stdout(project_root: &Path, args: &[&str]) -> Result<String> {
+    command_stdout(project_root, "git", args).map_err(anyhow::Error::msg)
+}
+
+fn command_stdout(project_root: &Path, program: &str, args: &[&str]) -> Result<String, String> {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(project_root)
+        .output()
+        .map_err(|error| format!("{program} {} failed to start: {error}", args.join(" ")))?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).to_string());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if stderr.is_empty() { stdout } else { stderr };
+    Err(format!(
+        "{program} {} exited {}{}",
+        args.join(" "),
+        output.status.code().unwrap_or(1),
+        if detail.is_empty() {
+            String::new()
+        } else {
+            format!(": {detail}")
+        }
+    ))
+}
+
+#[cfg(test)]
+#[path = "plan_cmd_completion_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/plan_cmd_completion_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_completion_tests.rs
@@ -1,0 +1,216 @@
+use super::*;
+
+fn completed_facts() -> Dev2MergeCompletionFacts {
+    Dev2MergeCompletionFacts {
+        publish_started: true,
+        push_gate_completed: true,
+        review_verdict_completed: true,
+        pr_completed: true,
+        pr_bot_completed: true,
+        post_merge_sync_completed: true,
+        branch: Some("fix/issue".to_string()),
+        pr_number: Some("42".to_string()),
+        pr_bot_done_marker: Some(PathBuf::from("/tmp/pr-bot.done")),
+    }
+}
+
+#[test]
+fn dev2merge_completion_passes_when_publish_side_effects_are_complete() {
+    let facts = completed_facts();
+    let observed = Dev2MergeObservedState {
+        pr_bot_marker_exists: Some(true),
+        pr_state: Some("MERGED".to_string()),
+        pr_state_error: None,
+    };
+
+    let failures = evaluate_dev2merge_completion(&facts, &observed);
+
+    assert!(
+        failures.is_empty(),
+        "complete publish side effects must not fail: {failures:?}"
+    );
+}
+
+#[test]
+fn dev2merge_completion_fails_when_pr_was_not_captured() {
+    let mut facts = completed_facts();
+    facts.pr_number = None;
+    let observed = Dev2MergeObservedState {
+        pr_bot_marker_exists: Some(true),
+        pr_state: None,
+        pr_state_error: None,
+    };
+
+    let failures = evaluate_dev2merge_completion(&facts, &observed);
+
+    assert!(
+        failures
+            .iter()
+            .any(|failure| failure.contains("PR_NUMBER was not captured")),
+        "missing PR_NUMBER must be actionable: {failures:?}"
+    );
+}
+
+#[test]
+fn dev2merge_completion_fails_when_pr_is_not_merged() {
+    let facts = completed_facts();
+    let observed = Dev2MergeObservedState {
+        pr_bot_marker_exists: Some(true),
+        pr_state: Some("OPEN".to_string()),
+        pr_state_error: None,
+    };
+
+    let failures = evaluate_dev2merge_completion(&facts, &observed);
+
+    assert!(
+        failures
+            .iter()
+            .any(|failure| failure.contains("PR state is OPEN; expected MERGED")),
+        "unmerged PR must fail closed: {failures:?}"
+    );
+}
+
+#[test]
+fn dev2merge_completion_fails_when_pr_bot_marker_is_missing() {
+    let facts = completed_facts();
+    let observed = Dev2MergeObservedState {
+        pr_bot_marker_exists: Some(false),
+        pr_state: Some("MERGED".to_string()),
+        pr_state_error: None,
+    };
+
+    let failures = evaluate_dev2merge_completion(&facts, &observed);
+
+    assert!(
+        failures
+            .iter()
+            .any(|failure| failure.contains("pr-bot completion marker is missing")),
+        "missing marker must fail closed: {failures:?}"
+    );
+}
+
+#[test]
+fn dev2merge_completion_fails_when_publish_step_was_skipped() {
+    let mut facts = completed_facts();
+    facts.push_gate_completed = false;
+    let observed = Dev2MergeObservedState {
+        pr_bot_marker_exists: Some(true),
+        pr_state: Some("MERGED".to_string()),
+        pr_state_error: None,
+    };
+
+    let failures = evaluate_dev2merge_completion(&facts, &observed);
+
+    assert!(
+        failures
+            .iter()
+            .any(|failure| failure.contains("Push Gate (Step 13) did not complete")),
+        "skipped publish step must be named: {failures:?}"
+    );
+}
+
+#[test]
+fn dev2merge_skip_does_not_count_completed_steps_as_publish_started() {
+    let results = Vec::new();
+    let completed_steps = vec![13, 14, 15, 16, 17];
+
+    assert!(!step_completed_successfully(
+        &results,
+        &completed_steps,
+        true,
+        13
+    ));
+}
+
+#[test]
+fn success_output_persists_summary_and_details_sections() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let report = PlanSuccessReport::new(
+        "plan: dev2merge",
+        Some("dev2merge for branch fix/issue: PR #42 is MERGED".to_string()),
+    );
+
+    persist_plan_success_output(temp.path(), &report).expect("success output should persist");
+
+    let summary = csa_session::read_section(temp.path(), "summary")
+        .expect("summary should load")
+        .expect("summary should exist");
+    assert!(
+        summary.contains("Plan complete: plan: dev2merge")
+            && summary.contains("Completion verification: dev2merge"),
+        "summary should expose completion verification: {summary}"
+    );
+    let details = csa_session::read_section(temp.path(), "details")
+        .expect("details should load")
+        .expect("details should exist");
+    assert!(
+        details.contains("Plan Completion Report") && details.contains("Status: `success`"),
+        "details should expose success report: {details}"
+    );
+}
+
+#[test]
+fn success_output_preserves_existing_summary_section() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    csa_session::persist_structured_output(
+        temp.path(),
+        "<!-- CSA:SECTION:summary -->\nExisting workflow summary\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("existing summary should persist");
+    let report = PlanSuccessReport::new("plan: mktd", None);
+
+    persist_plan_success_output(temp.path(), &report).expect("success output should no-op");
+
+    let summary = csa_session::read_section(temp.path(), "summary")
+        .expect("summary should load")
+        .expect("summary should exist");
+    assert_eq!(summary, "Existing workflow summary");
+}
+
+#[test]
+fn verify_dev2merge_completion_missing_pr_returns_structured_failure_report() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let workflow_path = temp.path().join("workflow.toml");
+    std::fs::write(&workflow_path, "[workflow]\nname = 'dev2merge'\n")
+        .expect("workflow should be written");
+    let marker = temp.path().join("marker.done");
+    std::fs::write(&marker, "").expect("marker should be written");
+    let vars = HashMap::from([
+        ("DEV2MERGE_SKIP".to_string(), "false".to_string()),
+        (
+            "PR_BOT_DONE_MARKER".to_string(),
+            marker.display().to_string(),
+        ),
+    ]);
+    let completed_steps = vec![13, 14, 15, 16, 17];
+    let snapshot = PlanCompletionSnapshot {
+        initial_branch: Some("fix/issue".to_string()),
+    };
+
+    let err = verify_plan_completion(PlanCompletionInput {
+        workflow_name: "dev2merge",
+        workflow_path: &workflow_path,
+        project_root: temp.path(),
+        results: &[],
+        completed_steps: &completed_steps,
+        vars: &vars,
+        snapshot: &snapshot,
+    })
+    .expect_err("missing PR_NUMBER must fail completion verification");
+
+    assert_eq!(
+        err.to_string(),
+        "dev2merge publish side-effect verification failed"
+    );
+    let summary = err.report().render_summary_section();
+    assert!(
+        summary.contains("Failed step: 18 (Dev2merge Publish Side-Effect Verification) exited 1"),
+        "summary should expose the synthetic verification step: {summary}"
+    );
+    let details = err.report().render_details_section();
+    assert!(
+        details.contains("PR_NUMBER was not captured")
+            && details.contains("callers should use this structured result"),
+        "details should include the actionable side-effect failure: {details}"
+    );
+}

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use chrono::Utc;
-use csa_session::{SessionResult, save_result};
+use csa_session::{SessionArtifact, SessionResult, save_result};
 use tracing::warn;
 
 use crate::cli::PlanCommands;
@@ -371,8 +371,29 @@ pub(crate) async fn handle_plan_run_daemon_child(
             "Failed to write plan failure structured output",
         );
     }
+    if let Ok(outcome) = &result {
+        let success_report = plan_cmd::plan_cmd_completion::PlanSuccessReport::new(
+            &workflow_label,
+            outcome.completion_summary.clone(),
+        );
+        if let Err(err) = plan_cmd::plan_cmd_completion::persist_success_report_for_session(
+            &project_root,
+            session_id,
+            &success_report,
+        ) {
+            warn!(
+                session_id = %session_id,
+                error = %err,
+                "Failed to write plan success structured output",
+            );
+        }
+    }
     let summary = match &result {
-        Ok(()) => format!("plan complete: {workflow_label}"),
+        Ok(outcome) => outcome
+            .completion_summary
+            .as_ref()
+            .map(|summary| format!("plan complete: {workflow_label}; {summary}"))
+            .unwrap_or_else(|| format!("plan complete: {workflow_label}")),
         Err(err) => {
             let mut text = failure_report
                 .as_ref()
@@ -400,10 +421,17 @@ pub(crate) async fn handle_plan_run_daemon_child(
         started_at,
         completed_at,
         events_count: 0,
-        artifacts: plan_cmd::plan_cmd_failure::session_artifacts(
-            &workflow_label,
-            failure_report.as_ref(),
-        ),
+        artifacts: {
+            let mut artifacts = plan_cmd::plan_cmd_failure::session_artifacts(
+                &workflow_label,
+                failure_report.as_ref(),
+            );
+            if result.is_ok() {
+                artifacts.push(SessionArtifact::new("output/summary.md"));
+                artifacts.push(SessionArtifact::new("output/details.md"));
+            }
+            artifacts
+        },
         ..Default::default()
     };
     if let Err(save_err) = save_result(&project_root, session_id, &session_result) {
@@ -423,7 +451,7 @@ pub(crate) async fn handle_plan_run_daemon_child(
     }
 
     match result {
-        Ok(()) => Ok(0),
+        Ok(_) => Ok(0),
         Err(err) => Err(err),
     }
 }
@@ -565,6 +593,9 @@ fn nested_session_env_present(startup_env: &StartupSubtreeEnv) -> bool {
 mod forwarding;
 pub(crate) use forwarding::{build_forwarded_plan_args, forwarded_args_with_feature_input};
 
+#[cfg(test)]
+#[path = "plan_cmd_daemon_completion_tests.rs"]
+mod completion_tests;
 #[cfg(test)]
 #[path = "plan_cmd_daemon_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_completion_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_completion_tests.rs
@@ -1,0 +1,197 @@
+use super::*;
+use crate::plan_cmd::{PlanRunArgs, PlanRunPipelineSource};
+use crate::startup_env::StartupSubtreeEnv;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn run_git(project_root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(args)
+        .output()
+        .expect("git command should start");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_plan_test_repo(project_root: &Path) {
+    run_git(project_root, &["init", "-b", "main"]);
+    run_git(
+        project_root,
+        &["config", "user.email", "csa-test@example.com"],
+    );
+    run_git(project_root, &["config", "user.name", "CSA Test"]);
+    run_git(project_root, &["config", "core.excludesFile", "/dev/null"]);
+    std::fs::write(
+        project_root.join(".git").join("info").join("exclude"),
+        ".csa/\n",
+    )
+    .expect("write repo-local exclude");
+    std::fs::write(project_root.join("README.md"), "test repo\n").expect("write readme");
+    std::fs::write(project_root.join("weave.lock"), "lock = 1\n").expect("write weave.lock");
+}
+
+fn commit_all(project_root: &Path, message: &str) {
+    run_git(
+        project_root,
+        &["add", "README.md", "weave.lock", "workflow.toml"],
+    );
+    run_git(project_root, &["commit", "-m", message]);
+}
+
+fn plan_daemon_args(project_root: &Path) -> PlanRunArgs {
+    PlanRunArgs {
+        file: Some("workflow.toml".to_string()),
+        pattern: None,
+        vars: vec![],
+        tool_override: None,
+        model_spec_override: None,
+        dry_run: false,
+        chunked: false,
+        resume: None,
+        cd: Some(project_root.display().to_string()),
+        no_fs_sandbox: false,
+        current_depth: 0,
+        pipeline_source: PlanRunPipelineSource::DirectPlanRun,
+        startup_env: StartupSubtreeEnv::default(),
+    }
+}
+
+fn prepare_plan_session(project_root: &Path, description: &str) -> (String, PathBuf) {
+    let session_id = csa_session::new_session_id();
+    let session_dir = csa_session::get_session_dir(project_root, &session_id)
+        .expect("session dir should resolve");
+    persist_placeholder_plan_session(project_root, &session_dir, &session_id, description)
+        .expect("placeholder plan session should persist");
+    (session_id, session_dir)
+}
+
+#[tokio::test]
+async fn daemon_child_successful_plan_writes_structured_success_output() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("repo");
+    std::fs::create_dir_all(&project_root).expect("repo dir should be created");
+    init_plan_test_repo(&project_root);
+    std::fs::write(
+        project_root.join("workflow.toml"),
+        r#"[workflow]
+name = "successful-plan"
+
+[[workflow.steps]]
+id = 1
+title = "Passing Bash"
+tool = "bash"
+prompt = '''
+```bash
+printf 'structured success\n'
+```
+'''
+on_fail = "abort"
+"#,
+    )
+    .expect("write workflow");
+    commit_all(&project_root, "initial");
+    let (session_id, session_dir) = prepare_plan_session(&project_root, "plan: successful-plan");
+
+    let result = handle_plan_run_daemon_child(plan_daemon_args(&project_root), &session_id).await;
+
+    assert!(
+        result.is_ok(),
+        "successful plan should return ok: {result:?}"
+    );
+    assert_eq!(result.expect("successful plan should expose exit code"), 0);
+    let summary = csa_session::read_section(&session_dir, "summary")
+        .expect("summary should load")
+        .expect("summary section should exist");
+    assert!(
+        summary.contains("Plan complete: plan: workflow.toml"),
+        "summary must expose daemon success to `csa session result --summary`: {summary}"
+    );
+    let details = csa_session::read_section(&session_dir, "details")
+        .expect("details should load")
+        .expect("details section should exist");
+    assert!(
+        details.contains("Plan Completion Report") && details.contains("Status: `success`"),
+        "details must expose a structured success report: {details}"
+    );
+    let persisted = csa_session::load_result(&project_root, &session_id)
+        .expect("result should load")
+        .expect("result.toml should exist");
+    assert_eq!(persisted.exit_code, 0);
+    assert!(
+        persisted
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == "output/summary.md"),
+        "success result artifacts must point callers at structured summary"
+    );
+}
+
+#[tokio::test]
+async fn daemon_child_dev2merge_partial_publish_fails_structured_completion_verification() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("repo");
+    std::fs::create_dir_all(&project_root).expect("repo dir should be created");
+    init_plan_test_repo(&project_root);
+    std::fs::write(
+        project_root.join("workflow.toml"),
+        r#"[workflow]
+name = "dev2merge"
+
+[[workflow.steps]]
+id = 13
+title = "Push Gate"
+tool = "bash"
+prompt = '''
+```bash
+printf 'synthetic push gate passed\n'
+```
+'''
+on_fail = "abort"
+"#,
+    )
+    .expect("write workflow");
+    commit_all(&project_root, "initial");
+    let (session_id, session_dir) = prepare_plan_session(&project_root, "plan: dev2merge");
+
+    let result = handle_plan_run_daemon_child(plan_daemon_args(&project_root), &session_id).await;
+
+    assert!(
+        result.is_err(),
+        "dev2merge that reached publish without required side effects must fail"
+    );
+    let summary = csa_session::read_section(&session_dir, "summary")
+        .expect("summary should load")
+        .expect("summary section should exist");
+    assert!(
+        summary.contains("dev2merge publish side-effect verification failed")
+            && summary
+                .contains("Failed step: 18 (Dev2merge Publish Side-Effect Verification) exited 1"),
+        "summary must expose synthetic completion-verification failure: {summary}"
+    );
+    let details = csa_session::read_section(&session_dir, "details")
+        .expect("details should load")
+        .expect("details section should exist");
+    assert!(
+        details.contains("PR_NUMBER was not captured")
+            && details.contains("Post-Merge Local Sync (Step 17) did not complete")
+            && details.contains("callers should use this structured result"),
+        "details must include actionable missing side effects: {details}"
+    );
+    let persisted = csa_session::load_result(&project_root, &session_id)
+        .expect("result should load")
+        .expect("result.toml should exist");
+    assert_eq!(persisted.exit_code, 1);
+    assert!(
+        persisted
+            .summary
+            .contains("dev2merge publish side-effect verification failed"),
+        "result summary must carry the completion verification failure: {}",
+        persisted.summary
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1027"
-weave = "0.1.1027"
+csa = "0.1.1028"
+weave = "0.1.1028"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Add dev2merge publish side-effect verification so plans that enter the publish/PR/review/merge phase fail if required side effects are missing.
- Persist structured success/failure summaries for plan-daemon runs so `csa session result --summary` has actionable output.
- Add synthetic completion and daemon regression coverage without real GitHub/provider/network calls.

Closes #2273

## Validation
- `cargo fmt --all -- --check`
- `just find-monolith-files`
- `cargo test -p cli-sub-agent plan_cmd_completion -- --nocapture`
- `cargo test -p cli-sub-agent daemon_child_successful_plan_writes_structured_success_output -- --nocapture`
- `cargo test -p cli-sub-agent daemon_child_dev2merge_partial_publish_fails_structured_completion_verification -- --nocapture`
- `cargo check -p cli-sub-agent`
- `cargo clippy -p cli-sub-agent -- -D warnings`
- hook-enabled `git commit` quality gates
- `target/debug/csa review --check-verdict --sa-mode true --range main...HEAD` (Codex session `01KVCFVVNYTXP7SQN64K5DMDXT`, reviewed `0fd40ed095d`, PASS)
