### PR TITLE
fix(session): preserve post-exec gate verdict in result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1036"
+version = "0.1.1037"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1036"
+version = "0.1.1037"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result.rs
@@ -299,11 +299,16 @@ pub(crate) use crate::session_cmds_result_measure::{compute_token_measurement, f
 pub(crate) use artifacts::handle_session_artifacts;
 #[cfg(test)]
 use display::{
-    build_result_json_payload, display_all_sections, display_single_section,
-    display_summary_section, render_result_sidecar_for_text, render_token_usage_lines,
+    build_all_sections_json_payload, build_gate_aware_summary_content, build_result_json_payload,
+    build_summary_section_json_payload, display_all_sections, display_single_section,
+    display_summary_section, gate_summary_employee_section, load_structured_post_exec_gate_report,
+    render_result_sidecar_for_text, render_token_usage_lines, structured_sections_with_gate_first,
 };
 pub(crate) use tool_output::handle_session_tool_output;
 
+#[cfg(test)]
+#[path = "session_cmds_result_post_exec_gate_tests.rs"]
+mod post_exec_gate_tests;
 #[cfg(test)]
 #[path = "session_cmds_result_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/session_cmds_result_display.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_display.rs
@@ -7,6 +7,17 @@ use std::path::Path;
 use super::{StructuredOutputOpts, TranscriptSummary};
 use crate::token_usage_display::{display_total_tokens, token_usage_json_value};
 
+#[path = "session_cmds_result_post_exec_gate.rs"]
+mod post_exec_gate;
+pub(super) use post_exec_gate::{
+    build_all_sections_json_payload, build_gate_aware_summary_content,
+    build_summary_section_json_payload, gate_summary_employee_section,
+    load_structured_post_exec_gate_report, structured_sections_with_gate_first,
+};
+use post_exec_gate::{
+    gate_failure_rendered_section, print_rendered_sections, rendered_fallback_sections,
+};
+
 pub(super) fn display_result_json(
     result: &SessionResultView,
     transcript_summary: Option<&TranscriptSummary>,
@@ -177,8 +188,12 @@ pub(super) fn build_result_json_payload(
 ) -> Result<serde_json::Value> {
     let mut payload = serde_json::to_value(&result.envelope)?;
     if let Some(report) = result.envelope.post_exec_gate.as_ref() {
-        payload["summary"] =
-            serde_json::Value::String(csa_session::post_exec_gate_failure_summary(report));
+        let authoritative_summary = csa_session::post_exec_gate_failure_summary(report);
+        if result.envelope.summary.trim() != authoritative_summary.as_str() {
+            payload["superseded_employee_summary"] =
+                serde_json::Value::String(result.envelope.summary.clone());
+        }
+        payload["summary"] = serde_json::Value::String(authoritative_summary);
     }
     if let Some(sidecar) = result
         .manager_sidecar
@@ -316,13 +331,28 @@ pub(super) fn display_summary_section(
 ) -> Result<()> {
     let unavailable_reason =
         crate::session_unavailable_reason::review_unavailable_reason_label(session_dir);
+    let post_exec_gate = load_structured_post_exec_gate_report(session_dir);
     let (section_id, content) = match csa_session::read_section(session_dir, "summary")? {
         Some(content) => ("summary", content),
         None => match csa_session::read_section(session_dir, "full")? {
             Some(content) => ("full", content),
-            None => return display_summary_fallback(session_dir, session_id, json),
+            None => {
+                if let Some(report) = post_exec_gate.as_ref() {
+                    return display_gate_summary_override(report, None, unavailable_reason, json);
+                }
+                return display_summary_fallback(session_dir, session_id, json);
+            }
         },
     };
+
+    if let Some(report) = post_exec_gate.as_ref() {
+        return display_gate_summary_override(
+            report,
+            gate_summary_employee_section(section_id, content.as_str()),
+            unavailable_reason,
+            json,
+        );
+    }
 
     if json {
         let payload = serde_json::json!({
@@ -337,6 +367,26 @@ pub(super) fn display_summary_section(
         print_unavailable_reason(unavailable_reason.as_deref());
     } else {
         println!("{content}");
+        print_unavailable_reason(unavailable_reason.as_deref());
+    }
+    Ok(())
+}
+
+fn display_gate_summary_override(
+    report: &csa_session::PostExecGateReport,
+    employee_section: Option<(&str, &str)>,
+    unavailable_reason: Option<String>,
+    json: bool,
+) -> Result<()> {
+    if json {
+        let payload =
+            build_summary_section_json_payload(employee_section, unavailable_reason, Some(report))?;
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        println!(
+            "{}",
+            build_gate_aware_summary_content(report, employee_section)
+        );
         print_unavailable_reason(unavailable_reason.as_deref());
     }
     Ok(())
@@ -442,52 +492,58 @@ pub(super) fn display_single_section(
 /// Show all sections in index order.
 pub(super) fn display_all_sections(session_dir: &Path, session_id: &str, json: bool) -> Result<()> {
     let sections = csa_session::read_all_sections(session_dir)?;
+    let post_exec_gate = load_structured_post_exec_gate_report(session_dir);
     if sections.is_empty() {
         let output_log = session_dir.join("output.log");
         if output_log.is_file() {
             let content = fs::read_to_string(&output_log)?;
             if !content.is_empty() {
                 if json {
-                    let payload = serde_json::json!({
-                        "sections": [{
-                            "section": "full",
-                            "content": content,
-                            "tokens": csa_session::estimate_tokens(&content),
-                        }]
-                    });
+                    let payload = if post_exec_gate.is_some() {
+                        build_all_sections_json_payload(&rendered_fallback_sections(
+                            content.as_str(),
+                            post_exec_gate.as_ref(),
+                        ))?
+                    } else {
+                        serde_json::json!({
+                            "sections": [{
+                                "section": "full",
+                                "content": content,
+                                "tokens": csa_session::estimate_tokens(&content),
+                            }]
+                        })
+                    };
                     println!("{}", serde_json::to_string_pretty(&payload)?);
                 } else {
+                    if let Some(report) = post_exec_gate.as_ref() {
+                        print_rendered_sections(&[gate_failure_rendered_section(report)]);
+                        println!();
+                    }
                     print!("{content}");
                 }
                 return Ok(());
             }
         }
+        if let Some(report) = post_exec_gate.as_ref() {
+            let gate_section = gate_failure_rendered_section(report);
+            if json {
+                let payload = build_all_sections_json_payload(&[gate_section])?;
+                println!("{}", serde_json::to_string_pretty(&payload)?);
+            } else {
+                print_rendered_sections(&[gate_section]);
+            }
+            return Ok(());
+        }
         eprintln!("No output found for session '{session_id}'");
         return Ok(());
     }
 
+    let rendered_sections = structured_sections_with_gate_first(&sections, post_exec_gate.as_ref());
     if json {
-        let json_sections: Vec<serde_json::Value> = sections
-            .iter()
-            .map(|(section, content)| {
-                serde_json::json!({
-                    "section": section.id,
-                    "title": section.title,
-                    "content": content,
-                    "tokens": section.token_estimate,
-                })
-            })
-            .collect();
-        let payload = serde_json::json!({ "sections": json_sections });
+        let payload = build_all_sections_json_payload(&rendered_sections)?;
         println!("{}", serde_json::to_string_pretty(&payload)?);
     } else {
-        for (i, (section, content)) in sections.iter().enumerate() {
-            if i > 0 {
-                println!();
-            }
-            println!("=== {} ({}) ===", section.title, section.id);
-            println!("{content}");
-        }
+        print_rendered_sections(&rendered_sections);
     }
     Ok(())
 }

--- a/crates/cli-sub-agent/src/session_cmds_result_post_exec_gate.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_post_exec_gate.rs
@@ -1,0 +1,183 @@
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+
+const POST_EXEC_GATE_SECTION_ID: &str = "post-exec-gate";
+const POST_EXEC_GATE_SECTION_TITLE: &str = "Post-Exec Gate Failure";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::session_cmds_result) struct RenderedStructuredSection {
+    id: String,
+    title: String,
+    content: String,
+    tokens: usize,
+    post_exec_gate: Option<csa_session::PostExecGateReport>,
+}
+
+pub(in crate::session_cmds_result) fn load_structured_post_exec_gate_report(
+    session_dir: &Path,
+) -> Option<csa_session::PostExecGateReport> {
+    let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
+    let content = fs::read_to_string(&result_path).ok()?;
+    let result: csa_session::SessionResult = toml::from_str(&content).ok()?;
+    result.post_exec_gate
+}
+
+pub(in crate::session_cmds_result) fn build_gate_aware_summary_content(
+    report: &csa_session::PostExecGateReport,
+    employee_section: Option<(&str, &str)>,
+) -> String {
+    let gate_summary = csa_session::post_exec_gate_failure_summary(report);
+    let Some((section_id, content)) = employee_section else {
+        return gate_summary;
+    };
+    let content = content.trim();
+    if content.is_empty() || content_leads_with_post_exec_gate(content) {
+        return gate_summary;
+    }
+    format!("{gate_summary}\n\n---\n\nSuperseded employee self-report ({section_id}):\n\n{content}")
+}
+
+pub(in crate::session_cmds_result) fn gate_summary_employee_section<'a>(
+    section_id: &'a str,
+    content: &'a str,
+) -> Option<(&'a str, &'a str)> {
+    (section_id != "full").then_some((section_id, content))
+}
+
+pub(in crate::session_cmds_result) fn build_summary_section_json_payload(
+    employee_section: Option<(&str, &str)>,
+    unavailable_reason: Option<String>,
+    post_exec_gate: Option<&csa_session::PostExecGateReport>,
+) -> Result<serde_json::Value> {
+    let Some(report) = post_exec_gate else {
+        let (section_id, content) = employee_section.unwrap_or(("summary", ""));
+        return Ok(serde_json::json!({
+            "section": section_id,
+            "content": content,
+            "tokens": csa_session::estimate_tokens(content),
+            "unavailable_reason": unavailable_reason,
+        }));
+    };
+
+    let gate_summary = csa_session::post_exec_gate_failure_summary(report);
+    let mut payload = serde_json::json!({
+        "section": POST_EXEC_GATE_SECTION_ID,
+        "content": gate_summary,
+        "tokens": csa_session::estimate_tokens(&gate_summary),
+        "post_exec_gate": report,
+        "unavailable_reason": unavailable_reason,
+    });
+    if let Some((section_id, content)) = employee_section
+        && !content.trim().is_empty()
+        && !content_leads_with_post_exec_gate(content)
+    {
+        payload["superseded_employee_self_report"] = serde_json::json!({
+            "section": section_id,
+            "content": content,
+            "tokens": csa_session::estimate_tokens(content),
+        });
+    }
+    Ok(payload)
+}
+
+pub(in crate::session_cmds_result) fn structured_sections_with_gate_first(
+    sections: &[(csa_session::OutputSection, String)],
+    post_exec_gate: Option<&csa_session::PostExecGateReport>,
+) -> Vec<RenderedStructuredSection> {
+    let mut rendered = Vec::with_capacity(sections.len() + usize::from(post_exec_gate.is_some()));
+    if let Some(report) = post_exec_gate {
+        rendered.push(gate_failure_rendered_section(report));
+    }
+    rendered.extend(
+        sections
+            .iter()
+            .map(|(section, content)| RenderedStructuredSection {
+                id: section.id.clone(),
+                title: section.title.clone(),
+                content: content.clone(),
+                tokens: section.token_estimate,
+                post_exec_gate: None,
+            }),
+    );
+    rendered
+}
+
+pub(in crate::session_cmds_result) fn build_all_sections_json_payload(
+    sections: &[RenderedStructuredSection],
+) -> Result<serde_json::Value> {
+    let json_sections: Vec<serde_json::Value> = sections
+        .iter()
+        .map(|section| {
+            let mut value = serde_json::json!({
+                "section": section.id,
+                "title": section.title,
+                "content": section.content,
+                "tokens": section.tokens,
+            });
+            if let Some(report) = section.post_exec_gate.as_ref() {
+                value["post_exec_gate"] = serde_json::to_value(report)?;
+            }
+            Ok(value)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut payload = serde_json::json!({ "sections": json_sections });
+    if let Some(gate_section) = sections
+        .iter()
+        .find(|section| section.id == POST_EXEC_GATE_SECTION_ID)
+    {
+        payload["post_exec_gate_summary"] = serde_json::Value::String(gate_section.content.clone());
+        if let Some(report) = gate_section.post_exec_gate.as_ref() {
+            payload["post_exec_gate"] = serde_json::to_value(report)?;
+        }
+    }
+    Ok(payload)
+}
+
+pub(super) fn rendered_fallback_sections(
+    content: &str,
+    post_exec_gate: Option<&csa_session::PostExecGateReport>,
+) -> Vec<RenderedStructuredSection> {
+    let fallback = RenderedStructuredSection {
+        id: "full".to_string(),
+        title: "Full Output".to_string(),
+        content: content.to_string(),
+        tokens: csa_session::estimate_tokens(content),
+        post_exec_gate: None,
+    };
+    let mut sections = Vec::with_capacity(1 + usize::from(post_exec_gate.is_some()));
+    if let Some(report) = post_exec_gate {
+        sections.push(gate_failure_rendered_section(report));
+    }
+    sections.push(fallback);
+    sections
+}
+
+pub(super) fn gate_failure_rendered_section(
+    report: &csa_session::PostExecGateReport,
+) -> RenderedStructuredSection {
+    let content = csa_session::post_exec_gate_failure_summary(report);
+    RenderedStructuredSection {
+        id: POST_EXEC_GATE_SECTION_ID.to_string(),
+        title: POST_EXEC_GATE_SECTION_TITLE.to_string(),
+        tokens: csa_session::estimate_tokens(&content),
+        content,
+        post_exec_gate: Some(report.clone()),
+    }
+}
+
+pub(super) fn print_rendered_sections(sections: &[RenderedStructuredSection]) {
+    for (i, section) in sections.iter().enumerate() {
+        if i > 0 {
+            println!();
+        }
+        println!("=== {} ({}) ===", section.title, section.id);
+        println!("{}", section.content);
+    }
+}
+
+fn content_leads_with_post_exec_gate(content: &str) -> bool {
+    let trimmed = content.trim_start();
+    trimmed.starts_with(csa_session::GATE_SUMMARY_LEAD)
+        || (trimmed.starts_with('>') && trimmed.contains(csa_session::GATE_SUMMARY_LEAD))
+}

--- a/crates/cli-sub-agent/src/session_cmds_result_post_exec_gate_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_post_exec_gate_tests.rs
@@ -1,0 +1,216 @@
+use super::{
+    build_all_sections_json_payload, build_gate_aware_summary_content, build_result_json_payload,
+    build_summary_section_json_payload, gate_summary_employee_section,
+    load_structured_post_exec_gate_report, structured_sections_with_gate_first,
+};
+use csa_session::{SessionResult, SessionResultView};
+
+fn issue_2311_gate_report() -> csa_session::PostExecGateReport {
+    csa_session::PostExecGateReport::from_redacted_gate_output(
+        "just pre-commit",
+        1,
+        "running just monolith-test\n\
+         FAIL [   0.005s] cli-sub-agent session_cmds_result::issue_2311\n\
+         error: Recipe `monolith-test` failed on line 123 with exit code 1\n",
+    )
+}
+
+#[test]
+fn issue_2311_summary_text_prefers_post_exec_gate_over_employee_success() {
+    let report = issue_2311_gate_report();
+    let employee_summary =
+        "Implemented the fix, committed it, and just pre-commit passed. Working tree clean.";
+
+    let content = build_gate_aware_summary_content(&report, Some(("summary", employee_summary)));
+
+    assert!(
+        content.starts_with(csa_session::GATE_SUMMARY_LEAD),
+        "summary must lead with gate verdict: {content}"
+    );
+    assert!(content.contains("phase=post-exec"));
+    assert!(content.contains("command=just pre-commit"));
+    assert!(content.contains("step=just monolith-test"));
+    assert!(content.contains("employee self-report SUPERSEDED by gate verdict"));
+    assert!(content.contains("Superseded employee self-report (summary):"));
+    assert!(content.contains(employee_summary));
+    let gate_pos = content.find(csa_session::GATE_SUMMARY_LEAD).unwrap();
+    let employee_pos = content.find(employee_summary).unwrap();
+    assert!(
+        gate_pos < employee_pos,
+        "employee self-report must be subordinate: {content}"
+    );
+}
+
+#[test]
+fn issue_2311_summary_json_reports_gate_and_subordinates_employee_success() {
+    let report = issue_2311_gate_report();
+    let employee_summary =
+        "Implemented the fix, committed it, and just pre-commit passed. Working tree clean.";
+
+    let payload = build_summary_section_json_payload(
+        Some(("summary", employee_summary)),
+        None,
+        Some(&report),
+    )
+    .unwrap();
+
+    assert_eq!(payload["section"], "post-exec-gate");
+    assert!(
+        payload["content"]
+            .as_str()
+            .unwrap()
+            .starts_with(csa_session::GATE_SUMMARY_LEAD),
+        "json summary must lead with gate verdict: {payload}"
+    );
+    assert_eq!(payload["post_exec_gate"]["gate_command"], "just pre-commit");
+    assert_eq!(payload["post_exec_gate"]["exit_code"], 1);
+    assert_eq!(
+        payload["post_exec_gate"]["failing_step"],
+        "just monolith-test"
+    );
+    assert_eq!(
+        payload["superseded_employee_self_report"]["section"],
+        "summary"
+    );
+    assert_eq!(
+        payload["superseded_employee_self_report"]["content"],
+        employee_summary
+    );
+}
+
+#[test]
+fn issue_2311_full_json_puts_post_exec_gate_section_first() {
+    let report = issue_2311_gate_report();
+    let employee_summary =
+        "Implemented the fix, committed it, and just pre-commit passed. Working tree clean.";
+    let sections = vec![(
+        csa_session::OutputSection {
+            id: "summary".to_string(),
+            title: "Summary".to_string(),
+            line_start: 1,
+            line_end: 1,
+            token_estimate: csa_session::estimate_tokens(employee_summary),
+            file_path: Some("summary.md".to_string()),
+        },
+        employee_summary.to_string(),
+    )];
+
+    let rendered = structured_sections_with_gate_first(&sections, Some(&report));
+    let payload = build_all_sections_json_payload(&rendered).unwrap();
+    let json_sections = payload["sections"].as_array().unwrap();
+
+    assert_eq!(json_sections[0]["section"], "post-exec-gate");
+    assert!(
+        json_sections[0]["content"]
+            .as_str()
+            .unwrap()
+            .starts_with(csa_session::GATE_SUMMARY_LEAD),
+        "full json first section must be gate verdict: {payload}"
+    );
+    assert_eq!(json_sections[0]["post_exec_gate"]["exit_code"], 1);
+    assert_eq!(
+        payload["post_exec_gate"]["failing_step"],
+        "just monolith-test"
+    );
+    assert_eq!(json_sections[1]["section"], "summary");
+    assert_eq!(json_sections[1]["content"], employee_summary);
+}
+
+#[test]
+fn issue_2311_result_json_summary_prefers_post_exec_gate() {
+    let now = chrono::Utc::now();
+    let employee_summary =
+        "Implemented the fix, committed it, and just pre-commit passed. Working tree clean.";
+    let result = SessionResult {
+        post_exec_gate: Some(issue_2311_gate_report()),
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: employee_summary.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    };
+
+    let payload = build_result_json_payload(
+        &SessionResultView {
+            envelope: result,
+            manager_sidecar: None,
+            legacy_sidecar: None,
+        },
+        None,
+        None,
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        payload["summary"]
+            .as_str()
+            .unwrap()
+            .starts_with(csa_session::GATE_SUMMARY_LEAD),
+        "result json summary must lead with gate verdict: {payload}"
+    );
+    assert_eq!(
+        payload["post_exec_gate"]["failing_step"],
+        "just monolith-test"
+    );
+    assert_eq!(payload["superseded_employee_summary"], employee_summary);
+}
+
+#[test]
+fn issue_2311_summary_text_does_not_append_full_fallback_transcript() {
+    let tmp = tempfile::tempdir().unwrap();
+    let long_full = (1..=30)
+        .map(|i| format!("raw full transcript line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    csa_session::persist_structured_output(tmp.path(), &long_full).unwrap();
+
+    let now = chrono::Utc::now();
+    let report = issue_2311_gate_report();
+    let result = SessionResult {
+        post_exec_gate: Some(report),
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "employee claimed success before gate".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    };
+    std::fs::write(
+        tmp.path().join(csa_session::result::RESULT_FILE_NAME),
+        toml::to_string(&result).unwrap(),
+    )
+    .unwrap();
+
+    assert!(
+        csa_session::read_section(tmp.path(), "summary")
+            .unwrap()
+            .is_none()
+    );
+    let full = csa_session::read_section(tmp.path(), "full")
+        .unwrap()
+        .unwrap();
+    let persisted_report = load_structured_post_exec_gate_report(tmp.path()).unwrap();
+    let content = build_gate_aware_summary_content(
+        &persisted_report,
+        gate_summary_employee_section("full", &full),
+    );
+
+    assert!(content.starts_with(csa_session::GATE_SUMMARY_LEAD));
+    assert!(!content.contains("Superseded employee self-report (full):"));
+    assert!(!content.contains("raw full transcript line 1"));
+    assert!(!content.contains("raw full transcript line 21"));
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1035"
-weave = "0.1.1035"
+csa = "0.1.1037"
+weave = "0.1.1037"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Preserve authoritative post-exec gate failure metadata in `csa session result` summary/full/JSON paths.
- Keep employee self-report text subordinate when a post-exec gate supersedes it.
- Preserve bounded `--summary` behavior for full-only fallback sections to avoid raw full-output token blowups.
- Add regression coverage for gate-failed sessions whose worker text claims success.

## Verification
- Hook-enabled pre-commit passed on commit/amend.
- CSA implementation session: `01KVKJ9EXF2J4SG3E0G5311HAS`.
- Review fix-finding session: `01KVKPBEJ1W19HD05CRWVZ3CEZ`.
- Exact-head CSA-Codex review PASS: `01KVKR0HA8TPS15Q31WA2S9TH7`.
- `csa review --check-verdict --sa-mode true --range main...HEAD` passed.

Closes #2311
