### PR TITLE
fix(review): prevent fail verdict with empty findings artifact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1031"
+version = "0.1.1032"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1031"
+version = "0.1.1032"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -593,5 +593,5 @@ mod terminal_error_reason_tests;
 #[path = "review_cmd_output_tests.rs"]
 mod tests;
 #[cfg(test)]
-#[path = "review_cmd_output_verdict_1981_tests.rs"]
-mod verdict_1981_tests;
+#[path = "review_cmd_output_verdict_tail_tests.rs"]
+mod verdict_tail_tests;

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -3,7 +3,10 @@ use std::path::Path;
 
 use anyhow::Result;
 use csa_core::types::ReviewDecision;
-use csa_session::{FindingsFile, ReviewVerdictArtifact, Severity, write_findings_toml};
+use csa_session::{
+    Finding, FindingsFile, ReviewFinding, ReviewFindingFileRange, ReviewVerdictArtifact, Severity,
+    write_findings_toml,
+};
 
 use super::artifacts::severity_counts_are_zero;
 use super::artifacts::{
@@ -14,6 +17,7 @@ use crate::review_cmd::prose_findings::severity_counts_from_review_findings;
 
 const PROSE_FINDINGS_UNPARSED_REASON: &str = "prose_findings_present_but_unparsed";
 const SEVERITY_FINDINGS_MISMATCH_REASON: &str = "severity_counts_findings_mismatch";
+const EMPTY_FAIL_FINDINGS_ARTIFACT_REASON: &str = "fail_verdict_empty_findings_artifact";
 
 pub(super) fn enforce_final_verdict_consistency(
     session_dir: &Path,
@@ -31,7 +35,14 @@ pub(super) fn enforce_final_verdict_consistency(
             .join("output")
             .join(super::super::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER)
             .exists();
-    let skip_prose_override = extraction_confirmed_empty || synthetic_empty;
+    let has_prose_failure_evidence = !prose_signals.findings.is_empty()
+        || prose_signals.blocking_summary
+        || prose_signals.parsed_findings_sections
+        || prose_signals.unparseable_findings_sections
+        || prose_signals.cross_dimension_blockers
+        || prose_signals.checklist_violation_findings;
+    let skip_prose_override =
+        (extraction_confirmed_empty || synthetic_empty) && !has_prose_failure_evidence;
     let findings_file = if findings_file.findings.is_empty()
         && !prose_signals.findings.is_empty()
         && !skip_prose_override
@@ -63,8 +74,12 @@ pub(super) fn enforce_final_verdict_consistency(
     let prose_grade = highest_prose_severity_grade(session_dir);
 
     let resume_to_fix = has_resume_to_fix_suggestion(session_dir)?;
-    let has_review_artifact_findings = load_review_artifact_from_output(session_dir)?
-        .is_some_and(|artifact| !artifact.findings.is_empty());
+    let review_artifact = load_review_artifact_from_output(session_dir)?;
+    let review_artifact_findings: &[Finding] = review_artifact
+        .as_ref()
+        .map(|artifact| artifact.findings.as_slice())
+        .unwrap_or(&[]);
+    let has_review_artifact_findings = !review_artifact_findings.is_empty();
     let has_structured_findings =
         !findings_file.findings.is_empty() || has_review_artifact_findings;
     let structured_mismatch =
@@ -119,9 +134,121 @@ pub(super) fn enforce_final_verdict_consistency(
     // higher count.
     if artifact.decision == ReviewDecision::Fail {
         ensure_fail_closed_grade(&mut artifact.severity_counts, prose_grade);
+        ensure_failed_verdict_findings_artifact(
+            session_dir,
+            artifact,
+            &findings_file,
+            &prose_signals.findings,
+            review_artifact_findings,
+        )?;
     }
 
     Ok(())
+}
+
+fn ensure_failed_verdict_findings_artifact(
+    session_dir: &Path,
+    artifact: &mut ReviewVerdictArtifact,
+    findings_file: &FindingsFile,
+    prose_findings: &[ReviewFinding],
+    review_artifact_findings: &[Finding],
+) -> Result<(), anyhow::Error> {
+    if !findings_file.findings.is_empty() {
+        return Ok(());
+    }
+
+    let backfilled_findings = if !prose_findings.is_empty() {
+        prose_findings.to_vec()
+    } else if !review_artifact_findings.is_empty() {
+        review_artifact_findings
+            .iter()
+            .enumerate()
+            .map(|(index, finding)| review_artifact_finding_to_findings_toml(finding, index + 1))
+            .collect()
+    } else {
+        artifact
+            .failure_reason
+            .get_or_insert_with(|| EMPTY_FAIL_FINDINGS_ARTIFACT_REASON.to_string());
+        vec![artifact_generation_failure_finding(artifact)]
+    };
+
+    write_findings_toml(
+        session_dir,
+        &FindingsFile {
+            findings: backfilled_findings,
+        },
+    )
+    .map_err(|error| anyhow::anyhow!("write fail-closed findings.toml: {error}"))?;
+    clear_empty_findings_markers(session_dir);
+    Ok(())
+}
+
+fn review_artifact_finding_to_findings_toml(finding: &Finding, index: usize) -> ReviewFinding {
+    let file_ranges = finding
+        .line
+        .filter(|_| !finding.file.trim().is_empty())
+        .map(|start| ReviewFindingFileRange {
+            path: finding.file.clone(),
+            start,
+            end: None,
+        })
+        .into_iter()
+        .collect();
+
+    ReviewFinding {
+        id: non_empty_or_else(&finding.fid, || format!("review-findings-{index:03}")),
+        severity: finding.severity.clone(),
+        file_ranges,
+        is_regression_of_commit: None,
+        suggested_test_scenario: None,
+        description: non_empty_or_else(&finding.summary, || {
+            "Review finding imported from review-findings.json".to_string()
+        }),
+    }
+}
+
+fn artifact_generation_failure_finding(artifact: &ReviewVerdictArtifact) -> ReviewFinding {
+    let reason = artifact
+        .failure_reason
+        .as_deref()
+        .unwrap_or(EMPTY_FAIL_FINDINGS_ARTIFACT_REASON);
+    ReviewFinding {
+        id: "artifact-generation-001".to_string(),
+        severity: highest_counted_severity(&artifact.severity_counts).unwrap_or(Severity::Medium),
+        file_ranges: Vec::new(),
+        is_regression_of_commit: None,
+        suggested_test_scenario: None,
+        description: format!(
+            "Artifact generation failed: review verdict is FAIL but CSA could not extract a structured finding. Reason: {reason}. Inspect output/details.md and output/review-verdict.json."
+        ),
+    }
+}
+
+fn highest_counted_severity(
+    severity_counts: &std::collections::BTreeMap<Severity, u32>,
+) -> Option<Severity> {
+    severity_counts
+        .iter()
+        .filter_map(|(severity, count)| (*count > 0).then_some(severity.clone()))
+        .max()
+}
+
+fn non_empty_or_else(value: &str, fallback: impl FnOnce() -> String) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        fallback()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn clear_empty_findings_markers(session_dir: &Path) {
+    for marker in [
+        super::super::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER,
+        super::super::findings_toml::FINDINGS_TOML_EXTRACTED_MARKER,
+    ] {
+        let _ = fs::remove_file(session_dir.join("output").join(marker));
+    }
 }
 
 /// Ensure a fail-closed verdict's severity counts reflect the reviewer's prose

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
@@ -167,7 +167,7 @@ No blocking issues.
     persist_review_verdict(&project_root, &meta, &[], Vec::new());
 
     let findings = read_findings_toml(&session_dir);
-    assert!(findings.findings.is_empty());
+    assert!(!findings.findings.is_empty());
     let verdict = read_verdict(&session_dir);
     assert_ne!(verdict.decision, ReviewDecision::Pass);
     assert_eq!(verdict.decision, ReviewDecision::Fail);
@@ -248,7 +248,7 @@ No blocking issues.
         persist_review_verdict(&project_root, &meta, &[], Vec::new());
 
         let findings = read_findings_toml(&session_dir);
-        assert!(findings.findings.is_empty(), "{heading}");
+        assert!(!findings.findings.is_empty());
         let verdict = read_verdict(&session_dir);
         assert_ne!(verdict.decision, ReviewDecision::Pass, "{heading}");
         assert_eq!(verdict.decision, ReviewDecision::Fail, "{heading}");
@@ -296,7 +296,7 @@ No blocking issues.
     persist_review_verdict(&project_root, &meta, &[], Vec::new());
 
     let findings = read_findings_toml(&session_dir);
-    assert!(findings.findings.is_empty());
+    assert!(!findings.findings.is_empty());
     let verdict = read_verdict(&session_dir);
     assert_eq!(verdict.decision, ReviewDecision::Fail);
     assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_2017_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_2017_tests.rs
@@ -1,0 +1,253 @@
+use super::*;
+use crate::test_env_lock::TEST_ENV_LOCK;
+use csa_session::FindingsFile;
+use csa_session::state::ReviewSessionMeta;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::OwnedMutexGuard;
+
+fn make_review_meta(session_id: &str) -> ReviewSessionMeta {
+    ReviewSessionMeta {
+        session_id: session_id.to_string(),
+        head_sha: String::new(),
+        decision: ReviewDecision::Fail.as_str().to_string(),
+        verdict: "HAS_ISSUES".to_string(),
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool: "codex".to_string(),
+        scope: "diff".to_string(),
+        exit_code: 1,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+        review_mode: None,
+        fix_convergence: None,
+    }
+}
+
+fn make_review_meta_with_decision(
+    session_id: &str,
+    decision: ReviewDecision,
+    verdict: &str,
+) -> ReviewSessionMeta {
+    let mut meta = make_review_meta(session_id);
+    meta.decision = decision.as_str().to_string();
+    meta.verdict = verdict.to_string();
+    meta
+}
+
+fn temp_project_root(test_name: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("csa-{test_name}-{suffix}"));
+    fs::create_dir_all(&path).expect("create temp project root");
+    path
+}
+
+fn create_session_dir(project_root: &Path, session_id: &str) -> PathBuf {
+    let session_dir = csa_session::get_session_root(project_root)
+        .expect("resolve session root")
+        .join("sessions")
+        .join(session_id);
+    fs::create_dir_all(session_dir.join("output")).expect("create session output dir");
+    session_dir
+}
+
+fn lock_test_session(test_name: &str, session_id: &str) -> (OwnedMutexGuard<()>, PathBuf, PathBuf) {
+    let env_lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let project_root = temp_project_root(test_name);
+    let session_dir = create_session_dir(&project_root, session_id);
+    (env_lock, project_root, session_dir)
+}
+
+fn read_findings_toml(session_dir: &Path) -> FindingsFile {
+    let findings_path = session_dir.join("output").join("findings.toml");
+    toml::from_str(&fs::read_to_string(findings_path).expect("read findings.toml"))
+        .expect("parse findings.toml")
+}
+
+fn read_verdict(session_dir: &Path) -> ReviewVerdictArtifact {
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    serde_json::from_str(&fs::read_to_string(verdict_path).expect("read verdict"))
+        .expect("parse verdict")
+}
+
+fn write_extracted_empty_findings(session_dir: &Path) {
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        "findings = []\n",
+    )
+    .expect("write empty findings.toml");
+    fs::write(
+        session_dir
+            .join("output")
+            .join(crate::review_cmd::findings_toml::FINDINGS_TOML_EXTRACTED_MARKER),
+        b"",
+    )
+    .expect("write extracted marker");
+}
+
+#[test]
+fn issue_2017_fail_verdict_backfills_parsed_details_finding_over_empty_artifact() {
+    let session_id = "01TEST2017BACKFILLFIND";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-2017-backfill-finding", session_id);
+
+    write_extracted_empty_findings(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+Review result: FAIL. One medium severity finding blocks the change.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+1. [Medium] `output/findings.toml` can be empty while the verdict fails (`crates/cli-sub-agent/src/review_cmd_output_consistency.rs:51`, confidence=0.91)
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 1);
+    assert_eq!(findings.findings[0].severity, Severity::Medium);
+    assert_eq!(
+        findings.findings[0].file_ranges[0].path,
+        "crates/cli-sub-agent/src/review_cmd_output_consistency.rs"
+    );
+    assert_eq!(findings.findings[0].file_ranges[0].start, 51);
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_2017_fail_verdict_with_unparseable_details_writes_explicit_artifact_error() {
+    let session_id = "01TEST2017ARTIFACTERR";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-2017-artifact-error", session_id);
+
+    write_extracted_empty_findings(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+Review result: FAIL. A finding exists but the structured artifact is empty.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+1. Medium correctness regression remains but this line intentionally lacks a parseable delimiter.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(
+        verdict.failure_reason.as_deref(),
+        Some("prose_findings_present_but_unparsed")
+    );
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 1);
+    assert_eq!(findings.findings[0].id, "artifact-generation-001");
+    assert_eq!(findings.findings[0].severity, Severity::Medium);
+    assert!(
+        findings.findings[0]
+            .description
+            .contains("Artifact generation failed")
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_2017_extracted_empty_summary_only_fail_writes_artifact_error() {
+    let session_id = "01TEST2017SUMMARYFAIL";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-2017-summary-fail", session_id);
+
+    write_extracted_empty_findings(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+Review verdict: FAIL. One blocking correctness issue remains.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+The reviewer reported a blocking failure but did not emit a parseable findings list.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(
+        verdict.failure_reason.as_deref(),
+        Some("fail_verdict_empty_findings_artifact")
+    );
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 1);
+    assert_eq!(findings.findings[0].id, "artifact-generation-001");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_2017_pass_without_findings_keeps_empty_findings_artifact_allowed() {
+    let session_id = "01TEST2017PASSEMPTY000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-2017-pass-empty", session_id);
+
+    write_extracted_empty_findings(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+Review result: PASS. No findings.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+No blocking findings found.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+
+    let findings = read_findings_toml(&session_dir);
+    assert!(findings.findings.is_empty());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_tail_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_tail_tests.rs
@@ -1,0 +1,6 @@
+use super::*;
+
+#[path = "review_cmd_output_verdict_1981_tests.rs"]
+mod verdict_1981_tests;
+#[path = "review_cmd_output_verdict_2017_tests.rs"]
+mod verdict_2017_tests;

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1031"
-weave = "0.1.1031"
+csa = "0.1.1032"
+weave = "0.1.1032"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Prevent failing review verdicts from silently leaving `findings.toml` empty.
- Backfill structured findings from parsed prose/review artifacts when possible.
- Write an explicit artifact-generation finding when a fail verdict has no parseable structured finding, while preserving empty findings for PASS/no-finding cases.

## Testing
- `cargo test -p cli-sub-agent issue_2017 -- --nocapture`
- `cargo test -p cli-sub-agent issue_1675 -- --nocapture`
- `cargo test -p cli-sub-agent issue_1804 -- --nocapture`
- `just find-monolith-files`
- `cargo check -p cli-sub-agent`
- pre-commit hooks: monolith / deny / clippy
- exact-head Codex review PASS: `01KVD3819CQJNDP7B51G22NQ18` at `d3b71fd6b6b`

## Notes
- CSA writer session `01KVCYNKJX8X9B8FNQFTWK1KWZ` hit the known started-session-not-found class; evidence was added to #2283.

Closes #2017
