### PR TITLE
fix(session): classify memory soft-limit side effects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1041"
+version = "0.1.1042"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1041"
+version = "0.1.1042"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -41,6 +41,7 @@ mod mcp_server;
 mod memory_capture;
 mod memory_cmd;
 mod memory_migrate;
+mod memory_soft_limit_recovery_display;
 mod merge_cmd;
 mod mktsk_cmd;
 mod pattern_resolver;

--- a/crates/cli-sub-agent/src/memory_soft_limit_recovery_display.rs
+++ b/crates/cli-sub-agent/src/memory_soft_limit_recovery_display.rs
@@ -1,0 +1,85 @@
+pub(crate) fn format_memory_soft_limit_recovery_lines(
+    diagnostic: &csa_session::MemorySoftLimitRecoveryDiagnostic,
+) -> Vec<String> {
+    let mut lines = vec![format!(
+        "Memory-soft-limit recovery: outcome={} dirty_worktree={} commit_created={} changed_paths={}",
+        diagnostic.outcome,
+        diagnostic.dirty_worktree,
+        diagnostic.commit_created,
+        diagnostic.changed_paths.len(),
+    )];
+    if !diagnostic.changed_paths.is_empty() || diagnostic.changed_paths_truncated > 0 {
+        lines.push(format!(
+            "Changed paths: {}",
+            format_changed_paths(
+                &diagnostic.changed_paths,
+                diagnostic.changed_paths_truncated
+            )
+        ));
+    }
+    if let Some(head) = format_head_commit(diagnostic) {
+        lines.push(format!("Head commit: {head}"));
+    }
+    lines.push(format!(
+        "Recovery action: {}",
+        diagnostic.suggested_recovery_action
+    ));
+    lines
+}
+
+fn format_changed_paths(paths: &[String], truncated: usize) -> String {
+    if paths.is_empty() {
+        return "<none recorded>".to_string();
+    }
+    let mut rendered = paths.join(", ");
+    if truncated > 0 {
+        rendered.push_str(&format!(" (+{truncated} more)"));
+    }
+    rendered
+}
+
+fn format_head_commit(
+    diagnostic: &csa_session::MemorySoftLimitRecoveryDiagnostic,
+) -> Option<String> {
+    let oid = diagnostic.head_oid.as_deref()?.trim();
+    if oid.is_empty() {
+        return None;
+    }
+    let short_oid = oid.chars().take(12).collect::<String>();
+    let summary = diagnostic
+        .head_summary
+        .as_deref()
+        .map(str::trim)
+        .filter(|summary| !summary.is_empty());
+    match summary {
+        Some(summary) => Some(format!("{short_oid} {summary}")),
+        None => Some(short_oid),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovery_lines_include_bounded_commit_metadata() {
+        let lines = format_memory_soft_limit_recovery_lines(
+            &csa_session::MemorySoftLimitRecoveryDiagnostic {
+                outcome: "clean_committed_work".to_string(),
+                commit_created: true,
+                dirty_worktree: false,
+                changed_paths: Vec::new(),
+                changed_paths_truncated: 0,
+                head_oid: Some("1234567890abcdef".to_string()),
+                head_summary: Some("fix session recovery".to_string()),
+                suggested_recovery_action: "inspect_head_commit_then_continue".to_string(),
+            },
+        );
+
+        let rendered = lines.join("\n");
+        assert!(rendered.contains("outcome=clean_committed_work"));
+        assert!(rendered.contains("commit_created=true"));
+        assert!(rendered.contains("Head commit: 1234567890ab fix session recovery"));
+        assert!(rendered.contains("Recovery action: inspect_head_commit_then_continue"));
+    }
+}

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -123,11 +123,14 @@ pub(super) async fn complete_session_execution(
     let snapshots_available = pre_run_workspace.is_some() && post_run_workspace.is_some();
     let mut commit_created = None;
     if commit_guard_enabled {
+        commit_created = pre_run_workspace
+            .as_ref()
+            .zip(post_run_workspace.as_ref())
+            .map(|(before, after)| before.head != after.head);
         let commit_guard = crate::run_cmd::evaluate_post_run_commit_guard(
             pre_run_workspace.as_ref(),
             post_run_workspace.as_ref(),
         );
-        commit_created = commit_guard.as_ref().map(|guard| guard.head_changed);
         let policy_evaluation_failed = require_commit_on_mutation
             && (!inside_git_worktree
                 || pre_run_workspace.is_none()
@@ -331,5 +334,94 @@ mod tests {
             .expect("result should be saved");
         assert_eq!(persisted.status, "failure");
         assert_eq!(persisted.exit_code, 1);
+    }
+
+    #[tokio::test]
+    async fn completion_reports_commit_created_when_head_advances_cleanly() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+        let project_root = tmp.path();
+        init_git_repo(project_root);
+        let before =
+            crate::run_cmd::capture_git_workspace_snapshot(project_root, false).expect("snapshot");
+
+        std::fs::write(project_root.join("tracked.txt"), "committed\n").expect("write change");
+        run_git(project_root, &["add", "tracked.txt"]);
+        run_git(project_root, &["commit", "-q", "-m", "clean commit"]);
+
+        let mut session = create_session(project_root, Some("clean commit"), None, Some("codex"))
+            .expect("create session");
+        let session_dir =
+            get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+        let executor = Executor::Codex {
+            model_override: None,
+            thinking_budget: None,
+            runtime_metadata: CodexRuntimeMetadata::current(),
+        };
+        let transport_result = TransportResult {
+            execution: csa_process::ExecutionResult {
+                output: "committed".to_string(),
+                stderr_output: String::new(),
+                summary: "committed".to_string(),
+                exit_code: 0,
+                model_completed: Some(true),
+                ..Default::default()
+            },
+            provider_session_id: None,
+            events: Vec::new(),
+            metadata: StreamingMetadata {
+                has_tool_calls: true,
+                has_execute_tool_calls: true,
+                turn_count: 1,
+                ..Default::default()
+            },
+        };
+        let plan = SessionCompletionPlan {
+            merged_env: Default::default(),
+            hooks_config: Default::default(),
+            sessions_root: session_dir
+                .parent()
+                .expect("sessions root")
+                .display()
+                .to_string(),
+            edit_guard: None,
+            new_file_guard: None,
+            result_file_cleared: false,
+            execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
+            commit_guard_enabled: true,
+            require_commit_on_mutation: false,
+            hook_bypass_scan_enabled: true,
+            is_git: true,
+            inside_git_worktree: true,
+            pre_run_workspace: Some(before),
+            pre_exec_snapshot: None,
+            timeout_diagnostics: None,
+            sa_mode: false,
+        };
+
+        let completed = complete_session_execution(
+            CompletionInput {
+                executor: &executor,
+                tool: &csa_core::types::ToolName::Codex,
+                prompt: "Commit the work",
+                output_format: &OutputFormat::Json,
+                task_type: Some("run"),
+                readonly_project_root: false,
+                project_root,
+                config: None,
+                global_config: None,
+                session_dir: &session_dir,
+                memory_project_key: None,
+                effective_prompt: "Commit the work".to_string(),
+                plan,
+                transport_result,
+            },
+            &mut session,
+        )
+        .await
+        .expect("complete session");
+
+        assert_eq!(completed.commit_created, Some(true));
+        assert_eq!(completed.execution.exit_code, 0);
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -306,6 +306,7 @@ mod tests {
                 uncommitted_changes: None,
                 large_diff_warning: None,
                 require_commit_recovery: None,
+                memory_soft_limit_recovery: None,
                 post_exec_gate: None,
                 manager_fields: Default::default(),
             },

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -505,6 +505,7 @@ async fn state_dir_cap_failure_overwrites_stale_result_for_resume() {
             uncommitted_changes: None,
             large_diff_warning: None,
             require_commit_recovery: None,
+            memory_soft_limit_recovery: None,
             manager_fields: csa_session::SessionManagerFields {
                 report: Some(
                     toml::toml! {

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -1,21 +1,30 @@
 //! Writer-session dirty-worktree signal for `csa run`.
 
 use std::collections::BTreeSet;
-use std::io::Read;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use csa_config::{RunLargeDiffWarningConfig, RunLargeDiffWarningMode};
 use tracing::warn;
 
 const MAX_UNCOMMITTED_FILES: usize = 20;
-const DIFF_BYTES_PER_TOKEN: usize = 4;
-const DIFF_TOKEN_READ_BUF_BYTES: usize = 16 * 1024;
 const REQUIRE_COMMIT_REASON: &str =
     "writer session ended without required commit (--require-commit set)";
 const REQUIRE_COMMIT_RECOVERY_ACTION: &str = "inspect_changed_paths_then_commit_or_revert";
 const REDACTED_PATH: &str = "[redacted-path]";
 const LARGE_DIFF_WARNING_TEXT: &str = "This CSA session left a large changed surface. Do not proceed directly to a single commit/PR unless this was explicitly intended. First inspect the file list, split into atomic logical units if possible, and run review per unit. If intentionally large, record that rationale in the commit/PR.";
+
+#[path = "run_cmd_uncommitted_diff_tokens.rs"]
+mod diff_tokens;
+#[path = "run_cmd_uncommitted_memory_soft_limit.rs"]
+mod memory_soft_limit_recovery;
+
+#[cfg(test)]
+use diff_tokens::{
+    DIFF_BYTES_PER_TOKEN, default_tracked_diff_token_threshold, estimate_diff_stream_tokens,
+    tracked_diff_byte_limit,
+};
+use diff_tokens::{estimate_changed_surface_tokens, tracked_diff_token_threshold};
 
 pub(crate) fn is_writer_session(sa_mode: bool, task_type: Option<&str>) -> bool {
     !sa_mode && matches!(task_type, Some("run"))
@@ -169,7 +178,8 @@ fn record_writer_uncommitted_changes_with_config(
     let require_commit_contract_failure =
         record.require_commit && !record.commit_created.unwrap_or(false);
 
-    if changes.is_none() && !require_commit_contract_failure {
+    let maybe_signal_exit = matches!(result.exit_code, 137 | 143);
+    if changes.is_none() && !require_commit_contract_failure && !maybe_signal_exit {
         return warning;
     }
 
@@ -182,12 +192,20 @@ fn record_writer_uncommitted_changes_with_config(
 
     match csa_session::load_result(project_root, session_id) {
         Ok(Some(mut session_result)) => {
+            let memory_soft_limit_recovery = memory_soft_limit_recovery::build_recovery_diagnostic(
+                project_root,
+                &session_result,
+                changes.as_ref(),
+                record.changed_paths,
+                record.commit_created,
+            );
             let recovery = require_commit_contract_failure.then(|| {
                 build_require_commit_recovery_diagnostic_for_state(
                     &session_result,
                     changes.as_ref(),
                 )
             });
+            let mut should_save = false;
             if let Some(changes) = changes.clone() {
                 apply_uncommitted_changes_to_result(
                     &mut session_result,
@@ -196,8 +214,17 @@ fn record_writer_uncommitted_changes_with_config(
                     require_commit_contract_failure,
                     recovery,
                 );
+                should_save = true;
             } else if let Some(recovery) = recovery {
                 apply_require_commit_contract_failure_to_result(&mut session_result, recovery);
+                should_save = true;
+            }
+            if let Some(recovery) = memory_soft_limit_recovery {
+                session_result.memory_soft_limit_recovery = Some(recovery);
+                should_save = true;
+            }
+            if !should_save {
+                return warning;
             }
             if let Err(err) = csa_session::save_result(project_root, session_id, &session_result) {
                 warn!(
@@ -500,119 +527,6 @@ fn collect_uncommitted_changes_with_filter_and_untracked_size(
     Some((changes, untracked))
 }
 
-fn estimate_changed_surface_tokens(
-    project_root: &Path,
-    path_filter: Option<&BTreeSet<String>>,
-    untracked: &crate::untracked_size::UntrackedDiffSize,
-    tracked_token_threshold: Option<usize>,
-) -> usize {
-    let untracked_bytes = usize::try_from(untracked.bytes).unwrap_or(usize::MAX);
-    let untracked_tokens = untracked_bytes / DIFF_BYTES_PER_TOKEN;
-    let Some(token_threshold) = tracked_token_threshold else {
-        return untracked_tokens;
-    };
-    if untracked_tokens > token_threshold {
-        return untracked_tokens;
-    }
-
-    let remaining_threshold = token_threshold.saturating_sub(untracked_tokens);
-    let tracked_tokens =
-        estimate_tracked_diff_tokens(project_root, path_filter, remaining_threshold)
-            .unwrap_or_default();
-    untracked_tokens.saturating_add(tracked_tokens)
-}
-
-fn tracked_diff_token_threshold(config: &RunLargeDiffWarningConfig) -> usize {
-    if config.approx_diff_tokens > 0 {
-        config.approx_diff_tokens
-    } else {
-        default_tracked_diff_token_threshold()
-    }
-}
-
-fn default_tracked_diff_token_threshold() -> usize {
-    RunLargeDiffWarningConfig::default().approx_diff_tokens
-}
-
-struct TrackedDiffTokenEstimate {
-    tokens: usize,
-    cap_reached: bool,
-}
-
-fn estimate_tracked_diff_tokens(
-    project_root: &Path,
-    path_filter: Option<&BTreeSet<String>>,
-    token_threshold: usize,
-) -> Option<usize> {
-    let mut command = Command::new("git");
-    command
-        .arg("-C")
-        .arg(project_root)
-        .args(["diff", "--no-ext-diff", "--no-color", "HEAD"])
-        .arg("--")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null());
-    if let Some(filter) = path_filter {
-        command.env("GIT_LITERAL_PATHSPECS", "1");
-        command.args(filter);
-    }
-
-    let mut child = command.spawn().ok()?;
-    let Some(stdout) = child.stdout.take() else {
-        let _ = child.kill();
-        let _ = child.wait();
-        return None;
-    };
-
-    let estimate = estimate_diff_stream_tokens(stdout, token_threshold)?;
-    if estimate.cap_reached {
-        let _ = child.kill();
-        let _ = child.wait();
-        return Some(token_threshold.saturating_add(1));
-    }
-
-    let status = child.wait().ok()?;
-    status.success().then_some(estimate.tokens)
-}
-
-fn estimate_diff_stream_tokens<R: Read>(
-    mut reader: R,
-    token_threshold: usize,
-) -> Option<TrackedDiffTokenEstimate> {
-    let byte_limit = tracked_diff_byte_limit(token_threshold);
-    let mut bytes_read = 0usize;
-    let mut buffer = [0u8; DIFF_TOKEN_READ_BUF_BYTES];
-
-    while bytes_read < byte_limit {
-        let remaining = byte_limit.saturating_sub(bytes_read);
-        let read_len = remaining.min(buffer.len());
-        let n = reader.read(&mut buffer[..read_len]).ok()?;
-        if n == 0 {
-            return Some(TrackedDiffTokenEstimate {
-                tokens: diff_bytes_to_approx_tokens(bytes_read),
-                cap_reached: false,
-            });
-        }
-        bytes_read = bytes_read.saturating_add(n);
-    }
-
-    Some(TrackedDiffTokenEstimate {
-        tokens: token_threshold.saturating_add(1),
-        cap_reached: true,
-    })
-}
-
-fn tracked_diff_byte_limit(token_threshold: usize) -> usize {
-    token_threshold
-        .saturating_mul(DIFF_BYTES_PER_TOKEN)
-        .saturating_add(1)
-}
-
-fn diff_bytes_to_approx_tokens(bytes: usize) -> usize {
-    bytes.saturating_add(DIFF_BYTES_PER_TOKEN - 1) / DIFF_BYTES_PER_TOKEN
-}
-
 fn run_git_capture(project_root: &Path, args: &[&str]) -> Option<String> {
     let output = Command::new("git")
         .arg("-C")
@@ -698,6 +612,10 @@ fn parse_numstat_totals(numstat: &str) -> (u64, u64) {
 #[cfg(test)]
 #[path = "run_cmd_uncommitted_incidental_tests.rs"]
 mod incidental_tests;
+
+#[cfg(test)]
+#[path = "run_cmd_uncommitted_memory_soft_limit_tests.rs"]
+mod memory_soft_limit_tests;
 
 #[cfg(test)]
 #[path = "run_cmd_uncommitted_tests.rs"]

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_diff_tokens.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_diff_tokens.rs
@@ -1,0 +1,122 @@
+use std::collections::BTreeSet;
+use std::io::Read;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use csa_config::RunLargeDiffWarningConfig;
+
+pub(super) const DIFF_BYTES_PER_TOKEN: usize = 4;
+const DIFF_TOKEN_READ_BUF_BYTES: usize = 16 * 1024;
+
+pub(super) fn estimate_changed_surface_tokens(
+    project_root: &Path,
+    path_filter: Option<&BTreeSet<String>>,
+    untracked: &crate::untracked_size::UntrackedDiffSize,
+    tracked_token_threshold: Option<usize>,
+) -> usize {
+    let untracked_bytes = usize::try_from(untracked.bytes).unwrap_or(usize::MAX);
+    let untracked_tokens = untracked_bytes / DIFF_BYTES_PER_TOKEN;
+    let Some(token_threshold) = tracked_token_threshold else {
+        return untracked_tokens;
+    };
+    if untracked_tokens > token_threshold {
+        return untracked_tokens;
+    }
+
+    let remaining_threshold = token_threshold.saturating_sub(untracked_tokens);
+    let tracked_tokens =
+        estimate_tracked_diff_tokens(project_root, path_filter, remaining_threshold)
+            .unwrap_or_default();
+    untracked_tokens.saturating_add(tracked_tokens)
+}
+
+pub(super) fn tracked_diff_token_threshold(config: &RunLargeDiffWarningConfig) -> usize {
+    if config.approx_diff_tokens > 0 {
+        config.approx_diff_tokens
+    } else {
+        default_tracked_diff_token_threshold()
+    }
+}
+
+pub(super) fn default_tracked_diff_token_threshold() -> usize {
+    RunLargeDiffWarningConfig::default().approx_diff_tokens
+}
+
+pub(super) struct TrackedDiffTokenEstimate {
+    pub(super) tokens: usize,
+    pub(super) cap_reached: bool,
+}
+
+fn estimate_tracked_diff_tokens(
+    project_root: &Path,
+    path_filter: Option<&BTreeSet<String>>,
+    token_threshold: usize,
+) -> Option<usize> {
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(project_root)
+        .args(["diff", "--no-ext-diff", "--no-color", "HEAD"])
+        .arg("--")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    if let Some(filter) = path_filter {
+        command.env("GIT_LITERAL_PATHSPECS", "1");
+        command.args(filter);
+    }
+
+    let mut child = command.spawn().ok()?;
+    let Some(stdout) = child.stdout.take() else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return None;
+    };
+
+    let estimate = estimate_diff_stream_tokens(stdout, token_threshold)?;
+    if estimate.cap_reached {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Some(token_threshold.saturating_add(1));
+    }
+
+    let status = child.wait().ok()?;
+    status.success().then_some(estimate.tokens)
+}
+
+pub(super) fn estimate_diff_stream_tokens<R: Read>(
+    mut reader: R,
+    token_threshold: usize,
+) -> Option<TrackedDiffTokenEstimate> {
+    let byte_limit = tracked_diff_byte_limit(token_threshold);
+    let mut bytes_read = 0usize;
+    let mut buffer = [0u8; DIFF_TOKEN_READ_BUF_BYTES];
+
+    while bytes_read < byte_limit {
+        let remaining = byte_limit.saturating_sub(bytes_read);
+        let read_len = remaining.min(buffer.len());
+        let n = reader.read(&mut buffer[..read_len]).ok()?;
+        if n == 0 {
+            return Some(TrackedDiffTokenEstimate {
+                tokens: diff_bytes_to_approx_tokens(bytes_read),
+                cap_reached: false,
+            });
+        }
+        bytes_read = bytes_read.saturating_add(n);
+    }
+
+    Some(TrackedDiffTokenEstimate {
+        tokens: token_threshold.saturating_add(1),
+        cap_reached: true,
+    })
+}
+
+pub(super) fn tracked_diff_byte_limit(token_threshold: usize) -> usize {
+    token_threshold
+        .saturating_mul(DIFF_BYTES_PER_TOKEN)
+        .saturating_add(1)
+}
+
+fn diff_bytes_to_approx_tokens(bytes: usize) -> usize {
+    bytes.saturating_add(DIFF_BYTES_PER_TOKEN - 1) / DIFF_BYTES_PER_TOKEN
+}

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_memory_soft_limit.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_memory_soft_limit.rs
@@ -1,0 +1,104 @@
+use std::path::Path;
+
+pub(super) const MEMORY_SOFT_LIMIT_NO_WORK_OUTCOME: &str = "no_tracked_repo_side_effects";
+pub(super) const MEMORY_SOFT_LIMIT_DIRTY_OUTCOME: &str = "dirty_or_staged_changes";
+pub(super) const MEMORY_SOFT_LIMIT_CLEAN_COMMITTED_OUTCOME: &str = "clean_committed_work";
+pub(super) const MEMORY_SOFT_LIMIT_NO_WORK_ACTION: &str =
+    "rerun_with_more_memory_or_reduce_parallelism";
+pub(super) const MEMORY_SOFT_LIMIT_DIRTY_ACTION: &str =
+    "inspect_changed_paths_then_salvage_or_revert";
+pub(super) const MEMORY_SOFT_LIMIT_CLEAN_COMMITTED_ACTION: &str =
+    "inspect_head_commit_then_continue";
+
+pub(super) fn build_recovery_diagnostic(
+    project_root: &Path,
+    result: &csa_session::SessionResult,
+    changes: Option<&csa_session::UncommittedChanges>,
+    changed_paths: Option<&[String]>,
+    commit_created: Option<bool>,
+) -> Option<csa_session::MemorySoftLimitRecoveryDiagnostic> {
+    if result.kill_hint.as_deref()
+        != Some(csa_resource::memory_monitor::MEMORY_SOFT_LIMIT_KILL_HINT)
+    {
+        return None;
+    }
+
+    if let Some(changes) = changes {
+        let changed_paths = changes
+            .files
+            .iter()
+            .map(|path| super::sanitize_diagnostic_path(path))
+            .collect();
+        return Some(csa_session::MemorySoftLimitRecoveryDiagnostic {
+            outcome: MEMORY_SOFT_LIMIT_DIRTY_OUTCOME.to_string(),
+            commit_created: commit_created.unwrap_or(false),
+            dirty_worktree: true,
+            changed_paths,
+            changed_paths_truncated: changes.truncated,
+            head_oid: None,
+            head_summary: None,
+            suggested_recovery_action: MEMORY_SOFT_LIMIT_DIRTY_ACTION.to_string(),
+        });
+    }
+
+    if commit_created.unwrap_or(false) {
+        let (head_oid, head_summary) = current_head_commit_summary(project_root);
+        let (changed_paths, changed_paths_truncated) =
+            bounded_sanitized_paths(changed_paths.unwrap_or_default());
+        return Some(csa_session::MemorySoftLimitRecoveryDiagnostic {
+            outcome: MEMORY_SOFT_LIMIT_CLEAN_COMMITTED_OUTCOME.to_string(),
+            commit_created: true,
+            dirty_worktree: false,
+            changed_paths,
+            changed_paths_truncated,
+            head_oid,
+            head_summary,
+            suggested_recovery_action: MEMORY_SOFT_LIMIT_CLEAN_COMMITTED_ACTION.to_string(),
+        });
+    }
+
+    if changed_paths.is_some_and(|paths| paths.is_empty()) {
+        return Some(csa_session::MemorySoftLimitRecoveryDiagnostic {
+            outcome: MEMORY_SOFT_LIMIT_NO_WORK_OUTCOME.to_string(),
+            commit_created: false,
+            dirty_worktree: false,
+            changed_paths: Vec::new(),
+            changed_paths_truncated: 0,
+            head_oid: None,
+            head_summary: None,
+            suggested_recovery_action: MEMORY_SOFT_LIMIT_NO_WORK_ACTION.to_string(),
+        });
+    }
+
+    None
+}
+
+fn bounded_sanitized_paths(paths: &[String]) -> (Vec<String>, usize) {
+    let total = paths.len();
+    let paths = paths
+        .iter()
+        .take(super::MAX_UNCOMMITTED_FILES)
+        .map(|path| super::sanitize_diagnostic_path(path))
+        .collect::<Vec<_>>();
+    let truncated = total.saturating_sub(paths.len());
+    (paths, truncated)
+}
+
+fn current_head_commit_summary(project_root: &Path) -> (Option<String>, Option<String>) {
+    let head_oid = super::run_git_capture(project_root, &["rev-parse", "--verify", "HEAD"])
+        .map(|value| bounded_one_line(&value, 80))
+        .filter(|value| !value.is_empty());
+    let head_summary = super::run_git_capture(project_root, &["log", "-1", "--format=%s"])
+        .map(|value| bounded_one_line(&value, 160))
+        .filter(|value| !value.is_empty());
+    (head_oid, head_summary)
+}
+
+fn bounded_one_line(value: &str, max_chars: usize) -> String {
+    value
+        .trim()
+        .chars()
+        .filter(|ch| !ch.is_control())
+        .take(max_chars)
+        .collect()
+}

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_memory_soft_limit_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_memory_soft_limit_tests.rs
@@ -1,0 +1,210 @@
+use super::memory_soft_limit_recovery::{
+    MEMORY_SOFT_LIMIT_CLEAN_COMMITTED_ACTION, MEMORY_SOFT_LIMIT_CLEAN_COMMITTED_OUTCOME,
+    MEMORY_SOFT_LIMIT_DIRTY_ACTION, MEMORY_SOFT_LIMIT_DIRTY_OUTCOME,
+    MEMORY_SOFT_LIMIT_NO_WORK_ACTION, MEMORY_SOFT_LIMIT_NO_WORK_OUTCOME,
+};
+use super::*;
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn memory_soft_limit_with_no_changed_paths_records_no_work_recovery() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    let session = csa_session::create_session(root, Some("run"), None, Some("codex"))
+        .expect("session should be created");
+    let mut session_result = session_result("signal", 143);
+    session_result.kill_hint = Some("memory_soft_limit".to_string());
+    csa_session::save_result(root, &session.meta_session_id, &session_result)
+        .expect("result should be saved");
+    let mut execution = csa_process::ExecutionResult {
+        exit_code: 143,
+        summary: "memory soft limit".to_string(),
+        ..Default::default()
+    };
+
+    record_writer_uncommitted_changes_with_config(
+        root,
+        Some(&session.meta_session_id),
+        &mut execution,
+        WriterUncommittedRecord {
+            sa_mode: false,
+            require_commit: false,
+            changed_paths: Some(&[]),
+            commit_created: Some(false),
+            large_diff_config: &RunLargeDiffWarningConfig::default(),
+        },
+    );
+
+    let loaded = csa_session::load_result(root, &session.meta_session_id)
+        .expect("load result")
+        .expect("result should exist");
+    let recovery = loaded
+        .memory_soft_limit_recovery
+        .expect("memory-soft-limit no-work recovery should be recorded");
+    assert_eq!(recovery.outcome, MEMORY_SOFT_LIMIT_NO_WORK_OUTCOME);
+    assert!(!recovery.dirty_worktree);
+    assert!(!recovery.commit_created);
+    assert!(recovery.changed_paths.is_empty());
+    assert_eq!(
+        recovery.suggested_recovery_action,
+        MEMORY_SOFT_LIMIT_NO_WORK_ACTION
+    );
+}
+
+#[test]
+fn memory_soft_limit_with_dirty_work_records_salvage_recovery() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    let session = csa_session::create_session(root, Some("run"), None, Some("codex"))
+        .expect("session should be created");
+    let mut session_result = session_result("signal", 143);
+    session_result.kill_hint = Some("memory_soft_limit".to_string());
+    csa_session::save_result(root, &session.meta_session_id, &session_result)
+        .expect("result should be saved");
+    std::fs::write(root.join("seed.txt"), "seed\npartial\n").expect("dirty file");
+    let mut execution = csa_process::ExecutionResult {
+        exit_code: 143,
+        summary: "memory soft limit".to_string(),
+        ..Default::default()
+    };
+
+    record_writer_uncommitted_changes_with_config(
+        root,
+        Some(&session.meta_session_id),
+        &mut execution,
+        WriterUncommittedRecord {
+            sa_mode: false,
+            require_commit: false,
+            changed_paths: Some(&["seed.txt".to_string()]),
+            commit_created: Some(false),
+            large_diff_config: &RunLargeDiffWarningConfig::default(),
+        },
+    );
+
+    let loaded = csa_session::load_result(root, &session.meta_session_id)
+        .expect("load result")
+        .expect("result should exist");
+    assert!(loaded.uncommitted_changes.is_some());
+    let recovery = loaded
+        .memory_soft_limit_recovery
+        .expect("memory-soft-limit dirty recovery should be recorded");
+    assert_eq!(recovery.outcome, MEMORY_SOFT_LIMIT_DIRTY_OUTCOME);
+    assert!(recovery.dirty_worktree);
+    assert!(!recovery.commit_created);
+    assert_eq!(recovery.changed_paths, vec!["seed.txt".to_string()]);
+    assert_eq!(
+        recovery.suggested_recovery_action,
+        MEMORY_SOFT_LIMIT_DIRTY_ACTION
+    );
+}
+
+#[test]
+fn memory_soft_limit_with_clean_commit_records_committed_recovery() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    let session = csa_session::create_session(root, Some("run"), None, Some("codex"))
+        .expect("session should be created");
+    let mut session_result = session_result("signal", 143);
+    session_result.kill_hint = Some("memory_soft_limit".to_string());
+    csa_session::save_result(root, &session.meta_session_id, &session_result)
+        .expect("result should be saved");
+    std::fs::write(root.join("seed.txt"), "seed\ncommitted\n").expect("edit file");
+    run_git(root, &["add", "seed.txt"]);
+    run_git(root, &["commit", "-q", "-m", "clean memory recovery"]);
+    let mut execution = csa_process::ExecutionResult {
+        exit_code: 143,
+        summary: "memory soft limit".to_string(),
+        ..Default::default()
+    };
+
+    record_writer_uncommitted_changes_with_config(
+        root,
+        Some(&session.meta_session_id),
+        &mut execution,
+        WriterUncommittedRecord {
+            sa_mode: false,
+            require_commit: false,
+            changed_paths: Some(&[]),
+            commit_created: Some(true),
+            large_diff_config: &RunLargeDiffWarningConfig::default(),
+        },
+    );
+
+    let loaded = csa_session::load_result(root, &session.meta_session_id)
+        .expect("load result")
+        .expect("result should exist");
+    assert!(loaded.uncommitted_changes.is_none());
+    let recovery = loaded
+        .memory_soft_limit_recovery
+        .expect("memory-soft-limit clean committed recovery should be recorded");
+    assert_eq!(recovery.outcome, MEMORY_SOFT_LIMIT_CLEAN_COMMITTED_OUTCOME);
+    assert!(!recovery.dirty_worktree);
+    assert!(recovery.commit_created);
+    assert!(recovery.changed_paths.is_empty());
+    assert!(
+        recovery
+            .head_oid
+            .as_deref()
+            .is_some_and(|head| head.len() >= 12)
+    );
+    assert_eq!(
+        recovery.head_summary.as_deref(),
+        Some("clean memory recovery")
+    );
+    assert_eq!(
+        recovery.suggested_recovery_action,
+        MEMORY_SOFT_LIMIT_CLEAN_COMMITTED_ACTION
+    );
+}
+
+fn session_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
+    let now = chrono::Utc::now();
+    csa_session::SessionResult {
+        post_exec_gate: None,
+        status: status.to_string(),
+        exit_code,
+        summary: "done".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    }
+}
+
+fn init_repo_with_initial_commit() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path();
+    run_git(root, &["init", "-q"]);
+    run_git(root, &["config", "user.email", "test@example.com"]);
+    run_git(root, &["config", "user.name", "Test User"]);
+    run_git(root, &["config", "commit.gpgsign", "false"]);
+    run_git(
+        root,
+        &["config", "core.hooksPath", "/nonexistent-csa-hooks"],
+    );
+    std::fs::write(root.join("seed.txt"), "seed\n").expect("write seed");
+    run_git(root, &["add", "seed.txt"]);
+    run_git(root, &["commit", "-q", "-m", "initial"]);
+    temp
+}
+
+fn run_git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git command should execute");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -143,6 +143,13 @@ pub(crate) fn render_wait_result_summary(
             crate::require_commit_recovery_display::format_require_commit_recovery_lines(recovery),
         );
     }
+    if let Some(recovery) = result.memory_soft_limit_recovery.as_ref() {
+        lines.extend(
+            crate::memory_soft_limit_recovery_display::format_memory_soft_limit_recovery_lines(
+                recovery,
+            ),
+        );
+    }
 
     if let Some(changes) = result.uncommitted_changes.as_ref() {
         lines.push(crate::run_cmd::format_uncommitted_warning(changes));
@@ -250,6 +257,7 @@ fn render_wait_result_json(
         "kill_hint": result.kill_hint.as_deref(),
         "kill_diagnostics": result.kill_diagnostics.as_ref(),
         "require_commit_recovery": result.require_commit_recovery.as_ref(),
+        "memory_soft_limit_recovery": result.memory_soft_limit_recovery.as_ref(),
         "post_exec_gate": result.post_exec_gate.as_ref(),
         "large_diff_warning": result.large_diff_warning.as_ref(),
         "warnings": result.warnings,

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_kill_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_kill_tests.rs
@@ -36,6 +36,19 @@ fn signal_result(summary: String) -> csa_session::SessionResult {
     }
 }
 
+fn clean_committed_recovery() -> csa_session::MemorySoftLimitRecoveryDiagnostic {
+    csa_session::MemorySoftLimitRecoveryDiagnostic {
+        outcome: "clean_committed_work".to_string(),
+        commit_created: true,
+        dirty_worktree: false,
+        changed_paths: Vec::new(),
+        changed_paths_truncated: 0,
+        head_oid: Some("1234567890abcdef".to_string()),
+        head_summary: Some("fix session recovery".to_string()),
+        suggested_recovery_action: "inspect_head_commit_then_continue".to_string(),
+    }
+}
+
 #[test]
 fn compact_summary_includes_signal_kill_hint() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
@@ -64,4 +77,32 @@ fn compact_json_includes_kill_diagnostics() {
     assert_eq!(value["kill_diagnostics"]["source"], "memory_soft_limit");
     assert_eq!(value["kill_diagnostics"]["current_mb"], 9216);
     assert_eq!(value["kill_diagnostics"]["threshold_mb"], 8601);
+}
+
+#[test]
+fn compact_summary_and_json_include_memory_soft_limit_recovery() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let mut result = signal_result("process killed by signal 15 (SIGTERM)".to_string());
+    result.memory_soft_limit_recovery = Some(clean_committed_recovery());
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITMEMREC", &result);
+
+    assert!(summary.contains("Memory-soft-limit recovery: outcome=clean_committed_work"));
+    assert!(summary.contains("commit_created=true"));
+    assert!(summary.contains("Head commit: 1234567890ab fix session recovery"));
+    assert!(summary.contains("Recovery action: inspect_head_commit_then_continue"));
+
+    let rendered = render_wait_result_json(temp.path(), "01TESTWAITMEMRECJSON", &result)
+        .expect("wait result JSON should render");
+    let value: serde_json::Value =
+        serde_json::from_str(&rendered).expect("wait result JSON should parse");
+
+    assert_eq!(
+        value["memory_soft_limit_recovery"]["outcome"],
+        "clean_committed_work"
+    );
+    assert_eq!(
+        value["memory_soft_limit_recovery"]["head_summary"],
+        "fix session recovery"
+    );
 }

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -336,6 +336,7 @@ fn compact_summary_labels_fix_loop_noop_from_review_meta() {
         uncommitted_changes: None,
         large_diff_warning: None,
         require_commit_recovery: None,
+        memory_soft_limit_recovery: None,
         manager_fields: Default::default(),
     };
 
@@ -469,6 +470,7 @@ fn compact_summary_includes_writer_uncommitted_warning() {
         }),
         large_diff_warning: None,
         require_commit_recovery: None,
+        memory_soft_limit_recovery: None,
         manager_fields: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/session_cmds_result_display.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_display.rs
@@ -82,6 +82,15 @@ pub(super) fn display_result_text(
             println!("{line}");
         }
     }
+    if let Some(recovery) = envelope.memory_soft_limit_recovery.as_ref() {
+        for line in
+            crate::memory_soft_limit_recovery_display::format_memory_soft_limit_recovery_lines(
+                recovery,
+            )
+        {
+            println!("{line}");
+        }
+    }
     if !envelope.artifacts.is_empty() {
         println!("Artifacts:");
         for a in &envelope.artifacts {

--- a/crates/cli-sub-agent/src/session_cmds_result_kill_diagnostics_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_kill_diagnostics_tests.rs
@@ -40,3 +40,50 @@ fn build_result_json_payload_includes_kill_diagnostics() {
     assert_eq!(payload["kill_diagnostics"]["current_mb"], 9216);
     assert_eq!(payload["kill_diagnostics"]["threshold_mb"], 8601);
 }
+
+#[test]
+fn build_result_json_payload_includes_memory_soft_limit_recovery() {
+    let now = chrono::Utc::now();
+    let result = SessionResultView {
+        envelope: SessionResult {
+            post_exec_gate: None,
+            status: "signal".to_string(),
+            exit_code: 143,
+            summary: "CSA diagnostic: signal kill hint: memory soft limit".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now,
+            events_count: 0,
+            artifacts: Vec::new(),
+            kill_hint: Some("memory_soft_limit".to_string()),
+            memory_soft_limit_recovery: Some(csa_session::MemorySoftLimitRecoveryDiagnostic {
+                outcome: "dirty_or_staged_changes".to_string(),
+                commit_created: false,
+                dirty_worktree: true,
+                changed_paths: vec!["src/lib.rs".to_string()],
+                changed_paths_truncated: 0,
+                head_oid: None,
+                head_summary: None,
+                suggested_recovery_action: "inspect_changed_paths_then_salvage_or_revert"
+                    .to_string(),
+            }),
+            ..Default::default()
+        },
+        manager_sidecar: None,
+        legacy_sidecar: None,
+    };
+
+    let payload = build_result_json_payload(&result, None, None, None).unwrap();
+
+    assert_eq!(
+        payload["memory_soft_limit_recovery"]["outcome"],
+        "dirty_or_staged_changes"
+    );
+    assert_eq!(
+        payload["memory_soft_limit_recovery"]["changed_paths"][0],
+        "src/lib.rs"
+    );
+}

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -85,8 +85,8 @@ pub use post_exec_gate_report::{
 pub use process_tree_memory::{SessionTreeMemorySampler, session_tree_rss_mb};
 pub use redact::{redact_event, redact_text_content};
 pub use result::{
-    RequireCommitRecoveryDiagnostic, SessionArtifact, SessionManagerFields, SessionResult,
-    UncommittedChanges,
+    MemorySoftLimitRecoveryDiagnostic, RequireCommitRecoveryDiagnostic, SessionArtifact,
+    SessionManagerFields, SessionResult, UncommittedChanges,
 };
 pub use review_artifact::{
     Finding, FindingsFile, REVIEW_VERDICT_SCHEMA_VERSION, ReviewArtifact, ReviewDiffSize,

--- a/crates/csa-session/src/manager_result.rs
+++ b/crates/csa-session/src/manager_result.rs
@@ -12,7 +12,7 @@ pub const RESULT_TOML_PATH_CONTRACT_ENV: &str = "CSA_RESULT_TOML_PATH_CONTRACT";
 pub const CONTRACT_RESULT_ARTIFACT_PATH: &str = "output/result.toml";
 pub const LEGACY_USER_RESULT_ARTIFACT_PATH: &str = "output/user-result.toml";
 const LEGACY_KILL_REASON_KEY: &str = "kill_reason";
-const RUNTIME_RESULT_KEYS: [&str; 24] = [
+const RUNTIME_RESULT_KEYS: [&str; 25] = [
     "status",
     "exit_code",
     "summary",
@@ -33,6 +33,7 @@ const RUNTIME_RESULT_KEYS: [&str; 24] = [
     "uncommitted_changes",
     "large_diff_warning",
     "require_commit_recovery",
+    "memory_soft_limit_recovery",
     "kill_hint",
     "kill_diagnostics",
     LEGACY_KILL_REASON_KEY,
@@ -446,6 +447,7 @@ fn value_matches_runtime_schema(key: &str, value: &toml::Value) -> bool {
         | "uncommitted_changes"
         | "large_diff_warning"
         | "require_commit_recovery"
+        | "memory_soft_limit_recovery"
         | "kill_diagnostics" => value.is_table(),
         _ => false,
     }

--- a/crates/csa-session/src/manager_result_spillover.rs
+++ b/crates/csa-session/src/manager_result_spillover.rs
@@ -344,6 +344,7 @@ mod tests {
             uncommitted_changes: None,
             large_diff_warning: None,
             require_commit_recovery: None,
+            memory_soft_limit_recovery: None,
             manager_fields: crate::result::SessionManagerFields {
                 report: Some(
                     toml::toml! {

--- a/crates/csa-session/src/manager_tests_audit.rs
+++ b/crates/csa-session/src/manager_tests_audit.rs
@@ -26,6 +26,7 @@ fn test_save_result_persists_manager_fields_sidecar() {
         uncommitted_changes: None,
         large_diff_warning: None,
         require_commit_recovery: None,
+        memory_soft_limit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             artifacts: Some(
                 toml::toml! {

--- a/crates/csa-session/src/manager_tests_result_view.rs
+++ b/crates/csa-session/src/manager_tests_result_view.rs
@@ -443,6 +443,7 @@ fn test_save_result_with_empty_manager_fields_preserves_existing_sidecar() {
         uncommitted_changes: None,
         large_diff_warning: None,
         require_commit_recovery: None,
+        memory_soft_limit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {
@@ -529,6 +530,7 @@ fn test_clear_manager_sidecar_removes_existing_sidecar() {
         uncommitted_changes: None,
         large_diff_warning: None,
         require_commit_recovery: None,
+        memory_soft_limit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {

--- a/crates/csa-session/src/manager_tests_sidecar_preservation.rs
+++ b/crates/csa-session/src/manager_tests_sidecar_preservation.rs
@@ -85,6 +85,7 @@ fn sidecar_write_failure_leaves_envelope_unchanged() {
         uncommitted_changes: None,
         large_diff_warning: None,
         require_commit_recovery: None,
+        memory_soft_limit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             artifacts: Some(
                 toml::toml! {
@@ -119,6 +120,7 @@ fn sidecar_write_failure_leaves_envelope_unchanged() {
         uncommitted_changes: None,
         large_diff_warning: None,
         require_commit_recovery: None,
+        memory_soft_limit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             artifacts: Some(
                 toml::toml! {
@@ -183,6 +185,7 @@ fn sidecar_clear_failure_or_crash_leaves_envelope_consistent() {
         uncommitted_changes: None,
         large_diff_warning: None,
         require_commit_recovery: None,
+        memory_soft_limit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {
@@ -261,6 +264,7 @@ fn sidecar_clear_happy_path_publishes_envelope_then_unlinks() {
         uncommitted_changes: None,
         large_diff_warning: None,
         require_commit_recovery: None,
+        memory_soft_limit_recovery: None,
         manager_fields: crate::result::SessionManagerFields {
             report: Some(
                 toml::toml! {

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -230,6 +230,31 @@ pub struct RequireCommitRecoveryDiagnostic {
     pub suggested_recovery_action: String,
 }
 
+/// Machine-readable recovery detail for a writer run that was terminated by
+/// CSA's memory soft-limit monitor after repository state may have changed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemorySoftLimitRecoveryDiagnostic {
+    /// Stable outcome code for the bounded side-effect classifier.
+    pub outcome: String,
+    /// Whether CSA observed a commit created during the run.
+    pub commit_created: bool,
+    /// Whether dirty or staged workspace changes remained after the run.
+    pub dirty_worktree: bool,
+    /// Sanitized relative paths still dirty after the run, capped by the caller.
+    pub changed_paths: Vec<String>,
+    /// Number of additional dirty paths omitted from `changed_paths`.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub changed_paths_truncated: usize,
+    /// Current HEAD commit, when a clean committed outcome can be evidenced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_oid: Option<String>,
+    /// Bounded current HEAD subject, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_summary: Option<String>,
+    /// Stable recovery action code for callers.
+    pub suggested_recovery_action: String,
+}
+
 /// Structured result of a session execution.
 /// Written to `sessions/{id}/result.toml` after each tool invocation.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -311,6 +336,11 @@ pub struct SessionResult {
     /// successful commits, and legacy result files.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub require_commit_recovery: Option<RequireCommitRecoveryDiagnostic>,
+    /// Structured recovery detail for memory-soft-limit writer terminations.
+    /// Omitted for non-memory terminations and sessions without bounded
+    /// repository side-effect evidence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_soft_limit_recovery: Option<MemorySoftLimitRecoveryDiagnostic>,
     /// Structured detail of a failed post-exec verification gate (#1726).
     /// Present ONLY when the gate (e.g. `just pre-commit`) failed, so an SA
     /// orchestrator can diagnose the failing step/test from `result.toml`

--- a/crates/csa-session/src/result_tests.rs
+++ b/crates/csa-session/src/result_tests.rs
@@ -77,6 +77,10 @@ fn test_session_result_empty_optional_fields_omitted() {
         "Clean sessions should omit require_commit_recovery"
     );
     assert!(
+        !toml_str.contains("memory_soft_limit_recovery"),
+        "Clean sessions should omit memory_soft_limit_recovery"
+    );
+    assert!(
         !toml_str.contains("kill_hint"),
         "Missing kill hint should be omitted from serialization"
     );
@@ -94,6 +98,7 @@ fn test_session_result_empty_optional_fields_omitted() {
     assert_eq!(loaded.events_count, 0);
     assert!(loaded.uncommitted_changes.is_none());
     assert!(loaded.require_commit_recovery.is_none());
+    assert!(loaded.memory_soft_limit_recovery.is_none());
 }
 
 #[test]
@@ -146,6 +151,51 @@ fn test_session_result_require_commit_recovery_roundtrip() {
 }
 
 #[test]
+fn test_session_result_memory_soft_limit_recovery_roundtrip() {
+    let now = Utc::now();
+    let result = SessionResult {
+        status: "signal".to_string(),
+        exit_code: 143,
+        summary: "CSA diagnostic: signal kill hint: memory soft limit".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        kill_hint: Some("memory_soft_limit".to_string()),
+        memory_soft_limit_recovery: Some(MemorySoftLimitRecoveryDiagnostic {
+            outcome: "clean_committed_work".to_string(),
+            commit_created: true,
+            dirty_worktree: false,
+            changed_paths: vec!["src/lib.rs".to_string()],
+            changed_paths_truncated: 1,
+            head_oid: Some("1234567890abcdef".to_string()),
+            head_summary: Some("fix session recovery".to_string()),
+            suggested_recovery_action: "inspect_head_commit_then_continue".to_string(),
+        }),
+        ..Default::default()
+    };
+
+    let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
+    assert!(toml_str.contains("[memory_soft_limit_recovery]"));
+    assert!(toml_str.contains("outcome = \"clean_committed_work\""));
+    assert!(toml_str.contains("head_oid = \"1234567890abcdef\""));
+    assert!(!toml_str.contains("transcript"));
+
+    let loaded: SessionResult = toml::from_str(&toml_str).expect("Deserialize should succeed");
+    let recovery = loaded
+        .memory_soft_limit_recovery
+        .expect("memory recovery diagnostic should roundtrip");
+    assert_eq!(recovery.outcome, "clean_committed_work");
+    assert!(recovery.commit_created);
+    assert!(!recovery.dirty_worktree);
+    assert_eq!(recovery.changed_paths, vec!["src/lib.rs".to_string()]);
+    assert_eq!(recovery.changed_paths_truncated, 1);
+    assert_eq!(
+        recovery.head_summary.as_deref(),
+        Some("fix session recovery")
+    );
+}
+
+#[test]
 fn test_session_result_uncommitted_changes_roundtrip() {
     let now = Utc::now();
     let result = SessionResult {
@@ -183,6 +233,7 @@ fn test_session_result_uncommitted_changes_roundtrip() {
             approx_diff_tokens: 1_024,
         }),
         require_commit_recovery: None,
+        memory_soft_limit_recovery: None,
         manager_fields: Default::default(),
     };
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1041"
-weave = "0.1.1041"
+csa = "0.1.1042"
+weave = "0.1.1042"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Classify `memory_soft_limit` / SIGTERM writer outcomes by repository side effects.
- Surface bounded recovery diagnostics for:
  - `no_tracked_repo_side_effects`
  - `dirty_or_staged_changes`
  - `clean_committed_work`
- Preserve actionable recovery guidance in `session result` and daemon wait summaries instead of reporting clean committed work as an opaque unresolved signal failure.
- Track clean commit creation via pre/post HEAD identity.

## Verification

- `cargo test -p cli-sub-agent memory_soft_limit -- --nocapture`
- `cargo test -p csa-session memory_soft_limit_recovery -- --nocapture`
- `cargo test -p cli-sub-agent completion_reports_commit_created_when_head_advances_cleanly -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check main...HEAD`
- `just find-monolith-files`
- hook-enabled commit / pre-commit gates passed
- pre-push `review-check` passed

## Review

- Exact-head CSA-Codex review: `01KVP8BV79D706QJR0FF2MAP1V`
- Reviewed SHA: `a1a5ae97a0d688ac033efadac237b6bf3dccdf1b`
- Scope: `main...HEAD`
- Verdict: PASS / no blocking findings
- `target/debug/csa review --check-verdict --sa-mode true --range main...HEAD` passed

## Operational notes

This change was completed via native-equivalent fallback after CSA operational failures were recorded separately:

- #2280: mktd Save TODO / `spec.toml` prose parse failure
- #2330: writer pre-exec host memory admission denied
- #2351: writer session lost after KV-warm and no-daemon recovery timeout

Closes #2289
