### PR TITLE
fix(dev2merge): support fresh repos without local patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1042"
+version = "0.1.1043"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1042"
+version = "0.1.1043"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pattern_resolver.rs
+++ b/crates/cli-sub-agent/src/pattern_resolver.rs
@@ -10,7 +10,7 @@
 //! 3. Superproject root (submodule only): `.csa/patterns/<name>/`
 //! 4. Superproject root (submodule only): `patterns/<name>/`
 //! 5. `<global_store>/<pkg>/<commit>/patterns/<name>/` from lockfiles under current/superproject
-//! 6. Binary-bundled fallback for first-party review/debate patterns
+//! 6. Binary-bundled fallback for first-party review/debate/planning patterns
 
 use anyhow::{Context, Result, bail};
 use csa_config::paths;
@@ -131,11 +131,45 @@ static BUNDLED_DEBATE_FILES: &[BundledPatternFile] = &[
     },
 ];
 
+static BUNDLED_MKTD_FILES: &[BundledPatternFile] = &[
+    BundledPatternFile {
+        path: ".skill.toml",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/mktd/.skill.toml"
+        )),
+    },
+    BundledPatternFile {
+        path: "PATTERN.md",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/mktd/PATTERN.md"
+        )),
+    },
+    BundledPatternFile {
+        path: "workflow.toml",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/mktd/workflow.toml"
+        )),
+    },
+    BundledPatternFile {
+        path: "skills/mktd/SKILL.md",
+        contents: include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../patterns/mktd/skills/mktd/SKILL.md"
+        )),
+    },
+];
+
 static BUNDLED_CSA_REVIEW_PATTERN: BundledPattern = BundledPattern {
     files: BUNDLED_CSA_REVIEW_FILES,
 };
 static BUNDLED_DEBATE_PATTERN: BundledPattern = BundledPattern {
     files: BUNDLED_DEBATE_FILES,
+};
+static BUNDLED_MKTD_PATTERN: BundledPattern = BundledPattern {
+    files: BUNDLED_MKTD_FILES,
 };
 
 // ---------------------------------------------------------------------------
@@ -301,6 +335,7 @@ fn bundled_pattern(name: &str) -> Option<&'static BundledPattern> {
     match name {
         "csa-review" => Some(&BUNDLED_CSA_REVIEW_PATTERN),
         "debate" => Some(&BUNDLED_DEBATE_PATTERN),
+        "mktd" => Some(&BUNDLED_MKTD_PATTERN),
         _ => None,
     }
 }
@@ -613,3 +648,7 @@ fn load_skill_config_with_user_dir(
 #[cfg(test)]
 #[path = "pattern_resolver_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "pattern_resolver_tests_2305.rs"]
+mod tests_2305;

--- a/crates/cli-sub-agent/src/pattern_resolver_tests_2305.rs
+++ b/crates/cli-sub-agent/src/pattern_resolver_tests_2305.rs
@@ -1,0 +1,55 @@
+use std::path::Path;
+
+use super::*;
+use tempfile::TempDir;
+
+#[test]
+fn resolve_pattern_falls_back_to_bundled_mktd_without_repo_local_pattern() {
+    let tmp = TempDir::new().unwrap();
+    let materialized = TempDir::new().unwrap();
+
+    let resolved =
+        resolve_pattern_with_materialization_root("mktd", tmp.path(), Some(materialized.path()))
+            .unwrap();
+
+    assert!(resolved.skill_md.contains("mktd: Make TODO"));
+    assert!(resolved.dir.starts_with(materialized.path()));
+    assert!(resolved.dir.join("workflow.toml").is_file());
+    assert!(resolved.dir.join("skills/mktd/SKILL.md").is_file());
+    assert!(!tmp.path().join(".csa").exists());
+    assert!(!tmp.path().join("patterns").exists());
+}
+
+#[test]
+fn materialize_bundled_mktd_writes_full_files_without_temp_residue() {
+    let materialized = TempDir::new().unwrap();
+    let dest =
+        materialize_bundled_pattern("mktd", &BUNDLED_MKTD_PATTERN, Some(materialized.path()))
+            .unwrap();
+
+    for file in BUNDLED_MKTD_PATTERN.files {
+        let path = dest.join(file.path);
+        assert_eq!(std::fs::read(&path).unwrap(), file.contents);
+    }
+
+    assert_no_temp_files(&dest);
+}
+
+fn assert_no_temp_files(dir: &Path) {
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            assert_no_temp_files(&path);
+        } else {
+            assert!(
+                !path
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .contains(".tmp."),
+                "temporary bundled file was left behind: {}",
+                path.display()
+            );
+        }
+    }
+}

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -652,6 +652,10 @@ mod tests_mktd_save;
 mod tests_dev2merge_2031;
 
 #[cfg(test)]
+#[path = "plan_cmd_tests_dev2merge_2305.rs"]
+mod tests_dev2merge_2305;
+
+#[cfg(test)]
 #[path = "plan_cmd_tests_pr_bot.rs"]
 mod tests_pr_bot;
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_dev2merge_2305.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_dev2merge_2305.rs
@@ -1,0 +1,228 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+use weave::compiler::plan_from_toml;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use crate::plan_cmd::extract_bash_code_block;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
+}
+
+fn dev2merge_workflow_step_bash(title: &str) -> String {
+    let workflow =
+        std::fs::read_to_string(workspace_root().join("patterns/dev2merge/workflow.toml")).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+    let step = plan
+        .steps
+        .iter()
+        .find(|step| step.title == title)
+        .unwrap_or_else(|| panic!("missing dev2merge step: {title}"));
+
+    extract_bash_code_block(&step.prompt)
+        .unwrap_or_else(|| panic!("missing bash block for dev2merge step: {title}"))
+        .trim()
+        .to_string()
+}
+
+fn markdown_step_section<'a>(content: &'a str, heading: &str) -> &'a str {
+    let start = content
+        .find(heading)
+        .unwrap_or_else(|| panic!("missing markdown step heading: {heading}"));
+    let rest = &content[start..];
+    let end = rest[1..]
+        .find("\n## Step ")
+        .map(|offset| offset + 1)
+        .unwrap_or(rest.len());
+    &rest[..end]
+}
+
+fn dev2merge_pattern_step_bash(pattern: &str, heading: &str) -> String {
+    let section = markdown_step_section(pattern, heading);
+    extract_bash_code_block(section)
+        .unwrap_or_else(|| panic!("missing bash block for dev2merge pattern heading: {heading}"))
+        .trim()
+        .to_string()
+}
+
+#[test]
+fn dev2merge_2305_changed_bash_blocks_stay_synced() {
+    let pattern =
+        std::fs::read_to_string(workspace_root().join("patterns/dev2merge/PATTERN.md")).unwrap();
+
+    for (title, heading) in [
+        (
+            "FAST_PATH Version Bump",
+            "## Step 5: FAST_PATH Version Bump",
+        ),
+        ("Plan with mktd", "## Step 7: Plan with mktd"),
+        ("Ensure Version Bumped", "## Step 10: Ensure Version Bumped"),
+    ] {
+        assert_eq!(
+            dev2merge_pattern_step_bash(&pattern, heading),
+            dev2merge_workflow_step_bash(title),
+            "dev2merge PATTERN.md and workflow.toml {heading} bash blocks must stay synced"
+        );
+    }
+}
+
+#[test]
+fn dev2merge_plan_step_resolves_mktd_by_pattern_unless_explicit_path_set() {
+    let script = dev2merge_workflow_step_bash("Plan with mktd");
+
+    assert!(
+        script.contains("MKTD=(--pattern mktd); [ -n \"${MKTD_WORKFLOW_PATH:-}\" ]"),
+        "Step 7 must expose an explicit mktd workflow path override while defaulting to pattern resolution"
+    );
+    assert!(
+        script.contains("MKTD=(--pattern mktd)"),
+        "Step 7 must default to pattern resolution instead of a target-repo-local path"
+    );
+    assert!(
+        script.contains("MKTD=(\"$MKTD_WORKFLOW_PATH\")"),
+        "Step 7 must honor explicit mktd workflow path configuration"
+    );
+    assert!(
+        !script.contains("csa plan run --sa-mode true patterns/mktd/workflow.toml"),
+        "Step 7 must not invoke target-repo-local patterns/mktd/workflow.toml by default"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn dev2merge_version_bump_skips_when_optional_check_recipe_absent() {
+    let fake_just = r#"
+case "${1:-}" in
+  --summary)
+    printf '%s\n' 'test check-version-bumped-extra'
+    ;;
+  *)
+    printf 'unexpected just invocation: %s\n' "$*" >&2
+    exit 97
+    ;;
+esac
+"#;
+
+    for title in ["FAST_PATH Version Bump", "Ensure Version Bumped"] {
+        let output = run_version_bump_script_with_fake_just(title, fake_just);
+        assert!(
+            output.status.success(),
+            "{title} must skip cleanly when check-version-bumped is absent: stdout={}\nstderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout)
+                .contains("Version bump skipped: no-check-version-bumped"),
+            "{title} must print a bounded skip message when check-version-bumped is absent"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn dev2merge_version_bump_uses_exact_optional_recipe_names() {
+    let fake_just = r#"
+case "${1:-}" in
+  --summary)
+    printf '%s\n' 'check-version-bumped foo-bump-patch bump-patch-extra'
+    ;;
+  check-version-bumped)
+    exit 1
+    ;;
+  *)
+    printf 'unexpected just invocation: %s\n' "$*" >&2
+    exit 97
+    ;;
+esac
+"#;
+
+    for title in ["FAST_PATH Version Bump", "Ensure Version Bumped"] {
+        let output = run_version_bump_script_with_fake_just(title, fake_just);
+        assert!(
+            output.status.success(),
+            "{title} must not treat hyphenated recipe substrings as exact recipe names: stdout={}\nstderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("Version bump skipped: no-bump-patch"),
+            "{title} must skip because exact bump-patch recipe is absent"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn dev2merge_version_bump_skips_when_optional_bump_recipe_absent() {
+    let fake_just = r#"
+case "${1:-}" in
+  --summary)
+    printf '%s\n' 'check-version-bumped'
+    ;;
+  check-version-bumped)
+    exit 1
+    ;;
+  *)
+    printf 'unexpected just invocation: %s\n' "$*" >&2
+    exit 97
+    ;;
+esac
+"#;
+
+    for title in ["FAST_PATH Version Bump", "Ensure Version Bumped"] {
+        let output = run_version_bump_script_with_fake_just(title, fake_just);
+        assert!(
+            output.status.success(),
+            "{title} must skip cleanly when bump-patch is absent: stdout={}\nstderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("Version bump skipped: no-bump-patch"),
+            "{title} must print a bounded skip message when bump-patch is absent"
+        );
+    }
+}
+
+#[cfg(unix)]
+fn run_version_bump_script_with_fake_just(
+    title: &str,
+    fake_just_body: &str,
+) -> std::process::Output {
+    let repo = TempDir::new().unwrap();
+    let bin = repo.path().join("bin");
+    std::fs::create_dir(&bin).unwrap();
+    let just_path = bin.join("just");
+    std::fs::write(
+        &just_path,
+        format!("#!/usr/bin/env bash\nset -euo pipefail\n{fake_just_body}"),
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&just_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&just_path, permissions).unwrap();
+    std::fs::write(
+        repo.path().join("Cargo.toml"),
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\nedition = \"2024\"\n",
+    )
+    .unwrap();
+
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    Command::new("bash")
+        .arg("-c")
+        .arg(dev2merge_workflow_step_bash(title))
+        .current_dir(repo.path())
+        .env("PATH", path)
+        .output()
+        .unwrap()
+}

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -279,23 +279,21 @@ echo "CSA_VAR:FAST_PATH_COMMITTED=true"
 ## Step 5: FAST_PATH Version Bump
 Tool: bash
 OnFail: abort
-Version bump is Rust-only (`just bump-patch` + `cargo metadata`). Repos without
-a `Cargo.toml` (e.g. Python/Node) skip this step with a warning instead of
-aborting the pipeline (#1658).
+Optional bump; missing recipes skip (#1658/#2305).
 
 ```bash
 set -euo pipefail
-if [ ! -f Cargo.toml ]; then
-  echo "Version bump skipped: no Cargo.toml found"
-  exit 0
-fi
-if ! just check-version-bumped 2>/dev/null; then
-  just bump-patch
-  cargo run -p weave -- lock 2>/dev/null || true
-  git add Cargo.toml Cargo.lock weave.lock 2>/dev/null || git add Cargo.toml weave.lock
-  VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')"
-  git commit -m "chore(release): bump workspace version to ${VERSION}"
-fi
+h(){ just --summary 2>/dev/null|tr ' ' '\n'|grep -qx "$1"; }
+s(){ echo "Version bump skipped: $1"; exit 0; }
+[ -f Cargo.toml ] || s no-Cargo.toml
+h check-version-bumped || s no-check-version-bumped
+just check-version-bumped&&exit 0||true
+h bump-patch || s no-bump-patch
+just bump-patch
+cargo run -p weave -- lock 2>/dev/null || true
+git add Cargo.toml Cargo.lock weave.lock 2>/dev/null || git add Cargo.toml weave.lock
+VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')"
+git commit -m "chore(release): bump workspace version to ${VERSION}"
 ```
 
 ## Step 6: FAST_PATH Pre-PR Review
@@ -318,10 +316,7 @@ echo '<!-- CSA:NEXT_STEP cmd="push to origin (Step 13)" required=true -->'
 Tool: bash
 OnFail: abort
 Condition: !(${RESUME_MODE})
-Skipped in resume mode (work already implemented). Generate a TODO via mktd
-with a hard timeout (default `1800`s). Intensity is
-`light` when the brief names at least two `path/file:LINE` refs or the diff is
-small; otherwise it is `full`.
+mktd TODO; --pattern mktd default, MKTD_WORKFLOW_PATH override, auto light/full.
 
 ```bash
 set -euo pipefail
@@ -331,11 +326,8 @@ USER_LANGUAGE_OVERRIDE="${CSA_USER_LANGUAGE:-}"
 MKTD_TOOL_EFFECTIVE="${MKTD_TOOL:-${CSA_MKTD_TOOL:-}}"
 MKTD_TIMEOUT_SECONDS="${MKTD_TIMEOUT_SECONDS:-1800}"
 MKTD_PLAN_TIER="${PLAN_TIER:-${TIER:-tier-3-complex}}"
-if [ -n "${MKTD_TOOL_EFFECTIVE}" ]; then
-  MKTD_TOOL_ARGS=(--tool "${MKTD_TOOL_EFFECTIVE}")
-else
-  MKTD_TOOL_ARGS=()
-fi
+MKTD=(--pattern mktd); [ -n "${MKTD_WORKFLOW_PATH:-}" ] && MKTD=("$MKTD_WORKFLOW_PATH")
+MKTD_TOOL_ARGS=(); [ -z "${MKTD_TOOL_EFFECTIVE}" ] || MKTD_TOOL_ARGS=(--tool "${MKTD_TOOL_EFFECTIVE}")
 LIGHT_THRESHOLD_FILES="${PLANNING_LIGHT_THRESHOLD_FILES:-2}"
 LIGHT_THRESHOLD_LINES="${PLANNING_LIGHT_THRESHOLD_LINES:-50}"
 PLAN_CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -cvE '\.(md|txt|lock|toml)$' || true)"
@@ -354,7 +346,7 @@ else
 fi
 echo "mktd hard-timeout: ${MKTD_TIMEOUT_SECONDS}s"
 set +e
-MKTD_OUTPUT="$(timeout -k 30 "${MKTD_TIMEOUT_SECONDS}" csa plan run --sa-mode true patterns/mktd/workflow.toml \
+MKTD_OUTPUT="$(timeout -k 30 "${MKTD_TIMEOUT_SECONDS}" csa plan run --sa-mode true "${MKTD[@]}" \
   "${MKTD_TOOL_ARGS[@]}" \
   --var CWD="$(pwd)" \
   --var FEATURE="Plan dev2merge for branch ${CURRENT_BRANCH}. Scope: ${FEATURE_INPUT}." \
@@ -477,23 +469,21 @@ git commit -m "${COMMIT_MSG}"
 ## Step 10: Ensure Version Bumped
 Tool: bash
 OnFail: abort
-Version bump is Rust-only (`just bump-patch` + `cargo metadata`). Repos without
-a `Cargo.toml` (e.g. Python/Node) skip this step with a warning instead of
-aborting the pipeline (#1658).
+Optional bump; missing recipes skip (#1658/#2305).
 
 ```bash
 set -euo pipefail
-if [ ! -f Cargo.toml ]; then
-  echo "Version bump skipped: no Cargo.toml found"
-  exit 0
-fi
-if ! just check-version-bumped 2>/dev/null; then
-  just bump-patch
-  cargo run -p weave -- lock 2>/dev/null || true
-  git add Cargo.toml Cargo.lock weave.lock 2>/dev/null || git add Cargo.toml weave.lock
-  VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')"
-  git commit -m "chore(release): bump workspace version to ${VERSION}"
-fi
+h(){ just --summary 2>/dev/null|tr ' ' '\n'|grep -qx "$1"; }
+s(){ echo "Version bump skipped: $1"; exit 0; }
+[ -f Cargo.toml ] || s no-Cargo.toml
+h check-version-bumped || s no-check-version-bumped
+just check-version-bumped&&exit 0||true
+h bump-patch || s no-bump-patch
+just bump-patch
+cargo run -p weave -- lock 2>/dev/null || true
+git add Cargo.toml Cargo.lock weave.lock 2>/dev/null || git add Cargo.toml weave.lock
+VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')"
+git commit -m "chore(release): bump workspace version to ${VERSION}"
 ```
 
 ## Step 11: Self-Review Gate

--- a/patterns/dev2merge/skills/dev2merge/SKILL.md
+++ b/patterns/dev2merge/skills/dev2merge/SKILL.md
@@ -186,13 +186,13 @@ All steps use `on_fail = "abort"`. Variables propagate via `CSA_VAR:KEY=value`.
 | 3 | L1/L2 Quality Gates | language-aware lint/test gate | bash |
 | **IF FAST_PATH** | | | |
 | 4 | Simplified Commit | `just test && git commit` | bash |
-| 5 | Version Bump | Rust-only `just bump-patch` if needed; non-Rust skips | bash |
+| 5 | Version Bump | optional local Just version recipes; missing recipes skip | bash |
 | 6 | Pre-PR Review | `csa review --range` then `csa review --check-verdict --range` | bash |
 | **ELSE (Full Pipeline)** | | | |
-| 7 | Plan with mktd | `csa plan run patterns/mktd/workflow.toml` (skipped in resume mode) | bash |
+| 7 | Plan with mktd | `csa plan run --pattern mktd` by default, `MKTD_WORKFLOW_PATH` override allowed (skipped in resume mode) | bash |
 | 8 | Execute with mktsk | Follow mktsk PATTERN.md directly, TaskCreate/TaskUpdate (skipped in resume mode) | main agent |
 | 9 | Resume Commit | resume mode only: L2 tests + commit uncommitted remainder | bash |
-| 10 | Version Bump | Rust-only `just bump-patch` if needed; non-Rust skips | bash |
+| 10 | Version Bump | optional local Just version recipes; missing recipes skip | bash |
 | 11 | Self-Review Gate | Main agent checks and fixes the full branch diff before CSA review | main agent |
 | 12 | Pre-PR Cumulative Review Gate | `csa review --range ${DEFAULT_BRANCH}...HEAD` then `csa review --check-verdict --range ${DEFAULT_BRANCH}...HEAD` | bash |
 | **ENDIF** | | | |
@@ -246,7 +246,7 @@ ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
 3. Language-aware L1/L2 gates exit 0.
 4. If full pipeline: mktd plan saved with `DONE WHEN` clauses, mktsk executed all tasks via main agent.
 5. If FAST_PATH: simplified commit created with tests passing.
-6. Rust repos have version bumped if needed; non-Rust repos skip version bump without aborting.
+6. Rust repos with local version recipes bump if needed; non-Rust repos or repos missing those optional recipes skip without aborting.
 7. Pre-PR cumulative review passed the PASS/CLEAN verdict check before setting `REVIEW_COMPLETED=true`.
 8. Push completed via `--force-with-lease` (pre-push hook verified review HEAD).
 9. Pre-PR review verdict check passed (`csa review --check-verdict --range ${DEFAULT_BRANCH}...HEAD`).

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -75,6 +75,8 @@ name = "MKTD_OUTPUT"
 [[workflow.variables]]
 name = "MKTD_TIMEOUT_SECONDS"
 [[workflow.variables]]
+name = "MKTD_WORKFLOW_PATH"
+[[workflow.variables]]
 name = "MKTD_TODO_TIMESTAMP"
 [[workflow.variables]]
 name = "MKTD_TOOL_EFFECTIVE"
@@ -317,23 +319,21 @@ id = 5
 title = "FAST_PATH Version Bump"
 tool = "bash"
 prompt = '''
-Version bump is Rust-only (`just bump-patch` + `cargo metadata`). Repos without
-a `Cargo.toml` (e.g. Python/Node) skip this step with a warning instead of
-aborting the pipeline (#1658).
+Optional bump; missing recipes skip (#1658/#2305).
 
 ```bash
 set -euo pipefail
-if [ ! -f Cargo.toml ]; then
-  echo "Version bump skipped: no Cargo.toml found"
-  exit 0
-fi
-if ! just check-version-bumped 2>/dev/null; then
-  just bump-patch
-  cargo run -p weave -- lock 2>/dev/null || true
-  git add Cargo.toml Cargo.lock weave.lock 2>/dev/null || git add Cargo.toml weave.lock
-  VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')"
-  git commit -m "chore(release): bump workspace version to ${VERSION}"
-fi
+h(){ just --summary 2>/dev/null|tr ' ' '\n'|grep -qx "$1"; }
+s(){ echo "Version bump skipped: $1"; exit 0; }
+[ -f Cargo.toml ] || s no-Cargo.toml
+h check-version-bumped || s no-check-version-bumped
+just check-version-bumped&&exit 0||true
+h bump-patch || s no-bump-patch
+just bump-patch
+cargo run -p weave -- lock 2>/dev/null || true
+git add Cargo.toml Cargo.lock weave.lock 2>/dev/null || git add Cargo.toml weave.lock
+VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')"
+git commit -m "chore(release): bump workspace version to ${VERSION}"
 ```'''
 on_fail = "abort"
 condition = "(!(${DEV2MERGE_SKIP})) && (${FAST_PATH})"
@@ -361,8 +361,7 @@ id = 7
 title = "Plan with mktd"
 tool = "bash"
 prompt = '''
-Generate a TODO via mktd with a hard timeout. Use `light` intensity for
-specific briefs or small diffs; otherwise use `full`.
+mktd TODO; --pattern mktd default, MKTD_WORKFLOW_PATH override, auto light/full.
 
 ```bash
 set -euo pipefail
@@ -372,11 +371,8 @@ USER_LANGUAGE_OVERRIDE="${CSA_USER_LANGUAGE:-}"
 MKTD_TOOL_EFFECTIVE="${MKTD_TOOL:-${CSA_MKTD_TOOL:-}}"
 MKTD_TIMEOUT_SECONDS="${MKTD_TIMEOUT_SECONDS:-1800}"
 MKTD_PLAN_TIER="${PLAN_TIER:-${TIER:-tier-3-complex}}"
-if [ -n "${MKTD_TOOL_EFFECTIVE}" ]; then
-  MKTD_TOOL_ARGS=(--tool "${MKTD_TOOL_EFFECTIVE}")
-else
-  MKTD_TOOL_ARGS=()
-fi
+MKTD=(--pattern mktd); [ -n "${MKTD_WORKFLOW_PATH:-}" ] && MKTD=("$MKTD_WORKFLOW_PATH")
+MKTD_TOOL_ARGS=(); [ -z "${MKTD_TOOL_EFFECTIVE}" ] || MKTD_TOOL_ARGS=(--tool "${MKTD_TOOL_EFFECTIVE}")
 LIGHT_THRESHOLD_FILES="${PLANNING_LIGHT_THRESHOLD_FILES:-2}"
 LIGHT_THRESHOLD_LINES="${PLANNING_LIGHT_THRESHOLD_LINES:-50}"
 PLAN_CODE_FILES="$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | grep -cvE '\.(md|txt|lock|toml)$' || true)"
@@ -395,7 +391,7 @@ else
 fi
 echo "mktd hard-timeout: ${MKTD_TIMEOUT_SECONDS}s"
 set +e
-MKTD_OUTPUT="$(timeout -k 30 "${MKTD_TIMEOUT_SECONDS}" csa plan run --sa-mode true patterns/mktd/workflow.toml \
+MKTD_OUTPUT="$(timeout -k 30 "${MKTD_TIMEOUT_SECONDS}" csa plan run --sa-mode true "${MKTD[@]}" \
   "${MKTD_TOOL_ARGS[@]}" \
   --var CWD="$(pwd)" \
   --var FEATURE="Plan dev2merge for branch ${CURRENT_BRANCH}. Scope: ${FEATURE_INPUT}." \
@@ -537,23 +533,21 @@ id = 10
 title = "Ensure Version Bumped"
 tool = "bash"
 prompt = '''
-Version bump is Rust-only (`just bump-patch` + `cargo metadata`). Repos without
-a `Cargo.toml` (e.g. Python/Node) skip this step with a warning instead of
-aborting the pipeline (#1658).
+Optional bump; missing recipes skip (#1658/#2305).
 
 ```bash
 set -euo pipefail
-if [ ! -f Cargo.toml ]; then
-  echo "Version bump skipped: no Cargo.toml found"
-  exit 0
-fi
-if ! just check-version-bumped 2>/dev/null; then
-  just bump-patch
-  cargo run -p weave -- lock 2>/dev/null || true
-  git add Cargo.toml Cargo.lock weave.lock 2>/dev/null || git add Cargo.toml weave.lock
-  VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')"
-  git commit -m "chore(release): bump workspace version to ${VERSION}"
-fi
+h(){ just --summary 2>/dev/null|tr ' ' '\n'|grep -qx "$1"; }
+s(){ echo "Version bump skipped: $1"; exit 0; }
+[ -f Cargo.toml ] || s no-Cargo.toml
+h check-version-bumped || s no-check-version-bumped
+just check-version-bumped&&exit 0||true
+h bump-patch || s no-bump-patch
+just bump-patch
+cargo run -p weave -- lock 2>/dev/null || true
+git add Cargo.toml Cargo.lock weave.lock 2>/dev/null || git add Cargo.toml weave.lock
+VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')"
+git commit -m "chore(release): bump workspace version to ${VERSION}"
 ```'''
 on_fail = "abort"
 condition = "(!(${DEV2MERGE_SKIP})) && (!(${FAST_PATH}))"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1042"
-weave = "0.1.1042"
+csa = "0.1.1043"
+weave = "0.1.1043"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Fix dev2merge fresh/minimal repository portability for bundled first-party mktd planning.
- Resolve `mktd` through bundled/global pattern lookup by default while keeping `MKTD_WORKFLOW_PATH` as an explicit override.
- Treat project-local version-bump Just recipes as optional: missing `Cargo.toml`, `check-version-bumped`, or `bump-patch` now skips with bounded messages instead of aborting tail/resume.
- Fix exact Just recipe probing so hyphenated recipe names such as `foo-bump-patch` do not satisfy exact `bump-patch`.
- Sync `patterns/dev2merge/PATTERN.md`, `patterns/dev2merge/workflow.toml`, and the dev2merge skill docs.
- Bump workspace version to `0.1.1043` and include `Cargo.lock` / `weave.lock` updates.

## Verification

- `cargo test -p cli-sub-agent dev2merge_2305 -- --nocapture`
- `cargo test -p cli-sub-agent resolve_pattern_falls_back_to_bundled_mktd_without_repo_local_pattern -- --nocapture`
- `cargo test -p cli-sub-agent materialize_bundled_mktd_writes_full_files_without_temp_residue -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check main...HEAD`
- `git diff --check`
- `just find-monolith-files`
- `just pre-commit-fast`
- hook-enabled commit passed
- rebuilt exact debug binary: `target/debug/csa 0.1.1043 (444af864)`

## Review

- Initial exact-head review: `01KVPH2HMN0NEXQPXFJVR1P2D6` returned FAIL for hyphenated Just recipe probing.
- Same-session fix-finding: `01KVPHEZKB516H6HK88YVX280M` amended the commit to `444af864d1e14edde177d9d96ca0507af9d0bb41`.
- Final exact-head review: `01KVPQHWP27GTZJHH2MD7G31WY` PASS/CLEAN for `range:main...HEAD`.
- `target/debug/csa review --check-verdict --sa-mode true --range main...HEAD`: passed.
- installed `csa review --check-verdict --sa-mode true --range main...HEAD`: passed.
- pre-push review-check: passed.

## CSA operational note

The first CSA-Codex writer session for #2305 reproduced session-registry loss after KV-warm and left dirty work. Evidence was appended to #2351, then this branch was completed via native-equivalent fallback and exact-head CSA review.

Closes #2305
