### PR TITLE
fix(session): persist pre-exec admission results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1039"
+version = "0.1.1040"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1039"
+version = "0.1.1040"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_failure.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure.rs
@@ -231,9 +231,13 @@ pub(crate) fn persist_plan_failure_output(
 }
 
 pub(crate) fn report_from_error(error: Option<&anyhow::Error>) -> Option<PlanFailureReport> {
-    error
-        .and_then(|err| err.downcast_ref::<PlanFailureError>())
+    let err = error?;
+    err.downcast_ref::<PlanFailureError>()
         .map(|err| err.report().clone())
+        .or_else(|| {
+            err.downcast_ref::<Box<PlanFailureError>>()
+                .map(|err| err.report().clone())
+        })
 }
 
 pub(crate) fn persist_report_for_session(

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -71,8 +71,9 @@ fn exact_test_project_config_with_enabled_tools(tools: &[&str]) -> csa_config::P
         schema_version: 1,
         project: csa_config::ProjectMeta::default(),
         resources: csa_config::ResourcesConfig {
-            memory_max_mb: Some(1024),
+            memory_max_mb: Some(if tools.contains(&"codex") { 8192 } else { 1024 }),
             min_free_memory_mb: 1,
+            soft_limit_percent: tools.contains(&"codex").then_some(100),
             ..Default::default()
         },
         acp: Default::default(),

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_1958_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_1958_tests.rs
@@ -11,8 +11,8 @@ use csa_core::types::ToolName;
 
 fn config_with_review_tier(enabled_tools: &[&str], models: &[&str]) -> csa_config::ProjectConfig {
     let mut config = project_config_with_enabled_tools(enabled_tools);
-    for tool_config in config.tools.values_mut() {
-        tool_config.memory_max_mb = Some(256);
+    for (n, c) in config.tools.iter_mut() {
+        c.memory_max_mb = (n != "codex").then_some(256);
     }
     if enabled_tools.contains(&"codex") {
         config.tools.get_mut("codex").unwrap().transport = Some(csa_config::TransportKind::Cli);

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
@@ -10,8 +10,8 @@ use csa_session::{ReviewVerdictArtifact, state::ReviewSessionMeta};
 
 fn config_with_review_tier(enabled_tools: &[&str], models: &[&str]) -> csa_config::ProjectConfig {
     let mut config = project_config_with_enabled_tools(enabled_tools);
-    for tool_config in config.tools.values_mut() {
-        tool_config.memory_max_mb = Some(256);
+    for (n, c) in config.tools.iter_mut() {
+        c.memory_max_mb = (n != "codex").then_some(256);
     }
     if enabled_tools.contains(&"codex") {
         config.tools.get_mut("codex").unwrap().transport = Some(csa_config::TransportKind::Cli);

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -101,7 +101,22 @@ fn current_round_review_prose_contents(
 }
 
 fn content_has_blocking_review_outcome(content: &str) -> bool {
+    if has_clean_verdict_prefix(content) && !detect_prose_fail_conclusion(content) {
+        return false;
+    }
     contains_blocking_issue_signal(content) || detect_prose_fail_conclusion(content)
+}
+
+fn has_clean_verdict_prefix(content: &str) -> bool {
+    content.lines().any(|line| {
+        let trimmed = line.trim_start();
+        ["PASS", "CLEAN"].iter().any(|token| {
+            trimmed
+                .strip_prefix(token)
+                .and_then(|rest| rest.chars().next())
+                .is_some_and(|ch| !ch.is_ascii_alphanumeric() && ch != '_')
+        })
+    })
 }
 
 fn push_review_content(contents: &mut Vec<(String, String)>, section_id: &str, content: String) {

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -44,12 +44,14 @@ pub(crate) fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig
         );
     }
 
+    let includes_codex = tools.iter().any(|tool| *tool == "codex");
     ProjectConfig {
         schema_version: 1,
         project: ProjectMeta::default(),
         resources: ResourcesConfig {
-            memory_max_mb: Some(1024),
+            memory_max_mb: Some(if includes_codex { 8192 } else { 1024 }),
             min_free_memory_mb: 1,
+            soft_limit_percent: includes_codex.then_some(100),
             ..Default::default()
         },
         acp: Default::default(),

--- a/crates/cli-sub-agent/src/session_cmds_result_display.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_display.rs
@@ -9,6 +9,8 @@ use crate::token_usage_display::{display_total_tokens, token_usage_json_value};
 
 #[path = "session_cmds_result_post_exec_gate.rs"]
 mod post_exec_gate;
+#[path = "session_cmds_result_pre_exec_summary.rs"]
+mod pre_exec_summary;
 pub(super) use post_exec_gate::{
     build_all_sections_json_payload, build_gate_aware_summary_content,
     build_summary_section_json_payload, gate_summary_employee_section,
@@ -473,7 +475,7 @@ fn display_summary_fallback(session_dir: &Path, session_id: &str, json: bool) ->
             return Ok(());
         }
     }
-    if let Some(reason) = unavailable_reason {
+    if let Some(reason) = unavailable_reason.as_deref() {
         if json {
             let payload = serde_json::json!({
                 "section": "summary",
@@ -482,8 +484,11 @@ fn display_summary_fallback(session_dir: &Path, session_id: &str, json: bool) ->
             });
             println!("{}", serde_json::to_string_pretty(&payload)?);
         } else {
-            print_unavailable_reason(Some(&reason));
+            print_unavailable_reason(Some(reason));
         }
+        return Ok(());
+    }
+    if pre_exec_summary::display_if_present(session_dir, unavailable_reason.as_deref(), json)? {
         return Ok(());
     }
     eprintln!("No output found for session '{session_id}'");

--- a/crates/cli-sub-agent/src/session_cmds_result_pre_exec_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_pre_exec_summary.rs
@@ -1,0 +1,54 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+
+pub(super) fn display_if_present(
+    session_dir: &Path,
+    unavailable_reason: Option<&str>,
+    json: bool,
+) -> Result<bool> {
+    let Some(summary) = read_pre_exec_result_summary(session_dir) else {
+        return Ok(false);
+    };
+
+    if json {
+        let payload = serde_json::json!({
+            "section": "summary",
+            "source": "result.toml",
+            "content": summary,
+            "tokens": csa_session::estimate_tokens(&summary),
+            "unavailable_reason": unavailable_reason,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        println!("{summary}");
+        if let Some(reason) = unavailable_reason {
+            println!("Unavailable reason: {reason}");
+        }
+    }
+    Ok(true)
+}
+
+fn read_pre_exec_result_summary(session_dir: &Path) -> Option<String> {
+    let raw = fs::read_to_string(session_dir.join(csa_session::result::RESULT_FILE_NAME)).ok()?;
+    let result: csa_session::SessionResult = toml::from_str(&raw).ok()?;
+    let summary = crate::session_summary_text::human_session_summary(session_dir, &result.summary)?;
+    let summary = compact_summary_line(&summary)?;
+    summary.starts_with("pre-exec:").then_some(summary)
+}
+
+fn compact_summary_line(summary: &str) -> Option<String> {
+    let summary = summary.trim();
+    if summary.is_empty() {
+        return None;
+    }
+
+    const MAX_CHARS: usize = 500;
+    let mut compact = summary.replace(['\r', '\n'], " ");
+    if compact.chars().count() > MAX_CHARS {
+        compact = compact.chars().take(MAX_CHARS).collect::<String>();
+        compact.push_str("...");
+    }
+    Some(compact)
+}

--- a/crates/cli-sub-agent/tests/session_summary_visibility.rs
+++ b/crates/cli-sub-agent/tests/session_summary_visibility.rs
@@ -4,6 +4,20 @@ use std::process::Command;
 use serial_test::serial;
 
 const PRE_EXEC_SUMMARY: &str = "pre-exec: Direct --tool is blocked when tiers are configured.";
+const HOST_ADMISSION_SUMMARY: &str = "pre-exec: CSA: host memory admission denied \u{2014} \
+available=9929MB < required=15512MB (reserve=512MB + projected_spawn=15000MB). \
+active_sessions=0 sampled_sessions=0 active_session_rss_mb=0 active_session_projected_mb=0 \
+swap_available_mb=7204 combined_available_mb=17133. Free host memory, wait for active CSA \
+sessions to finish, or lower tool memory limits before spawning more work. For one csa run, \
+pass --memory-max-mb <MB> to lower projected_spawn or --min-free-memory-mb <MB> to lower the \
+reserve. Persistent config keys: resources.memory_max_mb, tools.<tool>.memory_max_mb, \
+resources.min_free_memory_mb.";
+const SOFT_LIMIT_ADMISSION_SUMMARY: &str = "pre-exec: CSA: memory_soft_limit_admission denied \
+-- codex writer soft memory threshold is 6300MB, below required=9000MB \
+(memory_max_mb=9000MB, soft_limit_percent=70). This writer session is likely to be terminated \
+by CSA's memory monitor after editing the worktree. Raise --memory-max-mb, \
+resources.memory_max_mb, or tools.codex.memory_max_mb to at least 12858MB, or raise \
+resources.soft_limit_percent only when host RAM makes that safe.";
 
 struct EnvVarGuard {
     key: &'static str,
@@ -203,6 +217,51 @@ fn assert_subcommand_surfaces_summary(subcommand: &str, session_name: &str) {
     assert_subcommand_surfaces_summary_for_session(tmp.path(), &project, subcommand, &session_id);
 }
 
+fn assert_session_result_summary_surfaces_pre_exec_result(
+    session_name: &str,
+    summary: &str,
+    expected_fragments: &[&str],
+) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (project, session_id, session_dir) =
+        create_empty_output_failure_session(tmp.path(), session_name);
+    write_failure_result(&session_dir, summary);
+
+    let output = csa_cmd(tmp.path())
+        .args([
+            "session",
+            "result",
+            "--summary",
+            "--session",
+            &session_id,
+            "--cd",
+            project.to_str().expect("project path utf8"),
+        ])
+        .current_dir(&project)
+        .output()
+        .expect("run csa session result --summary");
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+    for expected in expected_fragments {
+        assert!(
+            combined.contains(expected),
+            "session result summary should contain {expected:?}, got stdout={stdout} stderr={stderr}"
+        );
+    }
+    assert!(
+        !combined.contains("No output found"),
+        "session result summary should use result.toml instead of missing-output fallback, got stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        combined.len() <= 700,
+        "session result summary should stay bounded, got {} bytes: stdout={stdout} stderr={stderr}",
+        combined.len()
+    );
+}
+
 #[test]
 #[serial]
 fn session_wait_surfaces_result_summary_when_failure_output_is_empty() {
@@ -304,6 +363,36 @@ fn session_result_summary_surfaces_provider_usage_limit_reason() {
         stdout.len() <= 700,
         "summary output should stay compact, got {} bytes: {stdout}",
         stdout.len()
+    );
+}
+
+#[test]
+#[serial]
+fn session_result_summary_surfaces_pre_exec_host_admission_result() {
+    assert_session_result_summary_surfaces_pre_exec_result(
+        "result-summary-host-admission",
+        HOST_ADMISSION_SUMMARY,
+        &[
+            "pre-exec: CSA: host memory admission denied",
+            "Free host memory",
+            "--memory-max-mb <MB> to lower projected_spawn",
+            "--min-free-memory-mb <MB> to lower the reserve",
+        ],
+    );
+}
+
+#[test]
+#[serial]
+fn session_result_summary_surfaces_pre_exec_soft_limit_admission_result() {
+    assert_session_result_summary_surfaces_pre_exec_result(
+        "result-summary-soft-limit-admission",
+        SOFT_LIMIT_ADMISSION_SUMMARY,
+        &[
+            "pre-exec: CSA: memory_soft_limit_admission denied",
+            "codex writer soft memory threshold is 6300MB",
+            "tools.codex.memory_max_mb to at least 12858MB",
+            "resources.soft_limit_percent only when host RAM makes that safe",
+        ],
     );
 }
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1039"
-weave = "0.1.1039"
+csa = "0.1.1040"
+weave = "0.1.1040"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Persist bounded pre-exec admission summaries so `csa session result --summary` no longer reports only `No output found` for admission-denied sessions.
- Cover both host projected-spawn admission denial and `memory_soft_limit_admission` soft-threshold denial.
- Keep summaries bounded/actionable and classified as pre-exec infrastructure/no-verdict, without raw provider transcript exposure.

## Verification
- `git diff --check`
- `cargo build -p cli-sub-agent --bin csa`
- `cargo test -p cli-sub-agent --test session_summary_visibility session_result_summary_surfaces_pre_exec_host_admission_result --all-features -- --nocapture`
- `cargo test -p cli-sub-agent --test session_summary_visibility session_result_summary_surfaces_pre_exec_soft_limit_admission_result --all-features -- --nocapture`
- Native exact-head full-diff review fallback: PASS/CLEAN for `c5ee295042db856ace465be4b54d6db13f6b961e` on `main...HEAD`

## Review gate note
CSA exact-head review for `c5ee2950` could not launch because host memory admission denied the Codex reviewer. The exact-head `target/debug/csa session result --summary` returned the bounded `pre-exec:` artifact as intended by #2307.

Evidence:
- No-verdict/dogfood evidence: https://github.com/RyderFreeman4Logos/cli-sub-agent/issues/2307#issuecomment-4762099074
- Native fallback PASS evidence: https://github.com/RyderFreeman4Logos/cli-sub-agent/issues/2307#issuecomment-4762123131

Closes #2307
