### PR TITLE
fix(review): avoid unsafe push next-step after failed fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1045"
+version = "0.1.1046"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1045"
+version = "0.1.1046"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -99,6 +99,7 @@ mod session_cmds_reconcile_liveness;
 mod session_cmds_result;
 mod session_cmds_result_measure;
 mod session_dispatch;
+mod session_fix_finding_recovery;
 mod session_guard;
 mod session_kill_diagnostics;
 mod session_observability;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_next_step.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_next_step.rs
@@ -13,6 +13,9 @@ pub(crate) fn synthesized_wait_next_step(session_dir: &Path) -> Result<Option<St
     {
         return Ok(None);
     }
+    if crate::session_fix_finding_recovery::suppresses_required_push_next_step(session_dir) {
+        return Ok(None);
+    }
 
     let unpushed_commits_path = session_dir.join("output").join("unpushed_commits.json");
     if unpushed_commits_path.is_file() {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -150,6 +150,9 @@ pub(crate) fn render_wait_result_summary(
             ),
         );
     }
+    lines.extend(crate::session_fix_finding_recovery::wait_summary_lines(
+        session_dir,
+    ));
 
     if let Some(changes) = result.uncommitted_changes.as_ref() {
         lines.push(crate::run_cmd::format_uncommitted_warning(changes));
@@ -258,6 +261,7 @@ fn render_wait_result_json(
         "kill_diagnostics": result.kill_diagnostics.as_ref(),
         "require_commit_recovery": result.require_commit_recovery.as_ref(),
         "memory_soft_limit_recovery": result.memory_soft_limit_recovery.as_ref(),
+        "fix_finding_recovery": crate::session_fix_finding_recovery::read_recovery_sidecar(session_dir),
         "post_exec_gate": result.post_exec_gate.as_ref(),
         "large_diff_warning": result.large_diff_warning.as_ref(),
         "warnings": result.warnings,

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_recovery_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_recovery_tests.rs
@@ -66,6 +66,84 @@ fn compact_summary_and_json_include_require_commit_recovery() {
 }
 
 #[test]
+fn compact_summary_and_json_include_fix_finding_recovery_sidecar() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let output_dir = temp.path().join("output");
+    std::fs::create_dir_all(&output_dir).expect("output dir should be created");
+    std::fs::write(
+        output_dir.join("fix_finding_recovery.json"),
+        r#"{
+  "schema_version": 1,
+  "kind": "fix_finding_failed_closed_recovery",
+  "session_id": "01TESTFIXRECOVERY",
+  "outcome": "failed_closed_missing_result",
+  "side_effects": {
+    "status": "dirty_or_committed_tracked_changes",
+    "added": {"paths": [], "truncated": 0},
+    "modified": {"paths": ["src/lib.rs"], "truncated": 0},
+    "deleted": {"paths": [], "truncated": 0},
+    "renamed": {"paths": [], "truncated": 0}
+  },
+  "allow_required_push_next_step": false,
+  "requires_fresh_exact_head_review": true,
+  "recovery_actions": [
+    "inspect_git_metadata",
+    "preserve_finish_or_discard_dirty_side_effects",
+    "create_hook_enabled_commit_if_appropriate",
+    "run_fresh_exact_head_review_before_push_or_pr"
+  ],
+  "git_inspection_commands": [
+    "git status --short",
+    "git diff",
+    "git diff --staged",
+    "git log --oneline -5"
+  ],
+  "guidance": "Inspect git metadata, preserve and finish or discard dirty/staged side effects, create a hook-enabled commit if appropriate, and run a fresh exact-head review before push/PR."
+}"#,
+    )
+    .expect("fix-finding recovery sidecar should be written");
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "fix-finding failed closed".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTFIXRECOVERY", &result);
+
+    assert!(summary.contains("Fix-finding recovery: failed_closed_missing_result"));
+    assert!(summary.contains("required push next-step suppressed"));
+    assert!(summary.contains(
+        "Side effects: repo_side_effects=dirty_or_committed_tracked_changes modified=[src/lib.rs]"
+    ));
+    assert!(summary.contains("hook-enabled commit"));
+    assert!(summary.contains("fresh exact-head review before push/PR"));
+
+    let json: serde_json::Value = serde_json::from_str(
+        &render_wait_result_json(temp.path(), "01TESTFIXRECOVERY", &result)
+            .expect("wait JSON should render"),
+    )
+    .expect("wait JSON should parse");
+    let recovery = &json["fix_finding_recovery"];
+    assert_eq!(
+        recovery["allow_required_push_next_step"],
+        serde_json::json!(false)
+    );
+    assert_eq!(
+        recovery["requires_fresh_exact_head_review"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        recovery["recovery_actions"][3],
+        serde_json::json!("run_fresh_exact_head_review_before_push_or_pr")
+    );
+}
+
+#[test]
 fn compact_summary_omits_require_commit_recovery_when_absent() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let now = Utc::now();

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -1,15 +1,12 @@
 use anyhow::{Context, Result, anyhow};
-use csa_core::vcs::VcsKind;
 use csa_session::{
     MetaSessionState, SessionPhase, SessionResult, get_session_dir, load_result, load_session,
 };
-use serde::{Deserialize, Serialize};
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tracing::{debug, info, warn};
 
-use crate::plan_cmd::shell_escape_for_command;
 #[cfg(test)]
 use crate::session_result_publish::publish_result_file_if_absent_with_writer;
 use crate::session_result_publish::{
@@ -24,29 +21,19 @@ mod reconcile_diagnostics;
 mod reconcile_fix_finding;
 #[path = "session_cmds_reconcile_git.rs"]
 mod reconcile_git;
+#[path = "session_cmds_reconcile_sidecars.rs"]
+mod reconcile_sidecars;
 use crate::session_cmds_reconcile_liveness::{
     ReconcileLivenessDecision, reconcile_liveness_decision,
 };
-use reconcile_git::{git_output, git_success, resolve_fallback_base_branch};
+#[cfg(test)]
+use reconcile_sidecars::write_sidecar_atomically;
+use reconcile_sidecars::{
+    ArtifactRollbackGuard, persist_fix_finding_recovery_sidecar, persist_unpushed_commits_sidecar,
+    rollback_sidecars,
+};
 
 type PersistSessionFn<'a> = dyn Fn(&Path, &MetaSessionState) -> Result<()> + 'a;
-const UNPUSHED_COMMITS_SIDECAR_PATH: &str = "output/unpushed_commits.json";
-
-#[rustfmt::skip]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct UnpushedCommitRecord { sha: String, subject: String }
-
-#[rustfmt::skip]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct UnpushedCommitsSidecar { branch: String, remote_ref: Option<String>, commits_ahead: u64, commits: Vec<UnpushedCommitRecord>, recovery_command: String }
-
-#[rustfmt::skip]
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ArtifactRollbackGuard { artifact_path: PathBuf, expected_contents: Vec<u8>, rollback_action: ArtifactRollbackAction }
-
-#[rustfmt::skip]
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum ArtifactRollbackAction { RemoveIfContentsMatch, RestoreOriginal(Vec<u8>) }
 
 #[rustfmt::skip]
 struct ArtifactRollbackLabels<'a> { removed_cleanup: &'a str, missing_after_match_cleanup: &'a str, remove_failed_cleanup: &'a str, preserved_cleanup: &'a str, missing_cleanup: &'a str, read_failed_cleanup: &'a str, artifact_label: &'a str }
@@ -109,84 +96,8 @@ pub(crate) fn with_reconcile_lock<R>(
 
 fn noop_path(_: &Path) {}
 
-fn inspect_unpushed_commits(
-    project_root: &Path,
-    branch: &str,
-) -> Result<Option<UnpushedCommitsSidecar>> {
-    let session_branch_ref = format!("refs/heads/{branch}");
-    let range = if git_success(
-        project_root,
-        &[
-            "rev-parse",
-            "--verify",
-            "--quiet",
-            &format!("refs/remotes/origin/{branch}"),
-        ],
-    ) {
-        (
-            Some(format!("origin/{branch}")),
-            format!("origin/{branch}..{session_branch_ref}"),
-        )
-    } else {
-        let Some(base_branch) = resolve_fallback_base_branch(project_root) else {
-            return Ok(None);
-        };
-        (None, format!("{base_branch}..{session_branch_ref}"))
-    };
-    let (remote_ref, rev_range) = range;
-
-    let count_output = git_output(project_root, &["rev-list", "--count", &rev_range])?;
-    if !count_output.status.success() {
-        return Ok(None);
-    }
-    let commits_ahead = String::from_utf8_lossy(&count_output.stdout)
-        .trim()
-        .parse::<u64>()
-        .unwrap_or(0);
-    if commits_ahead == 0 {
-        return Ok(None);
-    }
-
-    let log_output = git_output(project_root, &["log", "--format=%H%x09%s", &rev_range])?;
-    if !log_output.status.success() {
-        return Ok(None);
-    }
-
-    let commits = String::from_utf8_lossy(&log_output.stdout)
-        .lines()
-        .filter_map(|line| {
-            let (sha, subject) = line.split_once('\t')?;
-            Some(UnpushedCommitRecord {
-                sha: sha.to_string(),
-                subject: subject.to_string(),
-            })
-        })
-        .collect::<Vec<_>>();
-    if commits.is_empty() {
-        return Ok(None);
-    }
-
-    Ok(Some(UnpushedCommitsSidecar {
-        branch: branch.to_string(),
-        remote_ref,
-        commits_ahead,
-        commits,
-        recovery_command: format_git_push_recovery_command(branch),
-    }))
-}
-
 #[rustfmt::skip]
-fn persist_unpushed_commits_sidecar(project_root: &Path, session: &MetaSessionState, session_dir: &Path) -> Result<Option<ArtifactRollbackGuard>> {
-    if session.resolved_identity().vcs_kind != VcsKind::Git { return Ok(None); }
-    let Some(branch) = session.branch.as_deref() else { return Ok(None); };
-    let Some(sidecar) = inspect_unpushed_commits(project_root, branch)? else { return Ok(None); };
-    fs::create_dir_all(session_dir.join("output"))?;
-    let sidecar_path = session_dir.join(UNPUSHED_COMMITS_SIDECAR_PATH);
-    let sidecar_contents = serde_json::to_vec_pretty(&sidecar)?;
-    let rollback_guard = artifact_rollback_guard(&sidecar_path, sidecar_contents.as_slice())?;
-    write_sidecar_atomically(&sidecar_path, &sidecar_contents)?;
-    Ok(rollback_guard)
-}
+fn push_sidecar_rollback_guard(guards: &mut Vec<ArtifactRollbackGuard>, label: &str, result: Result<Option<ArtifactRollbackGuard>>, session_id: &str, trigger: &str) { match result { Ok(Some(rollback_guard)) => guards.push(rollback_guard), Ok(None) => {}, Err(err) => warn!(session_id = %session_id, trigger = %trigger, recovery_sidecar = %label, error = %err, "Failed to persist recovery sidecar"), } }
 
 pub(crate) fn ensure_terminal_result_for_dead_active_session(
     project_root: &Path,
@@ -386,19 +297,21 @@ where
         .max_by_key(|(_, state)| state.updated_at)
         .map(|(tool, _)| tool.clone())
         .unwrap_or_else(|| "unknown".to_string());
-    #[rustfmt::skip]
-    let sidecar_rollback_guard = match persist_unpushed_commits_sidecar(project_root, &session, session_dir) {
-        Ok(rollback_guard) => rollback_guard,
-        Err(err) => {
-            warn!(
-                session_id = %session_id,
-                trigger = %trigger,
-                error = %err,
-                "Failed to persist unpushed commit recovery sidecar"
-            );
-            None
-        }
-    };
+    let mut sidecar_rollback_guards = Vec::new();
+    push_sidecar_rollback_guard(
+        &mut sidecar_rollback_guards,
+        "unpushed commit recovery",
+        persist_unpushed_commits_sidecar(project_root, &session, session_dir),
+        session_id,
+        trigger,
+    );
+    push_sidecar_rollback_guard(
+        &mut sidecar_rollback_guards,
+        "fix-finding recovery",
+        persist_fix_finding_recovery_sidecar(project_root, &session, session_dir),
+        session_id,
+        trigger,
+    );
     #[rustfmt::skip]
     let artifacts = crate::pipeline_post_exec::collect_fallback_result_artifacts(project_root, session_id);
     let output_log_mtime = format_optional_file_mtime(&session_dir.join("output.log"));
@@ -426,7 +339,7 @@ where
     let result_contents = toml::to_string_pretty(&fallback).map_err(|err| anyhow!("Failed to serialize synthetic result for {session_id}: {err}"))?;
     match persist_new_result_file(&result_path, &result_contents, before_write)? {
         SyntheticResultPersistOutcome::AlreadyExists => {
-            if let Err(err) = rollback_sidecar(sidecar_rollback_guard.as_ref()) {
+            if let Err(err) = rollback_sidecars(&sidecar_rollback_guards) {
                 warn!(
                     session_id = %session_id,
                     trigger = %trigger,
@@ -473,7 +386,7 @@ where
         rollback_reconciliation_artifacts(
             &result_path,
             result_contents.as_bytes(),
-            sidecar_rollback_guard.as_ref(),
+            &sidecar_rollback_guards,
         )
         .map_err(|cleanup_err| {
             anyhow!(
@@ -496,7 +409,7 @@ where
         rollback_reconciliation_artifacts(
             &result_path,
             result_contents.as_bytes(),
-            sidecar_rollback_guard.as_ref(),
+            &sidecar_rollback_guards,
         )
         .map_err(|cleanup_err| {
             anyhow!(
@@ -595,7 +508,7 @@ where
         &packet,
         completed_at,
     ) {
-        rollback_reconciliation_artifacts(result_path, result_contents.as_bytes(), None)
+        rollback_reconciliation_artifacts(result_path, result_contents.as_bytes(), &[])
             .map_err(|cleanup_err| {
                 anyhow!(
                     "Failed to transition daemon-completed session to Retired phase during reconciliation for {session_id}; additionally failed to remove daemon completion result: {cleanup_err}"
@@ -765,23 +678,13 @@ pub(crate) fn persist_session_state_atomically(
 fn remove_synthetic_result_if_unchanged(result_path: &Path, expected_contents: &[u8]) -> std::io::Result<()> {
     remove_artifact_if_unchanged(result_path, expected_contents, ArtifactRollbackLabels { removed_cleanup: "removed_synthetic_result", missing_after_match_cleanup: "result_missing_after_match", remove_failed_cleanup: "remove_failed", preserved_cleanup: "late_real_result_preserved", missing_cleanup: "result_missing", read_failed_cleanup: "read_failed", artifact_label: "synthetic result.toml" })
 }
-#[rustfmt::skip]
-fn rollback_sidecar(rollback_guard: Option<&ArtifactRollbackGuard>) -> std::io::Result<()> {
-    let Some(rollback_guard) = rollback_guard else { return Ok(()); };
-    match &rollback_guard.rollback_action {
-        ArtifactRollbackAction::RemoveIfContentsMatch => remove_artifact_if_unchanged(&rollback_guard.artifact_path, rollback_guard.expected_contents.as_slice(), ArtifactRollbackLabels { removed_cleanup: "removed_unpushed_commits_sidecar", missing_after_match_cleanup: "sidecar_missing_after_match", remove_failed_cleanup: "sidecar_remove_failed", preserved_cleanup: "preexisting_sidecar_preserved", missing_cleanup: "sidecar_missing", read_failed_cleanup: "sidecar_read_failed", artifact_label: "unpushed_commits.json sidecar" }),
-        ArtifactRollbackAction::RestoreOriginal(original_contents) => match fs::read(&rollback_guard.artifact_path) {
-            Ok(current_contents) if current_contents == rollback_guard.expected_contents => { fs::write(&rollback_guard.artifact_path, original_contents)?; warn!(artifact_path = %rollback_guard.artifact_path.display(), rollback_cleanup = "restored_preexisting_unpushed_commits_sidecar", "Rollback restored preexisting unpushed_commits.json sidecar after reconciliation failure"); Ok(()) }
-            Ok(_) => { warn!(artifact_path = %rollback_guard.artifact_path.display(), rollback_cleanup = "preexisting_sidecar_preserved", "Rollback preserved unpushed_commits.json sidecar because contents changed after reconciliation failure"); Ok(()) }
-            Err(err) if err.kind() == ErrorKind::NotFound => { warn!(artifact_path = %rollback_guard.artifact_path.display(), rollback_cleanup = "sidecar_missing", "Rollback found no unpushed_commits.json sidecar to restore after reconciliation failure"); Ok(()) }
-            Err(err) => { warn!(artifact_path = %rollback_guard.artifact_path.display(), rollback_cleanup = "sidecar_read_failed", error = %err, "Rollback failed to read unpushed_commits.json sidecar for content-aware restore after reconciliation failure"); Ok(()) }
-        },
-    }
-}
-#[rustfmt::skip]
-fn rollback_reconciliation_artifacts(result_path: &Path, result_contents: &[u8], sidecar_rollback_guard: Option<&ArtifactRollbackGuard>) -> std::io::Result<()> {
+fn rollback_reconciliation_artifacts(
+    result_path: &Path,
+    result_contents: &[u8],
+    sidecar_rollback_guards: &[ArtifactRollbackGuard],
+) -> std::io::Result<()> {
     remove_synthetic_result_if_unchanged(result_path, result_contents)?;
-    rollback_sidecar(sidecar_rollback_guard)
+    rollback_sidecars(sidecar_rollback_guards)
 }
 #[rustfmt::skip]
 fn remove_artifact_if_unchanged(artifact_path: &Path, expected_contents: &[u8], labels: ArtifactRollbackLabels<'_>) -> std::io::Result<()> {
@@ -797,47 +700,6 @@ fn remove_artifact_if_unchanged(artifact_path: &Path, expected_contents: &[u8], 
         Err(err) => { warn!(artifact_path = %artifact_path.display(), rollback_cleanup = labels.read_failed_cleanup, error = %err, "Rollback failed to read {} for content-aware cleanup after reconciliation failure", labels.artifact_label); Ok(()) }
     }
 }
-
-#[rustfmt::skip]
-fn artifact_rollback_guard(artifact_path: &Path, expected_contents: &[u8]) -> std::io::Result<Option<ArtifactRollbackGuard>> {
-    match fs::read(artifact_path) {
-        Ok(current_contents) if current_contents == expected_contents => Ok(None),
-        Ok(current_contents) => Ok(Some(ArtifactRollbackGuard {
-            artifact_path: artifact_path.to_path_buf(),
-            expected_contents: expected_contents.to_vec(),
-            rollback_action: ArtifactRollbackAction::RestoreOriginal(current_contents),
-        })),
-        Err(err) if err.kind() == ErrorKind::NotFound => Ok(Some(ArtifactRollbackGuard {
-            artifact_path: artifact_path.to_path_buf(),
-            expected_contents: expected_contents.to_vec(),
-            rollback_action: ArtifactRollbackAction::RemoveIfContentsMatch,
-        })),
-        Err(err) => Err(err),
-    }
-}
-
-#[rustfmt::skip]
-fn write_sidecar_atomically(sidecar_path: &Path, contents: &[u8]) -> Result<()> {
-    let sidecar_dir = sidecar_path.parent().ok_or_else(|| anyhow!("Unpushed commit sidecar path has no parent: {}", sidecar_path.display()))?;
-    let mut temp_file = tempfile::NamedTempFile::new_in(sidecar_dir).with_context(|| format!("Failed to create temporary unpushed commit sidecar in {}", sidecar_dir.display()))?;
-    temp_file.as_file_mut().write_all(contents).with_context(|| format!("Failed to write temporary unpushed commit sidecar for {}", sidecar_path.display()))?;
-    temp_file.as_file_mut().sync_all().with_context(|| format!("Failed to sync temporary unpushed commit sidecar for {}", sidecar_path.display()))?;
-    preserve_existing_permissions_if_present(temp_file.as_file_mut(), sidecar_path, "unpushed commit sidecar")?;
-    temp_file.persist(sidecar_path).map_err(|err| anyhow!("Failed to publish unpushed commit sidecar {}: {}", sidecar_path.display(), err.error))?;
-    Ok(())
-}
-
-#[rustfmt::skip]
-fn format_git_push_recovery_command(branch: &str) -> String {
-    if branch_is_shell_word_safe(branch) {
-        format!("git push -u origin {branch}")
-    } else {
-        format!("git push -u origin {}", shell_escape_for_command(branch))
-    }
-}
-
-#[rustfmt::skip]
-fn branch_is_shell_word_safe(branch: &str) -> bool { branch.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-')) }
 
 fn persist_new_result_file<F>(
     result_path: &Path,

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_fix_finding.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_fix_finding.rs
@@ -1,10 +1,8 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use csa_session::MetaSessionState;
 
 use super::reconcile_diagnostics::synthetic_failure_diagnostics;
-
-const FIX_FINDING_TASK_TYPE: &str = "review_fix_finding";
 
 pub(super) fn missing_result_summary_prefix(
     project_root: &Path,
@@ -22,81 +20,22 @@ pub(super) fn missing_result_summary_prefix(
              {diagnostics}"
         )
     };
-    if session.task_context.task_type.as_deref() != Some(FIX_FINDING_TASK_TYPE) {
+    if !crate::session_fix_finding_recovery::is_fix_finding_session(session) {
         return default();
     }
 
-    let side_effects = fix_finding_side_effect_diagnostic(project_root, session)
-        .unwrap_or_else(|| "repo_side_effects=unknown".to_string());
+    let side_effects =
+        crate::session_fix_finding_recovery::side_effect_diagnostic(project_root, session);
     format!(
         "`csa review --fix-finding` session failed closed: process dead before writing \
          result.toml for fix session {} (output_log_mtime={output_log_mtime}). \
          The original failed review verdict is not a fix-session result. {side_effects}. \
-         Recovery: inspect `git status --short`, decide whether the dirty/staged work \
-         is a complete fix to commit or incomplete work to salvage/revert, then run a \
-         fresh `csa review` session for the next review round. Diagnostics are from {}.\
+         Recovery: inspect `git status --short`, `git diff`, and `git diff --staged`; \
+         preserve/finish or discard dirty side effects; create a hook-enabled commit if \
+         appropriate; then run a fresh exact-head `csa review` before push/PR. \
+         Diagnostics are from {}.\
          {diagnostics}",
         session.meta_session_id,
         session_dir.display()
     )
-}
-
-fn fix_finding_side_effect_diagnostic(
-    project_root: &Path,
-    session: &MetaSessionState,
-) -> Option<String> {
-    let pre_head = session.git_head_at_creation.as_deref()?;
-    let audit = csa_session::compute_repo_write_audit(
-        project_root,
-        pre_head,
-        session.pre_session_porcelain.as_deref(),
-    )
-    .ok()?;
-    if audit.is_empty() {
-        return Some("repo_side_effects=none_detected".to_string());
-    }
-
-    let mut parts = Vec::new();
-    push_path_group(&mut parts, "added", &audit.added);
-    push_path_group(&mut parts, "modified", &audit.modified);
-    push_path_group(&mut parts, "deleted", &audit.deleted);
-    if !audit.renamed.is_empty() {
-        let renames = audit
-            .renamed
-            .iter()
-            .take(8)
-            .map(|(from, to)| format!("{}->{}", from.display(), to.display()))
-            .collect::<Vec<_>>()
-            .join(",");
-        let truncated = audit.renamed.len().saturating_sub(8);
-        let suffix = if truncated > 0 {
-            format!("(+{truncated} more)")
-        } else {
-            String::new()
-        };
-        parts.push(format!("renamed=[{renames}]{suffix}"));
-    }
-    Some(format!(
-        "repo_side_effects=dirty_or_committed_tracked_changes {}",
-        parts.join(" ")
-    ))
-}
-
-fn push_path_group(parts: &mut Vec<String>, label: &str, paths: &[PathBuf]) {
-    if paths.is_empty() {
-        return;
-    }
-    let rendered = paths
-        .iter()
-        .take(8)
-        .map(|path| path.display().to_string())
-        .collect::<Vec<_>>()
-        .join(",");
-    let truncated = paths.len().saturating_sub(8);
-    let suffix = if truncated > 0 {
-        format!("(+{truncated} more)")
-    } else {
-        String::new()
-    };
-    parts.push(format!("{label}=[{rendered}]{suffix}"));
 }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_fix_finding_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_fix_finding_tests.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+use csa_session::{TaskContext, save_session};
+
+#[cfg(unix)]
+#[test]
+fn fix_finding_missing_result_with_unpushed_commits_suppresses_push_next_step() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path().join("project");
+    let origin = td.path().join("origin.git");
+    fs::create_dir_all(&project).unwrap();
+
+    run_git(&project, &["init", "--initial-branch", "main"]);
+    run_git(&project, &["config", "user.email", "test@example.com"]);
+    run_git(&project, &["config", "user.name", "Test User"]);
+    fs::write(project.join("README.md"), "base\n").unwrap();
+    run_git(&project, &["add", "README.md"]);
+    run_git(&project, &["commit", "-m", "init"]);
+
+    run_git(td.path(), &["init", "--bare", origin.to_str().unwrap()]);
+    run_git(
+        &project,
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+    );
+    run_git(&project, &["push", "-u", "origin", "main"]);
+
+    run_git(&project, &["checkout", "-b", "fix/finding-side-effects"]);
+    let mut session = create_session(
+        &project,
+        Some("fix finding from review"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    session.task_context = TaskContext {
+        task_type: Some("review_fix_finding".to_string()),
+        tier_name: None,
+    };
+    save_session(&session).unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(&project, &session_id).unwrap();
+
+    fs::write(project.join("committed-fix.txt"), "committed\n").unwrap();
+    run_git(&project, &["add", "committed-fix.txt"]);
+    run_git(&project, &["commit", "-m", "fix: committed side effect"]);
+    fs::write(project.join("staged-fix.txt"), "staged\n").unwrap();
+    run_git(&project, &["add", "staged-fix.txt"]);
+    tail_backdate_tree(&session_dir, 120);
+
+    let reconciled =
+        ensure_terminal_result_for_dead_active_session(&project, &session_id, "session wait")
+            .unwrap();
+    assert_eq!(
+        reconciled,
+        DeadActiveSessionReconciliation::SynthesizedFailure
+    );
+
+    let unpushed_sidecar: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(session_dir.join("output").join("unpushed_commits.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        unpushed_sidecar["recovery_command"],
+        "git push -u origin fix/finding-side-effects"
+    );
+
+    let recovery_sidecar_path =
+        crate::session_fix_finding_recovery::recovery_sidecar_path(&session_dir);
+    let recovery_sidecar: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&recovery_sidecar_path).unwrap()).unwrap();
+    assert_eq!(
+        recovery_sidecar["outcome"],
+        serde_json::json!("failed_closed_missing_result")
+    );
+    assert_eq!(
+        recovery_sidecar["allow_required_push_next_step"],
+        serde_json::json!(false)
+    );
+    assert_eq!(
+        recovery_sidecar["requires_fresh_exact_head_review"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        recovery_sidecar["side_effects"]["status"],
+        serde_json::json!("dirty_or_committed_tracked_changes")
+    );
+
+    assert!(
+        crate::session_cmds_daemon::synthesized_wait_next_step(&session_dir)
+            .unwrap()
+            .is_none(),
+        "failed-closed fix-finding recovery must not synthesize a required git push next-step"
+    );
+
+    let result = load_result(&project, &session_id).unwrap().unwrap();
+    let wait_summary =
+        crate::session_cmds_daemon::render_wait_result_summary(&session_dir, &session_id, &result);
+    assert!(wait_summary.contains("required push next-step suppressed"));
+    assert!(wait_summary.contains("hook-enabled commit"));
+    assert!(wait_summary.contains("fresh exact-head review before push/PR"));
+}

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_sidecars.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_sidecars.rs
@@ -1,0 +1,178 @@
+use anyhow::{Context, Result, anyhow};
+use csa_core::vcs::VcsKind;
+use csa_session::MetaSessionState;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
+use tracing::warn;
+
+use crate::plan_cmd::shell_escape_for_command;
+use crate::session_result_publish::preserve_existing_permissions_if_present;
+
+use super::reconcile_git::{git_output, git_success, resolve_fallback_base_branch};
+
+const UNPUSHED_COMMITS_SIDECAR_PATH: &str = "output/unpushed_commits.json";
+
+#[rustfmt::skip]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct UnpushedCommitRecord { sha: String, subject: String }
+
+#[rustfmt::skip]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct UnpushedCommitsSidecar { branch: String, remote_ref: Option<String>, commits_ahead: u64, commits: Vec<UnpushedCommitRecord>, recovery_command: String }
+
+#[rustfmt::skip]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ArtifactRollbackGuard { artifact_path: PathBuf, expected_contents: Vec<u8>, rollback_action: ArtifactRollbackAction }
+
+#[rustfmt::skip]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ArtifactRollbackAction { RemoveIfContentsMatch, RestoreOriginal(Vec<u8>) }
+
+fn inspect_unpushed_commits(
+    project_root: &Path,
+    branch: &str,
+) -> Result<Option<UnpushedCommitsSidecar>> {
+    let session_branch_ref = format!("refs/heads/{branch}");
+    let range = if git_success(
+        project_root,
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/remotes/origin/{branch}"),
+        ],
+    ) {
+        (
+            Some(format!("origin/{branch}")),
+            format!("origin/{branch}..{session_branch_ref}"),
+        )
+    } else {
+        let Some(base_branch) = resolve_fallback_base_branch(project_root) else {
+            return Ok(None);
+        };
+        (None, format!("{base_branch}..{session_branch_ref}"))
+    };
+    let (remote_ref, rev_range) = range;
+
+    let count_output = git_output(project_root, &["rev-list", "--count", &rev_range])?;
+    if !count_output.status.success() {
+        return Ok(None);
+    }
+    let commits_ahead = String::from_utf8_lossy(&count_output.stdout)
+        .trim()
+        .parse::<u64>()
+        .unwrap_or(0);
+    if commits_ahead == 0 {
+        return Ok(None);
+    }
+
+    let log_output = git_output(project_root, &["log", "--format=%H%x09%s", &rev_range])?;
+    if !log_output.status.success() {
+        return Ok(None);
+    }
+
+    let commits = String::from_utf8_lossy(&log_output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (sha, subject) = line.split_once('\t')?;
+            Some(UnpushedCommitRecord {
+                sha: sha.to_string(),
+                subject: subject.to_string(),
+            })
+        })
+        .collect::<Vec<_>>();
+    if commits.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(UnpushedCommitsSidecar {
+        branch: branch.to_string(),
+        remote_ref,
+        commits_ahead,
+        commits,
+        recovery_command: format_git_push_recovery_command(branch),
+    }))
+}
+
+#[rustfmt::skip]
+pub(super) fn persist_unpushed_commits_sidecar(project_root: &Path, session: &MetaSessionState, session_dir: &Path) -> Result<Option<ArtifactRollbackGuard>> {
+    if session.resolved_identity().vcs_kind != VcsKind::Git { return Ok(None); }
+    let Some(branch) = session.branch.as_deref() else { return Ok(None); };
+    let Some(sidecar) = inspect_unpushed_commits(project_root, branch)? else { return Ok(None); };
+    fs::create_dir_all(session_dir.join("output"))?;
+    let sidecar_path = session_dir.join(UNPUSHED_COMMITS_SIDECAR_PATH);
+    let sidecar_contents = serde_json::to_vec_pretty(&sidecar)?;
+    let rollback_guard = artifact_rollback_guard(&sidecar_path, sidecar_contents.as_slice())?;
+    write_sidecar_atomically(&sidecar_path, &sidecar_contents)?;
+    Ok(rollback_guard)
+}
+
+#[rustfmt::skip]
+pub(super) fn persist_fix_finding_recovery_sidecar(project_root: &Path, session: &MetaSessionState, session_dir: &Path) -> Result<Option<ArtifactRollbackGuard>> {
+    let Some(sidecar) = crate::session_fix_finding_recovery::build_recovery_sidecar(project_root, session) else { return Ok(None); };
+    fs::create_dir_all(session_dir.join("output"))?;
+    let sidecar_path = crate::session_fix_finding_recovery::recovery_sidecar_path(session_dir);
+    let sidecar_contents = serde_json::to_vec_pretty(&sidecar)?;
+    let rollback_guard = artifact_rollback_guard(&sidecar_path, sidecar_contents.as_slice())?;
+    write_sidecar_atomically(&sidecar_path, &sidecar_contents)?;
+    Ok(rollback_guard)
+}
+
+#[rustfmt::skip]
+fn rollback_sidecar(rollback_guard: &ArtifactRollbackGuard) -> std::io::Result<()> {
+    match &rollback_guard.rollback_action {
+        ArtifactRollbackAction::RemoveIfContentsMatch => super::remove_artifact_if_unchanged(&rollback_guard.artifact_path, rollback_guard.expected_contents.as_slice(), super::ArtifactRollbackLabels { removed_cleanup: "removed_recovery_sidecar", missing_after_match_cleanup: "sidecar_missing_after_match", remove_failed_cleanup: "sidecar_remove_failed", preserved_cleanup: "preexisting_sidecar_preserved", missing_cleanup: "sidecar_missing", read_failed_cleanup: "sidecar_read_failed", artifact_label: "recovery sidecar" }),
+        ArtifactRollbackAction::RestoreOriginal(original_contents) => match fs::read(&rollback_guard.artifact_path) {
+            Ok(current_contents) if current_contents == rollback_guard.expected_contents => { fs::write(&rollback_guard.artifact_path, original_contents)?; warn!(artifact_path = %rollback_guard.artifact_path.display(), rollback_cleanup = "restored_preexisting_recovery_sidecar", "Rollback restored preexisting recovery sidecar after reconciliation failure"); Ok(()) }
+            Ok(_) => { warn!(artifact_path = %rollback_guard.artifact_path.display(), rollback_cleanup = "preexisting_sidecar_preserved", "Rollback preserved recovery sidecar because contents changed after reconciliation failure"); Ok(()) }
+            Err(err) if err.kind() == ErrorKind::NotFound => { warn!(artifact_path = %rollback_guard.artifact_path.display(), rollback_cleanup = "sidecar_missing", "Rollback found no recovery sidecar to restore after reconciliation failure"); Ok(()) }
+            Err(err) => { warn!(artifact_path = %rollback_guard.artifact_path.display(), rollback_cleanup = "sidecar_read_failed", error = %err, "Rollback failed to read recovery sidecar for content-aware restore after reconciliation failure"); Ok(()) }
+        },
+    }
+}
+
+#[rustfmt::skip]
+pub(super) fn rollback_sidecars(rollback_guards: &[ArtifactRollbackGuard]) -> std::io::Result<()> { for rollback_guard in rollback_guards { rollback_sidecar(rollback_guard)?; } Ok(()) }
+
+#[rustfmt::skip]
+fn artifact_rollback_guard(artifact_path: &Path, expected_contents: &[u8]) -> std::io::Result<Option<ArtifactRollbackGuard>> {
+    match fs::read(artifact_path) {
+        Ok(current_contents) if current_contents == expected_contents => Ok(None),
+        Ok(current_contents) => Ok(Some(ArtifactRollbackGuard {
+            artifact_path: artifact_path.to_path_buf(),
+            expected_contents: expected_contents.to_vec(),
+            rollback_action: ArtifactRollbackAction::RestoreOriginal(current_contents),
+        })),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(Some(ArtifactRollbackGuard {
+            artifact_path: artifact_path.to_path_buf(),
+            expected_contents: expected_contents.to_vec(),
+            rollback_action: ArtifactRollbackAction::RemoveIfContentsMatch,
+        })),
+        Err(err) => Err(err),
+    }
+}
+
+#[rustfmt::skip]
+pub(super) fn write_sidecar_atomically(sidecar_path: &Path, contents: &[u8]) -> Result<()> {
+    let sidecar_dir = sidecar_path.parent().ok_or_else(|| anyhow!("Recovery sidecar path has no parent: {}", sidecar_path.display()))?;
+    let mut temp_file = tempfile::NamedTempFile::new_in(sidecar_dir).with_context(|| format!("Failed to create temporary recovery sidecar in {}", sidecar_dir.display()))?;
+    temp_file.as_file_mut().write_all(contents).with_context(|| format!("Failed to write temporary recovery sidecar for {}", sidecar_path.display()))?;
+    temp_file.as_file_mut().sync_all().with_context(|| format!("Failed to sync temporary recovery sidecar for {}", sidecar_path.display()))?;
+    preserve_existing_permissions_if_present(temp_file.as_file_mut(), sidecar_path, "recovery sidecar")?;
+    temp_file.persist(sidecar_path).map_err(|err| anyhow!("Failed to publish recovery sidecar {}: {}", sidecar_path.display(), err.error))?;
+    Ok(())
+}
+
+#[rustfmt::skip]
+fn format_git_push_recovery_command(branch: &str) -> String {
+    if branch_is_shell_word_safe(branch) {
+        format!("git push -u origin {branch}")
+    } else {
+        format!("git push -u origin {}", shell_escape_for_command(branch))
+    }
+}
+
+#[rustfmt::skip]
+fn branch_is_shell_word_safe(branch: &str) -> bool { branch.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'/' | b'.' | b'_' | b'-')) }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_tests_tail.rs
@@ -10,6 +10,9 @@ use std::fs;
 use std::os::unix::ffi::OsStrExt;
 use tempfile::tempdir;
 
+#[path = "session_cmds_reconcile_fix_finding_tests.rs"]
+mod fix_finding_tests;
+
 struct SessionTestEnv {
     _sandbox: ScopedSessionSandbox,
 }

--- a/crates/cli-sub-agent/src/session_cmds_result_fix_finding_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_fix_finding_tests.rs
@@ -106,4 +106,37 @@ fn handle_session_result_on_fix_finding_reports_fix_session_missing_result() {
         "{}",
         result.summary
     );
+    let recovery_path =
+        crate::session_fix_finding_recovery::recovery_sidecar_path(&fix_session_dir);
+    let recovery: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&recovery_path).unwrap()).unwrap();
+    assert_eq!(
+        recovery["kind"],
+        serde_json::json!("fix_finding_failed_closed_recovery")
+    );
+    assert_eq!(
+        recovery["allow_required_push_next_step"],
+        serde_json::json!(false)
+    );
+    assert_eq!(
+        recovery["requires_fresh_exact_head_review"],
+        serde_json::json!(true)
+    );
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == "output/fix_finding_recovery.json"),
+        "synthetic result should advertise the fix-finding recovery sidecar"
+    );
+
+    let wait_summary = crate::session_cmds_daemon::render_wait_result_summary(
+        &fix_session_dir,
+        &fix_session_id,
+        &result,
+    );
+    assert!(wait_summary.contains("Fix-finding recovery"));
+    assert!(wait_summary.contains("git status/diff/staged"));
+    assert!(wait_summary.contains("hook-enabled commit"));
+    assert!(wait_summary.contains("fresh exact-head review before push/PR"));
 }

--- a/crates/cli-sub-agent/src/session_fix_finding_recovery.rs
+++ b/crates/cli-sub-agent/src/session_fix_finding_recovery.rs
@@ -1,0 +1,245 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use csa_session::MetaSessionState;
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+pub(crate) const FIX_FINDING_RECOVERY_SIDECAR_PATH: &str = "output/fix_finding_recovery.json";
+
+const FIX_FINDING_TASK_TYPE: &str = "review_fix_finding";
+const RECOVERY_OUTCOME: &str = "failed_closed_missing_result";
+const MAX_RECORDED_PATHS: usize = 8;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct FixFindingRecoverySidecar {
+    pub(crate) schema_version: u8,
+    pub(crate) kind: String,
+    pub(crate) session_id: String,
+    pub(crate) outcome: String,
+    pub(crate) side_effects: FixFindingSideEffects,
+    pub(crate) allow_required_push_next_step: bool,
+    pub(crate) requires_fresh_exact_head_review: bool,
+    pub(crate) recovery_actions: Vec<String>,
+    pub(crate) git_inspection_commands: Vec<String>,
+    pub(crate) guidance: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct FixFindingSideEffects {
+    pub(crate) status: String,
+    pub(crate) added: BoundedPathGroup,
+    pub(crate) modified: BoundedPathGroup,
+    pub(crate) deleted: BoundedPathGroup,
+    pub(crate) renamed: BoundedRenameGroup,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub(crate) struct BoundedPathGroup {
+    pub(crate) paths: Vec<String>,
+    pub(crate) truncated: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub(crate) struct BoundedRenameGroup {
+    pub(crate) paths: Vec<BoundedRename>,
+    pub(crate) truncated: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct BoundedRename {
+    pub(crate) from: String,
+    pub(crate) to: String,
+}
+
+impl FixFindingSideEffects {
+    fn none_detected() -> Self {
+        Self {
+            status: "none_detected".to_string(),
+            added: BoundedPathGroup::default(),
+            modified: BoundedPathGroup::default(),
+            deleted: BoundedPathGroup::default(),
+            renamed: BoundedRenameGroup::default(),
+        }
+    }
+
+    fn unknown() -> Self {
+        Self {
+            status: "unknown".to_string(),
+            added: BoundedPathGroup::default(),
+            modified: BoundedPathGroup::default(),
+            deleted: BoundedPathGroup::default(),
+            renamed: BoundedRenameGroup::default(),
+        }
+    }
+
+    pub(crate) fn diagnostic_label(&self) -> String {
+        let mut parts = Vec::new();
+        push_path_group_label(&mut parts, "added", &self.added);
+        push_path_group_label(&mut parts, "modified", &self.modified);
+        push_path_group_label(&mut parts, "deleted", &self.deleted);
+        if !self.renamed.paths.is_empty() {
+            let renames = self
+                .renamed
+                .paths
+                .iter()
+                .map(|path| format!("{}->{}", path.from, path.to))
+                .collect::<Vec<_>>()
+                .join(",");
+            let suffix = truncated_suffix(self.renamed.truncated);
+            parts.push(format!("renamed=[{renames}]{suffix}"));
+        }
+        if parts.is_empty() {
+            format!("repo_side_effects={}", self.status)
+        } else {
+            format!("repo_side_effects={} {}", self.status, parts.join(" "))
+        }
+    }
+}
+
+pub(crate) fn is_fix_finding_session(session: &MetaSessionState) -> bool {
+    session.task_context.task_type.as_deref() == Some(FIX_FINDING_TASK_TYPE)
+}
+
+pub(crate) fn recovery_sidecar_path(session_dir: &Path) -> PathBuf {
+    session_dir.join(FIX_FINDING_RECOVERY_SIDECAR_PATH)
+}
+
+pub(crate) fn build_recovery_sidecar(
+    project_root: &Path,
+    session: &MetaSessionState,
+) -> Option<FixFindingRecoverySidecar> {
+    if !is_fix_finding_session(session) {
+        return None;
+    }
+    Some(FixFindingRecoverySidecar {
+        schema_version: 1,
+        kind: "fix_finding_failed_closed_recovery".to_string(),
+        session_id: session.meta_session_id.clone(),
+        outcome: RECOVERY_OUTCOME.to_string(),
+        side_effects: side_effects(project_root, session),
+        allow_required_push_next_step: false,
+        requires_fresh_exact_head_review: true,
+        recovery_actions: vec![
+            "inspect_git_metadata".to_string(),
+            "preserve_finish_or_discard_dirty_side_effects".to_string(),
+            "create_hook_enabled_commit_if_appropriate".to_string(),
+            "run_fresh_exact_head_review_before_push_or_pr".to_string(),
+        ],
+        git_inspection_commands: vec![
+            "git status --short".to_string(),
+            "git diff".to_string(),
+            "git diff --staged".to_string(),
+            "git log --oneline -5".to_string(),
+        ],
+        guidance: "Inspect git metadata, preserve and finish or discard dirty/staged side effects, create a hook-enabled commit if appropriate, and run a fresh exact-head review before push/PR.".to_string(),
+    })
+}
+
+pub(crate) fn side_effect_diagnostic(project_root: &Path, session: &MetaSessionState) -> String {
+    side_effects(project_root, session).diagnostic_label()
+}
+
+pub(crate) fn read_recovery_sidecar(session_dir: &Path) -> Option<FixFindingRecoverySidecar> {
+    let path = recovery_sidecar_path(session_dir);
+    let contents = fs::read_to_string(&path).ok()?;
+    match serde_json::from_str::<FixFindingRecoverySidecar>(&contents) {
+        Ok(sidecar) => Some(sidecar),
+        Err(err) => {
+            warn!(
+                sidecar_path = %path.display(),
+                error = %err,
+                "Ignoring malformed fix-finding recovery sidecar"
+            );
+            None
+        }
+    }
+}
+
+pub(crate) fn suppresses_required_push_next_step(session_dir: &Path) -> bool {
+    let path = recovery_sidecar_path(session_dir);
+    if !path.is_file() {
+        return false;
+    }
+    read_recovery_sidecar(session_dir)
+        .map(|sidecar| !sidecar.allow_required_push_next_step)
+        .unwrap_or(true)
+}
+
+pub(crate) fn wait_summary_lines(session_dir: &Path) -> Vec<String> {
+    let Some(sidecar) = read_recovery_sidecar(session_dir) else {
+        return Vec::new();
+    };
+    vec![
+        format!(
+            "Fix-finding recovery: {} (required push next-step suppressed)",
+            sidecar.outcome
+        ),
+        format!("Side effects: {}", sidecar.side_effects.diagnostic_label()),
+        "Recovery action: inspect git status/diff/staged; preserve/finish or discard dirty side effects; create a hook-enabled commit if appropriate; run a fresh exact-head review before push/PR".to_string(),
+    ]
+}
+
+fn side_effects(project_root: &Path, session: &MetaSessionState) -> FixFindingSideEffects {
+    let Some(pre_head) = session.git_head_at_creation.as_deref() else {
+        return FixFindingSideEffects::unknown();
+    };
+    let Ok(audit) = csa_session::compute_repo_write_audit(
+        project_root,
+        pre_head,
+        session.pre_session_porcelain.as_deref(),
+    ) else {
+        return FixFindingSideEffects::unknown();
+    };
+    if audit.is_empty() {
+        return FixFindingSideEffects::none_detected();
+    }
+    FixFindingSideEffects {
+        status: "dirty_or_committed_tracked_changes".to_string(),
+        added: bounded_paths(&audit.added),
+        modified: bounded_paths(&audit.modified),
+        deleted: bounded_paths(&audit.deleted),
+        renamed: bounded_renames(&audit.renamed),
+    }
+}
+
+fn bounded_paths(paths: &[PathBuf]) -> BoundedPathGroup {
+    BoundedPathGroup {
+        paths: paths
+            .iter()
+            .take(MAX_RECORDED_PATHS)
+            .map(|path| path.display().to_string())
+            .collect(),
+        truncated: paths.len().saturating_sub(MAX_RECORDED_PATHS),
+    }
+}
+
+fn bounded_renames(paths: &[(PathBuf, PathBuf)]) -> BoundedRenameGroup {
+    BoundedRenameGroup {
+        paths: paths
+            .iter()
+            .take(MAX_RECORDED_PATHS)
+            .map(|(from, to)| BoundedRename {
+                from: from.display().to_string(),
+                to: to.display().to_string(),
+            })
+            .collect(),
+        truncated: paths.len().saturating_sub(MAX_RECORDED_PATHS),
+    }
+}
+
+fn push_path_group_label(parts: &mut Vec<String>, label: &str, group: &BoundedPathGroup) {
+    if group.paths.is_empty() {
+        return;
+    }
+    let suffix = truncated_suffix(group.truncated);
+    parts.push(format!("{label}=[{}]{suffix}", group.paths.join(",")));
+}
+
+fn truncated_suffix(truncated: usize) -> String {
+    if truncated > 0 {
+        format!("(+{truncated} more)")
+    } else {
+        String::new()
+    }
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1045"
-weave = "0.1.1045"
+csa = "0.1.1046"
+weave = "0.1.1046"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Prevent failed fix-finding recovery with dirty/staged side effects from emitting a required `git push` next-step.
- Persist bounded `fix_finding_recovery.json` sidecar metadata so callers get actionable recovery guidance when a fix-finding child session fails before a normal result artifact.
- Preserve required push guidance for genuinely clean, reviewed, push-ready states.
- Split recovery sidecar handling into focused modules and bump the workspace to `0.1.1046`.

Closes #2344

## Test Plan

- `cargo test -p cli-sub-agent fix_finding --all-features`
- `cargo test -p cli-sub-agent unpushed_commits --all-features`
- `cargo test -p cli-sub-agent next_step --all-features`
- `cargo test -p cli-sub-agent recovery --all-features -- --test-threads=1`
- `cargo fmt --all -- --check`
- `git diff --cached --check`
- `git diff --check`
- `git diff --check main...HEAD`
- `just find-monolith-files`
- `just pre-commit-fast`
- Hook-enabled commit with lefthook `quality-gates`

## Review Evidence

- Exact-head review session: `01KVQPBDZVDCMWKQ3J11AVBTM4`
- Reviewed SHA: `f1f2be146a02f9640a7588df7790a8bb7d0bb419`
- Range: `main...HEAD`
- Verdict: PASS/CLEAN
- `target/debug/csa review --check-verdict --sa-mode true --range main...HEAD`: passed
- Installed `csa review --check-verdict --sa-mode true --range main...HEAD`: passed

## Operational Notes

- This PR was completed via native-equivalent fallback after CSA writer session `01KVQG83SEJZ60D7ZNJJAE1DRB` reproduced KV-warm -> exact-id registry loss on `0.1.1045`.
- Superseding CSA session-loss issue filed: #2362
