### PR TITLE
fix(codex): surface usage-limit cooldown in summaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1038"
+version = "0.1.1039"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1038"
+version = "0.1.1039"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -102,6 +102,7 @@ mod session_guard;
 mod session_kill_diagnostics;
 mod session_observability;
 mod session_outcome;
+mod session_provider_quota;
 mod session_result_publish;
 mod session_resume_handoff;
 mod session_summary_text;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -106,6 +106,8 @@ pub(crate) fn render_wait_result_summary(
     session_id: &str,
     result: &csa_session::SessionResult,
 ) -> String {
+    let provider_quota =
+        crate::session_provider_quota::provider_quota_display_for_result(session_dir, result);
     let mut lines = vec![
         format!("Session: {session_id}"),
         format!("Status: {}", result.status),
@@ -160,8 +162,15 @@ pub(crate) fn render_wait_result_summary(
         ));
     }
 
-    if let Some(summary) = wait_display_summary(session_dir, result) {
+    let display_summary = wait_display_summary(session_dir, result, provider_quota.as_ref());
+    let used_provider_quota = provider_quota
+        .as_ref()
+        .is_some_and(|quota| display_summary.as_deref() == Some(quota.summary.as_str()));
+    if let Some(summary) = display_summary {
         lines.push(format!("Summary: {summary}"));
+    }
+    if let (true, Some(provider_quota)) = (used_provider_quota, provider_quota.as_ref()) {
+        lines.push(format!("Hint: {}", provider_quota.hint));
     }
 
     lines.join("\n")
@@ -215,6 +224,8 @@ fn render_wait_result_json(
     session_id: &str,
     result: &csa_session::SessionResult,
 ) -> Result<String> {
+    let provider_quota =
+        crate::session_provider_quota::provider_quota_display_for_result(session_dir, result);
     let tokens = extract_wait_token_summary(result).map(|usage| {
         serde_json::json!({
             "input_tokens": usage.input_tokens,
@@ -242,17 +253,27 @@ fn render_wait_result_json(
         "post_exec_gate": result.post_exec_gate.as_ref(),
         "large_diff_warning": result.large_diff_warning.as_ref(),
         "warnings": result.warnings,
-        "summary": wait_display_summary(session_dir, result),
+        "summary": wait_display_summary(session_dir, result, provider_quota.as_ref()),
+        "provider_quota_hint": provider_quota.as_ref().map(|quota| quota.hint.as_str()),
     });
     serde_json::to_string_pretty(&value).map_err(Into::into)
 }
 
-fn wait_display_summary(session_dir: &Path, result: &csa_session::SessionResult) -> Option<String> {
+fn wait_display_summary(
+    session_dir: &Path,
+    result: &csa_session::SessionResult,
+    provider_quota: Option<&crate::session_provider_quota::ProviderQuotaDisplay>,
+) -> Option<String> {
     if let Some(report) = result.post_exec_gate.as_ref() {
         return compact_wait_summary_text(&csa_session::post_exec_gate_failure_summary(report));
     }
-    crate::session_summary_text::human_session_summary(session_dir, &result.summary)
-        .and_then(|text| compact_wait_summary_text(&text))
+    if let Some(text) =
+        crate::session_summary_text::human_session_summary(session_dir, &result.summary)
+            .and_then(|text| compact_wait_summary_text(&text))
+    {
+        return Some(text);
+    }
+    provider_quota.and_then(|quota| compact_wait_summary_text(&quota.summary))
 }
 
 fn wait_result_tool_label(result: &csa_session::SessionResult) -> String {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_provider_quota_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_provider_quota_tests.rs
@@ -1,0 +1,49 @@
+use chrono::Utc;
+
+use super::render_wait_result_summary;
+
+#[test]
+fn compact_summary_surfaces_codex_usage_limit_cooldown_from_bounded_output() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let api_field = concat!("api", "_", "key");
+    let fake_value = concat!("sk", "-", "sec", "...", "6789");
+    std::fs::write(
+        temp.path().join("output.log"),
+        format!(
+            "noise before provider output\n\
+             You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage \
+             to purchase more credits or try again at Jun 24th, 2026 3:39 PM. \
+             {api_field}={fake_value}\n\
+             raw transcript line that should not be echoed\n"
+        ),
+    )
+    .expect("output log should be written");
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        post_exec_gate: None,
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: r#"{"type":"turn.failed","error":"provider_error"}"#.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(4),
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITCODEXQUOTA", &result);
+
+    assert!(summary.contains("Summary: provider quota exhausted: Codex usage limit hit"));
+    assert!(summary.contains("retry_after=try again at Jun 24th, 2026 3:39 PM"));
+    assert!(summary.contains("Hint: do not retry CSA-Codex sessions until cooldown expires"));
+    assert!(!summary.contains(fake_value));
+    assert!(!summary.contains("raw transcript line"));
+    assert!(
+        summary.len() <= 2048,
+        "wait summary should stay bounded: {summary}"
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -7,6 +7,8 @@ use super::{
 
 #[path = "session_cmds_daemon_wait_summary_kill_tests.rs"]
 mod kill_diagnostics;
+#[path = "session_cmds_daemon_wait_summary_provider_quota_tests.rs"]
+mod provider_quota;
 #[path = "session_cmds_daemon_wait_summary_recovery_tests.rs"]
 mod recovery;
 #[path = "session_cmds_daemon_wait_summary_unavailable_tests.rs"]

--- a/crates/cli-sub-agent/src/session_cmds_result_display.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_display.rs
@@ -38,6 +38,8 @@ pub(super) fn display_result_text(
     token_usage: Option<&TokenUsage>,
 ) {
     let envelope = &result.envelope;
+    let provider_quota =
+        crate::session_provider_quota::provider_quota_display_for_result(session_dir, envelope);
     println!("Session: {session_id}");
     println!("Status:  {}", envelope.status);
     println!("Exit:    {}", envelope.exit_code);
@@ -50,8 +52,15 @@ pub(super) fn display_result_text(
             csa_session::post_exec_gate_failure_label(report)
         );
     }
-    if let Some(summary) = result_display_summary(session_dir, envelope) {
+    let display_summary = result_display_summary(session_dir, envelope, provider_quota.as_ref());
+    let used_provider_quota = provider_quota
+        .as_ref()
+        .is_some_and(|quota| display_summary.as_deref() == Some(quota.summary.as_str()));
+    if let Some(summary) = display_summary {
         println!("Summary: {summary}");
+    }
+    if let (true, Some(provider_quota)) = (used_provider_quota, provider_quota.as_ref()) {
+        println!("Hint: {}", provider_quota.hint);
     }
     if let Some(reason) =
         crate::session_unavailable_reason::review_unavailable_reason_label(session_dir)
@@ -230,12 +239,19 @@ pub(super) fn build_result_json_payload(
 fn result_display_summary(
     session_dir: &Path,
     envelope: &csa_session::SessionResult,
+    provider_quota: Option<&crate::session_provider_quota::ProviderQuotaDisplay>,
 ) -> Option<String> {
     if let Some(report) = envelope.post_exec_gate.as_ref() {
         return Some(csa_session::post_exec_gate_failure_summary(report));
     }
-    crate::session_summary_text::human_session_summary(session_dir, &envelope.summary)
-        .map(|summary| crate::session_summary_text::enrich_review_summary(session_dir, &summary))
+    if let Some(summary) =
+        crate::session_summary_text::human_session_summary(session_dir, &envelope.summary).map(
+            |summary| crate::session_summary_text::enrich_review_summary(session_dir, &summary),
+        )
+    {
+        return Some(summary);
+    }
+    provider_quota.map(|quota| quota.summary.clone())
 }
 
 fn format_kill_diagnostics(diagnostics: &csa_session::KillDiagnosticReport) -> String {
@@ -332,6 +348,8 @@ pub(super) fn display_summary_section(
     let unavailable_reason =
         crate::session_unavailable_reason::review_unavailable_reason_label(session_dir);
     let post_exec_gate = load_structured_post_exec_gate_report(session_dir);
+    let provider_quota =
+        crate::session_provider_quota::provider_quota_display_for_session_dir(session_dir);
     let (section_id, content) = match csa_session::read_section(session_dir, "summary")? {
         Some(content) => ("summary", content),
         None => match csa_session::read_section(session_dir, "full")? {
@@ -339,6 +357,13 @@ pub(super) fn display_summary_section(
             None => {
                 if let Some(report) = post_exec_gate.as_ref() {
                     return display_gate_summary_override(report, None, unavailable_reason, json);
+                }
+                if let Some(provider_quota) = provider_quota.as_ref() {
+                    return display_provider_quota_summary(
+                        provider_quota,
+                        unavailable_reason,
+                        json,
+                    );
                 }
                 return display_summary_fallback(session_dir, session_id, json);
             }
@@ -355,6 +380,9 @@ pub(super) fn display_summary_section(
     }
 
     if json {
+        if let (true, Some(provider_quota)) = (section_id == "full", provider_quota.as_ref()) {
+            return display_provider_quota_summary(provider_quota, unavailable_reason, json);
+        }
         let payload = serde_json::json!({
             "section": section_id,
             "content": content,
@@ -363,6 +391,9 @@ pub(super) fn display_summary_section(
         });
         println!("{}", serde_json::to_string_pretty(&payload)?);
     } else if section_id == "full" {
+        if let Some(provider_quota) = provider_quota.as_ref() {
+            return display_provider_quota_summary(provider_quota, unavailable_reason, json);
+        }
         print_truncated_content(&content, FALLBACK_LINES);
         print_unavailable_reason(unavailable_reason.as_deref());
     } else {
@@ -392,9 +423,36 @@ fn display_gate_summary_override(
     Ok(())
 }
 
+fn display_provider_quota_summary(
+    provider_quota: &crate::session_provider_quota::ProviderQuotaDisplay,
+    unavailable_reason: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let content = format!("{}\nHint: {}", provider_quota.summary, provider_quota.hint);
+    if json {
+        let payload = serde_json::json!({
+            "section": "summary",
+            "source": "provider_quota",
+            "content": content,
+            "tokens": csa_session::estimate_tokens(&provider_quota.summary),
+            "unavailable_reason": unavailable_reason,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        println!("{content}");
+        print_unavailable_reason(unavailable_reason.as_deref());
+    }
+    Ok(())
+}
+
 fn display_summary_fallback(session_dir: &Path, session_id: &str, json: bool) -> Result<()> {
     let unavailable_reason =
         crate::session_unavailable_reason::review_unavailable_reason_label(session_dir);
+    if let Some(provider_quota) =
+        crate::session_provider_quota::provider_quota_display_for_session_dir(session_dir)
+    {
+        return display_provider_quota_summary(&provider_quota, unavailable_reason, json);
+    }
     let output_log = session_dir.join("output.log");
     if output_log.is_file() {
         let content = fs::read_to_string(&output_log)?;

--- a/crates/cli-sub-agent/src/session_provider_quota.rs
+++ b/crates/cli-sub-agent/src/session_provider_quota.rs
@@ -1,0 +1,334 @@
+use std::fs;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+const PROVIDER_QUOTA_SCAN_MAX_BYTES: u64 = 64 * 1024;
+const PROVIDER_QUOTA_DETAIL_MAX_CHARS: usize = 220;
+const PROVIDER_QUOTA_RETRY_MAX_CHARS: usize = 160;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProviderQuotaDisplay {
+    pub(crate) summary: String,
+    pub(crate) hint: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProviderQuotaCandidate {
+    score: u32,
+    tool: Option<String>,
+    retry_after: Option<String>,
+    detail: String,
+}
+
+pub(crate) fn provider_quota_display_for_result(
+    session_dir: &Path,
+    result: &csa_session::SessionResult,
+) -> Option<ProviderQuotaDisplay> {
+    if result.status.eq_ignore_ascii_case("success") || result.exit_code == 0 {
+        return None;
+    }
+    provider_quota_display(
+        session_dir,
+        Some(result.tool.as_str()),
+        Some(result.summary.as_str()),
+    )
+}
+
+pub(crate) fn provider_quota_display_for_session_dir(
+    session_dir: &Path,
+) -> Option<ProviderQuotaDisplay> {
+    let result = read_result_summary_from_dir(session_dir);
+    if result.as_ref().is_some_and(|result| {
+        result.status.eq_ignore_ascii_case("success") || result.exit_code == 0
+    }) {
+        return None;
+    }
+    provider_quota_display(
+        session_dir,
+        result.as_ref().map(|result| result.tool.as_str()),
+        result.as_ref().map(|result| result.summary.as_str()),
+    )
+}
+
+fn provider_quota_display(
+    session_dir: &Path,
+    tool: Option<&str>,
+    raw_summary: Option<&str>,
+) -> Option<ProviderQuotaDisplay> {
+    let mut candidates = Vec::new();
+    if let Some(candidate) = raw_summary.and_then(|summary| provider_quota_candidate(summary, tool))
+    {
+        candidates.push(candidate);
+    }
+
+    for path in provider_quota_scan_paths(session_dir) {
+        let Some(text) = read_bounded_tail(&path) else {
+            continue;
+        };
+        if let Some(candidate) = provider_quota_candidate(&text, tool) {
+            candidates.push(candidate);
+        }
+    }
+
+    let candidate = candidates
+        .into_iter()
+        .max_by_key(|candidate| candidate.score)?;
+    let tool_label = candidate
+        .tool
+        .as_deref()
+        .or(tool)
+        .map(provider_tool_label)
+        .unwrap_or("provider");
+    let issue = if tool_label == "Codex"
+        && candidate
+            .detail
+            .to_ascii_lowercase()
+            .contains("usage limit")
+    {
+        "Codex usage limit hit".to_string()
+    } else {
+        format!("{tool_label} quota/rate limit hit")
+    };
+    let mut summary = format!("provider quota exhausted: {issue}");
+    if let Some(retry_after) = candidate.retry_after.as_deref() {
+        summary.push_str("; retry_after=");
+        summary.push_str(retry_after);
+    } else if !candidate.detail.is_empty() {
+        summary.push_str("; detail=");
+        summary.push_str(&candidate.detail);
+    }
+
+    Some(ProviderQuotaDisplay {
+        summary,
+        hint: provider_quota_hint(tool_label).to_string(),
+    })
+}
+
+fn read_result_summary_from_dir(session_dir: &Path) -> Option<csa_session::SessionResult> {
+    let raw = fs::read_to_string(session_dir.join(csa_session::result::RESULT_FILE_NAME)).ok()?;
+    toml::from_str::<csa_session::SessionResult>(&raw).ok()
+}
+
+fn provider_quota_scan_paths(session_dir: &Path) -> Vec<PathBuf> {
+    [
+        session_dir.join("stderr.log"),
+        session_dir.join("stdout.log"),
+        session_dir.join("output.log"),
+        session_dir.join("output").join("full.md"),
+        session_dir.join("output").join("acp-events.jsonl"),
+    ]
+    .into_iter()
+    .collect()
+}
+
+fn read_bounded_tail(path: &Path) -> Option<String> {
+    let mut file = fs::File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    let start = len.saturating_sub(PROVIDER_QUOTA_SCAN_MAX_BYTES);
+    file.seek(SeekFrom::Start(start)).ok()?;
+    let mut buf = Vec::new();
+    file.take(PROVIDER_QUOTA_SCAN_MAX_BYTES)
+        .read_to_end(&mut buf)
+        .ok()?;
+    if buf.is_empty() {
+        return None;
+    }
+    let mut text = String::from_utf8_lossy(&buf).into_owned();
+    if let Some(newline) = (start > 0).then(|| text.find('\n')).flatten() {
+        text = text[newline + 1..].to_string();
+    }
+    Some(text)
+}
+
+fn provider_quota_candidate(text: &str, tool: Option<&str>) -> Option<ProviderQuotaCandidate> {
+    let score = provider_quota_score(text)?;
+    let detail = provider_quota_detail(text)?;
+    let retry_after = retry_after_snippet(&detail).or_else(|| retry_after_snippet(text));
+    let inferred_tool = infer_provider_tool(text).or_else(|| tool.map(ToOwned::to_owned));
+    Some(ProviderQuotaCandidate {
+        score,
+        tool: inferred_tool,
+        retry_after,
+        detail: clip_chars(
+            &compact_visible_text(&csa_session::redact_text_content(&detail)),
+            PROVIDER_QUOTA_DETAIL_MAX_CHARS,
+        ),
+    })
+}
+
+fn provider_quota_score(text: &str) -> Option<u32> {
+    let lower = text.to_ascii_lowercase();
+    let mut score = 0_u32;
+    for (needle, weight) in [
+        ("you've hit your usage limit", 30),
+        ("you have hit your usage limit", 30),
+        ("usage_limit_exceeded", 24),
+        ("usage limit", 20),
+        ("monthly usage", 16),
+        ("quota_exhausted", 14),
+        ("quota exhausted", 14),
+        ("quota exceeded", 12),
+        ("rate_limit_exceeded", 10),
+        ("rate limit", 9),
+        ("too many requests", 8),
+        ("http 429", 8),
+        ("status 429", 8),
+        ("429", 4),
+    ] {
+        if lower.contains(needle) {
+            score = score.saturating_add(weight);
+        }
+    }
+    for (needle, weight) in [
+        ("try again at", 8),
+        ("try again", 5),
+        ("retry after", 5),
+        ("reset", 4),
+        ("purchase", 2),
+        ("credit", 2),
+        ("billing", 2),
+    ] {
+        if lower.contains(needle) {
+            score = score.saturating_add(weight);
+        }
+    }
+    (score >= 8).then_some(score)
+}
+
+fn provider_quota_detail(text: &str) -> Option<String> {
+    let lower = text.to_ascii_lowercase();
+    let signal_index = [
+        "you've hit your usage limit",
+        "you have hit your usage limit",
+        "usage_limit_exceeded",
+        "usage limit",
+        "monthly usage",
+        "quota_exhausted",
+        "quota exhausted",
+        "quota exceeded",
+        "rate_limit_exceeded",
+        "rate limit",
+        "too many requests",
+        "http 429",
+        "status 429",
+        "429",
+    ]
+    .into_iter()
+    .filter_map(|needle| lower.find(needle))
+    .min()?;
+    let start = previous_detail_boundary(text, signal_index);
+    let tail = text
+        .get(start..)?
+        .trim_start_matches([' ', '\t', '\r', '\n', ',', ';']);
+    Some(tail.to_string())
+}
+
+fn retry_after_snippet(text: &str) -> Option<String> {
+    let lower = text.to_ascii_lowercase();
+    for marker in [
+        "try again at",
+        "retry after",
+        "quota will reset",
+        "reset at",
+    ] {
+        let Some(index) = lower.find(marker) else {
+            continue;
+        };
+        let snippet = text.get(index..)?;
+        let end = snippet_end(snippet);
+        let compact = compact_visible_text(&csa_session::redact_text_content(&snippet[..end]));
+        if !compact.is_empty() {
+            return Some(clip_chars(&compact, PROVIDER_QUOTA_RETRY_MAX_CHARS));
+        }
+    }
+    None
+}
+
+fn previous_detail_boundary(text: &str, before: usize) -> usize {
+    let Some(prefix) = text.get(..before) else {
+        return 0;
+    };
+    prefix
+        .char_indices()
+        .rev()
+        .find_map(|(idx, ch)| matches!(ch, '\n' | '\r' | ';').then_some(idx + ch.len_utf8()))
+        .unwrap_or(0)
+}
+
+fn snippet_end(text: &str) -> usize {
+    for (idx, ch) in text.char_indices() {
+        if matches!(ch, '\n' | '\r' | ';') {
+            return idx;
+        }
+        if ch == '.' {
+            let after = idx + ch.len_utf8();
+            if text[after..].starts_with(' ') || after == text.len() {
+                return after;
+            }
+        }
+    }
+    text.len()
+}
+
+fn compact_visible_text(text: &str) -> String {
+    let mut compact = String::with_capacity(text.len().min(PROVIDER_QUOTA_DETAIL_MAX_CHARS));
+    let mut last_was_space = false;
+    for ch in text.chars() {
+        if ch.is_whitespace() || ch.is_control() {
+            if !last_was_space {
+                compact.push(' ');
+                last_was_space = true;
+            }
+            continue;
+        }
+        compact.push(ch);
+        last_was_space = false;
+    }
+    compact.trim().to_string()
+}
+
+fn clip_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let keep = max_chars.saturating_sub(3);
+    let mut clipped = text.chars().take(keep).collect::<String>();
+    clipped = clipped.trim_end().to_string();
+    clipped.push_str("...");
+    clipped
+}
+
+fn infer_provider_tool(text: &str) -> Option<String> {
+    let lower = text.to_ascii_lowercase();
+    if lower.contains("codex") || lower.contains("chatgpt.com/codex") {
+        return Some("codex".to_string());
+    }
+    if lower.contains("gemini") {
+        return Some("gemini-cli".to_string());
+    }
+    None
+}
+
+fn provider_tool_label(tool: &str) -> &'static str {
+    match tool {
+        "codex" => "Codex",
+        "gemini-cli" | "antigravity-cli" => "Gemini",
+        "claude-code" => "Claude Code",
+        "opencode" => "OpenCode",
+        _ => "provider",
+    }
+}
+
+fn provider_quota_hint(tool_label: &str) -> &'static str {
+    match tool_label {
+        "Codex" => {
+            "do not retry CSA-Codex sessions until cooldown expires unless using a different configured provider."
+        }
+        "Gemini" => {
+            "do not retry Gemini-backed sessions until quota resets unless using a different configured provider."
+        }
+        _ => {
+            "do not retry this provider until quota/cooldown clears unless using a different configured provider."
+        }
+    }
+}

--- a/crates/cli-sub-agent/tests/session_summary_visibility.rs
+++ b/crates/cli-sub-agent/tests/session_summary_visibility.rs
@@ -85,6 +85,10 @@ fn scrub_inherited_csa_env(cmd: &mut Command) {
 }
 
 fn write_pre_exec_failure_result(session_dir: &Path) {
+    write_failure_result(session_dir, PRE_EXEC_SUMMARY);
+}
+
+fn write_failure_result(session_dir: &Path, summary: &str) {
     std::fs::create_dir_all(session_dir.join("output")).expect("create empty output dir");
     std::fs::write(session_dir.join("stdout.log"), "").expect("write empty stdout log");
     std::fs::write(
@@ -92,7 +96,7 @@ fn write_pre_exec_failure_result(session_dir: &Path) {
         format!(
             r#"status = "failure"
 exit_code = 1
-summary = "{PRE_EXEC_SUMMARY}"
+summary = {summary:?}
 tool = "codex"
 started_at = "2026-04-27T00:00:00Z"
 completed_at = "2026-04-27T00:00:01Z"
@@ -136,6 +140,32 @@ fn create_empty_output_failure_session(
     write_pre_exec_failure_result(&session_dir);
 
     (project, session_id, session_dir)
+}
+
+fn create_codex_usage_limit_failure_session(
+    tmp: &Path,
+    name: &str,
+) -> (std::path::PathBuf, String, std::path::PathBuf, String) {
+    let (project, session_id, session_dir) = create_empty_output_failure_session(tmp, name);
+    write_failure_result(
+        &session_dir,
+        r#"{"type":"turn.failed","error":"provider_error"}"#,
+    );
+    let api_field = concat!("api", "_", "key");
+    let fake_value = concat!("sk", "-", "sec", "...", "6789").to_string();
+    std::fs::write(
+        session_dir.join("output.log"),
+        format!(
+            "provider prelude that must stay hidden\n\
+             You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage \
+             to purchase more credits or try again at Jun 24th, 2026 3:39 PM. \
+             {api_field}={fake_value}\n\
+             provider epilogue that must stay hidden\n"
+        ),
+    )
+    .expect("write output log");
+
+    (project, session_id, session_dir, fake_value)
 }
 
 fn assert_subcommand_surfaces_summary_for_session(
@@ -314,6 +344,44 @@ fn session_result_summary_json_surfaces_provider_usage_limit_reason_without_outp
     assert!(reason.contains("try again at Jun 20th, 2026 6:48 PM"));
     assert!(!reason.contains(concat!("sk", "-", "sec", "...", "6789")));
     assert!(reason.contains("[REDACTED]"));
+}
+
+#[test]
+#[serial]
+fn session_result_summary_surfaces_codex_usage_limit_from_bounded_output() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (project, session_id, _, fake_value) = create_codex_usage_limit_failure_session(
+        tmp.path(),
+        "result-summary-codex-usage-limit-output",
+    );
+
+    let output = csa_cmd(tmp.path())
+        .args([
+            "session",
+            "result",
+            "--summary",
+            "--session",
+            &session_id,
+            "--cd",
+            project.to_str().expect("project path utf8"),
+        ])
+        .current_dir(&project)
+        .output()
+        .expect("run csa session result --summary");
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("provider quota exhausted: Codex usage limit hit"));
+    assert!(stdout.contains("retry_after=try again at Jun 24th, 2026 3:39 PM"));
+    assert!(stdout.contains("Hint: do not retry CSA-Codex sessions until cooldown expires"));
+    assert!(!stdout.contains(&fake_value));
+    assert!(!stdout.contains("provider prelude"));
+    assert!(!stdout.contains("provider epilogue"));
+    assert!(
+        stdout.len() <= 700,
+        "summary output should stay compact, got {} bytes: {stdout}",
+        stdout.len()
+    );
 }
 
 #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1038"
-weave = "0.1.1038"
+csa = "0.1.1039"
+weave = "0.1.1039"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Detect bounded Codex/ChatGPT usage-limit provider errors from session artifacts.
- Surface provider quota/cooldown summaries in `csa session wait` and `csa session result --summary` without dumping raw transcripts.
- Add synthetic regression coverage for wait and result summary visibility.

## Verification
- `cargo test -p cli-sub-agent --bin csa compact_summary_surfaces_codex_usage_limit_cooldown_from_bounded_output --all-features`
- `cargo test -p cli-sub-agent --test session_summary_visibility session_result_summary_surfaces_codex_usage_limit_from_bounded_output --all-features`
- Hook-enabled commit passed lefthook pre-commit, including quality gates.
- Exact-head review PASS: `01KVMQ76287WB25AE5VH2ZJFKN`
- `target/debug/csa review --check-verdict --sa-mode true --range main...HEAD`

Closes #2322.
