### PR TITLE
fix(csa): persist no-provider memory diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1055"
+version = "0.1.1056"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1055"
+version = "0.1.1056"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -44,6 +44,7 @@ mod memory_migrate;
 mod memory_soft_limit_recovery_display;
 mod merge_cmd;
 mod mktsk_cmd;
+mod no_provider_launch;
 mod pattern_resolver;
 mod pipeline;
 mod pipeline_env;

--- a/crates/cli-sub-agent/src/no_provider_launch.rs
+++ b/crates/cli-sub-agent/src/no_provider_launch.rs
@@ -1,0 +1,167 @@
+use anyhow::Error;
+use csa_config::ProjectConfig;
+use csa_resource::{MemoryAdmissionError, memory_policy};
+use csa_session::{
+    MetaSessionState, NO_PROVIDER_LAUNCH_SCHEMA_VERSION, NoProviderLaunchDiagnostic,
+    NoProviderLaunchMemoryDiagnostic,
+};
+
+use crate::resource_admission_soft_limit::MemorySoftLimitAdmissionError;
+use crate::run_resource_overrides::RunResourceOverrides;
+
+pub(crate) const HOST_MEMORY_ADMISSION_REASON: &str = "host_memory_admission";
+
+pub(crate) struct NoProviderLaunchContext<'a> {
+    pub(crate) session: &'a MetaSessionState,
+    pub(crate) tool_name: &'a str,
+    pub(crate) task_type: Option<&'a str>,
+    pub(crate) config: Option<&'a ProjectConfig>,
+    pub(crate) resource_overrides: RunResourceOverrides,
+}
+
+pub(crate) fn diagnostic_from_error(
+    ctx: NoProviderLaunchContext<'_>,
+    error: &Error,
+) -> Option<NoProviderLaunchDiagnostic> {
+    if let Some(soft_limit) = error.downcast_ref::<MemorySoftLimitAdmissionError>() {
+        return Some(from_soft_limit_admission(ctx, soft_limit));
+    }
+    if let Some(host_memory) = error.downcast_ref::<MemoryAdmissionError>() {
+        return Some(from_host_memory_admission(ctx, host_memory));
+    }
+    None
+}
+
+fn from_soft_limit_admission(
+    ctx: NoProviderLaunchContext<'_>,
+    error: &MemorySoftLimitAdmissionError,
+) -> NoProviderLaunchDiagnostic {
+    base_diagnostic(
+        &ctx,
+        error.role(),
+        MemorySoftLimitAdmissionError::TERMINATION_REASON,
+        NoProviderLaunchMemoryDiagnostic {
+            effective_memory_max_mb: Some(error.memory_max_mb()),
+            soft_limit_percent: Some(error.soft_limit_percent()),
+            soft_threshold_mb: Some(error.threshold_mb()),
+            required_floor_mb: Some(error.required_threshold_mb()),
+            required_memory_max_mb: Some(error.required_memory_max_mb()),
+            ..Default::default()
+        },
+        error.guidance(),
+    )
+}
+
+fn from_host_memory_admission(
+    ctx: NoProviderLaunchContext<'_>,
+    error: &MemoryAdmissionError,
+) -> NoProviderLaunchDiagnostic {
+    let effective_memory_max_mb = error.projected_spawn_mb.or_else(|| {
+        ctx.resource_overrides
+            .resolve_memory_max_mb(ctx.config, ctx.tool_name)
+    });
+    let soft_limit_percent = effective_memory_max_mb.map(|_| {
+        ctx.config
+            .and_then(|cfg| cfg.resources.soft_limit_percent)
+            .unwrap_or(memory_policy::DEFAULT_SOFT_LIMIT_PERCENT)
+    });
+    let required_floor_mb =
+        crate::resource_admission_soft_limit::codex_soft_limit_required_floor_mb(
+            ctx.task_type,
+            ctx.tool_name,
+        );
+    let required_memory_max_mb =
+        required_floor_mb
+            .zip(soft_limit_percent)
+            .and_then(|(floor, percent)| {
+                memory_policy::required_memory_max_for_soft_limit_mb(floor, percent)
+            });
+    let soft_threshold_mb = effective_memory_max_mb
+        .zip(soft_limit_percent)
+        .and_then(|(cap, percent)| memory_policy::soft_limit_threshold_mb(cap, percent));
+
+    base_diagnostic(
+        &ctx,
+        role_from_task_type(ctx.task_type),
+        error.kind.denial_class(),
+        NoProviderLaunchMemoryDiagnostic {
+            effective_memory_max_mb,
+            soft_limit_percent,
+            soft_threshold_mb,
+            required_floor_mb,
+            required_memory_max_mb,
+            reserve_mb: Some(error.reserve_mb),
+            available_memory_mb: Some(error.available_phys_mb),
+            required_available_mb: error.required_available_mb,
+            projected_spawn_mb: error.projected_spawn_mb,
+            active_session_rss_mb: error.active_session_rss_mb,
+            active_session_projected_mb: error.active_session_projected_mb,
+            active_session_count: error.active_session_count,
+            sampled_session_count: error.sampled_session_count,
+        },
+        host_memory_guidance(ctx.task_type),
+    )
+}
+
+fn base_diagnostic(
+    ctx: &NoProviderLaunchContext<'_>,
+    role: &str,
+    denial_class: &str,
+    memory: NoProviderLaunchMemoryDiagnostic,
+    guidance: Vec<String>,
+) -> NoProviderLaunchDiagnostic {
+    NoProviderLaunchDiagnostic {
+        schema_version: NO_PROVIDER_LAUNCH_SCHEMA_VERSION,
+        session_id: ctx.session.meta_session_id.clone(),
+        timestamp: chrono::Utc::now(),
+        tool: ctx.tool_name.to_string(),
+        role: role.to_string(),
+        session_class: ctx.task_type.map(str::to_string),
+        denial_class: denial_class.to_string(),
+        no_provider_launch: true,
+        provider_side_effects: false,
+        head_sha: ctx.session.git_head_at_creation.clone(),
+        scope: None,
+        range: None,
+        memory,
+        guidance,
+    }
+}
+
+pub(crate) fn role_from_task_type(task_type: Option<&str>) -> &'static str {
+    match task_type {
+        Some("reviewer_sub_session" | "review_fix_finding" | "review") => "reviewer",
+        Some("run") | None => "writer",
+        Some(_) => "session",
+    }
+}
+
+fn host_memory_guidance(task_type: Option<&str>) -> Vec<String> {
+    match role_from_task_type(task_type) {
+        "reviewer" => vec![
+            "Host memory admission failed before the reviewer provider launched; this is infrastructure no-verdict, not PASS/FAIL.".to_string(),
+            "Retry the same cap with a lower --min-free-memory-mb only when the host reserve is intentionally conservative; otherwise wait/free memory or use another configured reviewer.".to_string(),
+            "If no reviewer fallback runs, fail closed and use native/manual review after one bounded retry.".to_string(),
+        ],
+        "writer" => vec![
+            "Host memory admission failed before the writer provider launched; no provider-side worktree mutation occurred.".to_string(),
+            "Lower only the reserve when safe, wait/free memory, or reduce the projected spawn cap without dropping below the role soft-limit floor.".to_string(),
+            "For dirty-work recovery, avoid repeated CSA retries in the same memory envelope; after one same-class retry, switch to documented recovery/manual fallback.".to_string(),
+        ],
+        _ => vec![
+            "Host memory admission failed before the provider launched; retry after freeing memory or lowering only safe resource overrides.".to_string(),
+        ],
+    }
+}
+
+pub(crate) fn enrich_review_diagnostic(
+    diagnostic: &mut NoProviderLaunchDiagnostic,
+    head_sha: &str,
+    scope: &str,
+) {
+    if diagnostic.head_sha.as_deref().is_none_or(str::is_empty) && !head_sha.is_empty() {
+        diagnostic.head_sha = Some(head_sha.to_string());
+    }
+    diagnostic.scope = Some(scope.to_string());
+    diagnostic.range = scope.strip_prefix("range:").map(str::to_string);
+}

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -48,7 +48,7 @@ mod session_exec_write_lock;
 #[path = "pipeline_session_exec_state_preflight.rs"]
 mod state_preflight;
 use self::session_exec_pre_exec::{
-    check_resources_before_spawn, persist_pipeline_pre_exec_failure,
+    PipelinePreExecFailureDetails, check_resources_before_spawn, persist_pipeline_pre_exec_failure,
     write_fatal_error_marker_sidecar,
 };
 pub(crate) use session_exec_api::execute_with_session;
@@ -140,6 +140,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
                 err,
                 &mut cleanup_guard,
                 None,
+                PipelinePreExecFailureDetails::default(),
             ));
         }
     };
@@ -158,6 +159,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
                 err,
                 &mut cleanup_guard,
                 None,
+                PipelinePreExecFailureDetails::default(),
             ));
         }
     };
@@ -177,6 +179,7 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
         &mut session,
         &mut cleanup_guard,
         resource_overrides,
+        task_type,
     )?;
     if let Some(ref budget) = session.token_budget {
         if budget.is_hard_exceeded() {

--- a/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
@@ -10,7 +10,16 @@ use crate::resource_admission::{
     build_spawn_memory_admission, spawn_memory_projection_mb_with_overrides,
 };
 use crate::run_resource_overrides::RunResourceOverrides;
-use crate::session_guard::{SessionCleanupGuard, write_pre_exec_error_result};
+use crate::session_guard::{
+    SessionCleanupGuard, write_pre_exec_error_result, write_pre_exec_error_result_with_no_provider,
+};
+
+#[derive(Clone, Copy, Default)]
+pub(super) struct PipelinePreExecFailureDetails<'a> {
+    pub(super) config: Option<&'a ProjectConfig>,
+    pub(super) task_type: Option<&'a str>,
+    pub(super) resource_overrides: RunResourceOverrides,
+}
 
 pub(super) fn check_resources_before_spawn(
     config: Option<&ProjectConfig>,
@@ -19,6 +28,7 @@ pub(super) fn check_resources_before_spawn(
     session: &mut MetaSessionState,
     cleanup_guard: &mut Option<SessionCleanupGuard>,
     resource_overrides: RunResourceOverrides,
+    task_type: Option<&str>,
 ) -> anyhow::Result<()> {
     let mut resource_guard = ResourceGuard::new(ResourceLimits {
         min_free_memory_mb: resource_overrides.resolve_min_free_memory_mb(config),
@@ -35,6 +45,11 @@ pub(super) fn check_resources_before_spawn(
             err.context("Failed to persist pre-spawn memory projection"),
             cleanup_guard,
             None,
+            PipelinePreExecFailureDetails {
+                config,
+                task_type,
+                resource_overrides,
+            },
         ));
     }
     let admission =
@@ -50,6 +65,11 @@ pub(super) fn check_resources_before_spawn(
             err,
             cleanup_guard,
             Some("low_memory"),
+            PipelinePreExecFailureDetails {
+                config,
+                task_type,
+                resource_overrides,
+            },
         ));
     }
     if let Some(cfg) = config {
@@ -92,6 +112,7 @@ pub(super) fn write_fatal_error_marker_sidecar(
             anyhow::anyhow!(err).context("Failed to reset active liveness scope"),
             cleanup_guard,
             None,
+            PipelinePreExecFailureDetails::default(),
         )
     })?;
 
@@ -108,6 +129,7 @@ pub(super) fn write_fatal_error_marker_sidecar(
             anyhow::anyhow!(err).context("Failed to write fatal error marker sidecar"),
             cleanup_guard,
             None,
+            PipelinePreExecFailureDetails::default(),
         )
     })
 }
@@ -131,8 +153,29 @@ pub(super) fn persist_pipeline_pre_exec_failure(
     err: anyhow::Error,
     cleanup_guard: &mut Option<SessionCleanupGuard>,
     termination_reason: Option<&str>,
+    details: PipelinePreExecFailureDetails<'_>,
 ) -> anyhow::Error {
-    write_pre_exec_error_result(project_root, &session.meta_session_id, tool_name, &err);
+    let no_provider_launch = crate::no_provider_launch::diagnostic_from_error(
+        crate::no_provider_launch::NoProviderLaunchContext {
+            session,
+            tool_name,
+            task_type: details.task_type,
+            config: details.config,
+            resource_overrides: details.resource_overrides,
+        },
+        &err,
+    );
+    if let Some(diagnostic) = no_provider_launch {
+        write_pre_exec_error_result_with_no_provider(
+            project_root,
+            &session.meta_session_id,
+            tool_name,
+            &err,
+            diagnostic,
+        );
+    } else {
+        write_pre_exec_error_result(project_root, &session.meta_session_id, tool_name, &err);
+    }
     let cleared_admission_projection =
         crate::resource_admission::clear_spawn_memory_projection(session);
     if let Some(reason) = termination_reason {

--- a/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_runtime.rs
@@ -14,7 +14,9 @@ use tracing::{debug, info, warn};
 use super::super::prompt_cache::PromptAssembly;
 use super::super::result_contract::clear_expected_result_artifacts_for_prompt;
 use super::super::session_exec_failover::apply_transport_failover_overrides;
-use super::session_exec_pre_exec::persist_pipeline_pre_exec_failure;
+use super::session_exec_pre_exec::{
+    PipelinePreExecFailureDetails, persist_pipeline_pre_exec_failure,
+};
 use super::session_exec_tool_state::ensure_tool_state_initialized;
 use super::{
     session_exec_audit, session_exec_memory, session_exec_metadata, session_exec_prompt_guard,
@@ -103,6 +105,11 @@ pub(super) async fn prepare_session_runtime(
 ) -> Result<SessionRuntimePlan> {
     let project_root = input.project_root;
     let tool_name = input.executor.tool_name().to_string();
+    let failure_details = PipelinePreExecFailureDetails {
+        config: input.config,
+        task_type: input.task_type,
+        resource_overrides: input.resource_overrides,
+    };
 
     prepare_session_runtime_inner(input, session)
         .await
@@ -119,6 +126,7 @@ pub(super) async fn prepare_session_runtime(
                 err,
                 cleanup_guard,
                 termination_reason,
+                failure_details,
             )
         })
 }

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -1,4 +1,6 @@
-use super::session_exec_pre_exec::persist_pipeline_pre_exec_failure;
+use super::session_exec_pre_exec::{
+    PipelinePreExecFailureDetails, persist_pipeline_pre_exec_failure,
+};
 use crate::session_guard::SessionCleanupGuard;
 use anyhow::{Context, Result};
 use csa_lock::WorktreeWriteLock;
@@ -21,6 +23,7 @@ pub(super) fn acquire_or_persist_failure(
             err,
             cleanup_guard,
             None,
+            PipelinePreExecFailureDetails::default(),
         )
     })
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -357,6 +357,31 @@ async fn low_memory_pre_spawn_failure_sets_termination_reason() {
     assert_eq!(result.status, "failure");
     assert!(result.summary.starts_with("pre-exec:"));
     assert!(result.summary.contains("CSA: low memory"));
+    assert!(
+        result
+            .artifacts
+            .iter()
+            .any(|artifact| { artifact.path == csa_session::NO_PROVIDER_LAUNCH_ARTIFACT_PATH })
+    );
+
+    let session_dir = csa_session::get_session_dir(project_root, session_id).unwrap();
+    let artifact_path = session_dir.join(csa_session::NO_PROVIDER_LAUNCH_ARTIFACT_PATH);
+    let no_provider: csa_session::NoProviderLaunchDiagnostic = serde_json::from_str(
+        &fs::read_to_string(&artifact_path).expect("no-verdict artifact should exist"),
+    )
+    .expect("no-verdict artifact should parse");
+    assert_eq!(
+        no_provider.denial_class,
+        crate::no_provider_launch::HOST_MEMORY_ADMISSION_REASON
+    );
+    assert_eq!(no_provider.role, "writer");
+    assert!(no_provider.no_provider_launch);
+    assert!(!no_provider.provider_side_effects);
+    assert_eq!(
+        no_provider.memory.reserve_mb,
+        Some(config.resources.min_free_memory_mb)
+    );
+    assert_eq!(no_provider.memory.effective_memory_max_mb, Some(1024));
 }
 
 #[tokio::test]

--- a/crates/cli-sub-agent/src/resource_admission_soft_limit.rs
+++ b/crates/cli-sub-agent/src/resource_admission_soft_limit.rs
@@ -15,16 +15,45 @@ pub(crate) const MEMORY_SOFT_LIMIT_ADMISSION_REASON: &str = "memory_soft_limit_a
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct MemorySoftLimitAdmissionError {
-    message: String,
+    tool_name: String,
+    denial: SoftLimitAdmissionDenial,
 }
 
 impl MemorySoftLimitAdmissionError {
     pub(crate) const TERMINATION_REASON: &'static str = MEMORY_SOFT_LIMIT_ADMISSION_REASON;
+
+    pub(crate) fn role(&self) -> &'static str {
+        self.denial.session_kind.label()
+    }
+
+    pub(crate) fn memory_max_mb(&self) -> u64 {
+        self.denial.memory_max_mb
+    }
+
+    pub(crate) fn soft_limit_percent(&self) -> u8 {
+        self.denial.soft_limit_percent
+    }
+
+    pub(crate) fn threshold_mb(&self) -> u64 {
+        self.denial.threshold_mb
+    }
+
+    pub(crate) fn required_threshold_mb(&self) -> u64 {
+        self.denial.required_threshold_mb
+    }
+
+    pub(crate) fn required_memory_max_mb(&self) -> u64 {
+        self.denial.required_memory_max_mb
+    }
+
+    pub(crate) fn guidance(&self) -> Vec<String> {
+        self.denial.guidance(&self.tool_name)
+    }
 }
 
 impl std::fmt::Display for MemorySoftLimitAdmissionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.message)
+        f.write_str(&self.denial.message(&self.tool_name))
     }
 }
 
@@ -41,6 +70,26 @@ struct SoftLimitAdmissionDenial {
 }
 
 impl SoftLimitAdmissionDenial {
+    fn guidance(self, tool_name: &str) -> Vec<String> {
+        let required_memory_max_mb = self.required_memory_max_mb;
+        match self.session_kind {
+            CodexSoftLimitAdmissionKind::Reviewer => vec![
+                format!(
+                    "Raise --memory-max-mb, resources.memory_max_mb, or tools.{tool_name}.memory_max_mb to at least {required_memory_max_mb}MB for this soft_limit_percent."
+                ),
+                "Remove a lower memory override so Codex can use its 12288MB default when that satisfies the reviewer floor.".to_string(),
+                "If host admission then fails, wait/free memory, lower only resources.min_free_memory_mb when safe, or use another configured reviewer/native fallback after a bounded retry.".to_string(),
+            ],
+            CodexSoftLimitAdmissionKind::Writer => vec![
+                format!(
+                    "Raise --memory-max-mb, resources.memory_max_mb, or tools.{tool_name}.memory_max_mb to at least {required_memory_max_mb}MB for this soft_limit_percent."
+                ),
+                "A practical Codex writer envelope such as 10000MB with soft_limit_percent=90 satisfies the 9000MB floor when host RAM allows it.".to_string(),
+                "Do not repeatedly retry dirty-work recovery through the same CSA memory envelope; after one same-class retry, switch to documented recovery/manual fallback to avoid partial worktree mutations.".to_string(),
+            ],
+        }
+    }
+
     fn message(self, tool_name: &str) -> String {
         let required_memory_max_mb = self.required_memory_max_mb;
         let recommendation = match self.session_kind {
@@ -83,8 +132,19 @@ pub(crate) fn ensure_memory_soft_limit_admission(
     };
 
     Err(MemorySoftLimitAdmissionError {
-        message: denial.message(tool_name),
+        tool_name: tool_name.to_string(),
+        denial,
     })
+}
+
+pub(crate) fn codex_soft_limit_required_floor_mb(
+    task_type: Option<&str>,
+    tool_name: &str,
+) -> Option<u64> {
+    if tool_name != "codex" {
+        return None;
+    }
+    CodexSoftLimitAdmissionKind::from_task_type(task_type).map(|kind| kind.required_threshold_mb())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -317,6 +377,17 @@ mod tests {
         assert_eq!(
             memory_soft_limit_admission_denial(Some(WRITER_TASK_TYPE), "codex", Some(&plan)),
             None
+        );
+    }
+
+    #[test]
+    fn codex_writer_soft_limit_admission_allows_10gb_with_soft90() {
+        let plan = isolation_plan(ResourceCapability::CgroupV2, Some(10_000), Some(90));
+
+        assert_eq!(
+            memory_soft_limit_admission_denial(Some(WRITER_TASK_TYPE), "codex", Some(&plan)),
+            None,
+            "10GB with soft90 reaches the 9000MB writer floor without forcing a 13GB cap"
         );
     }
 

--- a/crates/cli-sub-agent/src/review_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute.rs
@@ -50,10 +50,11 @@ use execute_once::execute_review_once_with_artifact_guard;
 #[cfg(test)]
 use failures::read_review_failure_excerpt;
 use failures::{
-    build_gemini_api_key_retry_env, classify_review_failover_error,
-    classify_review_failover_reason, classify_review_failure_result,
-    extract_meta_session_id_from_error, maybe_synthesize_missing_review_result,
-    repair_completed_review_restriction_result, retire_tier_failover_session,
+    build_gemini_api_key_retry_env, classify_no_provider_launch_error_text,
+    classify_review_failover_error, classify_review_failover_reason,
+    classify_review_failure_result, extract_meta_session_id_from_error,
+    maybe_synthesize_missing_review_result, repair_completed_review_restriction_result,
+    retire_tier_failover_session,
 };
 
 const CSA_READONLY_SESSION_ENV: &str = "CSA_READONLY_SESSION";
@@ -494,6 +495,45 @@ pub(crate) async fn execute_review_with_tier_filter(
                     execution_started_at,
                     &err,
                 );
+                if let Some(no_provider_reason) =
+                    classify_no_provider_launch_error_text(&error_text)
+                {
+                    let meta_session_id = extract_meta_session_id_from_error(&err)
+                        .unwrap_or_else(|| "unknown".to_string());
+                    let fallback_guidance = if !tier_fallback_enabled || no_failover {
+                        "review failover was disabled for this invocation"
+                    } else if candidates.len() <= 1 {
+                        "no alternate configured reviewer candidate was available"
+                    } else {
+                        "no alternate configured reviewer candidate remained"
+                    };
+                    return Ok(ReviewExecutionOutcome {
+                        execution: crate::pipeline::SessionExecutionResult {
+                            execution: csa_process::ExecutionResult {
+                                exit_code: 1,
+                                output: String::new(),
+                                stderr_output: error_text.clone(),
+                                summary: "Review unavailable".to_string(),
+                                peak_memory_mb: None,
+                                ..Default::default()
+                            },
+                            meta_session_id: meta_session_id.clone(),
+                            provider_session_id: None,
+                            changed_paths: None,
+                            commit_created: None,
+                        },
+                        persistable_session_id: (meta_session_id != "unknown")
+                            .then_some(meta_session_id),
+                        executed_tool: *attempt_tool,
+                        status_reason: Some(no_provider_reason.to_string()),
+                        forced_decision: Some(ReviewDecision::Unavailable),
+                        routed_to: None,
+                        primary_failure: Some(no_provider_reason.to_string()),
+                        failure_reason: Some(format!(
+                            "{no_provider_reason}: reviewer provider did not launch; {fallback_guidance}"
+                        )),
+                    });
+                }
                 return Err(err);
             }
         };

--- a/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
@@ -73,6 +73,40 @@ fn classify_review_failover_error_uses_late_gemini_http_400_for_review_fallback(
 }
 
 #[test]
+fn classify_review_failover_error_detects_memory_soft_limit_admission() {
+    let failure = classify_review_failover_error(
+        ToolName::Codex,
+        Some("codex/openai/gpt-5.5/xhigh"),
+        "CSA: memory_soft_limit_admission denied -- codex reviewer soft memory threshold is 5734MB",
+        Some(std::time::Duration::from_secs(1)),
+    )
+    .expect("reviewer memory admission should be failover eligible");
+
+    assert_eq!(
+        failure.reason,
+        crate::resource_admission_soft_limit::MEMORY_SOFT_LIMIT_ADMISSION_REASON
+    );
+    assert_eq!(failure.quota_exhausted, Some(false));
+}
+
+#[test]
+fn classify_review_failover_error_detects_host_memory_admission() {
+    let failure = classify_review_failover_error(
+        ToolName::Codex,
+        Some("codex/openai/gpt-5.5/xhigh"),
+        "CSA: host memory admission denied — available=11385MB < required=12858MB",
+        Some(std::time::Duration::from_secs(1)),
+    )
+    .expect("reviewer host admission should be failover eligible");
+
+    assert_eq!(
+        failure.reason,
+        crate::no_provider_launch::HOST_MEMORY_ADMISSION_REASON
+    );
+    assert_eq!(failure.quota_exhausted, Some(false));
+}
+
+#[test]
 fn classify_review_failover_reason_detects_gemini_noninteractive_manual_auth() {
     let stderr = "\
 Error authenticating: FatalAuthenticationError: Manual authorization is required but the current session is non-interactive. \

--- a/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
@@ -37,6 +37,17 @@ pub(super) fn classify_review_failover_reason(
         "{}\n{}",
         execution.execution.summary, execution.execution.output
     );
+    let combined = format!(
+        "{}\n{}",
+        stdout_with_summary, execution.execution.stderr_output
+    );
+    if let Some(reason) = classify_memory_admission_error_text(&combined) {
+        return Some(ReviewFailoverFailure {
+            reason: reason.to_string(),
+            quota_exhausted: Some(false),
+        });
+    }
+
     classify_next_model_failure_with_elapsed(
         tool.as_str(),
         &execution.execution.stderr_output,
@@ -58,6 +69,13 @@ pub(super) fn classify_review_failover_error(
     error_text: &str,
     attempt_elapsed: Option<std::time::Duration>,
 ) -> Option<ReviewFailoverFailure> {
+    if let Some(reason) = classify_memory_admission_error_text(error_text) {
+        return Some(ReviewFailoverFailure {
+            reason: reason.to_string(),
+            quota_exhausted: Some(false),
+        });
+    }
+
     classify_next_model_failure_with_elapsed(
         tool.as_str(),
         error_text,
@@ -71,6 +89,24 @@ pub(super) fn classify_review_failover_error(
         quota_exhausted: Some(detected.quota_exhausted),
     })
     .or_else(|| classify_gemini_cli_runtime_error_text(tool, error_text))
+}
+
+fn classify_memory_admission_error_text(error_text: &str) -> Option<&'static str> {
+    let lower = error_text.to_ascii_lowercase();
+    if lower.contains(crate::resource_admission_soft_limit::MEMORY_SOFT_LIMIT_ADMISSION_REASON) {
+        Some(crate::resource_admission_soft_limit::MEMORY_SOFT_LIMIT_ADMISSION_REASON)
+    } else if lower.contains("host memory admission denied")
+        || lower.contains("active-session memory admission denied")
+        || lower.contains("csa: low memory")
+    {
+        Some(crate::no_provider_launch::HOST_MEMORY_ADMISSION_REASON)
+    } else {
+        None
+    }
+}
+
+pub(super) fn classify_no_provider_launch_error_text(error_text: &str) -> Option<&'static str> {
+    classify_memory_admission_error_text(error_text)
 }
 
 fn classify_gemini_cli_runtime_failure(

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -19,6 +19,8 @@ mod diagnostics;
 mod exit_code;
 #[path = "review_cmd_output_fail_closed.rs"]
 mod fail_closed;
+#[path = "review_cmd_output_no_provider.rs"]
+mod no_provider;
 #[path = "review_cmd_output_prose_signals.rs"]
 mod prose_signals;
 #[path = "review_cmd_output_sections.rs"]
@@ -31,6 +33,8 @@ mod terminal_error;
 mod text;
 #[path = "review_cmd_output_tool_failure.rs"]
 mod tool_failure;
+#[path = "review_cmd_output_worktree.rs"]
+mod worktree;
 use artifacts::{
     has_blocking_severity, json_severity_counts_if_present, load_findings_toml_from_output,
     load_review_artifact_from_output, severity_counts_are_zero, severity_counts_for_artifact,
@@ -47,6 +51,7 @@ pub(super) use diagnostics::{ReviewerOutcome, print_reviewer_outcomes};
 pub(super) use exit_code::{persist_review_result_exit_code, persisted_review_verdict_exit_code};
 pub(super) use fail_closed::fail_closed_review_meta;
 use fail_closed::fail_closed_review_verdict_artifact;
+use no_provider::attach_no_provider_launch_diagnostic;
 use prose_signals::{reconcile_counts_with_prose, review_prose_signals};
 pub(super) use sections::{
     derive_review_result_summary, has_structured_review_content, sanitize_review_output,
@@ -63,6 +68,7 @@ pub(super) use text::{
     extract_review_text, stream_started_without_terminal_event, terminal_tool_error_reason,
 };
 pub(super) use tool_failure::{ToolReviewFailureKind, detect_tool_review_failure};
+pub(super) use worktree::is_worktree_submodule;
 
 const REVIEW_RESULT_SUMMARY_MAX_CHARS: usize = 200;
 const EDIT_RESTRICTION_SUMMARY_PREFIX: &str = "Edit restriction violated:";
@@ -118,6 +124,7 @@ pub(super) fn persist_review_verdict_artifact(
             artifact.primary_failure = meta.primary_failure.clone();
             artifact.failure_reason = meta.failure_reason.clone().or(artifact.failure_reason);
             artifact.review_mode = meta.review_mode.clone();
+            attach_no_provider_launch_diagnostic(&session_dir, meta, &mut artifact);
             if let Err(error) = enforce_final_verdict_consistency(&session_dir, &mut artifact) {
                 warn!(
                     session_id = %meta.session_id,
@@ -548,6 +555,7 @@ fn build_review_verdict_artifact(
         large_diff_warning: false,
         large_diff_warning_threshold: None,
         large_diff_warning_changed_lines: None,
+        no_provider_launch: None,
     }
 }
 
@@ -559,26 +567,6 @@ fn legacy_verdict_for_decision(decision: ReviewDecision, fallback: &str) -> Stri
             fallback.to_string()
         }
     }
-}
-
-/// Detect whether `project_root` resides inside a git worktree submodule.
-///
-/// A worktree submodule's `.git` is a file (not directory) containing a
-/// `gitdir:` reference that traverses both `worktrees/` and `modules/`
-/// path segments — the hallmark of the nested worktree-submodule layout.
-pub(super) fn is_worktree_submodule(project_root: &Path) -> bool {
-    let git_marker = project_root.join(".git");
-    if !git_marker.is_file() {
-        return false;
-    }
-    let Ok(marker) = std::fs::read_to_string(&git_marker) else {
-        return false;
-    };
-    let Some(gitdir_raw) = marker.trim().strip_prefix("gitdir:") else {
-        return false;
-    };
-    let gitdir = gitdir_raw.trim();
-    gitdir.contains("/worktrees/") && gitdir.contains("/modules/")
 }
 
 pub(in crate::review_cmd) use clean_detection::is_review_output_empty;

--- a/crates/cli-sub-agent/src/review_cmd_output_no_provider.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_no_provider.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+use csa_session::ReviewVerdictArtifact;
+use csa_session::state::ReviewSessionMeta;
+use tracing::warn;
+
+pub(super) fn attach_no_provider_launch_diagnostic(
+    session_dir: &Path,
+    meta: &ReviewSessionMeta,
+    artifact: &mut ReviewVerdictArtifact,
+) {
+    let Ok(Some(mut diagnostic)) = csa_session::read_no_provider_launch_diagnostic(session_dir)
+    else {
+        return;
+    };
+
+    crate::no_provider_launch::enrich_review_diagnostic(
+        &mut diagnostic,
+        &meta.head_sha,
+        &meta.scope,
+    );
+    if let Err(error) = csa_session::write_no_provider_launch_diagnostic(session_dir, &diagnostic) {
+        warn!(
+            session_id = %meta.session_id,
+            error = %error,
+            "Failed to rewrite enriched no-provider diagnostic"
+        );
+    }
+    artifact.no_provider_launch = Some(diagnostic);
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_worktree.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_worktree.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+/// Detect whether `project_root` resides inside a git worktree submodule.
+///
+/// A worktree submodule's `.git` is a file (not directory) containing a
+/// `gitdir:` reference that traverses both `worktrees/` and `modules/`
+/// path segments — the hallmark of the nested worktree-submodule layout.
+pub(in crate::review_cmd) fn is_worktree_submodule(project_root: &Path) -> bool {
+    let git_marker = project_root.join(".git");
+    if !git_marker.is_file() {
+        return false;
+    }
+    let Ok(marker) = std::fs::read_to_string(&git_marker) else {
+        return false;
+    };
+    let Some(gitdir_raw) = marker.trim().strip_prefix("gitdir:") else {
+        return false;
+    };
+    let gitdir = gitdir_raw.trim();
+    gitdir.contains("/worktrees/") && gitdir.contains("/modules/")
+}

--- a/crates/cli-sub-agent/src/review_cmd_tests_pre_exec.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_pre_exec.rs
@@ -81,3 +81,113 @@ async fn handle_review_persists_result_for_prior_rounds_summary_parse_failure() 
             .contains("Failed to read prior-rounds summary file")
     );
 }
+
+#[test]
+fn review_verdict_carries_no_provider_launch_diagnostic() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let session = csa_session::create_session(
+        project_dir.path(),
+        Some("reviewer soft-limit admission"),
+        None,
+        Some("codex"),
+    )
+    .expect("create review session");
+    let session_id = session.meta_session_id;
+    let diagnostic = csa_session::NoProviderLaunchDiagnostic {
+        schema_version: csa_session::NO_PROVIDER_LAUNCH_SCHEMA_VERSION,
+        session_id: session_id.clone(),
+        timestamp: chrono::Utc::now(),
+        tool: "codex".to_string(),
+        role: "reviewer".to_string(),
+        session_class: Some("reviewer_sub_session".to_string()),
+        denial_class: crate::resource_admission_soft_limit::MEMORY_SOFT_LIMIT_ADMISSION_REASON
+            .to_string(),
+        no_provider_launch: true,
+        provider_side_effects: false,
+        head_sha: None,
+        scope: None,
+        range: None,
+        memory: csa_session::NoProviderLaunchMemoryDiagnostic {
+            effective_memory_max_mb: Some(8192),
+            soft_limit_percent: Some(70),
+            soft_threshold_mb: Some(5734),
+            required_floor_mb: Some(8192),
+            required_memory_max_mb: Some(11_703),
+            ..Default::default()
+        },
+        guidance: vec![
+            "remove a lower memory override so Codex can use its 12288MB default".to_string(),
+        ],
+    };
+    csa_session::save_result(
+        project_dir.path(),
+        &session_id,
+        &csa_session::SessionResult {
+            status: "failure".to_string(),
+            exit_code: 1,
+            summary: "pre-exec: CSA: memory_soft_limit_admission denied".to_string(),
+            tool: "codex".to_string(),
+            started_at: chrono::Utc::now(),
+            completed_at: chrono::Utc::now(),
+            artifacts: vec![csa_session::SessionArtifact::new(
+                csa_session::NO_PROVIDER_LAUNCH_ARTIFACT_PATH,
+            )],
+            ..Default::default()
+        },
+    )
+    .expect("save synthetic result");
+    let session_dir = csa_session::get_session_dir(project_dir.path(), &session_id).unwrap();
+    csa_session::write_no_provider_launch_diagnostic(&session_dir, &diagnostic)
+        .expect("write synthetic no-provider sidecar");
+
+    let review_meta = ReviewSessionMeta {
+        session_id: session_id.clone(),
+        head_sha: "abc123def456".to_string(),
+        decision: ReviewDecision::Unavailable.as_str().to_string(),
+        verdict: "UNAVAILABLE".to_string(),
+        review_mode: Some("standard".to_string()),
+        status_reason: Some(
+            crate::resource_admission_soft_limit::MEMORY_SOFT_LIMIT_ADMISSION_REASON.to_string(),
+        ),
+        routed_to: None,
+        primary_failure: Some(
+            crate::resource_admission_soft_limit::MEMORY_SOFT_LIMIT_ADMISSION_REASON.to_string(),
+        ),
+        failure_reason: Some("reviewer provider did not launch".to_string()),
+        tool: "codex".to_string(),
+        scope: "range:main...HEAD".to_string(),
+        exit_code: 1,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: chrono::Utc::now(),
+        diff_fingerprint: None,
+        fix_convergence: None,
+    };
+
+    persist_review_sidecars_if_session_exists(project_dir.path(), &review_meta, Some(&session_id));
+
+    let verdict: csa_session::ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json"))
+            .expect("review-verdict.json should exist"),
+    )
+    .expect("review verdict should parse");
+    assert_eq!(verdict.decision, ReviewDecision::Unavailable);
+    let no_provider = verdict
+        .no_provider_launch
+        .as_ref()
+        .expect("review verdict should carry no-provider diagnostic");
+    assert_eq!(no_provider.role, "reviewer");
+    assert_eq!(no_provider.scope.as_deref(), Some("range:main...HEAD"));
+    assert_eq!(no_provider.range.as_deref(), Some("main...HEAD"));
+    assert_eq!(no_provider.head_sha.as_deref(), Some("abc123def456"));
+    assert_eq!(no_provider.memory.required_memory_max_mb, Some(11_703));
+
+    let sidecar: csa_session::NoProviderLaunchDiagnostic = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join(csa_session::NO_PROVIDER_LAUNCH_ARTIFACT_PATH))
+            .expect("enriched no-verdict sidecar should exist"),
+    )
+    .expect("enriched no-verdict sidecar should parse");
+    assert_eq!(sidecar.scope.as_deref(), Some("range:main...HEAD"));
+}

--- a/crates/cli-sub-agent/src/session_guard.rs
+++ b/crates/cli-sub-agent/src/session_guard.rs
@@ -5,7 +5,8 @@ use std::path::{Path, PathBuf};
 use tracing::{info, warn};
 
 use csa_session::{
-    SaveOptions, SessionResult, create_session, save_result_with_options, save_session,
+    NO_PROVIDER_LAUNCH_ARTIFACT_PATH, NoProviderLaunchDiagnostic, SaveOptions, SessionArtifact,
+    SessionResult, create_session, save_result_with_options, save_session,
 };
 
 /// RAII guard that cleans up a newly created session directory on failure.
@@ -80,7 +81,37 @@ pub(crate) fn write_pre_exec_error_result(
     tool_name: &str,
     error: &anyhow::Error,
 ) {
+    write_pre_exec_error_result_inner(project_root, session_id, tool_name, error, None);
+}
+
+pub(crate) fn write_pre_exec_error_result_with_no_provider(
+    project_root: &Path,
+    session_id: &str,
+    tool_name: &str,
+    error: &anyhow::Error,
+    no_provider_launch: NoProviderLaunchDiagnostic,
+) {
+    write_pre_exec_error_result_inner(
+        project_root,
+        session_id,
+        tool_name,
+        error,
+        Some(no_provider_launch),
+    );
+}
+
+fn write_pre_exec_error_result_inner(
+    project_root: &Path,
+    session_id: &str,
+    tool_name: &str,
+    error: &anyhow::Error,
+    no_provider_launch: Option<NoProviderLaunchDiagnostic>,
+) {
     let now = chrono::Utc::now();
+    let artifacts = no_provider_launch
+        .as_ref()
+        .map(|_| vec![SessionArtifact::new(NO_PROVIDER_LAUNCH_ARTIFACT_PATH)])
+        .unwrap_or_default();
     let result = SessionResult {
         post_exec_gate: None,
         status: "failure".to_string(),
@@ -93,7 +124,7 @@ pub(crate) fn write_pre_exec_error_result(
         started_at: now,
         completed_at: now,
         events_count: 0,
-        artifacts: Vec::new(),
+        artifacts,
         ..Default::default()
     };
     if let Err(e) = save_result_with_options(
@@ -105,6 +136,12 @@ pub(crate) fn write_pre_exec_error_result(
         },
     ) {
         warn!("Failed to save pre-execution error result: {}", e);
+    }
+    if let Some(diagnostic) = no_provider_launch
+        && let Ok(session_dir) = csa_session::get_session_dir(project_root, session_id)
+        && let Err(e) = csa_session::write_no_provider_launch_diagnostic(&session_dir, &diagnostic)
+    {
+        warn!("Failed to save pre-execution no-provider diagnostic: {}", e);
     }
     // Best-effort cooldown marker
     csa_session::write_cooldown_marker_for_project(project_root, session_id, now);

--- a/crates/cli-sub-agent/src/session_unavailable_reason.rs
+++ b/crates/cli-sub-agent/src/session_unavailable_reason.rs
@@ -211,6 +211,7 @@ mod tests {
             large_diff_warning: false,
             large_diff_warning_threshold: None,
             large_diff_warning_changed_lines: None,
+            no_provider_launch: None,
         }
     }
 

--- a/crates/csa-resource/src/guard.rs
+++ b/crates/csa-resource/src/guard.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use sysinfo::System;
 use tracing::warn;
 
@@ -34,6 +34,81 @@ pub struct SpawnMemoryAdmission {
     pub active_session_count: u64,
     /// Number of active sessions whose process tree RSS was sampled successfully.
     pub sampled_session_count: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryAdmissionKind {
+    Reserve,
+    HostSpawn,
+    ActiveSession,
+}
+
+impl MemoryAdmissionKind {
+    pub const fn denial_class(self) -> &'static str {
+        match self {
+            Self::Reserve | Self::HostSpawn | Self::ActiveSession => "host_memory_admission",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryAdmissionError {
+    message: String,
+    pub kind: MemoryAdmissionKind,
+    pub available_phys_mb: u64,
+    pub available_swap_mb: u64,
+    pub available_combined_mb: u64,
+    pub total_ram_mb: u64,
+    pub reserve_mb: u64,
+    pub required_available_mb: Option<u64>,
+    pub projected_spawn_mb: Option<u64>,
+    pub active_session_rss_mb: Option<u64>,
+    pub active_session_projected_mb: Option<u64>,
+    pub active_session_count: Option<u64>,
+    pub sampled_session_count: Option<u64>,
+}
+
+impl MemoryAdmissionError {
+    fn new(message: String, kind: MemoryAdmissionKind, snapshot: MemoryAdmissionSnapshot) -> Self {
+        Self {
+            message,
+            kind,
+            available_phys_mb: snapshot.available_phys_mb,
+            available_swap_mb: snapshot.available_swap_mb,
+            available_combined_mb: snapshot.available_combined_mb,
+            total_ram_mb: snapshot.total_ram_mb,
+            reserve_mb: snapshot.reserve_mb,
+            required_available_mb: snapshot.required_available_mb,
+            projected_spawn_mb: snapshot.projected_spawn_mb,
+            active_session_rss_mb: snapshot.active_session_rss_mb,
+            active_session_projected_mb: snapshot.active_session_projected_mb,
+            active_session_count: snapshot.active_session_count,
+            sampled_session_count: snapshot.sampled_session_count,
+        }
+    }
+}
+
+impl std::fmt::Display for MemoryAdmissionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for MemoryAdmissionError {}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct MemoryAdmissionSnapshot {
+    available_phys_mb: u64,
+    available_swap_mb: u64,
+    available_combined_mb: u64,
+    total_ram_mb: u64,
+    reserve_mb: u64,
+    required_available_mb: Option<u64>,
+    projected_spawn_mb: Option<u64>,
+    active_session_rss_mb: Option<u64>,
+    active_session_projected_mb: Option<u64>,
+    active_session_count: Option<u64>,
+    sampled_session_count: Option<u64>,
 }
 
 /// Guards resource availability before launching tools.
@@ -145,6 +220,15 @@ fn evaluate_memory_availability(
     reserve_mb: u64,
     admission: Option<SpawnMemoryAdmission>,
 ) -> Result<()> {
+    let base_snapshot = MemoryAdmissionSnapshot {
+        available_phys_mb,
+        available_swap_mb,
+        available_combined_mb,
+        total_ram_mb,
+        reserve_mb,
+        ..Default::default()
+    };
+
     if available_phys_mb < reserve_mb {
         let message = format!(
             "CSA: low memory — available={available_phys_mb}MB < required={reserve_mb}MB. \
@@ -153,10 +237,15 @@ fn evaluate_memory_availability(
              swap_available_mb={available_swap_mb} combined_available_mb={available_combined_mb}"
         );
         eprintln!("{message}");
-        bail!(
-            "{message}. Free system memory or reduce [resources] min_free_memory_mb in \
-             .csa/config.toml. For one csa run, pass --min-free-memory-mb <MB>."
+        let error = MemoryAdmissionError::new(
+            format!(
+                "{message}. Free system memory or reduce [resources] min_free_memory_mb in \
+                 .csa/config.toml. For one csa run, pass --min-free-memory-mb <MB>."
+            ),
+            MemoryAdmissionKind::Reserve,
+            base_snapshot,
         );
+        return Err(error.into());
     }
 
     let warn_threshold = reserve_mb.saturating_mul(WARNING_MULTIPLIER_NUM) / WARNING_MULTIPLIER_DEN;
@@ -195,13 +284,26 @@ fn evaluate_memory_availability(
                 active_projected = admission.active_session_projected_mb,
             );
             eprintln!("{message}");
-            bail!(
-                "{message}. Free host memory, wait for active CSA sessions to finish, or lower \
-                 tool memory limits before spawning more work. For one csa run, pass \
-                 --memory-max-mb <MB> to lower projected_spawn or --min-free-memory-mb <MB> \
-                 to lower the reserve. Persistent config keys: resources.memory_max_mb, \
-                 tools.<tool>.memory_max_mb, resources.min_free_memory_mb."
+            let error = MemoryAdmissionError::new(
+                format!(
+                    "{message}. Free host memory, wait for active CSA sessions to finish, or lower \
+                     tool memory limits before spawning more work. For one csa run, pass \
+                     --memory-max-mb <MB> to lower projected_spawn or --min-free-memory-mb <MB> \
+                     to lower the reserve. Persistent config keys: resources.memory_max_mb, \
+                     tools.<tool>.memory_max_mb, resources.min_free_memory_mb."
+                ),
+                MemoryAdmissionKind::HostSpawn,
+                MemoryAdmissionSnapshot {
+                    required_available_mb: Some(required_available_mb),
+                    projected_spawn_mb: Some(admission.projected_spawn_mb),
+                    active_session_rss_mb: Some(admission.active_session_rss_mb),
+                    active_session_projected_mb: Some(admission.active_session_projected_mb),
+                    active_session_count: Some(admission.active_session_count),
+                    sampled_session_count: Some(admission.sampled_session_count),
+                    ..base_snapshot
+                },
             );
+            return Err(error.into());
         }
 
         let host_safe_limit_mb = total_ram_mb.saturating_mul(ACTIVE_SESSION_SAFE_FRACTION_NUM)
@@ -225,11 +327,24 @@ fn evaluate_memory_availability(
                 projected_spawn_mb = admission.projected_spawn_mb,
             );
             eprintln!("{message}");
-            bail!(
-                "{message}. CSA is refusing to launch work that could collectively exhaust host RAM. \
-                 For one csa run, pass --memory-max-mb <MB> to lower projected_spawn. \
-                 Persistent config keys: resources.memory_max_mb or tools.<tool>.memory_max_mb."
+            let error = MemoryAdmissionError::new(
+                format!(
+                    "{message}. CSA is refusing to launch work that could collectively exhaust host RAM. \
+                     For one csa run, pass --memory-max-mb <MB> to lower projected_spawn. \
+                     Persistent config keys: resources.memory_max_mb or tools.<tool>.memory_max_mb."
+                ),
+                MemoryAdmissionKind::ActiveSession,
+                MemoryAdmissionSnapshot {
+                    required_available_mb: Some(host_safe_limit_mb),
+                    projected_spawn_mb: Some(admission.projected_spawn_mb),
+                    active_session_rss_mb: Some(admission.active_session_rss_mb),
+                    active_session_projected_mb: Some(admission.active_session_projected_mb),
+                    active_session_count: Some(admission.active_session_count),
+                    sampled_session_count: Some(admission.sampled_session_count),
+                    ..base_snapshot
+                },
             );
+            return Err(error.into());
         }
 
         let host_warning_limit_mb = host_safe_limit_mb

--- a/crates/csa-resource/src/lib.rs
+++ b/crates/csa-resource/src/lib.rs
@@ -22,7 +22,9 @@ pub use cgroup::{
     scope_unit_name,
 };
 pub use filesystem_sandbox::{FilesystemCapability, detect_filesystem_capability};
-pub use guard::{ResourceGuard, ResourceLimits, SpawnMemoryAdmission};
+pub use guard::{
+    MemoryAdmissionError, MemoryAdmissionKind, ResourceGuard, ResourceLimits, SpawnMemoryAdmission,
+};
 pub use isolation_plan::{EnforcementMode, IsolationPlan, IsolationPlanBuilder};
 pub use landlock::apply_landlock_rules;
 pub use rlimit::apply_rlimits;

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -85,8 +85,11 @@ pub use post_exec_gate_report::{
 pub use process_tree_memory::{SessionTreeMemorySampler, session_tree_rss_mb};
 pub use redact::{redact_event, redact_text_content};
 pub use result::{
-    MemorySoftLimitRecoveryDiagnostic, RequireCommitRecoveryDiagnostic, SessionArtifact,
-    SessionManagerFields, SessionResult, UncommittedChanges,
+    MemorySoftLimitRecoveryDiagnostic, NO_PROVIDER_LAUNCH_ARTIFACT_PATH,
+    NO_PROVIDER_LAUNCH_SCHEMA_VERSION, NoProviderLaunchDiagnostic,
+    NoProviderLaunchMemoryDiagnostic, RequireCommitRecoveryDiagnostic, SessionArtifact,
+    SessionManagerFields, SessionResult, UncommittedChanges, read_no_provider_launch_diagnostic,
+    write_no_provider_launch_diagnostic,
 };
 pub use review_artifact::{
     Finding, FindingsFile, REVIEW_VERDICT_SCHEMA_VERSION, ReviewArtifact, ReviewDiffSize,

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -5,7 +5,7 @@ use crate::large_diff_warning::LargeDiffWarningReport;
 use chrono::{DateTime, Utc};
 use csa_core::types::FallbackAttempt;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::fmt;
+use std::{fmt, path::Path};
 use toml::Value as TomlValue;
 
 pub const RESULT_FILE_NAME: &str = "result.toml";
@@ -258,6 +258,92 @@ pub struct MemorySoftLimitRecoveryDiagnostic {
     pub head_summary: Option<String>,
     /// Stable recovery action code for callers.
     pub suggested_recovery_action: String,
+}
+
+pub const NO_PROVIDER_LAUNCH_ARTIFACT_PATH: &str = "output/no-verdict.json";
+pub const NO_PROVIDER_LAUNCH_SCHEMA_VERSION: u32 = 1;
+
+/// Machine-readable diagnostic for sessions that were rejected before the
+/// external tool/provider launched.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NoProviderLaunchDiagnostic {
+    pub schema_version: u32,
+    pub session_id: String,
+    pub timestamp: DateTime<Utc>,
+    pub tool: String,
+    /// Stable role label such as "writer" or "reviewer".
+    pub role: String,
+    /// Raw task/session class when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_class: Option<String>,
+    /// Stable denial class, e.g. "memory_soft_limit_admission" or
+    /// "host_memory_admission".
+    pub denial_class: String,
+    pub no_provider_launch: bool,
+    pub provider_side_effects: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range: Option<String>,
+    pub memory: NoProviderLaunchMemoryDiagnostic,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub guidance: Vec<String>,
+}
+
+/// Memory-specific fields for a no-provider-launch diagnostic.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NoProviderLaunchMemoryDiagnostic {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_memory_max_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub soft_limit_percent: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub soft_threshold_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_floor_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_memory_max_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reserve_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub available_memory_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_available_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projected_spawn_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_session_rss_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_session_projected_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_session_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sampled_session_count: Option<u64>,
+}
+
+pub fn write_no_provider_launch_diagnostic(
+    session_dir: &Path,
+    diagnostic: &NoProviderLaunchDiagnostic,
+) -> std::io::Result<()> {
+    let output_dir = session_dir.join("output");
+    std::fs::create_dir_all(&output_dir)?;
+    let json = serde_json::to_vec_pretty(diagnostic)?;
+    std::fs::write(session_dir.join(NO_PROVIDER_LAUNCH_ARTIFACT_PATH), json)
+}
+
+pub fn read_no_provider_launch_diagnostic(
+    session_dir: &Path,
+) -> std::io::Result<Option<NoProviderLaunchDiagnostic>> {
+    let path = session_dir.join(NO_PROVIDER_LAUNCH_ARTIFACT_PATH);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(path)?;
+    serde_json::from_str(&raw)
+        .map(Some)
+        .map_err(|error| std::io::Error::other(format!("parse no-provider diagnostic: {error}")))
 }
 
 /// Structured result of a session execution.

--- a/crates/csa-session/src/review_artifact.rs
+++ b/crates/csa-session/src/review_artifact.rs
@@ -4,6 +4,8 @@ use chrono::{DateTime, Utc};
 use csa_core::types::ReviewDecision;
 use serde::{Deserialize, Serialize};
 
+use crate::result::NoProviderLaunchDiagnostic;
+
 fn default_schema_version() -> String {
     "1.0".to_string()
 }
@@ -136,6 +138,8 @@ pub struct ReviewVerdictArtifact {
     pub large_diff_warning_threshold: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub large_diff_warning_changed_lines: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub no_provider_launch: Option<NoProviderLaunchDiagnostic>,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -179,6 +183,7 @@ impl ReviewVerdictArtifact {
             large_diff_warning: false,
             large_diff_warning_threshold: None,
             large_diff_warning_changed_lines: None,
+            no_provider_launch: None,
         }
     }
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1055"
-weave = "0.1.1055"
+csa = "0.1.1056"
+weave = "0.1.1056"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- fail pre-provider memory admission with structured `no_provider_launch` diagnostics instead of silent no-verdict artifacts
- carry memory admission diagnostics through session result/review verdict artifacts so review/pr-bot consumers can reconcile infrastructure failures
- add memory-soft-limit recovery guidance and tests for run/review pre-exec no-provider paths

## Verification
- `cargo check --workspace --all-features`
- `cargo test -p cli-sub-agent resource_admission_soft_limit -- --nocapture`
- `cargo test -p cli-sub-agent no_provider -- --nocapture`
- `cargo test -p cli-sub-agent is_worktree_submodule -- --nocapture`
- `cargo test -p csa-session -- --nocapture`
- `scripts/monolith/check.sh --scope staged --baseline scripts/monolith/baseline.toml --report-all`
- `just pre-commit-fast`
- hook-enabled commit quality gates
- exact-head release build: `target/release/csa --version` => `csa 0.1.1056 (6ab9c396)`
- exact-head CSA review: `01KVTTF5FCXFAMXC2S78NWA1DK` PASS/CLEAN for `range:main...HEAD`
- `target/release/csa review --check-verdict --sa-mode true --range main...HEAD --cd "$PWD"`
- pre-push hook review-check/version-check passed

Fixes #2330
Fixes #2333
