### PR TITLE
fix(review): surface provider usage-limit summaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1034"
+version = "0.1.1035"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1034"
+version = "0.1.1035"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -102,6 +102,7 @@ mod session_outcome;
 mod session_result_publish;
 mod session_summary_text;
 mod session_tier_failover;
+mod session_unavailable_reason;
 mod setup_cmds;
 mod skill_cmds;
 mod skill_dispatch;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -122,6 +122,12 @@ pub(crate) fn render_wait_result_summary(
         lines.push(format!("Review verdict: {verdict}"));
     }
 
+    if let Some(reason) =
+        crate::session_unavailable_reason::review_unavailable_reason_label(session_dir)
+    {
+        lines.push(format!("Unavailable reason: {reason}"));
+    }
+
     if let Some(failover) = format_failover_chain_label(session_dir, result) {
         lines.push(format!("Failover: {failover}"));
     }
@@ -228,6 +234,7 @@ fn render_wait_result_json(
         "elapsed_seconds": wait_elapsed_seconds(result),
         "tokens": tokens,
         "review_verdict": read_review_verdict_label(session_dir, result),
+        "unavailable_reason": crate::session_unavailable_reason::review_unavailable_reason_label(session_dir),
         "failover": format_failover_chain_label(session_dir, result),
         "kill_hint": result.kill_hint.as_deref(),
         "kill_diagnostics": result.kill_diagnostics.as_ref(),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -9,10 +9,12 @@ use super::{
 mod kill_diagnostics;
 #[path = "session_cmds_daemon_wait_summary_recovery_tests.rs"]
 mod recovery;
+#[path = "session_cmds_daemon_wait_summary_unavailable_tests.rs"]
+mod unavailable_reason;
 
 #[test]
 fn read_wait_output_log_tails_large_stdout_without_loading_prefix() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let stdout_log = temp.path().join("stdout.log");
     let prefix = vec![b'a'; WAIT_OUTPUT_MAX_BYTES as usize];
     let suffix = b"\nfinal visible line\n";
@@ -45,7 +47,7 @@ fn render_truncated_codex_json_tail_filters_agent_messages() {
 
 #[test]
 fn compact_summary_includes_usage_and_review_verdict() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let output_dir = temp.path().join("output");
     std::fs::create_dir_all(&output_dir).expect("output dir should be created");
     std::fs::write(
@@ -99,7 +101,7 @@ fn compact_summary_includes_usage_and_review_verdict() {
 
 #[test]
 fn compact_json_includes_token_cache_derived_fields() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let now = Utc::now();
     let result = csa_session::SessionResult {
         post_exec_gate: None,
@@ -129,7 +131,7 @@ fn compact_json_includes_token_cache_derived_fields() {
 
 #[test]
 fn compact_summary_includes_nested_input_cache_details() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let now = Utc::now();
     let result = csa_session::SessionResult {
         post_exec_gate: None,
@@ -156,7 +158,7 @@ fn compact_summary_includes_nested_input_cache_details() {
 
 #[test]
 fn compact_summary_prefers_post_exec_gate_failure_over_success_markdown() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let output_dir = temp.path().join("output");
     std::fs::create_dir_all(&output_dir).expect("output dir should be created");
     std::fs::write(
@@ -208,7 +210,7 @@ fn compact_summary_prefers_post_exec_gate_failure_over_success_markdown() {
 
 #[test]
 fn compact_summary_includes_unknown_signal_evidence() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let now = Utc::now();
     let diagnostic = "CSA diagnostic: signal kill hint: unknown_signal (termination_reason=sigterm, MemAvailable: 12000 MB / MemTotal: 16000 MB, earlyoom not running, cgroup memory.events oom=0 oom_kill=0). No timeout or cgroup OOM evidence was found, and memory checks did not identify a concrete kill source; reason remains unknown.";
     let result = csa_session::SessionResult {
@@ -241,7 +243,7 @@ fn compact_summary_includes_unknown_signal_evidence() {
 
 #[test]
 fn compact_summary_includes_csa_timeout_effective_timeout_details() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let now = Utc::now();
     let diagnostic = "CSA diagnostic: signal kill hint: csa_timeout (termination_reason=initial_response_timeout, CSA supervisor timeout metadata matched signal exit, requested_timeout_seconds=10800, effective_timeout_kind=initial_response_timeout, effective_timeout_seconds=45, effective_timeout_source=initial_response_timeout, idle_timeout_seconds=10800, initial_response_timeout_seconds=45). The recorded timeout is the concrete kill reason.";
     let result = csa_session::SessionResult {
@@ -275,7 +277,7 @@ fn compact_summary_includes_csa_timeout_effective_timeout_details() {
 
 #[test]
 fn compact_summary_labels_fix_loop_noop_from_review_meta() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let output_dir = temp.path().join("output");
     std::fs::create_dir_all(&output_dir).expect("output dir should be created");
     std::fs::write(
@@ -344,7 +346,7 @@ fn compact_summary_labels_fix_loop_noop_from_review_meta() {
 
 #[test]
 fn compact_summary_uses_primary_failure_and_opaque_total_exhaustion_failover() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let output_dir = temp.path().join("output");
     std::fs::create_dir_all(&output_dir).expect("output dir should be created");
     std::fs::write(
@@ -400,7 +402,7 @@ fn compact_summary_uses_primary_failure_and_opaque_total_exhaustion_failover() {
 
 #[test]
 fn compact_summary_prints_pass_from_canonical_artifact_when_result_succeeded() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let output_dir = temp.path().join("output");
     std::fs::create_dir_all(&output_dir).expect("output dir should be created");
     std::fs::write(
@@ -432,7 +434,7 @@ fn compact_summary_prints_pass_from_canonical_artifact_when_result_succeeded() {
 
 #[test]
 fn compact_summary_includes_writer_uncommitted_warning() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let now = Utc::now();
     let result = csa_session::SessionResult {
         post_exec_gate: None,
@@ -481,7 +483,7 @@ fn compact_summary_includes_writer_uncommitted_warning() {
 
 #[test]
 fn compact_summary_includes_large_diff_warning_block() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let now = Utc::now();
     let warning = csa_session::LargeDiffWarningReport {
         changed_files: 9,
@@ -512,7 +514,7 @@ fn compact_summary_includes_large_diff_warning_block() {
 
 #[test]
 fn compact_summary_does_not_print_pass_when_result_failed() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let output_dir = temp.path().join("output");
     std::fs::create_dir_all(&output_dir).expect("output dir should be created");
     std::fs::write(
@@ -546,7 +548,7 @@ fn compact_summary_does_not_print_pass_when_result_failed() {
 
 #[test]
 fn compact_summary_does_not_print_pass_for_failed_fix_convergence() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
     let output_dir = temp.path().join("output");
     std::fs::create_dir_all(&output_dir).expect("output dir should be created");
     std::fs::write(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_unavailable_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_unavailable_tests.rs
@@ -1,0 +1,87 @@
+use chrono::Utc;
+
+use super::render_wait_result_summary;
+
+fn write_review_verdict(session_dir: &std::path::Path, body: String) {
+    let output_dir = session_dir.join("output");
+    std::fs::create_dir_all(&output_dir).expect("output dir should be created");
+    std::fs::write(output_dir.join("review-verdict.json"), body)
+        .expect("review verdict should be written");
+}
+
+#[test]
+fn compact_summary_includes_redacted_provider_usage_limit_reason() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let long_tail = " provider-debug".repeat(80);
+    let api_field = concat!("api", "_", "key");
+    let fake_value = concat!("sk", "-", "sec", "...", "6789");
+    write_review_verdict(
+        temp.path(),
+        format!(
+            r#"{{"schema_version":1,"session_id":"01TESTWAITUSAGE","timestamp":"2026-04-01T00:00:00Z","decision":"unavailable","verdict_legacy":"UNAVAILABLE","severity_counts":{{"critical":0,"high":0,"medium":0,"low":0}},"primary_failure":"HTTP 429","failure_reason":"codex/openai/gpt-5.5/xhigh=You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Jun 20th, 2026 6:48 PM. {api_field}={fake_value} {long_tail}","prior_round_refs":[]}}"#
+        ),
+    );
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        post_exec_gate: None,
+        status: "failed".to_string(),
+        exit_code: 1,
+        summary: "review unavailable".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITUSAGE", &result);
+
+    assert!(summary.contains("Review verdict: UNAVAILABLE (HTTP 429)"));
+    assert!(summary.contains("Unavailable reason: provider_usage_limit:"));
+    assert!(summary.contains("You've hit your usage limit."));
+    assert!(summary.contains("try again at Jun 20th, 2026 6:48 PM"));
+    assert!(!summary.contains(fake_value));
+    assert!(summary.contains("[REDACTED]"));
+    assert!(
+        summary.len() <= 2048,
+        "summary should stay bounded: {summary}"
+    );
+}
+
+#[test]
+fn compact_summary_omits_provider_usage_reason_for_auth_only_unavailable() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let api_field = concat!("api", "_", "key");
+    let fake_value = concat!("sk", "-", "sec", "...", "6789");
+    write_review_verdict(
+        temp.path(),
+        format!(
+            r#"{{"schema_version":1,"session_id":"01TESTWAITAUTHA","timestamp":"2026-04-01T00:00:00Z","decision":"unavailable","verdict_legacy":"UNAVAILABLE","severity_counts":{{"critical":0,"high":0,"medium":0,"low":0}},"primary_failure":"api_key_invalid","failure_reason":"gemini-cli tool failure: API Key not found; {api_field}={fake_value}","prior_round_refs":[]}}"#
+        ),
+    );
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        post_exec_gate: None,
+        status: "failed".to_string(),
+        exit_code: 1,
+        summary: "review unavailable".to_string(),
+        tool: "gemini-cli".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITAUTHA", &result);
+
+    assert!(!summary.contains("Unavailable reason:"));
+    assert!(!summary.contains(fake_value));
+}

--- a/crates/cli-sub-agent/src/session_cmds_result_display.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_display.rs
@@ -42,6 +42,11 @@ pub(super) fn display_result_text(
     if let Some(summary) = result_display_summary(session_dir, envelope) {
         println!("Summary: {summary}");
     }
+    if let Some(reason) =
+        crate::session_unavailable_reason::review_unavailable_reason_label(session_dir)
+    {
+        println!("Unavailable reason: {reason}");
+    }
     if let Some(kill_hint) = envelope.kill_hint.as_deref() {
         println!("Kill hint: {kill_hint}");
     }
@@ -309,6 +314,8 @@ pub(super) fn display_summary_section(
     session_id: &str,
     json: bool,
 ) -> Result<()> {
+    let unavailable_reason =
+        crate::session_unavailable_reason::review_unavailable_reason_label(session_dir);
     let (section_id, content) = match csa_session::read_section(session_dir, "summary")? {
         Some(content) => ("summary", content),
         None => match csa_session::read_section(session_dir, "full")? {
@@ -322,17 +329,22 @@ pub(super) fn display_summary_section(
             "section": section_id,
             "content": content,
             "tokens": csa_session::estimate_tokens(&content),
+            "unavailable_reason": unavailable_reason,
         });
         println!("{}", serde_json::to_string_pretty(&payload)?);
     } else if section_id == "full" {
         print_truncated_content(&content, FALLBACK_LINES);
+        print_unavailable_reason(unavailable_reason.as_deref());
     } else {
         println!("{content}");
+        print_unavailable_reason(unavailable_reason.as_deref());
     }
     Ok(())
 }
 
 fn display_summary_fallback(session_dir: &Path, session_id: &str, json: bool) -> Result<()> {
+    let unavailable_reason =
+        crate::session_unavailable_reason::review_unavailable_reason_label(session_dir);
     let output_log = session_dir.join("output.log");
     if output_log.is_file() {
         let content = fs::read_to_string(&output_log)?;
@@ -343,16 +355,37 @@ fn display_summary_fallback(session_dir: &Path, session_id: &str, json: bool) ->
                     "source": "output.log",
                     "content": content.lines().take(FALLBACK_LINES).collect::<Vec<_>>().join("\n"),
                     "truncated": content.lines().count() > FALLBACK_LINES,
+                    "unavailable_reason": unavailable_reason,
                 });
                 println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
                 print_truncated_content(&content, FALLBACK_LINES);
+                print_unavailable_reason(unavailable_reason.as_deref());
             }
             return Ok(());
         }
     }
+    if let Some(reason) = unavailable_reason {
+        if json {
+            let payload = serde_json::json!({
+                "section": "summary",
+                "content": serde_json::Value::Null,
+                "unavailable_reason": reason,
+            });
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        } else {
+            print_unavailable_reason(Some(&reason));
+        }
+        return Ok(());
+    }
     eprintln!("No output found for session '{session_id}'");
     Ok(())
+}
+
+fn print_unavailable_reason(reason: Option<&str>) {
+    if let Some(reason) = reason {
+        println!("Unavailable reason: {reason}");
+    }
 }
 
 fn print_truncated_content(content: &str, max_lines: usize) {

--- a/crates/cli-sub-agent/src/session_unavailable_reason.rs
+++ b/crates/cli-sub-agent/src/session_unavailable_reason.rs
@@ -1,0 +1,276 @@
+use std::path::Path;
+
+use csa_core::types::ReviewDecision;
+use csa_session::ReviewVerdictArtifact;
+
+const UNAVAILABLE_REASON_KIND: &str = "provider_usage_limit";
+const UNAVAILABLE_REASON_MAX_CHARS: usize = 360;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UnavailableReason {
+    kind: &'static str,
+    message: String,
+}
+
+impl UnavailableReason {
+    pub(crate) fn render(&self) -> String {
+        format!("{}: {}", self.kind, self.message)
+    }
+}
+
+pub(crate) fn review_unavailable_reason_label(session_dir: &Path) -> Option<String> {
+    let artifact = read_review_verdict_artifact(session_dir)?;
+    review_unavailable_reason(&artifact).map(|reason| reason.render())
+}
+
+pub(crate) fn review_unavailable_reason(
+    artifact: &ReviewVerdictArtifact,
+) -> Option<UnavailableReason> {
+    if artifact.decision != ReviewDecision::Unavailable {
+        return None;
+    }
+
+    let candidates = [
+        artifact.failure_reason.as_deref(),
+        artifact.primary_failure.as_deref(),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .filter_map(provider_limit_candidate)
+        .max_by_key(|candidate| candidate.score)
+        .map(|candidate| UnavailableReason {
+            kind: UNAVAILABLE_REASON_KIND,
+            message: candidate.message,
+        })
+}
+
+fn read_review_verdict_artifact(session_dir: &Path) -> Option<ReviewVerdictArtifact> {
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    if !verdict_path.is_file() {
+        return None;
+    }
+    let raw = std::fs::read_to_string(&verdict_path).ok()?;
+    serde_json::from_str::<ReviewVerdictArtifact>(&raw).ok()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReasonCandidate {
+    score: u32,
+    message: String,
+}
+
+fn provider_limit_candidate(text: &str) -> Option<ReasonCandidate> {
+    let score = provider_limit_score(text)?;
+    let excerpt = excerpt_around_first_limit_signal(text)?;
+    let redacted = csa_session::redact_text_content(&excerpt);
+    let compact = compact_visible_text(&redacted);
+    if compact.is_empty() {
+        return None;
+    }
+    Some(ReasonCandidate {
+        score,
+        message: clip_chars(&compact, UNAVAILABLE_REASON_MAX_CHARS),
+    })
+}
+
+fn provider_limit_score(text: &str) -> Option<u32> {
+    let lower = text.to_ascii_lowercase();
+    let mut score = 0_u32;
+    for (needle, weight) in [
+        ("usage limit", 12),
+        ("monthly usage", 12),
+        ("credit", 10),
+        ("quota", 9),
+        ("resource_exhausted", 8),
+        ("resource exhausted", 8),
+        ("rate limit", 7),
+        ("rate-limit", 7),
+        ("too many requests", 6),
+        ("http 429", 6),
+        ("status 429", 6),
+        ("api_error_status\":429", 6),
+        ("429", 4),
+    ] {
+        if lower.contains(needle) {
+            score = score.saturating_add(weight);
+        }
+    }
+    for (needle, weight) in [
+        ("try again", 5),
+        ("reset", 4),
+        ("retry", 2),
+        ("purchase", 2),
+        ("billing", 2),
+    ] {
+        if lower.contains(needle) {
+            score = score.saturating_add(weight);
+        }
+    }
+    (score > 0).then_some(score)
+}
+
+fn excerpt_around_first_limit_signal(text: &str) -> Option<String> {
+    let lower = text.to_ascii_lowercase();
+    let signal_index = [
+        "usage limit",
+        "monthly usage",
+        "credit",
+        "quota",
+        "resource_exhausted",
+        "resource exhausted",
+        "rate limit",
+        "rate-limit",
+        "too many requests",
+        "http 429",
+        "status 429",
+        "api_error_status\":429",
+        "429",
+    ]
+    .into_iter()
+    .filter_map(|needle| lower.find(needle))
+    .min()?;
+    let start = previous_excerpt_boundary(text, signal_index);
+    let excerpt = text
+        .get(start..)?
+        .trim_start_matches([' ', '\t', '\r', '\n', ',', ';']);
+    Some(excerpt.to_string())
+}
+
+fn previous_excerpt_boundary(text: &str, before: usize) -> usize {
+    let prefix = match text.get(..before) {
+        Some(prefix) => prefix,
+        None => return 0,
+    };
+    prefix
+        .char_indices()
+        .rev()
+        .find_map(|(idx, ch)| matches!(ch, '\n' | '\r' | ';' | ',').then_some(idx + ch.len_utf8()))
+        .unwrap_or(0)
+}
+
+fn compact_visible_text(text: &str) -> String {
+    let mut compact = String::with_capacity(text.len().min(UNAVAILABLE_REASON_MAX_CHARS));
+    let mut last_was_space = false;
+    for ch in text.chars() {
+        if ch.is_whitespace() || ch.is_control() {
+            if !last_was_space {
+                compact.push(' ');
+                last_was_space = true;
+            }
+            continue;
+        }
+        compact.push(ch);
+        last_was_space = false;
+    }
+    compact.trim().to_string()
+}
+
+fn clip_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let keep = max_chars.saturating_sub(3);
+    let mut clipped = text.chars().take(keep).collect::<String>();
+    clipped = clipped.trim_end().to_string();
+    clipped.push_str("...");
+    clipped
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use chrono::Utc;
+    use csa_session::Severity;
+
+    use super::*;
+
+    fn unavailable_artifact(
+        primary_failure: Option<&str>,
+        failure_reason: Option<&str>,
+    ) -> ReviewVerdictArtifact {
+        ReviewVerdictArtifact {
+            schema_version: 1,
+            session_id: "01TESTUNAVAILABLE".to_string(),
+            timestamp: Utc::now(),
+            decision: ReviewDecision::Unavailable,
+            verdict_legacy: "UNAVAILABLE".to_string(),
+            severity_counts: BTreeMap::from([
+                (Severity::Critical, 0),
+                (Severity::High, 0),
+                (Severity::Medium, 0),
+                (Severity::Low, 0),
+            ]),
+            review_mode: None,
+            routed_to: None,
+            primary_failure: primary_failure.map(str::to_string),
+            failure_reason: failure_reason.map(str::to_string),
+            prior_round_refs: Vec::new(),
+            diff_size: None,
+            large_diff_warning: false,
+            large_diff_warning_threshold: None,
+            large_diff_warning_changed_lines: None,
+        }
+    }
+
+    #[test]
+    fn review_unavailable_reason_surfaces_codex_usage_limit_hint() {
+        let artifact = unavailable_artifact(
+            Some("HTTP 429"),
+            Some(
+                "codex/openai/gpt-5.5/xhigh=You've hit your usage limit. Visit \
+                 https://chatgpt.com/codex/settings/usage to purchase more credits or try again \
+                 at Jun 20th, 2026 6:48 PM.",
+            ),
+        );
+
+        let reason = review_unavailable_reason(&artifact).expect("usage-limit reason");
+
+        assert_eq!(reason.kind, "provider_usage_limit");
+        assert!(reason.message.contains("You've hit your usage limit."));
+        assert!(
+            reason
+                .message
+                .contains("try again at Jun 20th, 2026 6:48 PM")
+        );
+    }
+
+    #[test]
+    fn review_unavailable_reason_redacts_and_bounds_provider_output() {
+        let long_tail = " provider-debug".repeat(80);
+        let api_field = concat!("api", "_", "key");
+        let fake_value = concat!("sk", "-", "sec", "...", "6789");
+        let artifact = unavailable_artifact(
+            Some("HTTP 429"),
+            Some(&format!(
+                "provider stderr: You've hit your usage limit. {api_field}={fake_value} \
+                 retry after reset.{long_tail}",
+            )),
+        );
+
+        let reason = review_unavailable_reason(&artifact).expect("usage-limit reason");
+
+        assert!(!reason.message.contains(fake_value));
+        assert!(reason.message.contains("[REDACTED]"));
+        assert!(reason.message.chars().count() <= UNAVAILABLE_REASON_MAX_CHARS);
+    }
+
+    #[test]
+    fn review_unavailable_reason_ignores_auth_only_unavailable() {
+        let artifact = unavailable_artifact(
+            Some("api_key_invalid"),
+            Some("gemini-cli tool failure: API Key not found"),
+        );
+
+        assert_eq!(review_unavailable_reason(&artifact), None);
+    }
+
+    #[test]
+    fn review_unavailable_reason_ignores_non_unavailable_verdict() {
+        let mut artifact = unavailable_artifact(Some("HTTP 429"), Some("usage limit"));
+        artifact.decision = ReviewDecision::Pass;
+
+        assert_eq!(review_unavailable_reason(&artifact), None);
+    }
+}

--- a/crates/cli-sub-agent/tests/session_summary_visibility.rs
+++ b/crates/cli-sub-agent/tests/session_summary_visibility.rs
@@ -103,6 +103,20 @@ gate_timeout = false
     .expect("write result.toml");
 }
 
+fn write_provider_usage_limit_verdict(session_dir: &Path, session_id: &str) {
+    let output_dir = session_dir.join("output");
+    std::fs::create_dir_all(&output_dir).expect("create output dir");
+    let token_field = concat!("to", "ken");
+    let fake_value = concat!("sk", "-", "sec", "...", "6789");
+    std::fs::write(
+        output_dir.join("review-verdict.json"),
+        format!(
+            r#"{{"schema_version":1,"session_id":"{session_id}","timestamp":"2026-04-01T00:00:00Z","decision":"unavailable","verdict_legacy":"UNAVAILABLE","severity_counts":{{"critical":0,"high":0,"medium":0,"low":0}},"primary_failure":"HTTP 429","failure_reason":"codex/openai/gpt-5.5/xhigh=You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Jun 20th, 2026 6:48 PM. {token_field}={fake_value}","prior_round_refs":[]}}"#
+        ),
+    )
+    .expect("write review verdict");
+}
+
 fn create_empty_output_failure_session(
     tmp: &Path,
     name: &str,
@@ -219,6 +233,87 @@ fn session_wait_default_bounds_output_and_hides_stdout_log() {
     assert!(stdout.contains("Tool: codex"));
     assert!(stdout.contains(PRE_EXEC_SUMMARY));
     assert!(!stdout.contains("verbose-only"));
+}
+
+#[test]
+#[serial]
+fn session_result_summary_surfaces_provider_usage_limit_reason() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (project, session_id, session_dir) =
+        create_empty_output_failure_session(tmp.path(), "result-summary-provider-usage-limit");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nUNAVAILABLE\n<!-- CSA:SECTION:summary:END -->",
+    )
+    .expect("persist structured summary");
+    write_provider_usage_limit_verdict(&session_dir, &session_id);
+
+    let output = csa_cmd(tmp.path())
+        .args([
+            "session",
+            "result",
+            "--summary",
+            "--session",
+            &session_id,
+            "--cd",
+            project.to_str().expect("project path utf8"),
+        ])
+        .current_dir(&project)
+        .output()
+        .expect("run csa session result --summary");
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("UNAVAILABLE"));
+    assert!(stdout.contains("Unavailable reason: provider_usage_limit:"));
+    assert!(stdout.contains("You've hit your usage limit."));
+    assert!(stdout.contains("try again at Jun 20th, 2026 6:48 PM"));
+    assert!(!stdout.contains(concat!("sk", "-", "sec", "...", "6789")));
+    assert!(stdout.contains("[REDACTED]"));
+    assert!(
+        stdout.len() <= 700,
+        "summary output should stay compact, got {} bytes: {stdout}",
+        stdout.len()
+    );
+}
+
+#[test]
+#[serial]
+fn session_result_summary_json_surfaces_provider_usage_limit_reason_without_output() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (project, session_id, session_dir) =
+        create_empty_output_failure_session(tmp.path(), "result-summary-json-provider-limit");
+    write_provider_usage_limit_verdict(&session_dir, &session_id);
+
+    let output = csa_cmd(tmp.path())
+        .args([
+            "session",
+            "result",
+            "--summary",
+            "--json",
+            "--session",
+            &session_id,
+            "--cd",
+            project.to_str().expect("project path utf8"),
+        ])
+        .current_dir(&project)
+        .output()
+        .expect("run csa session result --summary --json");
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf8");
+    let summary: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|err| panic!("stdout should be JSON: {err}; stdout={stdout}"));
+    assert_eq!(summary["section"], "summary");
+    assert!(summary["content"].is_null());
+    let reason = summary["unavailable_reason"]
+        .as_str()
+        .expect("unavailable_reason string");
+    assert!(reason.starts_with("provider_usage_limit:"));
+    assert!(reason.contains("You've hit your usage limit."));
+    assert!(reason.contains("try again at Jun 20th, 2026 6:48 PM"));
+    assert!(!reason.contains(concat!("sk", "-", "sec", "...", "6789")));
+    assert!(reason.contains("[REDACTED]"));
 }
 
 #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1034"
-weave = "0.1.1034"
+csa = "0.1.1035"
+weave = "0.1.1035"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Surface compact provider usage/quota unavailable reasons in `csa session wait` summaries.
- Surface the same redacted/bounded reason in `csa session result --summary`, including JSON output and unavailable-reason-only fallback paths.
- Add focused coverage for classifier behavior, redaction/bounding, wait rendering, and result summary text/JSON visibility.

## Validation
- `cargo test -p cli-sub-agent --test session_summary_visibility -- --nocapture`
- `cargo test -p cli-sub-agent session_unavailable_reason -- --nocapture`
- `cargo test -p cli-sub-agent provider_usage_limit -- --nocapture`
- `just find-monolith-files`
- `cargo check -p cli-sub-agent`
- `git diff --check` / `git diff --cached --check`
- staged secret scan
- Exact-head CSA/Codex review initially found a JSON fallback contract bug; fixed and amended.
- Follow-up CSA reviews reported no findings but no PASS/CLEAN artifact (`UNAVAILABLE` / artifact recovery issue tracked in #2286).
- Same-SHA Hermes native subagent fallback review: `deleg_db203ffe`, HEAD `3a3efcdbde47`, verdict `PASS/CLEAN`.

Closes #2259
