### PR TITLE
fix(mktd): keep save todo shell extraction quote-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1032"
+version = "0.1.1033"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1032"
+version = "0.1.1033"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -644,6 +644,10 @@ mod tests_manual_handoff;
 mod tests_workflows;
 
 #[cfg(test)]
+#[path = "plan_cmd_tests_mktd_save.rs"]
+mod tests_mktd_save;
+
+#[cfg(test)]
 #[path = "plan_cmd_tests_dev2merge_2031.rs"]
 mod tests_dev2merge_2031;
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_mktd_save.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_mktd_save.rs
@@ -1,0 +1,208 @@
+use std::path::{Path, PathBuf};
+
+use weave::compiler::plan_from_toml;
+
+use crate::plan_cmd::extract_bash_code_block;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
+}
+
+#[cfg(unix)]
+#[test]
+fn mktd_save_step_persists_issue_quoted_content_without_shell_parse_break() -> anyhow::Result<()> {
+    let workflow_path = workspace_root().join("patterns/mktd/workflow.toml");
+    let workflow = std::fs::read_to_string(&workflow_path)?;
+    let plan = plan_from_toml(&workflow)?;
+    let save_step = plan
+        .steps
+        .iter()
+        .find(|step| step.id == 13)
+        .expect("missing mktd save step");
+    let save_script =
+        extract_bash_code_block(&save_step.prompt).expect("mktd save step must have bash block");
+
+    assert!(
+        !save_script.contains("```"),
+        "Save TODO bash source must not contain markdown fence literals; simple fence extractors can truncate them into an unmatched single quote"
+    );
+    let simple_extracted = simple_first_fence_body(&save_step.prompt)
+        .expect("simple extractor must find the mktd save bash block");
+    assert_eq!(
+        simple_extracted, save_script,
+        "Save TODO must stay robust for simple fence extractors used by older generated-command paths"
+    );
+    let parse_status = std::process::Command::new("bash")
+        .args(["-n", "-c", simple_extracted])
+        .status()?;
+    assert!(
+        parse_status.success(),
+        "Save TODO script must parse after simple fence extraction; #2041 failed as an unexpected EOF in a single-quoted sed expression"
+    );
+
+    let project_dir = tempfile::tempdir()?;
+    let session_dir = tempfile::tempdir()?;
+    let bin_dir = tempfile::tempdir()?;
+    let csa_stub = bin_dir.path().join("csa");
+    std::fs::write(&csa_stub, csa_stub_script())?;
+    make_executable(&csa_stub)?;
+
+    run_git(project_dir.path(), &["init"])?;
+    run_git(project_dir.path(), &["checkout", "-b", "fix/2041-test"])?;
+
+    let existing_path = std::env::var("PATH").unwrap_or_default();
+    let output = std::process::Command::new("bash")
+        .arg("-c")
+        .arg(save_script)
+        .current_dir(project_dir.path())
+        .env(
+            "PATH",
+            format!("{}:{existing_path}", bin_dir.path().display()),
+        )
+        .env("CSA_SESSION_DIR", session_dir.path())
+        .env("STEP_12_OUTPUT", tricky_todo())
+        .env("STEP_8_OUTPUT", spec_toml())
+        .env("STEP_2_OUTPUT", "English")
+        .env("FEATURE", tricky_feature())
+        .output()?;
+    assert!(
+        output.status.success(),
+        "Save TODO script failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let todo_artifact =
+        std::fs::read_to_string(session_dir.path().join("output/mktd-save/TODO.md"))?;
+    assert!(todo_artifact.contains("status = \"failure\""));
+    assert!(todo_artifact.contains("failing_step = 'just find-monolith-files'"));
+    assert!(todo_artifact.contains("command = `csa session wait`"));
+    assert!(todo_artifact.contains("```text"));
+    assert!(todo_artifact.contains("```epic-plan.toml"));
+
+    let spec_artifact =
+        std::fs::read_to_string(session_dir.path().join("output/mktd-save/spec.toml"))?;
+    assert!(spec_artifact.contains("plan_ulid = \"01J2041SHELLQUOTE0000000000\""));
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn simple_first_fence_body(prompt: &str) -> Option<&str> {
+    let fence_start = prompt.find("```bash")?;
+    let code_start = prompt[fence_start..].find('\n')? + fence_start + 1;
+    let rest = &prompt[code_start..];
+    let fence_end = rest.find("```")?;
+    Some(rest[..fence_end].trim())
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = std::fs::metadata(path)?.permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn run_git(project_dir: &Path, args: &[&str]) -> anyhow::Result<()> {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(project_dir)
+        .output()?;
+    anyhow::ensure!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+fn csa_stub_script() -> &'static str {
+    r#"#!/bin/sh
+set -eu
+plan_id='01J2041SHELLQUOTE0000000000'
+if [ "${1:-}" != "todo" ]; then
+  echo "unexpected csa command: $*" >&2
+  exit 64
+fi
+shift
+case "${1:-}" in
+  create)
+    printf '%s\n' "$plan_id"
+    ;;
+  persist)
+    todo_file=''
+    spec_file=''
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --todo-file) shift; todo_file="${1:-}" ;;
+        --spec-file) shift; spec_file="${1:-}" ;;
+        --epic-plan-file) shift; test -s "${1:-}" || exit 67 ;;
+      esac
+      shift || true
+    done
+    test -s "$todo_file" || exit 65
+    test -s "$spec_file" || exit 66
+    printf '%s/.todos/%s/TODO.md\n' "$PWD" "$plan_id"
+    ;;
+  show)
+    printf '%s/.todos/%s/TODO.md\n' "$PWD" "$plan_id"
+    ;;
+  *)
+    echo "unexpected csa todo command: $*" >&2
+    exit 64
+    ;;
+esac
+"#
+}
+
+#[cfg(unix)]
+fn tricky_todo() -> &'static str {
+    r#"# Plan
+
+## Tasks
+
+- [ ] Preserve issue body excerpts safely.
+  DONE WHEN: Save TODO persists TODO.md with `status = "failure"`, 'single quotes', and fenced snippets intact.
+
+Issue excerpt:
+
+```text
+status = "failure"
+summary = "POST-EXEC GATE FAILED (exit=1, step=just find-monolith-files)"
+failing_step = 'just find-monolith-files'
+command = `csa session wait`
+```
+
+```epic-plan.toml
+stories = []
+note = "don't break shell parsing"
+```
+"#
+}
+
+#[cfg(unix)]
+fn spec_toml() -> &'static str {
+    concat!(
+        "schema_version = 1\n",
+        "plan_ulid = \"__PLAN_ID__\"\n",
+        "summary = \"",
+        "\u{4fdd}\u{5b58}\u{5f15}\u{53f7}\u{548c}\u{4ee3}\u{7801}\u{5757}\u{3002}",
+        "\"\n\n",
+        "[[criteria]]\n",
+        "kind = \"check\"\n",
+        "id = \"check-shell-safe\"\n",
+        "description = \"Save TODO preserves quoted issue excerpts.\"\n",
+        "status = \"pending\"\n",
+    )
+}
+
+#[cfg(unix)]
+fn tricky_feature() -> &'static str {
+    "Issue #2041: user's `result.toml` says status = \"failure\"\nsummary = \"POST-EXEC GATE FAILED\""
+}

--- a/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_workflows.rs
@@ -297,10 +297,13 @@ fn mktd_save_step_uses_session_output_artifacts_and_persist() {
             r#"SAVE_DIR="${CSA_SESSION_DIR:?CSA_SESSION_DIR must be set}/output/mktd-save""#,
             r#"TODO_ARTIFACT="${SAVE_DIR}/TODO.md""#,
             r#"SPEC_ARTIFACT="${SAVE_DIR}/spec.toml""#,
+            r#"FENCE=$(printf '\140\140\140')"#,
+            r#"awk -v s="${FENCE}epic-plan.toml" -v e="${FENCE}" '$0 == s"#,
             r#"FIRST_SPEC_LINE=$(sed -n 's/^[[:space:]]*//; /[^[:space:]]/{p;q;}' "${SPEC_ARTIFACT}")"#,
             r#"LOWER_SPEC_LINE="${FIRST_SPEC_LINE,,}""#,
             r#"SPEC_MARKER_KIND="""#,
             r#"SPEC_MARKER_KIND="CSA section marker""#,
+            r#""${FENCE}"*) SPEC_MARKER_KIND="Markdown code fence" ;;"#,
             r#"spec artifact-shape error: expected TOML spec.toml"#,
             r#"first marker kind: %s"#,
             r#"Spec artifact path: %s"#,
@@ -321,6 +324,8 @@ fn mktd_save_step_uses_session_output_artifacts_and_persist() {
             "csa todo save -t",
             r#"Artifact preview:"#,
             r#"sed -n '1,8p' "${SPEC_ARTIFACT}""#,
+            r#"sed -n '/^```epic-plan.toml$/,/^```$/p'"#,
+            r#"'```'*) SPEC_MARKER_KIND="Markdown code fence" ;;"#,
         ] {
             assert!(
                 !content.contains(forbidden),

--- a/patterns/mktd/PATTERN.md
+++ b/patterns/mktd/PATTERN.md
@@ -680,9 +680,10 @@ mkdir -p "${SAVE_DIR}" || { echo "create mktd save output dir failed" >&2; exit 
 TODO_ARTIFACT="${SAVE_DIR}/TODO.md"
 SPEC_ARTIFACT="${SAVE_DIR}/spec.toml"
 EPIC_ARTIFACT="${SAVE_DIR}/epic-plan.toml"
+FENCE=$(printf '\140\140\140')
 printf '%s\n' "${FINAL_TODO}" > "${TODO_ARTIFACT}" || { echo "write TODO artifact failed" >&2; exit 1; }
-# Extract epic-plan.toml if present in FINAL_TODO; csa todo persist writes it to todo state.
-EPIC_PLAN=$(printf '%s\n' "${FINAL_TODO}" | sed -n '/^```epic-plan.toml$/,/^```$/p' | sed '1d;$d')
+# Extract epic-plan.toml; persist writes it to todo state.
+EPIC_PLAN=$(printf '%s\n' "${FINAL_TODO}" | awk -v s="${FENCE}epic-plan.toml" -v e="${FENCE}" '$0 == s { p=1; next } p && $0 == e { p=0; next } p { print }')
 EPIC_ARGS=()
 if [[ -n "${EPIC_PLAN:-}" ]]; then
   printf '%s\n' "${EPIC_PLAN}" > "${EPIC_ARTIFACT}" || { echo "write epic-plan.toml artifact failed" >&2; exit 1; }
@@ -700,7 +701,7 @@ case "${LOWER_SPEC_LINE}" in
   '<!-- csa:section:'*) SPEC_MARKER_KIND="CSA section marker" ;;
   '<!--'*) SPEC_MARKER_KIND="HTML marker" ;;
   '<!doctype html'*|'<html'*) SPEC_MARKER_KIND="HTML document marker" ;;
-  '```'*) SPEC_MARKER_KIND="Markdown code fence" ;;
+  "${FENCE}"*) SPEC_MARKER_KIND="Markdown code fence" ;;
 esac
 if [[ -n "${SPEC_MARKER_KIND}" ]]; then
   printf 'spec artifact-shape error: expected TOML spec.toml; first marker kind: %s\nSpec artifact path: %s\n' "${SPEC_MARKER_KIND}" "${SPEC_ARTIFACT}" >&2

--- a/patterns/mktd/workflow.toml
+++ b/patterns/mktd/workflow.toml
@@ -728,9 +728,10 @@ mkdir -p "${SAVE_DIR}" || { echo "create mktd save output dir failed" >&2; exit 
 TODO_ARTIFACT="${SAVE_DIR}/TODO.md"
 SPEC_ARTIFACT="${SAVE_DIR}/spec.toml"
 EPIC_ARTIFACT="${SAVE_DIR}/epic-plan.toml"
+FENCE=$(printf '\140\140\140')
 printf '%s\n' "${FINAL_TODO}" > "${TODO_ARTIFACT}" || { echo "write TODO artifact failed" >&2; exit 1; }
-# Extract epic-plan.toml if present in FINAL_TODO; csa todo persist writes it to todo state.
-EPIC_PLAN=$(printf '%s\n' "${FINAL_TODO}" | sed -n '/^```epic-plan.toml$/,/^```$/p' | sed '1d;$d')
+# Extract epic-plan.toml; persist writes it to todo state.
+EPIC_PLAN=$(printf '%s\n' "${FINAL_TODO}" | awk -v s="${FENCE}epic-plan.toml" -v e="${FENCE}" '$0 == s { p=1; next } p && $0 == e { p=0; next } p { print }')
 EPIC_ARGS=()
 if [[ -n "${EPIC_PLAN:-}" ]]; then
   printf '%s\n' "${EPIC_PLAN}" > "${EPIC_ARTIFACT}" || { echo "write epic-plan.toml artifact failed" >&2; exit 1; }
@@ -748,7 +749,7 @@ case "${LOWER_SPEC_LINE}" in
   '<!-- csa:section:'*) SPEC_MARKER_KIND="CSA section marker" ;;
   '<!--'*) SPEC_MARKER_KIND="HTML marker" ;;
   '<!doctype html'*|'<html'*) SPEC_MARKER_KIND="HTML document marker" ;;
-  '```'*) SPEC_MARKER_KIND="Markdown code fence" ;;
+  "${FENCE}"*) SPEC_MARKER_KIND="Markdown code fence" ;;
 esac
 if [[ -n "${SPEC_MARKER_KIND}" ]]; then
   printf 'spec artifact-shape error: expected TOML spec.toml; first marker kind: %s\nSpec artifact path: %s\n' "${SPEC_MARKER_KIND}" "${SPEC_ARTIFACT}" >&2

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1032"
-weave = "0.1.1032"
+csa = "0.1.1033"
+weave = "0.1.1033"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Avoid literal markdown fences inside the mktd Save TODO bash source so simple generated-command extractors do not truncate the script.
- Keep PATTERN.md and workflow.toml Save TODO behavior synchronized while preserving quoted file arguments for `csa todo persist`.
- Add a regression that executes the Save TODO script with single quotes, backticks, and fenced text/TOML snippets and verifies artifacts remain intact.

## Tests
- `cargo test -p cli-sub-agent mktd_save -- --nocapture`
- `just check-chinese`
- `just find-monolith-files`
- `cargo check -p cli-sub-agent`
- `git diff --check`
- `git diff --cached --check`
- staged secret scan: `SECRET_SCAN_PASS`
- exact-head Codex review: `01KVD7P1ZGH2VXENM6286F3HN8` PASS/CLEAN for `a2746d5bcd8`

Closes #2041
