### PR TITLE
fix(session): classify lost session registry lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1040"
+version = "0.1.1041"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1040"
+version = "0.1.1041"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -134,14 +134,20 @@ pub(crate) fn handle_session_wait_with_emitters(
         worktree_lock_root.as_deref(),
         &[resolved.session_id.as_str(), &wait_target.session_id],
     ) {
-        eprintln!(
-            "Session {} appears stale: {}",
-            wait_target.session_id, stale_err
-        );
-        eprintln!(
-            "Run `csa session result --session {}` for diagnostics.",
-            wait_target.session_id
-        );
+        if !crate::session_observability::emit_session_registry_state_loss_diagnostic(
+            effective_root,
+            &wait_target.session_id,
+            &wait_target.session_dir,
+        ) {
+            eprintln!(
+                "Session {} appears stale: {}",
+                wait_target.session_id, stale_err
+            );
+            eprintln!(
+                "Run `csa session result --session {}` for diagnostics.",
+                wait_target.session_id
+            );
+        }
         return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
     }
 

--- a/crates/cli-sub-agent/src/session_cmds_resolve.rs
+++ b/crates/cli-sub-agent/src/session_cmds_resolve.rs
@@ -138,7 +138,16 @@ pub(crate) fn resolve_session_prefix_with_global_fallback(
                     foreign_project_root,
                 });
             }
-            Err(project_err)
+            if !should_fallback_to_legacy(&project_err) {
+                return Err(project_err);
+            }
+            Err(anyhow::anyhow!(
+                "{}",
+                crate::session_observability::build_session_registry_lookup_miss_diagnostic(
+                    prefix,
+                    project_root,
+                )
+            ))
         }
     }
 }

--- a/crates/cli-sub-agent/src/session_cmds_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result.rs
@@ -18,7 +18,8 @@ mod display;
 mod tool_output;
 
 use display::{
-    display_result_json, display_result_text, display_structured_output, load_total_token_usage,
+    display_pre_exec_summary_if_present, display_result_json, display_result_text,
+    display_structured_output, load_total_token_usage,
 };
 
 #[derive(Debug, Clone)]
@@ -107,6 +108,26 @@ pub(crate) fn handle_session_result(
         .unwrap_or(&project_root);
     let is_cross_project = resolved.foreign_project_root.is_some();
 
+    let registry_state_loss = wrapper_session_dir.is_dir()
+        && csa_session::load_session(effective_root, &wrapper_id).is_err();
+    if registry_state_loss
+        && structured.summary
+        && display_pre_exec_summary_if_present(&wrapper_session_dir, json)?
+    {
+        return Ok(());
+    }
+
+    if registry_state_loss
+        && !registry_loss_display_artifact_exists(&wrapper_session_dir, &structured)?
+        && crate::session_observability::emit_session_registry_state_loss_diagnostic(
+            effective_root,
+            &wrapper_id,
+            &wrapper_session_dir,
+        )
+    {
+        return Ok(());
+    }
+
     let resume_target = csa_session::resolve_resume_target_from_dir(effective_root, &session_dir)?;
     let follows_resume_target = resume_target.is_some();
     if let Some(target) = resume_target {
@@ -152,7 +173,7 @@ pub(crate) fn handle_session_result(
         );
     }
 
-    let repaired_result = if is_cross_project {
+    let repaired_result = if is_cross_project || registry_state_loss {
         match crate::session_observability::refresh_and_repair_result_from_dir(&session_dir) {
             Ok(result) => result,
             Err(err) => {
@@ -280,6 +301,68 @@ pub(crate) fn handle_session_result(
         }
     }
     Ok(())
+}
+
+fn registry_loss_display_artifact_exists(
+    session_dir: &Path,
+    structured: &StructuredOutputOpts,
+) -> Result<bool> {
+    if session_dir
+        .join(csa_session::result::RESULT_FILE_NAME)
+        .is_file()
+    {
+        return Ok(true);
+    }
+
+    requested_structured_output_exists(session_dir, structured)
+}
+
+fn requested_structured_output_exists(
+    session_dir: &Path,
+    structured: &StructuredOutputOpts,
+) -> Result<bool> {
+    if !structured.is_active() {
+        return Ok(false);
+    }
+
+    let output_log = session_dir.join("output.log");
+    let output_log_non_empty = output_log
+        .metadata()
+        .is_ok_and(|metadata| metadata.len() > 0);
+
+    if structured.summary {
+        return Ok(output_index_has_section(session_dir, "summary")?
+            || output_index_has_section(session_dir, "full")?
+            || output_log_non_empty);
+    }
+
+    if let Some(section_id) = structured.section.as_deref() {
+        return output_index_has_section(session_dir, section_id);
+    }
+
+    if structured.full {
+        return Ok(output_index_has_any_section(session_dir)? || output_log_non_empty);
+    }
+
+    Ok(false)
+}
+
+fn output_index_has_section(session_dir: &Path, section_id: &str) -> Result<bool> {
+    Ok(
+        csa_session::load_output_index(session_dir)?.is_some_and(|index| {
+            index
+                .sections
+                .iter()
+                .any(|section| section.id == section_id)
+        }),
+    )
+}
+
+fn output_index_has_any_section(session_dir: &Path) -> Result<bool> {
+    Ok(
+        csa_session::load_output_index(session_dir)?
+            .is_some_and(|index| !index.sections.is_empty()),
+    )
 }
 
 fn load_review_meta(session_dir: &Path) -> Result<Option<ReviewSessionMeta>> {

--- a/crates/cli-sub-agent/src/session_cmds_result_display.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_display.rs
@@ -319,6 +319,13 @@ fn print_rendered_sidecar(rendered: &str, indent: usize) {
 
 const FALLBACK_LINES: usize = 20;
 
+/// Display a bounded pre-exec result artifact without falling back to raw logs.
+pub(super) fn display_pre_exec_summary_if_present(session_dir: &Path, json: bool) -> Result<bool> {
+    let unavailable_reason =
+        crate::session_unavailable_reason::review_unavailable_reason_label(session_dir);
+    pre_exec_summary::display_if_present(session_dir, unavailable_reason.as_deref(), json)
+}
+
 /// Display structured output sections based on the requested mode.
 pub(super) fn display_structured_output(
     session_dir: &Path,

--- a/crates/cli-sub-agent/src/session_observability.rs
+++ b/crates/cli-sub-agent/src/session_observability.rs
@@ -10,8 +10,13 @@ use tracing::debug;
 mod gate;
 #[path = "session_observability_legacy_review_pass.rs"]
 mod legacy_review_pass;
+#[path = "session_observability_registry.rs"]
+mod registry;
 #[path = "session_observability_review_verdict.rs"]
 mod review_verdict;
+pub(crate) use registry::{
+    build_session_registry_lookup_miss_diagnostic, emit_session_registry_state_loss_diagnostic,
+};
 
 const SUMMARY_MAX_CHARS: usize = 200;
 const REVIEW_SUMMARY_FAIL_TOKENS: &[&str] = &["FAIL", "HAS_ISSUES", "REJECT"];

--- a/crates/cli-sub-agent/src/session_observability_legacy_review_pass.rs
+++ b/crates/cli-sub-agent/src/session_observability_legacy_review_pass.rs
@@ -15,7 +15,18 @@ pub(super) fn recover_legacy_plain_pass_review_sidecars_from_dir(
     if review_sidecar_exists(session_dir) {
         return Ok(false);
     }
-    let Some(session) = read_session_state(session_dir)? else {
+    let session = match read_session_state(session_dir) {
+        Ok(session) => session,
+        Err(error) => {
+            tracing::debug!(
+                path = %session_dir.display(),
+                error = %error,
+                "skipping legacy review sidecar recovery because session state is unreadable"
+            );
+            None
+        }
+    };
+    let Some(session) = session else {
         return Ok(false);
     };
     let project_root = PathBuf::from(&session.project_path);

--- a/crates/cli-sub-agent/src/session_observability_registry.rs
+++ b/crates/cli-sub-agent/src/session_observability_registry.rs
@@ -1,0 +1,95 @@
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SessionRegistryStateIssue {
+    Missing,
+    Unreadable,
+    Corrupt,
+    Invalid,
+}
+
+impl SessionRegistryStateIssue {
+    fn description(&self) -> &'static str {
+        match self {
+            Self::Missing => "state.toml is missing",
+            Self::Unreadable => "state.toml is unreadable",
+            Self::Corrupt => "corrupt state.toml",
+            Self::Invalid => "state.toml is not a readable session registration",
+        }
+    }
+}
+
+pub(crate) fn classify_session_registry_state_loss(
+    project_root: &Path,
+    session_id: &str,
+    session_dir: &Path,
+) -> Option<SessionRegistryStateIssue> {
+    if !session_dir.is_dir() {
+        return None;
+    }
+    if csa_session::load_session(project_root, session_id).is_ok() {
+        return None;
+    }
+
+    let state_path = session_dir.join("state.toml");
+    if !state_path.exists() {
+        return Some(SessionRegistryStateIssue::Missing);
+    }
+
+    let contents = match fs::read_to_string(&state_path) {
+        Ok(contents) => contents,
+        Err(_) => return Some(SessionRegistryStateIssue::Unreadable),
+    };
+
+    if toml::from_str::<toml::Value>(&contents).is_err() {
+        Some(SessionRegistryStateIssue::Corrupt)
+    } else {
+        Some(SessionRegistryStateIssue::Invalid)
+    }
+}
+
+pub(crate) fn emit_session_registry_state_loss_diagnostic(
+    project_root: &Path,
+    session_id: &str,
+    session_dir: &Path,
+) -> bool {
+    let Some(issue) = classify_session_registry_state_loss(project_root, session_id, session_dir)
+    else {
+        return false;
+    };
+    eprintln!(
+        "{}",
+        build_session_registry_state_loss_diagnostic(session_id, &issue, project_root)
+    );
+    true
+}
+
+fn build_session_registry_state_loss_diagnostic(
+    session_id: &str,
+    issue: &SessionRegistryStateIssue,
+    project_root: &Path,
+) -> String {
+    let cd_arg = crate::daemon_caller_hints::format_cd_arg(project_root);
+    format!(
+        "session registry lookup failed for session '{session_id}': the session directory exists but {}. \
+         This is CSA infrastructure session-registry loss, not a product-code failure. \
+         Dirty or staged work may still be in the project worktree; inspect with `git status --short` and `git diff`. \
+         Captured output may still be discoverable via `csa session logs --session {session_id}{cd_arg}` \
+         or `csa session logs --session {session_id} --events{cd_arg}`.",
+        issue.description(),
+    )
+}
+
+pub(crate) fn build_session_registry_lookup_miss_diagnostic(
+    session_id: &str,
+    project_root: &Path,
+) -> String {
+    let cd_arg = crate::daemon_caller_hints::format_cd_arg(project_root);
+    format!(
+        "session registry lookup failed for session '{session_id}': no session registration was found in the current project, legacy state, or global exact lookup. \
+         If this id came from CSA:SESSION_STARTED, this is CSA infrastructure session-registry loss, not a product-code failure. \
+         Dirty or staged work may still be in the project worktree; inspect with `git status --short` and `git diff`. \
+         If captured output exists, try `csa session logs --session {session_id}{cd_arg}`."
+    )
+}

--- a/crates/cli-sub-agent/tests/session_registry_loss.rs
+++ b/crates/cli-sub-agent/tests/session_registry_loss.rs
@@ -1,0 +1,295 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn csa_cmd(tmp: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    scrub_inherited_csa_env(&mut cmd);
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
+    cmd
+}
+
+fn scrub_inherited_csa_env(cmd: &mut Command) {
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("CSA_") {
+            cmd.env_remove(key);
+        }
+    }
+}
+
+fn global_config_path(tmp: &Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        tmp.join("Library/Application Support/cli-sub-agent/config.toml")
+    } else {
+        tmp.join(".config/cli-sub-agent/config.toml")
+    }
+}
+
+fn session_dir_for(tmp: &Path, project: &Path, session_id: &str) -> PathBuf {
+    let canonical_project = project.canonicalize().expect("canonical project path");
+    let storage_key = canonical_project
+        .to_string_lossy()
+        .trim_start_matches('/')
+        .replace('/', std::path::MAIN_SEPARATOR_STR);
+    tmp.join(".local/state")
+        .join("cli-sub-agent")
+        .join(storage_key)
+        .join("sessions")
+        .join(session_id)
+}
+
+fn synthetic_registered_dir(tmp: &Path, project: &Path, session_id: &str) -> PathBuf {
+    let session_dir = session_dir_for(tmp, project, session_id);
+    std::fs::create_dir_all(session_dir.join("input")).expect("create synthetic input dir");
+    std::fs::create_dir_all(session_dir.join("output")).expect("create synthetic output dir");
+    session_dir
+}
+
+#[cfg(unix)]
+fn set_mtime_seconds_ago(path: &Path, seconds_ago: u64) {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before unix epoch");
+    let target = now.saturating_sub(std::time::Duration::from_secs(seconds_ago));
+    let times = [
+        libc::timespec {
+            tv_sec: target.as_secs() as libc::time_t,
+            tv_nsec: target.subsec_nanos() as libc::c_long,
+        },
+        libc::timespec {
+            tv_sec: target.as_secs() as libc::time_t,
+            tv_nsec: target.subsec_nanos() as libc::c_long,
+        },
+    ];
+    let c_path = CString::new(path.as_os_str().as_bytes()).expect("path contains NUL");
+    // SAFETY: `c_path` is a NUL-terminated path and `times` lives until the call returns.
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+    assert_eq!(rc, 0, "utimensat failed for {}", path.display());
+}
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn write_pre_exec_result(session_dir: &Path, summary: &str) {
+    std::fs::write(
+        session_dir.join("result.toml"),
+        format!(
+            r#"status = "failure"
+exit_code = 1
+summary = {summary:?}
+tool = "codex"
+started_at = "2026-04-27T00:00:00Z"
+completed_at = "2026-04-27T00:00:01Z"
+gate_timeout = false
+"#
+        ),
+    )
+    .expect("write result.toml");
+}
+
+fn assert_session_result_summary_prefers_result_toml_over_registry_loss(corrupt_state: bool) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project");
+    let session_id = csa_session::new_session_id();
+    let session_dir = synthetic_registered_dir(tmp.path(), &project, &session_id);
+    if corrupt_state {
+        std::fs::write(
+            session_dir.join("state.toml"),
+            "this is not valid toml {{{\n",
+        )
+        .expect("write corrupt state");
+    }
+    write_pre_exec_result(&session_dir, "pre-exec: host memory admission denied");
+
+    let output = csa_cmd(tmp.path())
+        .args([
+            "session",
+            "result",
+            "--session",
+            &session_id,
+            "--summary",
+            "--cd",
+            project.to_str().expect("utf-8 project path"),
+        ])
+        .output()
+        .expect("run csa session result --summary");
+
+    assert!(output.status.success(), "{}", output_text(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("pre-exec: host memory admission denied"),
+        "bounded result.toml summary should be printed first, got stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        !stderr.contains("session registry lookup failed"),
+        "registry-loss diagnostics must not suppress a bounded result.toml summary: {stderr}"
+    );
+}
+
+fn assert_session_result_prefers_result_toml_over_registry_loss(corrupt_state: bool) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project");
+    let session_id = csa_session::new_session_id();
+    let session_dir = synthetic_registered_dir(tmp.path(), &project, &session_id);
+    if corrupt_state {
+        std::fs::write(
+            session_dir.join("state.toml"),
+            "this is not valid toml {{{\n",
+        )
+        .expect("write corrupt state");
+    }
+    write_pre_exec_result(&session_dir, "pre-exec: host memory admission denied");
+
+    let output = csa_cmd(tmp.path())
+        .args([
+            "session",
+            "result",
+            "--session",
+            &session_id,
+            "--cd",
+            project.to_str().expect("utf-8 project path"),
+        ])
+        .output()
+        .expect("run csa session result");
+
+    assert!(output.status.success(), "{}", output_text(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains(&format!("Session: {session_id}")),
+        "{stdout}"
+    );
+    assert!(stdout.contains("Status:  failure"), "{stdout}");
+    assert!(stdout.contains("Exit:    1"), "{stdout}");
+    assert!(
+        stdout.contains("Summary: pre-exec: host memory admission denied"),
+        "{stdout}"
+    );
+    assert!(
+        !stderr.contains("session registry lookup failed"),
+        "registry-loss diagnostics must not suppress result.toml: {stderr}"
+    );
+}
+
+#[test]
+fn session_result_summary_prefers_result_toml_when_state_is_missing() {
+    assert_session_result_summary_prefers_result_toml_over_registry_loss(false);
+}
+
+#[test]
+fn session_result_summary_prefers_result_toml_when_state_is_corrupt() {
+    assert_session_result_summary_prefers_result_toml_over_registry_loss(true);
+}
+
+#[test]
+fn session_result_prefers_result_toml_when_state_is_missing() {
+    assert_session_result_prefers_result_toml_over_registry_loss(false);
+}
+
+#[test]
+fn session_result_prefers_result_toml_when_state_is_corrupt() {
+    assert_session_result_prefers_result_toml_over_registry_loss(true);
+}
+
+#[test]
+fn session_result_classifies_missing_state_as_registry_loss() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project");
+    let session_id = csa_session::new_session_id();
+    let session_dir = synthetic_registered_dir(tmp.path(), &project, &session_id);
+    std::fs::write(session_dir.join("stdout.log"), "captured progress\n")
+        .expect("write synthetic stdout log");
+
+    let output = csa_cmd(tmp.path())
+        .args([
+            "session",
+            "result",
+            "--session",
+            &session_id,
+            "--cd",
+            project.to_str().expect("utf-8 project path"),
+        ])
+        .output()
+        .expect("run csa session result");
+
+    assert!(output.status.success(), "{}", output_text(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("session registry lookup failed"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("CSA infrastructure"), "{stderr}");
+    assert!(stderr.contains("not a product-code failure"), "{stderr}");
+    assert!(stderr.contains("git status --short"), "{stderr}");
+    assert!(stderr.contains("csa session logs --session"), "{stderr}");
+
+    let logs = csa_cmd(tmp.path())
+        .args([
+            "session",
+            "logs",
+            "--session",
+            &session_id,
+            "--cd",
+            project.to_str().expect("utf-8 project path"),
+        ])
+        .output()
+        .expect("run csa session logs");
+    assert!(logs.status.success(), "{}", output_text(&logs));
+    let logs_text = output_text(&logs);
+    assert!(logs_text.contains("captured progress"), "{logs_text}");
+}
+
+#[cfg(unix)]
+#[test]
+fn session_wait_classifies_corrupt_state_as_registry_loss() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = global_config_path(tmp.path());
+    std::fs::create_dir_all(config_path.parent().expect("config parent"))
+        .expect("create config dir");
+    std::fs::write(&config_path, "[kv_cache]\nlong_poll_seconds = 1\n")
+        .expect("write short wait config");
+
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project");
+    let session_id = csa_session::new_session_id();
+    let session_dir = synthetic_registered_dir(tmp.path(), &project, &session_id);
+    let state_path = session_dir.join("state.toml");
+    std::fs::write(&state_path, "this is not valid toml {{{\n").expect("write corrupt state");
+    set_mtime_seconds_ago(&state_path, 5);
+
+    let output = csa_cmd(tmp.path())
+        .args([
+            "session",
+            "wait",
+            "--session",
+            &session_id,
+            "--cd",
+            project.to_str().expect("utf-8 project path"),
+        ])
+        .output()
+        .expect("run csa session wait");
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_text(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("session registry lookup failed"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("corrupt state.toml"), "{stderr}");
+    assert!(stderr.contains("CSA infrastructure"), "{stderr}");
+    assert!(stderr.contains("not a product-code failure"), "{stderr}");
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1040"
-weave = "0.1.1040"
+csa = "0.1.1041"
+weave = "0.1.1041"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Classify lost session registry/state lookups for `session result`, `session wait`, and full-ULID resume/lookup misses.
- Preserve safe bounded `result.toml` summaries before registry-loss diagnostics when state is missing/corrupt.
- Add synthetic regressions for missing/corrupt `state.toml`, logs recovery, and result-summary/default-result visibility.

## Verification

- `cargo build -p cli-sub-agent --bin csa --all-features`
- `target/debug/csa --version` → `csa 0.1.1041 (dedd6eed)`
- `cargo test -p cli-sub-agent --test session_registry_loss --all-features -- --nocapture`
- `cargo test -p cli-sub-agent --test session_summary_visibility --all-features session_result_summary -- --nocapture`
- `cargo test -p cli-sub-agent session_cmds_result --all-features -- --nocapture`
- `git diff --check main...HEAD`
- hook-enabled amend / `pre-commit-fast`: passed
- pre-push hook: passed
- exact-head CSA review: `01KVNVNMW9JD9KEKVCWFDWAD49` CLEAN/PASS for `main...HEAD` at `dedd6eed1a1423acd4e851823e98d5dd131c62e4`
- `target/debug/csa review --check-verdict --sa-mode true --range main...HEAD`: passed

Closes #2283
