### PR TITLE
fix(review): guide memory admission retry windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1071"
+version = "0.1.1072"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1071"
+version = "0.1.1072"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_plan.rs
+++ b/crates/cli-sub-agent/src/cli_plan.rs
@@ -70,6 +70,14 @@ pub enum PlanCommands {
         #[arg(long)]
         no_fs_sandbox: bool,
 
+        /// Override memory cap/projection for CSA tool steps in this plan run.
+        #[arg(long, value_name = "MB", value_parser = clap::value_parser!(u64).range(256..))]
+        memory_max_mb: Option<u64>,
+
+        /// Override minimum MemAvailable reserve for CSA tool steps in this plan run.
+        #[arg(long, value_name = "MB")]
+        min_free_memory_mb: Option<u64>,
+
         /// Block instead of daemonizing (auto for --dry-run/--chunked/--resume).
         #[arg(long)]
         foreground: bool,

--- a/crates/cli-sub-agent/src/no_provider_launch.rs
+++ b/crates/cli-sub-agent/src/no_provider_launch.rs
@@ -181,45 +181,52 @@ fn suggested_host_memory_retry(
     let required_floor_mb = memory.required_floor_mb?;
     let soft_limit_percent = memory.soft_limit_percent?;
     let available_mb = memory.available_memory_mb?;
-    let suggested_cap_mb = round_up_to_100(required_cap_mb);
+    let current_reserve_mb = memory.reserve_mb.unwrap_or(0);
+    let current_upper_mb = available_mb.saturating_sub(current_reserve_mb);
     let suggested_soft_threshold_mb =
-        memory_policy::soft_limit_threshold_mb(suggested_cap_mb, soft_limit_percent)?;
-    if suggested_soft_threshold_mb < required_floor_mb || available_mb <= suggested_cap_mb {
+        memory_policy::soft_limit_threshold_mb(required_cap_mb, soft_limit_percent)?;
+    if suggested_soft_threshold_mb < required_floor_mb || available_mb <= required_cap_mb {
         return None;
     }
 
-    let max_reserve_mb = available_mb.saturating_sub(suggested_cap_mb);
-    let current_reserve_mb = memory.reserve_mb.unwrap_or(max_reserve_mb);
-    let preferred_reserve_mb = current_reserve_mb.min(6_000);
+    if required_cap_mb <= current_upper_mb {
+        let host_required_mb = required_cap_mb.saturating_add(current_reserve_mb);
+        return Some(format!(
+            "Suggested bounded retry for {tool_name}: --memory-max-mb {required_cap_mb} \
+             (current retry window is {required_cap_mb}..={current_upper_mb}MB with \
+             min_free_memory_mb={current_reserve_mb}; soft_limit_percent={soft_limit_percent} \
+             gives soft threshold {suggested_soft_threshold_mb}MB >= required floor \
+             {required_floor_mb}MB; host required {host_required_mb}MB <= physical \
+             available {available_mb}MB)."
+        ));
+    }
+
+    let max_reserve_mb = available_mb.saturating_sub(required_cap_mb);
+    if max_reserve_mb == 0 {
+        return None;
+    }
+    let preferred_reserve_mb = current_reserve_mb.clamp(1, 6_000);
     let suggested_reserve_mb = if max_reserve_mb >= preferred_reserve_mb {
         preferred_reserve_mb
     } else {
-        round_down_to_100(max_reserve_mb)
+        max_reserve_mb
     };
-    if suggested_reserve_mb == 0 {
-        return None;
-    }
-
-    let host_required_mb = suggested_cap_mb.saturating_add(suggested_reserve_mb);
+    let suggested_upper_mb = available_mb.saturating_sub(suggested_reserve_mb);
+    let host_required_mb = required_cap_mb.saturating_add(suggested_reserve_mb);
     if host_required_mb > available_mb {
         return None;
     }
 
     Some(format!(
-        "Suggested bounded retry for {tool_name}: --memory-max-mb {suggested_cap_mb} \
-         --min-free-memory-mb {suggested_reserve_mb} (minimum cap for \
-         soft_limit_percent={soft_limit_percent} is {required_cap_mb}MB; suggested soft \
-         threshold {suggested_soft_threshold_mb}MB >= required floor {required_floor_mb}MB; \
+        "Suggested bounded retry for {tool_name}: --memory-max-mb {required_cap_mb} \
+         --min-free-memory-mb {suggested_reserve_mb} (no cap satisfies the current \
+         retry window because required lower bound {required_cap_mb}MB > current \
+         upper bound {current_upper_mb}MB at min_free_memory_mb={current_reserve_mb}; \
+         lowering reserve opens retry window {required_cap_mb}..={suggested_upper_mb}MB; \
+         soft_limit_percent={soft_limit_percent} gives soft threshold \
+         {suggested_soft_threshold_mb}MB >= required floor {required_floor_mb}MB; \
          host required {host_required_mb}MB <= physical available {available_mb}MB)."
     ))
-}
-
-fn round_up_to_100(value: u64) -> u64 {
-    value.saturating_add(99) / 100 * 100
-}
-
-fn round_down_to_100(value: u64) -> u64 {
-    value / 100 * 100
 }
 
 pub(crate) fn enrich_review_diagnostic(
@@ -258,9 +265,33 @@ mod tests {
 
         assert!(joined.contains("physical MemAvailable only"));
         assert!(joined.contains("swap/combined memory is diagnostic"));
-        assert!(joined.contains("--memory-max-mb 9200 --min-free-memory-mb 6000"));
-        assert!(joined.contains("minimum cap for soft_limit_percent=90 is 9103MB"));
-        assert!(joined.contains("soft threshold 8280MB >= required floor 8192MB"));
-        assert!(joined.contains("host required 15200MB <= physical available 17033MB"));
+        assert!(joined.contains("--memory-max-mb 9103 --min-free-memory-mb 6000"));
+        assert!(joined.contains("required lower bound 9103MB > current upper bound 8033MB"));
+        assert!(joined.contains("soft threshold 8192MB >= required floor 8192MB"));
+        assert!(joined.contains("host required 15103MB <= physical available 17033MB"));
+    }
+
+    #[test]
+    fn host_memory_reviewer_guidance_preserves_tight_retry_window() {
+        let memory = NoProviderLaunchMemoryDiagnostic {
+            effective_memory_max_mb: Some(10_000),
+            soft_limit_percent: Some(90),
+            soft_threshold_mb: Some(9_000),
+            required_floor_mb: Some(8_192),
+            required_memory_max_mb: Some(9_103),
+            reserve_mb: Some(256),
+            available_memory_mb: Some(9_296),
+            required_available_mb: Some(10_256),
+            projected_spawn_mb: Some(10_000),
+            ..Default::default()
+        };
+
+        let guidance = host_memory_guidance(Some("reviewer_sub_session"), "codex", &memory);
+        let joined = guidance.join("\n");
+
+        assert!(joined.contains("--memory-max-mb 9103 --min-free-memory-mb 193"));
+        assert!(joined.contains("required lower bound 9103MB > current upper bound 9040MB"));
+        assert!(joined.contains("lowering reserve opens retry window 9103..=9103MB"));
+        assert!(joined.contains("host required 9296MB <= physical available 9296MB"));
     }
 }

--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -28,6 +28,7 @@ use weave::compiler::{ExecutionPlan, plan_from_toml};
 use crate::pattern_resolver;
 use crate::pipeline::determine_project_root;
 use crate::plan_display::{print_plan, print_summary};
+use crate::run_resource_overrides::RunResourceOverrides;
 use crate::startup_env::StartupSubtreeEnv;
 
 #[path = "plan_cmd_exec.rs"]
@@ -185,6 +186,7 @@ pub(crate) struct PlanRunArgs {
     pub complete_manual_step: Option<usize>,
     pub cd: Option<String>,
     pub no_fs_sandbox: bool,
+    pub resources: RunResourceOverrides,
     pub current_depth: u32,
     pub pipeline_source: PlanRunPipelineSource,
     pub startup_env: StartupSubtreeEnv,
@@ -215,6 +217,7 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<PlanRunOutcome>
         complete_manual_step,
         cd,
         no_fs_sandbox,
+        resources,
         current_depth,
         pipeline_source,
         startup_env,
@@ -389,6 +392,7 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<PlanRunOutcome>
         resume_completed_steps: &resume_context.completed_steps,
         chunked,
         no_fs_sandbox,
+        resources,
         startup_env: &startup_env,
     };
 

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -20,6 +20,7 @@ use crate::pipeline::determine_project_root;
 use crate::plan_cmd::{
     self, FEATURE_INPUT_VAR, ISSUE_NUMBER_VAR, PlanRunArgs, PlanRunPipelineSource, handle_plan_run,
 };
+use crate::run_resource_overrides::RunResourceOverrides;
 use crate::startup_env::StartupSubtreeEnv;
 use crate::{error_hints, error_report, exit_current_process};
 
@@ -69,6 +70,8 @@ pub(crate) async fn dispatch(
         complete_manual_step,
         cd,
         no_fs_sandbox,
+        memory_max_mb,
+        min_free_memory_mb,
         foreground,
         daemon_child,
         session_id,
@@ -86,14 +89,7 @@ pub(crate) async fn dispatch(
         );
     }
 
-    // Resolve `--issue <N>` into workflow variables before the daemon/foreground
-    // split. Fetching in the top-level invocation means a bad issue number or
-    // auth failure fails fast with a non-zero exit rather than surfacing only
-    // via the daemon session result, and the issue is fetched exactly once: the
-    // resolved variables are forwarded to the daemon child in place of `--issue`
-    // (see `forwarded_args_with_feature_input`). A daemon child never sees
-    // `--issue` (the parent strips it), so this branch only runs in the
-    // top-level/foreground process.
+    // Resolve --issue once in the parent; daemon children receive forwarded vars.
     let mut vars = vars;
     let mut forwarded_args = None;
     if let Some(issue_number) = issue {
@@ -133,6 +129,7 @@ pub(crate) async fn dispatch(
         complete_manual_step,
         cd,
         no_fs_sandbox,
+        resources: RunResourceOverrides::new(memory_max_mb, min_free_memory_mb),
         current_depth,
         pipeline_source,
         startup_env: startup_env.clone(),

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_completion_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_completion_tests.rs
@@ -58,6 +58,7 @@ fn plan_daemon_args(project_root: &Path) -> PlanRunArgs {
         complete_manual_step: None,
         cd: Some(project_root.display().to_string()),
         no_fs_sandbox: false,
+        resources: Default::default(),
         current_depth: 0,
         pipeline_source: PlanRunPipelineSource::DirectPlanRun,
         startup_env: StartupSubtreeEnv::default(),

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_mktd_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_mktd_tests.rs
@@ -57,6 +57,7 @@ fn plan_daemon_args(project_root: &Path) -> PlanRunArgs {
         complete_manual_step: None,
         cd: Some(project_root.display().to_string()),
         no_fs_sandbox: false,
+        resources: Default::default(),
         current_depth: 0,
         pipeline_source: PlanRunPipelineSource::DirectPlanRun,
         startup_env: StartupSubtreeEnv::default(),

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
@@ -17,6 +17,7 @@ fn make_args() -> PlanRunArgs {
         complete_manual_step: None,
         cd: None,
         no_fs_sandbox: false,
+        resources: Default::default(),
         current_depth: 0,
         pipeline_source: crate::plan_cmd::PlanRunPipelineSource::DirectPlanRun,
         startup_env: crate::startup_env::StartupSubtreeEnv::default(),
@@ -426,6 +427,33 @@ fn forwarded_args_preserve_no_fs_sandbox_flag() {
     ];
     let forwarded = build_forwarded_plan_args(&argv);
     assert_eq!(forwarded, vec!["--no-fs-sandbox", "workflow.toml"]);
+}
+
+#[test]
+fn forwarded_args_preserve_plan_memory_overrides() {
+    let argv = vec![
+        "csa".to_string(),
+        "plan".to_string(),
+        "run".to_string(),
+        "--memory-max-mb".to_string(),
+        "9103".to_string(),
+        "--min-free-memory-mb".to_string(),
+        "193".to_string(),
+        "workflow.toml".to_string(),
+    ];
+
+    let forwarded = build_forwarded_plan_args(&argv);
+
+    assert_eq!(
+        forwarded,
+        vec![
+            "--memory-max-mb",
+            "9103",
+            "--min-free-memory-mb",
+            "193",
+            "workflow.toml",
+        ]
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -16,6 +16,7 @@ use crate::pipeline::{
     ParentSessionSource, SessionCreationMode, execute_with_session_and_meta_with_parent_source,
 };
 use crate::run_helpers::build_executor;
+use crate::run_resource_overrides::RunResourceOverrides;
 use crate::startup_env::StartupSubtreeEnv;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
@@ -32,6 +33,7 @@ pub(super) struct CsaStepExecutionOptions<'a> {
     pub(super) forwarded_session: Option<&'a str>,
     pub(super) no_fs_sandbox: bool,
     pub(super) readonly_project_root: bool,
+    pub(super) resources: RunResourceOverrides,
     pub(super) startup_env: &'a StartupSubtreeEnv,
 }
 
@@ -322,7 +324,7 @@ pub(super) async fn execute_csa_step(
             None,
             ParentSessionSource::ExplicitOnly,
             SessionCreationMode::FreshChild,
-            Default::default(),
+            options.resources,
             options.no_fs_sandbox,
             options.readonly_project_root,
             &[],   // extra_writable

--- a/crates/cli-sub-agent/src/plan_cmd_steps.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps.rs
@@ -25,6 +25,7 @@ use super::{
     PlanRunJournal, apply_repo_fingerprint, detect_repo_fingerprint, persist_plan_journal,
     substitute_vars,
 };
+use crate::run_resource_overrides::RunResourceOverrides;
 use crate::startup_env::StartupSubtreeEnv;
 
 #[path = "plan_cmd_step_failure.rs"]
@@ -40,7 +41,7 @@ pub(crate) use step_target::{
     StepTarget, resolve_step_tool_with_variables, step_readonly_project_root,
 };
 
-/// Result of executing a single step.
+/// Step result.
 #[derive(Serialize, Deserialize)]
 pub(crate) struct StepResult {
     pub(crate) step_id: usize,
@@ -49,14 +50,14 @@ pub(crate) struct StepResult {
     pub(crate) duration_secs: f64,
     pub(crate) skipped: bool,
     pub(crate) error: Option<String>,
-    /// Captured step output, exposed to later steps as `${STEP_<id>_OUTPUT}`.
+    /// Output as `${STEP_<id>_OUTPUT}`.
     pub(crate) output: Option<String>,
-    /// CSA meta session ID, exposed to later steps as `${STEP_<id>_SESSION}`.
+    /// CSA session exposed as `${STEP_<id>_SESSION}`.
     pub(crate) session_id: Option<String>,
-    /// Human-readable command or dispatch description for failure reports.
+    /// Command description for failures.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) command: Option<String>,
-    /// Captured stderr from the final attempt, kept out of step output variables.
+    /// Final stderr kept out of step output variables.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) stderr: Option<String>,
 }
@@ -72,6 +73,7 @@ pub(super) struct PlanRunContext<'a> {
     pub(super) resume_completed_steps: &'a HashSet<usize>,
     pub(super) chunked: bool,
     pub(super) no_fs_sandbox: bool,
+    pub(super) resources: RunResourceOverrides,
     pub(super) startup_env: &'a StartupSubtreeEnv,
 }
 
@@ -82,6 +84,7 @@ pub(crate) struct StepExecutionContext<'a> {
     pub(crate) tool_override: Option<&'a ToolName>,
     pub(crate) model_spec_override: Option<&'a String>,
     pub(crate) no_fs_sandbox: bool,
+    pub(crate) resources: RunResourceOverrides,
     pub(crate) startup_env: &'a StartupSubtreeEnv,
 }
 
@@ -130,6 +133,7 @@ pub(super) async fn execute_plan_with_journal(
                 tool_override: run_ctx.tool_override,
                 model_spec_override: run_ctx.model_spec_override,
                 no_fs_sandbox: run_ctx.no_fs_sandbox,
+                resources: run_ctx.resources,
                 startup_env: run_ctx.startup_env,
             },
         )
@@ -141,7 +145,7 @@ pub(super) async fn execute_plan_with_journal(
         };
         let is_failure = !result.skipped && result.exit_code != 0;
 
-        // Inject step output for subsequent steps (successful steps only).
+        // Inject successful step output for later steps.
         let var_key = format!("STEP_{}_OUTPUT", result.step_id);
         let raw_output = result.output.as_deref().unwrap_or("").to_string();
         let assignment_markers = if !is_failure && should_inject_assignment_markers(step) {
@@ -149,7 +153,7 @@ pub(super) async fn execute_plan_with_journal(
         } else {
             Vec::new()
         };
-        // Strip CSA_VAR: lines so downstream variable references keep clean step output.
+        // Strip CSA_VAR lines from downstream output.
         let var_value = strip_assignment_marker_lines(&raw_output);
         vars.insert(var_key, var_value);
         let session_var_key = format!("STEP_{}_SESSION", result.step_id);

--- a/crates/cli-sub-agent/src/plan_cmd_steps_test_helpers.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_steps_test_helpers.rs
@@ -39,6 +39,7 @@ pub(crate) async fn execute_plan(
         resume_completed_steps: &completed,
         chunked: false,
         no_fs_sandbox: false,
+        resources: Default::default(),
         startup_env: &startup_env,
     };
     execute_plan_with_journal(plan, variables, &mut run_ctx).await
@@ -65,6 +66,7 @@ pub(crate) async fn execute_step(
             tool_override,
             model_spec_override,
             no_fs_sandbox: false,
+            resources: Default::default(),
             startup_env: &startup_env,
         },
     )

--- a/crates/cli-sub-agent/src/plan_cmd_tests_chunked.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_chunked.rs
@@ -25,6 +25,7 @@ fn make_chunked_run_ctx<'a>(
         resume_completed_steps,
         chunked,
         no_fs_sandbox: false,
+        resources: Default::default(),
         startup_env: &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
     }
 }

--- a/crates/cli-sub-agent/src/plan_cmd_tests_manual_handoff.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_manual_handoff.rs
@@ -127,6 +127,7 @@ fn plan_run_args(project_root: &Path, workflow_path: &Path) -> PlanRunArgs {
         complete_manual_step: None,
         cd: Some(project_root.display().to_string()),
         no_fs_sandbox: false,
+        resources: Default::default(),
         current_depth: 0,
         pipeline_source: PlanRunPipelineSource::DirectPlanRun,
         startup_env: crate::startup_env::StartupSubtreeEnv::default(),
@@ -154,6 +155,7 @@ async fn execute_plan_stops_after_manual_handoff() {
         resume_completed_steps: &completed,
         chunked: false,
         no_fs_sandbox: false,
+        resources: Default::default(),
         startup_env: &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
     };
 
@@ -357,6 +359,7 @@ async fn execute_plan_resume_replays_manual_handoff_step() {
             resume_completed_steps: &completed,
             chunked: false,
             no_fs_sandbox: false,
+            resources: Default::default(),
             startup_env: &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
         };
 
@@ -392,6 +395,7 @@ async fn execute_plan_resume_replays_manual_handoff_step() {
         resume_completed_steps: &resumed_completed,
         chunked: false,
         no_fs_sandbox: false,
+        resources: Default::default(),
         startup_env: &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
     };
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_pr_bot.rs
@@ -37,6 +37,7 @@ async fn execute_step_with_workflow_exposes_runtime_paths_to_bash() {
             tool_override: None,
             model_spec_override: None,
             no_fs_sandbox: false,
+            resources: Default::default(),
             startup_env: &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
         },
     )

--- a/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_tail.rs
@@ -27,10 +27,7 @@ async fn execute_step_skips_when_condition_is_false() {
     let tmp = tempfile::tempdir().unwrap();
     let result = execute_step(&step, &vars, tmp.path(), None, None, None).await;
     assert!(result.skipped, "unset condition var must skip");
-    assert_eq!(
-        result.exit_code, 0,
-        "condition-false skip is intentional, not a failure"
-    );
+    assert_eq!(result.exit_code, 0, "condition-false skip succeeds");
 }
 
 #[tokio::test]
@@ -101,10 +98,7 @@ async fn execute_step_skips_weave_include() {
     let tmp = tempfile::tempdir().unwrap();
     let result = execute_step(&step, &vars, tmp.path(), None, None, None).await;
     assert!(result.skipped);
-    assert_eq!(
-        result.exit_code, 0,
-        "INCLUDE skip should be success (harmless)"
-    );
+    assert_eq!(result.exit_code, 0, "INCLUDE skip succeeds");
 }
 
 #[tokio::test]
@@ -219,6 +213,7 @@ async fn execute_plan_stops_for_await_user() {
         resume_completed_steps: &completed,
         chunked: false,
         no_fs_sandbox: false,
+        resources: Default::default(),
         startup_env: &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
     };
 
@@ -285,6 +280,7 @@ async fn execute_plan_continues_after_skipped_await_user_step() {
         resume_completed_steps: &completed,
         chunked: false,
         no_fs_sandbox: false,
+        resources: Default::default(),
         startup_env: &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
     };
 

--- a/crates/cli-sub-agent/src/plan_cmd_tier_failover.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tier_failover.rs
@@ -82,6 +82,7 @@ pub(super) async fn execute_csa_step_with_tier_failover(
                     },
                     no_fs_sandbox: step_ctx.no_fs_sandbox,
                     readonly_project_root: params.readonly_project_root,
+                    resources: step_ctx.resources,
                     startup_env: step_ctx.startup_env,
                 },
             ),

--- a/crates/cli-sub-agent/src/sa_mode_tests.rs
+++ b/crates/cli-sub-agent/src/sa_mode_tests.rs
@@ -105,6 +105,35 @@ mod tests {
     }
 
     #[test]
+    fn plan_run_parses_memory_override_flags() {
+        let plan_cli = Cli::try_parse_from([
+            "csa",
+            "plan",
+            "run",
+            "--memory-max-mb",
+            "9103",
+            "--min-free-memory-mb",
+            "193",
+            "flow.toml",
+        ])
+        .expect("plan run memory override flags should parse");
+        match plan_cli.command {
+            Commands::Plan {
+                cmd:
+                    PlanCommands::Run {
+                        memory_max_mb,
+                        min_free_memory_mb,
+                        ..
+                    },
+            } => {
+                assert_eq!(memory_max_mb, Some(9103));
+                assert_eq!(min_free_memory_mb, Some(193));
+            }
+            _ => panic!("expected plan command"),
+        }
+    }
+
+    #[test]
     fn top_level_help_omits_dev2merge_subcommand() {
         // The `csa dev2merge` subcommand was removed in #1638; the dev2merge
         // pipeline is reached via `csa plan run patterns/dev2merge/workflow.toml`

--- a/crates/cli-sub-agent/src/session_guard.rs
+++ b/crates/cli-sub-agent/src/session_guard.rs
@@ -112,11 +112,12 @@ fn write_pre_exec_error_result_inner(
         .as_ref()
         .map(|_| vec![SessionArtifact::new(NO_PROVIDER_LAUNCH_ARTIFACT_PATH)])
         .unwrap_or_default();
+    let summary = pre_exec_summary(error, no_provider_launch.as_ref());
     let result = SessionResult {
         post_exec_gate: None,
         status: "failure".to_string(),
         exit_code: 1,
-        summary: format!("pre-exec: {error}"),
+        summary,
         tool: tool_name.to_string(),
         original_tool: None,
         fallback_tool: None,
@@ -145,6 +146,26 @@ fn write_pre_exec_error_result_inner(
     }
     // Best-effort cooldown marker
     csa_session::write_cooldown_marker_for_project(project_root, session_id, now);
+}
+
+fn pre_exec_summary(
+    error: &anyhow::Error,
+    no_provider_launch: Option<&NoProviderLaunchDiagnostic>,
+) -> String {
+    let mut summary = format!("pre-exec: {error}");
+    let Some(diagnostic) = no_provider_launch else {
+        return summary;
+    };
+    if diagnostic.guidance.is_empty() {
+        return summary;
+    }
+
+    summary.push_str("\nGuidance:");
+    for item in &diagnostic.guidance {
+        summary.push_str("\n- ");
+        summary.push_str(item);
+    }
+    summary
 }
 
 fn create_pre_exec_failure_session(

--- a/crates/csa-resource/src/guard.rs
+++ b/crates/csa-resource/src/guard.rs
@@ -270,6 +270,7 @@ fn evaluate_memory_availability(
     {
         let required_available_mb = reserve_mb.saturating_add(admission.projected_spawn_mb);
         if available_phys_mb < required_available_mb {
+            let host_cap_upper_mb = available_phys_mb.saturating_sub(reserve_mb);
             let message = format!(
                 "CSA: host memory admission denied — available={available_phys_mb}MB < \
                  required={required_available_mb}MB (reserve={reserve_mb}MB + \
@@ -291,8 +292,12 @@ fn evaluate_memory_availability(
                      MemAvailable only; swap and combined memory are reported for diagnostics but \
                      do not satisfy this pre-spawn gate. For one csa run, pass \
                      --memory-max-mb <MB> to lower projected_spawn or --min-free-memory-mb <MB> \
-                     to lower the reserve. Persistent config keys: resources.memory_max_mb, \
-                     tools.<tool>.memory_max_mb, resources.min_free_memory_mb."
+                     to lower the reserve. Current host-only retry upper bound is \
+                     memory_max_mb <= {host_cap_upper_mb}MB with reserve={reserve_mb}MB; \
+                     role-specific soft-limit lower bounds may require a higher cap, so choose \
+                     a value inside both bounds or free memory/lower reserve. Persistent config \
+                     keys: resources.memory_max_mb, tools.<tool>.memory_max_mb, \
+                     resources.min_free_memory_mb."
                 ),
                 MemoryAdmissionKind::HostSpawn,
                 MemoryAdmissionSnapshot {
@@ -540,6 +545,7 @@ mod tests {
         assert!(msg.contains("swap and combined memory are reported for diagnostics"));
         assert!(msg.contains("--memory-max-mb <MB>"));
         assert!(msg.contains("--min-free-memory-mb <MB>"));
+        assert!(msg.contains("memory_max_mb <= 5904MB"));
         assert!(msg.contains("tools.<tool>.memory_max_mb"));
     }
 

--- a/justfile
+++ b/justfile
@@ -15,6 +15,11 @@ set dotenv-load := true
 # Calculate repo root (compatible with submodules)
 _repo_root := `git rev-parse --show-superproject-working-tree 2>/dev/null | grep . || git rev-parse --show-toplevel`
 _cargo := _repo_root + "/scripts/cargo-env-normalize.sh cargo"
+# Default Cargo/rustc fan-out for Just recipes; override with
+# `CARGO_BUILD_JOBS=<n> just ...`. Do not default NEXTEST_TEST_THREADS here:
+# full-suite runs need nextest's normal parallelism to avoid serializing
+# thousands of tests.
+export CARGO_BUILD_JOBS := env_var_or_default("CARGO_BUILD_JOBS", "1")
 # Just already executes repository-controlled code, so trust this checkout's
 # mise config and avoid interactive trust prompts on sandboxed commit paths.
 export MISE_TRUSTED_CONFIG_PATHS := _repo_root
@@ -195,7 +200,7 @@ deny:
 # ==============================================================================
 
 # Run all tests in the workspace across default and feature builds.
-# Env: CARGO_BUILD_JOBS caps cargo/rustc parallelism; NEXTEST_TEST_THREADS caps test fan-out.
+# Env: CARGO_BUILD_JOBS defaults to 1; NEXTEST_TEST_THREADS is caller-controlled.
 test:
     just check-cargo-target-writable
     just check-nextest-state-writable
@@ -204,14 +209,14 @@ test:
     {{_cargo}} nextest run --workspace --all-features
 
 # Run e2e tests only.
-# Env: CARGO_BUILD_JOBS caps cargo/rustc parallelism; NEXTEST_TEST_THREADS caps test fan-out.
+# Env: CARGO_BUILD_JOBS defaults to 1; NEXTEST_TEST_THREADS is caller-controlled.
 test-e2e:
     just check-cargo-target-writable
     just check-nextest-state-writable
     {{_cargo}} nextest run --package cli-sub-agent --test e2e --all-features
 
 # Run tests for a specific package.
-# Env: CARGO_BUILD_JOBS caps cargo/rustc parallelism; NEXTEST_TEST_THREADS caps test fan-out.
+# Env: CARGO_BUILD_JOBS defaults to 1; NEXTEST_TEST_THREADS is caller-controlled.
 # Usage: just test-p my-crate
 test-p package:
     just check-cargo-target-writable
@@ -219,7 +224,7 @@ test-p package:
     {{_cargo}} nextest run -p {{package}} --all-features
 
 # Run tests matching a specific pattern/name.
-# Env: CARGO_BUILD_JOBS caps cargo/rustc parallelism; NEXTEST_TEST_THREADS caps test fan-out.
+# Env: CARGO_BUILD_JOBS defaults to 1; NEXTEST_TEST_THREADS is caller-controlled.
 # Usage: just test-f login_validation
 test-f pattern:
     just check-cargo-target-writable

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1071"
-weave = "0.1.1071"
+csa = "0.1.1072"
+weave = "0.1.1072"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Report feasible host-memory retry bounds using the physical MemAvailable upper bound and role soft-limit lower bound together.
- Thread `csa plan run --memory-max-mb` / `--min-free-memory-mb` through daemonized workflow step execution.
- Default Justfile Cargo build fan-out to one job without serializing nextest test fan-out.

## Local validation
- `just pre-commit-fast`
- Focused Cargo tests:
  - `cargo test -p cli-sub-agent host_memory_reviewer_guidance -- --nocapture`
  - `cargo test -p cli-sub-agent plan_run_parses_memory_override_flags -- --nocapture`
  - `cargo test -p cli-sub-agent forwarded_args_preserve_plan_memory_overrides -- --nocapture`
  - `cargo test -p csa-resource --lib memory -- --nocapture`
- Hook-enabled `git commit` passed lefthook quality gates including monolith, deny, and clippy.
- Exact-head release build:
  - `target/release/csa --version` → `csa 0.1.1072 (a72dc251)`
  - `target/release/weave --version` → `weave 0.1.1072 (a72dc251)`
- Exact-head CSA/Codex range review:
  - session `01KW26AYKSMCJPK7ZWTFWEPPF4`
  - range `main...HEAD`
  - reviewed SHA `a72dc2511379ed94016189e93aff46b310aa7a42`
  - verdict `PASS`
- `target/release/csa review --check-verdict --range main...HEAD --cd "$PWD"` passed.
- Hook-enabled push passed pre-push `review-check` and `version-check`.

Closes #2463.
