### PR TITLE
fix(review): reconcile pass verdict artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1056"
+version = "0.1.1057"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1056"
+version = "0.1.1057"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
@@ -540,6 +540,13 @@ fn read_review_meta_after_recovery(
     session_id: &str,
     session_dir: &Path,
 ) -> Result<Option<ReviewSessionMeta>> {
+    if !session_dir
+        .join("output")
+        .join("review-verdict.json")
+        .is_file()
+    {
+        recover_review_sidecars_before_meta(project_root, session_id);
+    }
     if let Some(meta) = read_review_meta(session_dir)? {
         return Ok(Some(meta));
     }

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_2236_clean_summary_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_2236_clean_summary_tests.rs
@@ -172,6 +172,10 @@ fn issue_2236_check_verdict_recovers_bounded_clean_verdict_summary_shapes() {
             "labeled emphasized verdict",
             "Verdict: __PASS__ - all tests passed\n",
         ),
+        (
+            "single-line pass clean explanation",
+            "PASS No blocking correctness, security, or AGENTS.md compliance findings found for `range:main...HEAD`.\n",
+        ),
     ];
 
     for (case_name, summary) in cases {
@@ -239,4 +243,124 @@ fn issue_2236_check_verdict_recovers_bounded_clean_verdict_summary_shapes() {
         assert_eq!(artifact.decision, ReviewDecision::Pass, "{case_name}");
         assert_eq!(artifact.verdict_legacy, "CLEAN", "{case_name}");
     }
+}
+
+#[test]
+fn issue_2393_existing_fail_meta_without_artifact_recovers_exact_head_pass_summary() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let state_home = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    let (project, branch, head_sha) = setup_feature_repo();
+    let expected_diff_fingerprint = crate::review_cmd::compute_review_diff_fingerprint(
+        project.path(),
+        REQUIRED_FULL_DIFF_SCOPE,
+    )
+    .expect("feature branch should have a main...HEAD diff");
+    let session_created_at =
+        utc_timestamp(latest_reflog_timestamp_secs(project.path(), "main") + 1);
+    let summary = "PASS No blocking correctness, security, or AGENTS.md compliance findings found for `range:main...HEAD`.\n";
+    let session_id = write_legacy_success_result_with_created_at(
+        project.path(),
+        &branch,
+        &head_sha,
+        summary,
+        session_created_at,
+    );
+    let session_dir = csa_session::get_session_dir(project.path(), &session_id).unwrap();
+    csa_session::save_result(
+        project.path(),
+        &session_id,
+        &SessionResult {
+            status: SessionResult::status_from_exit_code(1),
+            exit_code: 1,
+            summary: summary.to_string(),
+            tool: "codex".to_string(),
+            started_at: session_created_at,
+            completed_at: session_created_at,
+            ..Default::default()
+        },
+    )
+    .expect("save failing legacy result");
+    csa_session::write_review_meta(
+        &session_dir,
+        &csa_session::ReviewSessionMeta {
+            session_id: session_id.clone(),
+            head_sha: head_sha.clone(),
+            decision: ReviewDecision::Fail.as_str().to_string(),
+            verdict: "HAS_ISSUES".to_string(),
+            review_mode: None,
+            status_reason: None,
+            routed_to: None,
+            primary_failure: None,
+            failure_reason: None,
+            tool: "codex".to_string(),
+            scope: REQUIRED_FULL_DIFF_SCOPE.to_string(),
+            exit_code: 1,
+            fix_attempted: false,
+            fix_rounds: 0,
+            review_iterations: 1,
+            timestamp: session_created_at,
+            diff_fingerprint: None,
+            fix_convergence: None,
+        },
+    )
+    .expect("write stale fail review meta");
+    assert!(
+        !session_dir
+            .join("output")
+            .join("review-verdict.json")
+            .exists(),
+        "test starts with missing review verdict artifact"
+    );
+
+    let args = parse_review_args(&["csa", "review", "--check-verdict"]);
+    let exit = handle_check_verdict(project.path(), &args).unwrap();
+    assert_eq!(
+        exit, 0,
+        "check-verdict should recover the exact-head PASS artifact"
+    );
+
+    let found = check_review_verdict_for_target(
+        project.path(),
+        &branch,
+        &head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        Some(expected_diff_fingerprint.as_str()),
+        None,
+    )
+    .unwrap()
+    .expect("recovered PASS should satisfy check-verdict");
+    assert_eq!(found.session_id, session_id);
+
+    let meta = read_review_meta(&session_dir)
+        .unwrap()
+        .expect("review_meta.json should remain present");
+    assert_eq!(meta.decision, ReviewDecision::Pass.as_str());
+    assert_eq!(meta.verdict, "CLEAN");
+    assert_eq!(meta.exit_code, 0);
+    assert_eq!(
+        meta.diff_fingerprint.as_deref(),
+        Some(expected_diff_fingerprint.as_str())
+    );
+
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json"))
+            .expect("review-verdict.json should be recovered"),
+    )
+    .expect("recovered review-verdict.json should parse");
+    assert_eq!(artifact.decision, ReviewDecision::Pass);
+    assert_eq!(artifact.verdict_legacy, "CLEAN");
+
+    let repaired = csa_session::load_result(project.path(), &session_id)
+        .unwrap()
+        .expect("result should remain loadable");
+    assert_eq!(repaired.exit_code, 0);
+    assert_eq!(repaired.status, SessionResult::status_from_exit_code(0));
+    let wait_summary = crate::session_cmds_daemon::render_wait_result_summary(
+        &session_dir,
+        &session_id,
+        &repaired,
+    );
+    assert!(wait_summary.contains("Review verdict: PASS"));
+    assert!(!wait_summary.contains("Review verdict: FAIL"));
 }

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -332,6 +332,17 @@ fn derive_review_verdict_artifact(
         return Ok(verdict_from_meta(meta, decision, severity_counts));
     }
 
+    if findings.is_empty()
+        && review_contains_prose_clean_conclusion(session_dir)?
+        && !prose_signals.has_failure_evidence()
+    {
+        return Ok(verdict_from_meta(
+            meta,
+            ReviewDecision::Pass,
+            zero_severity_counts(),
+        ));
+    }
+
     if let Some(artifact) = infer_review_verdict_from_full_output(session_dir, meta)? {
         return Ok(artifact);
     }

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use anyhow::Result;
 use csa_session::{ReviewFinding, Severity};
 
+use super::artifacts::has_blocking_severity;
 use super::clean_detection::{
     contains_clean_phrase, detect_prose_clean_conclusion, detect_prose_fail_conclusion,
 };
@@ -23,6 +24,18 @@ pub(super) struct ReviewProseSignals {
     pub(super) cross_dimension_blockers: bool,
     pub(super) checklist_violation_findings: bool,
     pub(super) findings: Vec<ReviewFinding>,
+}
+
+impl ReviewProseSignals {
+    pub(super) fn has_failure_evidence(&self) -> bool {
+        has_blocking_severity(&self.severity_counts)
+            || self.blocking_summary
+            || self.parsed_findings_sections
+            || self.unparseable_findings_sections
+            || self.cross_dimension_blockers
+            || self.checklist_violation_findings
+            || !self.findings.is_empty()
+    }
 }
 
 pub(super) fn review_prose_signals(session_dir: &Path) -> Result<ReviewProseSignals> {

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1804_tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use csa_session::FindingsFile;
-
 fn read_findings_toml(session_dir: &Path) -> FindingsFile {
     let findings_path = session_dir.join("output").join("findings.toml");
     toml::from_str(&fs::read_to_string(findings_path).expect("read findings.toml"))

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1852_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1852_tests.rs
@@ -201,3 +201,5 @@ The reviewer flagged a `[correctness]` concern but assigned no severity grade.
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
+
+include!("review_cmd_output_verdict_2393_tests.rs");

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_2393_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_2393_tests.rs
@@ -1,0 +1,37 @@
+fn read_verdict(session_dir: &Path) -> ReviewVerdictArtifact {
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    serde_json::from_str(&fs::read_to_string(verdict_path).expect("read verdict"))
+        .expect("parse verdict")
+}
+
+#[test]
+fn issue_2393_pass_summary_without_findings_artifact_overrides_stale_fail_meta() {
+    let session_id = "01TEST2393PASSSUMMARY000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-2393-pass-summary-stale-fail-meta", session_id);
+
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+PASS No blocking correctness, security, or AGENTS.md compliance findings found for `range:main...HEAD`.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+No blocking findings found.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let mut meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    meta.exit_code = 1;
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(verdict.failure_reason.is_none());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/session_observability_legacy_review_pass.rs
+++ b/crates/cli-sub-agent/src/session_observability_legacy_review_pass.rs
@@ -8,11 +8,14 @@ use chrono::{DateTime, Utc};
 use csa_core::types::ReviewDecision;
 use csa_session::{ReviewVerdictArtifact, SessionResult};
 
+#[path = "session_observability_legacy_review_pass_clean.rs"]
+mod clean_summary;
+
 pub(super) fn recover_legacy_plain_pass_review_sidecars_from_dir(
     session_dir: &Path,
     result: &mut SessionResult,
 ) -> Result<bool> {
-    if review_sidecar_exists(session_dir) {
+    if review_verdict_artifact_exists(session_dir) {
         return Ok(false);
     }
     let session = match read_session_state(session_dir) {
@@ -44,10 +47,24 @@ pub(super) fn recover_legacy_plain_pass_review_sidecars(
     session_dir: &Path,
     result: &mut SessionResult,
 ) -> Result<bool> {
-    if review_sidecar_exists(session_dir) {
+    if review_verdict_artifact_exists(session_dir) {
         return Ok(false);
     }
-    let session = csa_session::load_session(project_root, session_id)?;
+    let session = match read_session_state(session_dir) {
+        Ok(session) => session,
+        Err(error) => {
+            tracing::debug!(
+                session_id,
+                path = %session_dir.display(),
+                error = %error,
+                "skipping legacy review sidecar recovery because session state is unreadable"
+            );
+            None
+        }
+    };
+    let Some(session) = session else {
+        return Ok(false);
+    };
     recover_legacy_plain_pass_review_sidecars_for_session(
         project_root,
         session_dir,
@@ -62,7 +79,7 @@ fn recover_legacy_plain_pass_review_sidecars_for_session(
     result: &mut SessionResult,
     session: &csa_session::MetaSessionState,
 ) -> Result<bool> {
-    if review_sidecar_exists(session_dir) || !is_review_session(session) {
+    if review_verdict_artifact_exists(session_dir) || !is_review_session(session) {
         return Ok(false);
     }
 
@@ -76,7 +93,12 @@ fn recover_legacy_plain_pass_review_sidecars_for_session(
     else {
         return Ok(false);
     };
-    if decision == ReviewDecision::Pass && result.exit_code != 0 {
+    let existing_meta = read_review_meta(session_dir);
+    if decision == ReviewDecision::Pass
+        && existing_meta
+            .as_ref()
+            .is_some_and(csa_session::ReviewSessionMeta::requires_fail_closed_verdict)
+    {
         return Ok(false);
     }
 
@@ -161,12 +183,11 @@ fn legacy_verdict_for_review_decision(decision: ReviewDecision) -> &'static str 
     }
 }
 
-fn review_sidecar_exists(session_dir: &Path) -> bool {
-    session_dir.join("review_meta.json").is_file()
-        || session_dir
-            .join("output")
-            .join("review-verdict.json")
-            .is_file()
+fn review_verdict_artifact_exists(session_dir: &Path) -> bool {
+    session_dir
+        .join("output")
+        .join("review-verdict.json")
+        .is_file()
 }
 
 fn read_session_state(session_dir: &Path) -> Result<Option<csa_session::MetaSessionState>> {
@@ -176,6 +197,12 @@ fn read_session_state(session_dir: &Path) -> Result<Option<csa_session::MetaSess
     }
     let raw = fs::read_to_string(&path)?;
     Ok(Some(toml::from_str(&raw)?))
+}
+
+fn read_review_meta(session_dir: &Path) -> Option<csa_session::ReviewSessionMeta> {
+    fs::read_to_string(session_dir.join("review_meta.json"))
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
 }
 
 pub(super) fn is_review_session_dir(session_dir: &Path) -> bool {
@@ -429,6 +456,8 @@ fn legacy_plain_review_summary_decision(summary: &str) -> Option<LegacyPlainRevi
                 if has_ambiguous_or_compound_clean_verdict_phrase(line) {
                     return Some(LegacyPlainReviewSummaryDecision::InvalidRecognizedLabel);
                 }
+                pass = true;
+            } else if clean_summary::unlabeled_clean_decision_with_clean_explanation(line) {
                 pass = true;
             }
             continue;

--- a/crates/cli-sub-agent/src/session_observability_legacy_review_pass_clean.rs
+++ b/crates/cli-sub-agent/src/session_observability_legacy_review_pass_clean.rs
@@ -1,0 +1,78 @@
+use csa_core::types::ReviewDecision;
+
+use super::{
+    is_legacy_decision_prefix_char, is_review_decision_token_char,
+    pass_like_decision_has_compound_word_suffix, review_decision_token,
+};
+
+pub(super) fn unlabeled_clean_decision_with_clean_explanation(line: &str) -> bool {
+    let value = line.trim_start_matches(is_legacy_decision_prefix_char);
+    let token_end = value
+        .char_indices()
+        .find_map(|(index, ch)| (!is_review_decision_token_char(ch)).then_some(index))
+        .unwrap_or(value.len());
+    let Some(token) = value.get(..token_end).filter(|token| !token.is_empty()) else {
+        return false;
+    };
+    let rest = value.get(token_end..).unwrap_or_default();
+    if !matches!(review_decision_token(token), Some(ReviewDecision::Pass))
+        || pass_like_decision_has_compound_word_suffix(token, rest)
+    {
+        return false;
+    }
+    let rest = rest.trim_start();
+    !rest.is_empty() && clean_explanation_has_no_findings(rest)
+}
+
+fn clean_explanation_has_no_findings(rest: &str) -> bool {
+    let lower = rest.to_ascii_lowercase();
+    [
+        "no blocking",
+        "no issues found",
+        "no issues were found",
+        "no actionable findings",
+        "no findings",
+        "no blockers",
+    ]
+    .iter()
+    .any(|phrase| lower.contains(phrase))
+        || contains_positive_no_issue_clause(&lower)
+}
+
+fn contains_positive_no_issue_clause(lower: &str) -> bool {
+    let tokens: Vec<&str> = lower
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .collect();
+    tokens.iter().enumerate().any(|(no_index, token)| {
+        *token == "no"
+            && tokens
+                .get(no_index + 1..(no_index + 7).min(tokens.len()))
+                .and_then(|window| {
+                    window
+                        .iter()
+                        .position(|candidate| {
+                            matches!(
+                                *candidate,
+                                "issue"
+                                    | "issues"
+                                    | "finding"
+                                    | "findings"
+                                    | "concern"
+                                    | "concerns"
+                            )
+                        })
+                        .map(|relative| no_index + 1 + relative)
+                })
+                .is_some_and(|noun_index| {
+                    tokens[noun_index + 1..(noun_index + 5).min(tokens.len())]
+                        .iter()
+                        .any(|candidate| {
+                            matches!(
+                                *candidate,
+                                "found" | "identified" | "detected" | "introduced"
+                            )
+                        })
+                })
+    })
+}

--- a/crates/cli-sub-agent/src/session_observability_legacy_review_pass_tests.rs
+++ b/crates/cli-sub-agent/src/session_observability_legacy_review_pass_tests.rs
@@ -53,6 +53,14 @@ fn legacy_plain_review_summary_decision_accepts_bounded_clean_verdict_shapes() {
             ReviewDecision::Pass
         ))
     );
+    assert_eq!(
+        legacy_plain_review_summary_decision(
+            "PASS No blocking correctness, security, or AGENTS.md compliance findings found for `range:main...HEAD`.\n"
+        ),
+        Some(LegacyPlainReviewSummaryDecision::Decision(
+            ReviewDecision::Pass
+        ))
+    );
 }
 
 #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1056"
-weave = "0.1.1056"
+csa = "0.1.1057"
+weave = "0.1.1057"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- reconcile PASS/no-findings review results with durable exact-head PASS/CLEAN verdict artifacts
- keep no-result/no-verdict infrastructure failures fail-closed with bounded diagnostics instead of contradictory FAIL-vs-PASS output
- cover the canonical review artifact mismatch class from #2315, #2286, and #2393

## Verification
- `target/release/csa --version` → `csa 0.1.1057 (e999a8dd)`
- `target/release/csa migrate --status` → lock/binary `0.1.1057`, pending migrations `0`
- `cargo build --release -p cli-sub-agent --bin csa`
- exact-head CSA review PASS: `01KVV26G4NKR9NZ06F8SSNT4S2`
- `target/release/csa review --check-verdict --sa-mode true --range main...HEAD --cd "$PWD"`
- hook-enabled `git push -u origin HEAD` passed pre-push `review-check` and `version-check`

Fixes #2315
Fixes #2286
Fixes #2393
