### PR TITLE
fix(run): wait for host memory admission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1072"
+version = "0.1.1073"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1072"
+version = "0.1.1073"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -82,6 +82,7 @@ mod review_session_findings;
 mod run_cmd;
 mod run_cmd_caller_fork;
 mod run_cmd_daemon;
+mod run_cmd_daemon_memory_wait;
 mod run_cmd_fork;
 mod run_cmd_model_pin;
 mod run_cmd_post;
@@ -366,6 +367,7 @@ async fn run() -> Result<()> {
                     prompt_file.as_deref(),
                     no_fs_sandbox,
                     &extra_writable,
+                    wait,
                 ),
             )?;
 

--- a/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
@@ -72,6 +72,25 @@ pub(super) fn check_resources_before_spawn(
             },
         ));
     }
+    if let Err(err) = crate::resource_admission::persist_spawn_memory_admission_ready(
+        project_root,
+        &session.meta_session_id,
+        projected_spawn_mb,
+    ) {
+        return Err(persist_pipeline_pre_exec_failure(
+            project_root,
+            session,
+            executor.tool_name(),
+            err.context("Failed to persist pre-spawn memory admission readiness"),
+            cleanup_guard,
+            None,
+            PipelinePreExecFailureDetails {
+                config,
+                task_type,
+                resource_overrides,
+            },
+        ));
+    }
     if let Some(cfg) = config {
         resource_guard.check_health(
             resource_overrides.resolve_memory_max_mb(config, executor.tool_name()),

--- a/crates/cli-sub-agent/src/resource_admission.rs
+++ b/crates/cli-sub-agent/src/resource_admission.rs
@@ -1,5 +1,6 @@
 use std::{io, path::Path};
 
+use anyhow::Context;
 use chrono::{DateTime, TimeDelta, Utc};
 use csa_config::ProjectConfig;
 use csa_resource::SpawnMemoryAdmission;
@@ -12,6 +13,7 @@ const FALLBACK_SPAWN_PROJECTION_MB: u64 = 4096;
 const RECENT_ACTIVE_FALLBACK_PROJECTION_MB: u64 = 4096;
 const RECENT_ACTIVE_FALLBACK_WINDOW_SECS: i64 = 15 * 60;
 const PRE_SPAWN_ADMISSION_MODE: &str = "admission";
+const PRE_SPAWN_MEMORY_ADMITTED_FILE: &str = ".pre-spawn-memory-admitted.toml";
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct ActiveSessionMemory {
@@ -57,6 +59,29 @@ pub(crate) fn persist_spawn_memory_projection(
         csa_session::save_session(session)?;
     }
     Ok(())
+}
+
+pub(crate) fn spawn_memory_admission_ready_path(session_dir: &Path) -> std::path::PathBuf {
+    session_dir.join(PRE_SPAWN_MEMORY_ADMITTED_FILE)
+}
+
+pub(crate) fn persist_spawn_memory_admission_ready(
+    project_root: &Path,
+    session_id: &str,
+    projected_spawn_mb: u64,
+) -> anyhow::Result<()> {
+    let session_dir = csa_session::get_session_dir(project_root, session_id)?;
+    let path = spawn_memory_admission_ready_path(&session_dir);
+    let content = format!(
+        "status = \"admitted\"\nprojected_spawn_mb = {projected_spawn_mb}\nrecorded_at = \"{}\"\n",
+        Utc::now().to_rfc3339()
+    );
+    std::fs::write(&path, content).with_context(|| {
+        format!(
+            "Failed to persist pre-spawn memory admission marker at {}",
+            path.display()
+        )
+    })
 }
 
 fn update_spawn_memory_projection(session: &mut MetaSessionState, projected_spawn_mb: u64) -> bool {

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -27,6 +27,7 @@ pub(crate) struct DaemonSpawnOptions {
     prompt_file_forward_arg: PromptFileForwardArg,
     no_fs_sandbox: bool,
     extra_writable: Vec<PathBuf>,
+    wait_for_pre_spawn_memory_admission: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -70,6 +71,7 @@ impl DaemonSpawnOptions {
         prompt_file: Option<&Path>,
         no_fs_sandbox: bool,
         extra_writable: &[PathBuf],
+        wait_for_pre_spawn_memory_admission: bool,
     ) -> Self {
         let run_stdin_prompt =
             if prompt_file.is_some_and(crate::run_helpers::is_prompt_file_stdin_sentinel) {
@@ -89,6 +91,7 @@ impl DaemonSpawnOptions {
             prompt_file_forward_arg: PromptFileForwardArg::PromptFile,
             no_fs_sandbox,
             extra_writable: extra_writable.to_vec(),
+            wait_for_pre_spawn_memory_admission,
             ..Default::default()
         }
     }
@@ -354,6 +357,13 @@ pub(crate) fn spawn_and_exit(
     };
 
     let result = csa_process::daemon::spawn_daemon(config)?;
+    if spawn_options.wait_for_pre_spawn_memory_admission {
+        crate::run_cmd_daemon_memory_wait::wait_for_daemon_pre_spawn_memory_admission(
+            &project_root,
+            &result.session_id,
+            &result.session_dir,
+        )?;
+    }
     verify_daemon_session_waitable(&project_root, &result.session_id)?;
     // stdout: machine-readable session ID (for script capture).
     println!("{}", result.session_id);

--- a/crates/cli-sub-agent/src/run_cmd_daemon_memory_wait.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_memory_wait.rs
@@ -1,0 +1,82 @@
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+
+pub(crate) fn wait_for_daemon_pre_spawn_memory_admission(
+    project_root: &Path,
+    session_id: &str,
+    session_dir: &Path,
+) -> Result<()> {
+    let ready_path = crate::resource_admission::spawn_memory_admission_ready_path(session_dir);
+    let timeout = daemon_pre_spawn_memory_admission_timeout(project_root);
+    let start = Instant::now();
+
+    loop {
+        if ready_path.is_file() {
+            return Ok(());
+        }
+        if let Some(message) =
+            daemon_pre_spawn_failure_message(project_root, session_id, session_dir)?
+        {
+            anyhow::bail!("{message}");
+        }
+        if start.elapsed() >= timeout {
+            eprintln!(
+                "CSA: warning — timed out after {secs}s waiting for daemon pre-spawn host-memory admission; emitting a waitable session handle.",
+                secs = timeout.as_secs()
+            );
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn daemon_pre_spawn_memory_admission_timeout(project_root: &Path) -> Duration {
+    let config = csa_config::ProjectConfig::load(project_root).ok().flatten();
+    let slot_wait =
+        crate::run_cmd_tool_selection::resolve_slot_wait_timeout_seconds(config.as_ref());
+    Duration::from_secs(slot_wait.saturating_add(5))
+}
+
+fn daemon_pre_spawn_failure_message(
+    project_root: &Path,
+    session_id: &str,
+    session_dir: &Path,
+) -> Result<Option<String>> {
+    if let Some(result) = csa_session::load_result(project_root, session_id)? {
+        let summary = result.summary.trim();
+        let detail = if summary.is_empty() {
+            format!(
+                "daemon exited before pre-spawn host-memory admission completed (exit_code={})",
+                result.exit_code
+            )
+        } else {
+            summary.to_string()
+        };
+        let prefix = if detail.contains("host memory admission denied") {
+            "CSA: host memory admission was denied before daemon session handoff"
+        } else {
+            "CSA: daemon failed before pre-spawn host-memory admission completed"
+        };
+        return Ok(Some(format!(
+            "{prefix}; no session-start marker was emitted, and no `csa session wait` is needed.\nSummary: {detail}"
+        )));
+    }
+
+    if let Some(packet) = crate::session_cmds_daemon::load_daemon_completion_packet(session_dir)?
+        && packet.exit_code != 0
+        && !csa_process::ToolLiveness::daemon_pid_is_alive(session_dir)
+    {
+        return Ok(Some(format!(
+            "CSA: daemon exited before pre-spawn host-memory admission completed \
+             (exit_code={}, status={}); no session-start marker was emitted, and no \
+             `csa session wait` is needed. Inspect daemon stderr at {}",
+            packet.exit_code,
+            packet.status,
+            session_dir.join("stderr.log").display()
+        )));
+    }
+
+    Ok(None)
+}

--- a/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
@@ -114,25 +114,26 @@ fn assert_daemon_wrapper_pin_resolves_for_command(command: &str, startup_env: &S
 
 #[test]
 fn run_daemon_options_detect_omitted_stdin_prompt_without_skill() {
-    let options = DaemonSpawnOptions::for_run(None, None, None, None, false, &[]);
+    let options = DaemonSpawnOptions::for_run(None, None, None, None, false, &[], false);
     assert_eq!(options.run_stdin_prompt, RunStdinPrompt::Omitted);
 }
 
 #[test]
 fn run_daemon_options_do_not_capture_stdin_for_skill_only_run() {
-    let options = DaemonSpawnOptions::for_run(Some("demo"), None, None, None, false, &[]);
+    let options = DaemonSpawnOptions::for_run(Some("demo"), None, None, None, false, &[], false);
     assert_eq!(options.run_stdin_prompt, RunStdinPrompt::None);
 }
 
 #[test]
 fn run_daemon_options_detect_positional_stdin_sentinel() {
-    let options = DaemonSpawnOptions::for_run(None, Some("-"), None, None, false, &[]);
+    let options = DaemonSpawnOptions::for_run(None, Some("-"), None, None, false, &[], false);
     assert_eq!(options.run_stdin_prompt, RunStdinPrompt::PositionalSentinel);
 }
 
 #[test]
 fn run_daemon_options_detect_prompt_file_stdin_sentinel() {
-    let options = DaemonSpawnOptions::for_run(None, None, None, Some(Path::new("-")), false, &[]);
+    let options =
+        DaemonSpawnOptions::for_run(None, None, None, Some(Path::new("-")), false, &[], false);
     assert_eq!(options.run_stdin_prompt, RunStdinPrompt::PromptFileSentinel);
 }
 

--- a/crates/cli-sub-agent/tests/run_wait_memory_admission.rs
+++ b/crates/cli-sub-agent/tests/run_wait_memory_admission.rs
@@ -1,0 +1,120 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn csa_cmd(tmp: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    scrub_inherited_csa_env(&mut cmd);
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1")
+        .env("CSA_DAEMON_INDEPENDENT_SCOPE", "0");
+    cmd
+}
+
+fn scrub_inherited_csa_env(cmd: &mut Command) {
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("CSA_") {
+            cmd.env_remove(key);
+        }
+    }
+}
+
+fn write_fake_codex_bin(tmp: &Path) -> PathBuf {
+    let bin_dir = tmp.join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("create fake bin dir");
+    let codex = bin_dir.join("codex");
+    std::fs::write(
+        &codex,
+        "#!/bin/sh\necho fake codex should not run >&2\nexit 77\n",
+    )
+    .expect("write fake codex");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&codex)
+            .expect("fake codex metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&codex, perms).expect("chmod fake codex");
+    }
+    bin_dir
+}
+
+fn prepend_path(bin_dir: &Path) -> String {
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = std::env::split_paths(&existing).collect::<Vec<_>>();
+    paths.insert(0, bin_dir.to_path_buf());
+    std::env::join_paths(paths)
+        .expect("join PATH")
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn stdout_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr_text(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn run_wait_host_memory_denial_fails_before_session_started_marker() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("repo");
+    std::fs::create_dir_all(project.join(".csa")).expect("create project config dir");
+    std::fs::write(
+        project.join(".csa/config.toml"),
+        "[resources]\nslot_wait_timeout_seconds = 1\n",
+    )
+    .expect("write project config");
+    let fake_bin = write_fake_codex_bin(tmp.path());
+
+    let output = csa_cmd(tmp.path())
+        .current_dir(&project)
+        .env("PATH", prepend_path(&fake_bin))
+        .args([
+            "run",
+            "--sa-mode",
+            "false",
+            "--wait",
+            "--tool",
+            "codex",
+            "--memory-max-mb",
+            "999999999999",
+            "--min-free-memory-mb",
+            "0",
+            "memory admission regression",
+        ])
+        .output()
+        .expect("run csa");
+
+    let stdout = stdout_text(&output);
+    let stderr = stderr_text(&output);
+
+    assert!(
+        !output.status.success(),
+        "run should fail host-memory admission; stdout={stdout:?} stderr={stderr:?}"
+    );
+    assert!(
+        !stdout.contains("CSA:SESSION_STARTED"),
+        "--wait must not emit SESSION_STARTED marker for pre-exec host-memory denial; stdout={stdout:?}"
+    );
+    assert!(
+        !stderr.contains("CSA:SESSION_STARTED"),
+        "--wait must not emit SESSION_STARTED marker for pre-exec host-memory denial; stderr={stderr:?}"
+    );
+    assert!(
+        stdout.trim().is_empty(),
+        "--wait host-memory denial must not print a waitable session id; stdout={stdout:?}"
+    );
+    assert!(
+        stderr.contains("host memory admission"),
+        "stderr should surface the host-memory denial; stderr={stderr:?}"
+    );
+    assert!(
+        stderr.contains("no `csa session wait` is needed"),
+        "stderr should tell the caller no session wait is needed; stderr={stderr:?}"
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1072"
-weave = "0.1.1072"
+csa = "0.1.1073"
+weave = "0.1.1073"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Delay `csa run --wait` daemon session handoff until pre-spawn host-memory admission reaches pass/fail.
- On pre-exec host-memory denial, return a direct error without emitting `CSA:SESSION_STARTED`, so callers know no `csa session wait` is needed.
- Preserve non-wait daemon handoff semantics and add regression coverage.

Fixes #2471.

## Verification

- `cargo test -p cli-sub-agent --test run_wait_memory_admission -- --nocapture`
- `cargo test -p cli-sub-agent resource_admission -- --nocapture`
- `just check-version-bumped`
- `scripts/monolith/check.sh --scope range --range main...HEAD --baseline scripts/monolith/baseline.toml --report-all`
- `git diff --check main...HEAD`
- `just pre-commit-fast`
- `just test`
- `just test-e2e`
- `cargo build --release -p cli-sub-agent --bin csa`
- `target/release/csa review --check-verdict --range 'main...HEAD' --cd '/home/obj/project/github/RyderFreeman4Logos/cli-sub-agent'`

CSA review: `01KW2EQWVGJ1GNR3NCEQ3KSGJQ` PASS for `main...HEAD` at `242f6f376fb`.
