### PR TITLE
fix(pr-bot): verify merge side effects in plan results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1029"
+version = "0.1.1030"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1029"
+version = "0.1.1030"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -484,20 +484,33 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<PlanRunOutcome>
         let recovery = recovery_snapshot
             .as_ref()
             .map(|snapshot| snapshot.recover_after_failure(&project_root));
-        let failure_report = plan_cmd_failure::PlanFailureReport::from_results(
-            &plan.name,
-            &workflow_path,
-            failure_summary.clone(),
-            &results,
-            recovery,
+        let verified_failure = plan_cmd_completion::verify_pr_bot_failure_side_effects(
+            plan_cmd_completion::PrBotFailureSideEffectInput {
+                workflow_name: &plan.name,
+                workflow_path: &workflow_path,
+                project_root: &project_root,
+                results: &results,
+                completed_steps: &journal.completed_steps,
+                vars: &journal.vars,
+                failure_summary: &failure_summary,
+            },
         );
+        let failure_error = verified_failure.unwrap_or_else(|| {
+            let failure_report = plan_cmd_failure::PlanFailureReport::from_results(
+                &plan.name,
+                &workflow_path,
+                failure_summary.clone(),
+                &results,
+                recovery,
+            );
+            plan_cmd_failure::PlanFailureError::new(failure_summary.clone(), failure_report)
+        });
+        let failure_summary = failure_error.to_string();
         journal.status = "failed".to_string();
         journal.last_error = Some(failure_summary.clone());
         apply_repo_fingerprint(&mut journal, &detect_repo_fingerprint(&project_root));
         persist_plan_journal(&journal_path, &journal)?;
-        return Err(
-            plan_cmd_failure::PlanFailureError::new(failure_summary, failure_report).into(),
-        );
+        return Err(failure_error.into());
     }
 
     let completion_summary = match plan_cmd_completion::verify_plan_completion(

--- a/crates/cli-sub-agent/src/plan_cmd_completion.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_completion.rs
@@ -7,6 +7,12 @@ use anyhow::{Context, Result};
 use super::StepResult;
 use super::plan_cmd_failure::{PlanFailureError, PlanFailureReport};
 
+#[path = "plan_cmd_pr_bot_completion.rs"]
+mod pr_bot_completion;
+pub(crate) use pr_bot_completion::{
+    PrBotFailureSideEffectInput, verify_pr_bot_failure_side_effects,
+};
+
 const DEV2MERGE_WORKFLOW_NAME: &str = "dev2merge";
 const DEV2MERGE_VERIFY_STEP_ID: usize = 18;
 const DEV2MERGE_PUBLISH_STEPS: [usize; 5] = [13, 14, 15, 16, 17];
@@ -113,6 +119,9 @@ pub(crate) fn persist_success_report_for_session(
 pub(crate) fn verify_plan_completion(
     input: PlanCompletionInput<'_>,
 ) -> std::result::Result<Option<String>, Box<PlanFailureError>> {
+    if pr_bot_completion::is_pr_bot_workflow(input.workflow_name) {
+        return pr_bot_completion::verify_pr_bot_completion(input);
+    }
     if input.workflow_name != DEV2MERGE_WORKFLOW_NAME {
         return Ok(None);
     }

--- a/crates/cli-sub-agent/src/plan_cmd_pr_bot_completion.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_pr_bot_completion.rs
@@ -1,0 +1,456 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+use crate::plan_cmd::StepResult;
+use crate::plan_cmd::plan_cmd_completion::PlanCompletionInput;
+use crate::plan_cmd::plan_cmd_failure::{PlanFailureError, PlanFailureReport};
+
+const PR_BOT_WORKFLOW_NAME: &str = "pr-bot";
+const PR_BOT_VERIFY_STEP_ID: usize = 26;
+const PR_BOT_MERGE_STEP_IDS: [usize; 2] = [22, 23];
+const PR_BOT_POST_MERGE_STEP_ID: usize = 24;
+
+pub(crate) struct PrBotFailureSideEffectInput<'a> {
+    pub(crate) workflow_name: &'a str,
+    pub(crate) workflow_path: &'a Path,
+    pub(crate) project_root: &'a Path,
+    pub(crate) results: &'a [StepResult],
+    pub(crate) completed_steps: &'a [usize],
+    pub(crate) vars: &'a HashMap<String, String>,
+    pub(crate) failure_summary: &'a str,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PrBotMergeFacts {
+    pr_number: Option<String>,
+    merge_verify_ref: Option<String>,
+    repo: Option<String>,
+    merge_completed_marker: bool,
+    merge_step_completed: bool,
+    post_merge_step_completed: bool,
+    merge_step_attempted: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PrBotObservedState {
+    pr_state: Option<String>,
+    pr_state_error: Option<String>,
+}
+
+pub(crate) fn is_pr_bot_workflow(workflow_name: &str) -> bool {
+    workflow_name == PR_BOT_WORKFLOW_NAME
+}
+
+pub(crate) fn verify_pr_bot_completion(
+    input: PlanCompletionInput<'_>,
+) -> std::result::Result<Option<String>, Box<PlanFailureError>> {
+    let facts = PrBotMergeFacts::from_completion_input(&input);
+    if !facts.should_verify_success() {
+        return Ok(None);
+    }
+
+    let observed = observe_pr_bot_state(input.project_root, &facts);
+    match evaluate_pr_bot_success(&facts, &observed) {
+        Ok(Some(summary)) => Ok(Some(summary)),
+        Ok(None) => Ok(None),
+        Err(failures) => Err(Box::new(pr_bot_completion_failure_report(
+            input.workflow_name,
+            input.workflow_path,
+            failures,
+        ))),
+    }
+}
+
+pub(crate) fn verify_pr_bot_failure_side_effects(
+    input: PrBotFailureSideEffectInput<'_>,
+) -> Option<PlanFailureError> {
+    if !is_pr_bot_workflow(input.workflow_name) {
+        return None;
+    }
+
+    let facts = PrBotMergeFacts::from_failure_input(&input);
+    facts.pr_reference()?;
+
+    let observed = observe_pr_bot_state(input.project_root, &facts);
+    verify_pr_bot_failure_side_effects_with_observed(&input, &facts, &observed)
+}
+
+fn verify_pr_bot_failure_side_effects_with_observed(
+    input: &PrBotFailureSideEffectInput<'_>,
+    facts: &PrBotMergeFacts,
+    observed: &PrBotObservedState,
+) -> Option<PlanFailureError> {
+    if observed.pr_state.as_deref() != Some("MERGED") {
+        return None;
+    }
+
+    Some(pr_bot_merged_despite_failure_report(
+        input.workflow_name,
+        input.workflow_path,
+        input.failure_summary,
+        input.results,
+        facts,
+        observed,
+    ))
+}
+
+impl PrBotMergeFacts {
+    fn from_completion_input(input: &PlanCompletionInput<'_>) -> Self {
+        let merge_verify_ref = non_empty_var(input.vars, "MERGED_PR_VERIFY_REF")
+            .or_else(|| output_assignment(input.results, "MERGED_PR_VERIFY_REF"))
+            .or_else(|| non_empty_var(input.vars, "PR_NUM"));
+        let pr_number = non_empty_var(input.vars, "PR_NUM")
+            .or_else(|| output_assignment(input.results, "PR_NUM"));
+        let repo = non_empty_var(input.vars, "REPO")
+            .or_else(|| non_empty_var(input.vars, "REPO_SLUG"))
+            .or_else(|| output_assignment(input.results, "REPO"))
+            .or_else(|| output_assignment(input.results, "REPO_SLUG"));
+        let merge_step_completed = PR_BOT_MERGE_STEP_IDS.into_iter().any(|step_id| {
+            step_completed_successfully(input.results, input.completed_steps, step_id)
+        });
+        let post_merge_step_completed = step_completed_successfully(
+            input.results,
+            input.completed_steps,
+            PR_BOT_POST_MERGE_STEP_ID,
+        );
+        let merge_step_attempted = PR_BOT_MERGE_STEP_IDS
+            .into_iter()
+            .any(|step_id| step_attempted(input.results, step_id));
+
+        Self {
+            pr_number,
+            merge_verify_ref,
+            repo,
+            merge_completed_marker: truthy(input.vars.get("MERGE_COMPLETED"))
+                || truthy(output_assignment(input.results, "MERGE_COMPLETED").as_ref()),
+            merge_step_completed,
+            post_merge_step_completed,
+            merge_step_attempted,
+        }
+    }
+
+    fn from_failure_input(input: &PrBotFailureSideEffectInput<'_>) -> Self {
+        let merge_verify_ref = non_empty_var(input.vars, "MERGED_PR_VERIFY_REF")
+            .or_else(|| output_assignment(input.results, "MERGED_PR_VERIFY_REF"))
+            .or_else(|| non_empty_var(input.vars, "PR_NUM"));
+        let pr_number = non_empty_var(input.vars, "PR_NUM")
+            .or_else(|| output_assignment(input.results, "PR_NUM"));
+        let repo = non_empty_var(input.vars, "REPO")
+            .or_else(|| non_empty_var(input.vars, "REPO_SLUG"))
+            .or_else(|| output_assignment(input.results, "REPO"))
+            .or_else(|| output_assignment(input.results, "REPO_SLUG"));
+        let merge_step_completed = PR_BOT_MERGE_STEP_IDS.into_iter().any(|step_id| {
+            step_completed_successfully(input.results, input.completed_steps, step_id)
+        });
+        let post_merge_step_completed = step_completed_successfully(
+            input.results,
+            input.completed_steps,
+            PR_BOT_POST_MERGE_STEP_ID,
+        );
+        let merge_step_attempted = PR_BOT_MERGE_STEP_IDS
+            .into_iter()
+            .any(|step_id| step_attempted(input.results, step_id));
+
+        Self {
+            pr_number,
+            merge_verify_ref,
+            repo,
+            merge_completed_marker: truthy(input.vars.get("MERGE_COMPLETED"))
+                || truthy(output_assignment(input.results, "MERGE_COMPLETED").as_ref()),
+            merge_step_completed,
+            post_merge_step_completed,
+            merge_step_attempted,
+        }
+    }
+
+    fn pr_reference(&self) -> Option<&str> {
+        self.merge_verify_ref
+            .as_deref()
+            .or(self.pr_number.as_deref())
+            .filter(|value| !value.trim().is_empty())
+    }
+
+    fn should_verify_success(&self) -> bool {
+        self.pr_reference().is_some()
+            && (self.merge_completed_marker
+                || self.merge_step_completed
+                || self.post_merge_step_completed
+                || self.merge_step_attempted)
+    }
+
+    fn merge_evidence(&self) -> String {
+        let mut evidence = Vec::new();
+        if self.merge_completed_marker {
+            evidence.push("MERGE_COMPLETED=true");
+        }
+        if self.merge_step_completed {
+            evidence.push("final merge step completed");
+        }
+        if self.post_merge_step_completed {
+            evidence.push("post-merge verification step completed");
+        }
+        if self.merge_step_attempted && !self.merge_step_completed {
+            evidence.push("final merge step attempted before failure");
+        }
+        if evidence.is_empty() {
+            "no local merge marker captured; observed state comes from GitHub".to_string()
+        } else {
+            evidence.join(", ")
+        }
+    }
+}
+
+fn evaluate_pr_bot_success(
+    facts: &PrBotMergeFacts,
+    observed: &PrBotObservedState,
+) -> std::result::Result<Option<String>, Vec<String>> {
+    let Some(pr_ref) = facts.pr_reference() else {
+        return Ok(None);
+    };
+
+    if let Some(error) = &observed.pr_state_error {
+        return Err(vec![format!(
+            "ERROR: failed to inspect pr-bot PR state via gh for PR {pr_ref}: {error}."
+        )]);
+    }
+
+    match observed.pr_state.as_deref() {
+        Some("MERGED") => Ok(Some(format!("pr-bot: PR #{pr_ref} is MERGED"))),
+        Some("") => Err(vec![format!(
+            "ERROR: pr-bot PR {pr_ref} state is empty; expected MERGED."
+        )]),
+        Some(state) => Err(vec![format!(
+            "ERROR: pr-bot PR {pr_ref} state is {state}; expected MERGED."
+        )]),
+        None => Err(vec![format!(
+            "ERROR: pr-bot PR {pr_ref} state was not observed; expected MERGED."
+        )]),
+    }
+}
+
+fn observe_pr_bot_state(project_root: &Path, facts: &PrBotMergeFacts) -> PrBotObservedState {
+    let Some(pr_ref) = facts.pr_reference() else {
+        return PrBotObservedState::default();
+    };
+
+    match gh_pr_state(project_root, pr_ref, facts.repo.as_deref()) {
+        Ok(value) => PrBotObservedState {
+            pr_state: Some(value.trim().to_string()),
+            pr_state_error: None,
+        },
+        Err(error) => PrBotObservedState {
+            pr_state: None,
+            pr_state_error: Some(error),
+        },
+    }
+}
+
+fn pr_bot_completion_failure_report(
+    workflow_name: &str,
+    workflow_path: &Path,
+    failures: Vec<String>,
+) -> PlanFailureError {
+    let summary = "pr-bot merge side-effect verification failed".to_string();
+    let mut error =
+        vec!["ERROR: pr-bot completed but merge side-effect verification failed.".to_string()];
+    error.extend(failures);
+    error.push(
+        "Use this structured result instead of hidden session transcripts; inspect the named PR and rerun pr-bot only if it is still unmerged."
+            .to_string(),
+    );
+    let error = error.join("\n");
+    let synthetic_result = StepResult {
+        step_id: PR_BOT_VERIFY_STEP_ID,
+        title: "pr-bot Merge Side-Effect Verification".to_string(),
+        exit_code: 1,
+        duration_secs: 0.0,
+        skipped: false,
+        error: Some(error.clone()),
+        output: None,
+        session_id: None,
+        command: Some(
+            "post-run verifier: check MERGED_PR_VERIFY_REF/PR_NUM and gh PR state".to_string(),
+        ),
+        stderr: Some(error),
+    };
+    let report = PlanFailureReport::from_results(
+        workflow_name,
+        workflow_path,
+        summary.clone(),
+        &[synthetic_result],
+        None,
+    );
+    PlanFailureError::new(summary, report)
+}
+
+fn pr_bot_merged_despite_failure_report(
+    workflow_name: &str,
+    workflow_path: &Path,
+    failure_summary: &str,
+    results: &[StepResult],
+    facts: &PrBotMergeFacts,
+    observed: &PrBotObservedState,
+) -> PlanFailureError {
+    let pr_ref = facts.pr_reference().unwrap_or("unknown");
+    let summary = format!(
+        "pr-bot observed PR #{pr_ref} is MERGED despite workflow failure; merge result takes precedence over failed decision summary"
+    );
+    let mut error = vec![
+        format!(
+            "ERROR: pr-bot failure summary contradicted the observed GitHub side effect for PR #{pr_ref}."
+        ),
+        format!(
+            "Observed PR state: {}.",
+            observed.pr_state.as_deref().unwrap_or("UNKNOWN")
+        ),
+        format!("Merge evidence: {}.", facts.merge_evidence()),
+        format!("Original failure summary: {failure_summary}."),
+    ];
+    if let Some(failed_step) = first_failed_step(results) {
+        error.push(format!(
+            "Original failed step: {} ({}) exited {}.",
+            failed_step.step_id, failed_step.title, failed_step.exit_code
+        ));
+        if let Some(detail) = failed_step_detail(failed_step) {
+            error.push(format!("Original failure detail: {detail}"));
+        }
+    }
+    error.push(
+        "Treat this as a fail-closed audit contradiction: do not claim the PR is unmerged; inspect the merged PR, the failed step, and whether the blocking finding was posted before or after the merge."
+            .to_string(),
+    );
+    let error = error.join("\n");
+    let synthetic_result = StepResult {
+        step_id: PR_BOT_VERIFY_STEP_ID,
+        title: "pr-bot Merge Side-Effect Verification".to_string(),
+        exit_code: 1,
+        duration_secs: 0.0,
+        skipped: false,
+        error: Some(error.clone()),
+        output: None,
+        session_id: None,
+        command: Some(format!(
+            "post-failure verifier: gh pr view {pr_ref} --json state -q .state"
+        )),
+        stderr: Some(error),
+    };
+    let report = PlanFailureReport::from_results(
+        workflow_name,
+        workflow_path,
+        summary.clone(),
+        &[synthetic_result],
+        None,
+    );
+    PlanFailureError::new(summary, report)
+}
+
+fn first_failed_step(results: &[StepResult]) -> Option<&StepResult> {
+    results
+        .iter()
+        .find(|result| !result.skipped && result.exit_code != 0)
+}
+
+fn failed_step_detail(step: &StepResult) -> Option<String> {
+    step.error
+        .as_deref()
+        .or(step.stderr.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.lines().next().unwrap_or(value).to_string())
+}
+
+fn step_completed_successfully(
+    results: &[StepResult],
+    completed_steps: &[usize],
+    step_id: usize,
+) -> bool {
+    if let Some(result) = results.iter().find(|result| result.step_id == step_id) {
+        return !result.skipped && result.exit_code == 0;
+    }
+    completed_steps.contains(&step_id)
+}
+
+fn step_attempted(results: &[StepResult], step_id: usize) -> bool {
+    results
+        .iter()
+        .any(|result| result.step_id == step_id && !result.skipped)
+}
+
+fn non_empty_var(vars: &HashMap<String, String>, key: &str) -> Option<String> {
+    vars.get(key)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn output_assignment(results: &[StepResult], key: &str) -> Option<String> {
+    results
+        .iter()
+        .rev()
+        .filter_map(|result| result.output.as_deref())
+        .flat_map(str::lines)
+        .filter_map(|line| parse_assignment_line(line, key))
+        .next()
+}
+
+fn parse_assignment_line(line: &str, key: &str) -> Option<String> {
+    let payload = line.trim().strip_prefix("CSA_VAR:")?.trim();
+    let (raw_key, raw_value) = payload.split_once('=')?;
+    (raw_key.trim() == key)
+        .then(|| raw_value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn truthy(value: Option<&String>) -> bool {
+    value
+        .map(|value| {
+            let lower = value.trim().to_ascii_lowercase();
+            !lower.is_empty() && lower != "false" && lower != "0"
+        })
+        .unwrap_or(false)
+}
+
+fn gh_pr_state(project_root: &Path, pr_ref: &str, repo: Option<&str>) -> Result<String, String> {
+    let mut args = vec![
+        "pr".to_string(),
+        "view".to_string(),
+        pr_ref.to_string(),
+        "--json".to_string(),
+        "state".to_string(),
+        "-q".to_string(),
+        ".state".to_string(),
+    ];
+    if let Some(repo) = repo.filter(|value| !value.trim().is_empty()) {
+        args.push("--repo".to_string());
+        args.push(repo.to_string());
+    }
+    command_stdout(project_root, "gh", &args)
+}
+
+fn command_stdout(project_root: &Path, program: &str, args: &[String]) -> Result<String, String> {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(project_root)
+        .output()
+        .map_err(|error| format!("{program} {} failed to start: {error}", args.join(" ")))?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).to_string());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if stderr.is_empty() { stdout } else { stderr };
+    Err(format!(
+        "{program} {} exited {}{}",
+        args.join(" "),
+        output.status.code().unwrap_or(1),
+        if detail.is_empty() {
+            String::new()
+        } else {
+            format!(": {detail}")
+        }
+    ))
+}
+
+#[cfg(test)]
+#[path = "plan_cmd_pr_bot_completion_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/plan_cmd_pr_bot_completion_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_pr_bot_completion_tests.rs
@@ -1,0 +1,172 @@
+use std::collections::HashMap;
+
+use super::*;
+use crate::plan_cmd::StepResult;
+
+fn failed_step_with_output(step_id: usize, error: &str, output: Option<&str>) -> StepResult {
+    StepResult {
+        step_id,
+        title: "Step 12b: Final Merge (Direct or Post-Rebase)".to_string(),
+        exit_code: 1,
+        duration_secs: 0.0,
+        skipped: false,
+        error: Some(error.to_string()),
+        output: output.map(str::to_string),
+        session_id: None,
+        command: Some("gh pr merge \"${MERGED_PR_VERIFY_REF}\"".to_string()),
+        stderr: Some(error.to_string()),
+    }
+}
+
+#[test]
+fn pr_bot_failure_reports_true_merge_state_when_blocking_finding_and_merge_observed() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workflow_path = temp.path().join("workflow.toml");
+    let error = "ERROR: new Codex P2 review finding is valid enough to block merge.";
+    let results = vec![failed_step_with_output(
+        23,
+        error,
+        Some("CSA_VAR:MERGED_PR_VERIFY_REF=2269\n"),
+    )];
+    let vars = HashMap::from([
+        ("PR_NUM".to_string(), "2269".to_string()),
+        ("REPO".to_string(), "owner/repo".to_string()),
+    ]);
+    let input = PrBotFailureSideEffectInput {
+        workflow_name: "pr-bot",
+        workflow_path: &workflow_path,
+        project_root: temp.path(),
+        results: &results,
+        completed_steps: &[],
+        vars: &vars,
+        failure_summary: "1 step(s) failed (1 execution, 0 unsupported-skip)",
+    };
+    let facts = PrBotMergeFacts::from_failure_input(&input);
+    let observed = PrBotObservedState {
+        pr_state: Some("MERGED".to_string()),
+        pr_state_error: None,
+    };
+
+    let err = verify_pr_bot_failure_side_effects_with_observed(&input, &facts, &observed)
+        .expect("merged PR side effect must override stale not-merged failure summary");
+
+    assert!(
+        err.to_string().contains("PR #2269 is MERGED"),
+        "summary must report true merge state: {err}"
+    );
+    let details = err.report().render_details_section();
+    assert!(
+        details.contains("Observed PR state: MERGED")
+            && details.contains("final merge step attempted before failure")
+            && details.contains("Original failure detail: ERROR: new Codex P2 review finding"),
+        "details must preserve merge evidence and original blocking reason: {details}"
+    );
+}
+
+#[test]
+fn pr_bot_failure_preserves_normal_not_merged_failure_summary() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workflow_path = temp.path().join("workflow.toml");
+    let results = vec![failed_step_with_output(
+        10,
+        "ERROR: Post-fix re-review found 1 new blocking finding(s). Cannot merge.",
+        None,
+    )];
+    let vars = HashMap::from([("PR_NUM".to_string(), "42".to_string())]);
+    let input = PrBotFailureSideEffectInput {
+        workflow_name: "pr-bot",
+        workflow_path: &workflow_path,
+        project_root: temp.path(),
+        results: &results,
+        completed_steps: &[],
+        vars: &vars,
+        failure_summary: "1 step(s) failed (1 execution, 0 unsupported-skip)",
+    };
+    let facts = PrBotMergeFacts::from_failure_input(&input);
+    let observed = PrBotObservedState {
+        pr_state: Some("OPEN".to_string()),
+        pr_state_error: None,
+    };
+
+    let err = verify_pr_bot_failure_side_effects_with_observed(&input, &facts, &observed);
+
+    assert!(
+        err.is_none(),
+        "ordinary blocking failure with OPEN PR should keep the original failure report"
+    );
+}
+
+#[test]
+fn pr_bot_success_reports_merged_pr_state() {
+    let facts = PrBotMergeFacts {
+        pr_number: Some("42".to_string()),
+        merge_verify_ref: Some("42".to_string()),
+        repo: Some("owner/repo".to_string()),
+        merge_completed_marker: true,
+        merge_step_completed: true,
+        post_merge_step_completed: true,
+        merge_step_attempted: true,
+    };
+    let observed = PrBotObservedState {
+        pr_state: Some("MERGED".to_string()),
+        pr_state_error: None,
+    };
+
+    let summary = evaluate_pr_bot_success(&facts, &observed)
+        .expect("merged state should pass")
+        .expect("merged state should produce completion summary");
+
+    assert_eq!(summary, "pr-bot: PR #42 is MERGED");
+}
+
+#[test]
+fn pr_bot_success_fails_closed_when_merge_effect_is_missing() {
+    let facts = PrBotMergeFacts {
+        pr_number: Some("42".to_string()),
+        merge_verify_ref: Some("42".to_string()),
+        repo: Some("owner/repo".to_string()),
+        merge_completed_marker: true,
+        merge_step_completed: true,
+        post_merge_step_completed: false,
+        merge_step_attempted: true,
+    };
+    let observed = PrBotObservedState {
+        pr_state: Some("OPEN".to_string()),
+        pr_state_error: None,
+    };
+
+    let failures = evaluate_pr_bot_success(&facts, &observed)
+        .expect_err("successful pr-bot result must fail closed when PR is still open");
+
+    assert!(
+        failures
+            .iter()
+            .any(|failure| failure.contains("PR 42 state is OPEN; expected MERGED")),
+        "missing merge effect must be actionable: {failures:?}"
+    );
+}
+
+#[test]
+fn pr_bot_failure_facts_recover_merge_ref_from_failed_step_output() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let workflow_path = temp.path().join("workflow.toml");
+    let results = vec![failed_step_with_output(
+        22,
+        "ERROR: checkout failed after merge",
+        Some("CSA_VAR:MERGED_PR_VERIFY_REF=99\n"),
+    )];
+    let vars = HashMap::from([("PR_NUM".to_string(), "42".to_string())]);
+    let input = PrBotFailureSideEffectInput {
+        workflow_name: "pr-bot",
+        workflow_path: &workflow_path,
+        project_root: temp.path(),
+        results: &results,
+        completed_steps: &[],
+        vars: &vars,
+        failure_summary: "1 step(s) failed (1 execution, 0 unsupported-skip)",
+    };
+
+    let facts = PrBotMergeFacts::from_failure_input(&input);
+
+    assert_eq!(facts.pr_reference(), Some("99"));
+}

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot_2014.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot_2014.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 const MERGE_COMMAND: &str = r#"gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}"#;
+const MERGE_REF_MARKER: &str = r#"echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}""#;
 const VERSION_GATE_COMMAND: &str = r#"bash "${CSA_WORKFLOW_DIR:-patterns/pr-bot}/scripts/pre-merge-version-check.sh" "${REMOTE_NAME}" "${DEFAULT_BRANCH}""#;
 const PRE_MERGE_PUSH: &str = r#"git push "${REMOTE_NAME}" "${WORKFLOW_BRANCH}""#;
 
@@ -87,6 +88,27 @@ fn pr_bot_final_merge_runs_version_gate_before_push_and_merge() {
         for section in sections {
             assert_order(&section, VERSION_GATE_COMMAND, PRE_MERGE_PUSH, path);
             assert_order(&section, VERSION_GATE_COMMAND, MERGE_COMMAND, path);
+        }
+    }
+}
+
+#[test]
+fn pr_bot_final_merge_publishes_verify_ref_before_merge_command() {
+    for path in [
+        "patterns/pr-bot/workflow.toml",
+        "patterns/pr-bot/PATTERN.md",
+    ] {
+        let text = artifact_text(path);
+        let sections = if path.ends_with("workflow.toml") {
+            vec![workflow_step(&text, 22), workflow_step(&text, 23)]
+        } else {
+            vec![
+                pattern_section(&text, "## Step 12: Final Merge"),
+                pattern_section(&text, "## Step 12b: Final Merge (Direct or Post-Rebase)"),
+            ]
+        };
+        for section in sections {
+            assert_order(&section, MERGE_REF_MARKER, MERGE_COMMAND, path);
         }
     }
 }

--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -2160,6 +2160,7 @@ DELETE_BRANCH_FLAG=""
 if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
   DELETE_BRANCH_FLAG="--delete-branch"
 fi
+echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}"
 # shellcheck disable=SC2086
 gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}
 
@@ -2180,7 +2181,6 @@ touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
 MERGE_COMPLETED=true
 echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
-echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}"
 echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```
 
@@ -2217,6 +2217,7 @@ DELETE_BRANCH_FLAG=""
 if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
   DELETE_BRANCH_FLAG="--delete-branch"
 fi
+echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}"
 # shellcheck disable=SC2086
 gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}
 
@@ -2237,7 +2238,6 @@ touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
 MERGE_COMPLETED=true
 echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
-echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}"
 echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```
 

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -2654,6 +2654,7 @@ DELETE_BRANCH_FLAG=""
 if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
   DELETE_BRANCH_FLAG="--delete-branch"
 fi
+echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}"
 # shellcheck disable=SC2086
 gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}
 
@@ -2674,7 +2675,6 @@ touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
 MERGE_COMPLETED=true
 echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
-echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}"
 echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```'''
 on_fail = "abort"
@@ -2712,6 +2712,7 @@ DELETE_BRANCH_FLAG=""
 if [ "$(csa config get pr_review.delete_branch --default false)" = "true" ]; then
   DELETE_BRANCH_FLAG="--delete-branch"
 fi
+echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}"
 # shellcheck disable=SC2086
 gh pr merge "${MERGED_PR_VERIFY_REF}" --repo "${REPO}" --"${MERGE_STRATEGY}" ${DELETE_BRANCH_FLAG} ${CSA_REAL_GH:+--force-skip-pr-bot}
 
@@ -2732,7 +2733,6 @@ touch "${MARKER_DIR}/${PR_NUM}-$(git rev-parse HEAD).done"
 
 MERGE_COMPLETED=true
 echo "CSA_VAR:MERGE_COMPLETED=$MERGE_COMPLETED"
-echo "CSA_VAR:MERGED_PR_VERIFY_REF=${MERGED_PR_VERIFY_REF}"
 echo '<!-- CSA:NEXT_STEP cmd="post-merge default branch checkout (Step 13)" required=true -->'
 ```'''
 on_fail = "abort"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1029"
-weave = "0.1.1029"
+csa = "0.1.1030"
+weave = "0.1.1030"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Add pr-bot completion verification so results cannot claim a PR was not merged when GitHub reports it is already merged.
- Correct blocking-finding failure summaries with the observed MERGED PR state and merge metadata.
- Preserve normal not-merged failure behavior when no merge is observed.
- Keep `patterns/pr-bot/PATTERN.md` and `workflow.toml` publish side-effect variables in sync.

Closes #2271

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p cli-sub-agent pr_bot_completion -- --nocapture`
- `cargo test -p cli-sub-agent pr_bot_2014 -- --nocapture`
- `just find-monolith-files`
- `cargo check -p cli-sub-agent`
- pre-commit hooks: monolith / deny / clippy PASS
- exact-head Codex review: `01KVCT7RVN3VKBAM2PXMZ9QJXC` PASS
