### PR TITLE
fix(config): remove gemini-cli from CSA routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1073"
+version = "0.1.1074"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1073"
+version = "0.1.1074"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Rust](https://img.shields.io/badge/rust-1.88%2B-orange)](https://www.rust-lang.org/)
 
 CSA is a **headless IDE runtime for AI agents**. It provides a unified CLI that
-orchestrates multiple AI coding tools (claude-code, codex, gemini-cli, opencode)
+orchestrates multiple AI coding tools (claude-code, codex, opencode)
 as composable Unix processes -- enabling recursive sub-agent spawning,
 model-heterogeneous code review, and resource-aware scheduling.
 
@@ -15,7 +15,7 @@ model-heterogeneous code review, and resource-aware scheduling.
 Built-in sub-agents and agent-teams are **homogeneous** -- they only use one
 model family. Reviews suffer from same-model blind spots. CSA enforces
 **heterogeneous execution**: if the parent is Claude, the reviewer is
-automatically Codex or Gemini, and vice versa. No silent fallback.
+automatically a different supported model family such as Codex or Claude. No silent fallback.
 
 ## Key Features
 
@@ -79,7 +79,7 @@ See [Getting Started](docs/getting-started.md) for full installation and setup i
 ```
 Main Agent (depth=0, claude-code)
   |-- Reviewer (depth=1, codex)         # heterogeneous review
-  |   +-- Analyzer (depth=2, gemini)    # deep analysis
+  |   +-- Analyzer (depth=2, opencode)  # deep analysis
   +-- Debater (depth=1, codex)          # adversarial debate
       +-- Adversary (depth=2, claude)   # counter-argument
 ```
@@ -111,7 +111,6 @@ See [Architecture](docs/architecture.md) for design principles and dependency gr
 |------|----------|-----------|---------|
 | **claude-code** | Anthropic | ACP | 200K |
 | **codex** | OpenAI | ACP | 200K |
-| **gemini-cli** | Google | Legacy CLI | 2M |
 | **opencode** | OpenRouter | Legacy CLI | 200K |
 
 `claude-code` and `codex` both default to ACP runtimes today. `csa doctor`

--- a/crates/cli-sub-agent/src/batch.rs
+++ b/crates/cli-sub-agent/src/batch.rs
@@ -28,7 +28,7 @@ struct BatchTask {
     /// Task name (unique identifier)
     name: String,
 
-    /// Tool to use (gemini-cli, opencode, codex, claude-code)
+    /// Tool to use (opencode, codex, claude-code)
     tool: String,
 
     /// Task prompt
@@ -707,7 +707,9 @@ async fn execute_task(
 /// Parse tool name string to ToolName enum.
 fn parse_tool_name(tool: &str) -> Result<ToolName> {
     match tool {
-        "gemini-cli" => Ok(ToolName::GeminiCli),
+        "gemini-cli" | "gemini" => {
+            anyhow::bail!("{}", csa_core::types::removed_tool_error("gemini-cli"))
+        }
         "opencode" => Ok(ToolName::Opencode),
         "codex" => Ok(ToolName::Codex),
         "claude-code" => Ok(ToolName::ClaudeCode),

--- a/crates/cli-sub-agent/src/batch_tests.rs
+++ b/crates/cli-sub-agent/src/batch_tests.rs
@@ -4,8 +4,9 @@ use super::*;
 
 #[test]
 fn parse_tool_name_gemini_cli() {
-    let result = parse_tool_name("gemini-cli").unwrap();
-    assert!(matches!(result, ToolName::GeminiCli));
+    let err = parse_tool_name("gemini-cli").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("no longer supported"), "{msg}");
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
+++ b/crates/cli-sub-agent/src/claude_sub_agent_cmd.rs
@@ -309,7 +309,7 @@ fn resolve_auto_tool(
     }
 
     // Fallback: first available in preference order
-    for preferred in &["codex", "claude-code", "opencode", "gemini-cli"] {
+    for preferred in &["codex", "claude-code", "opencode"] {
         if let Ok(tool) = crate::run_helpers::parse_tool_name(preferred)
             && available_tools.contains(&tool)
         {
@@ -326,7 +326,7 @@ fn get_auto_selectable_tools(
     _project_root: &Path,
 ) -> Vec<ToolName> {
     if let Some(cfg) = project_config {
-        csa_config::global::all_known_tools()
+        csa_config::global::routing_candidate_tools()
             .iter()
             .filter(|t| cfg.is_tool_auto_selectable(t.as_str()))
             .copied()
@@ -358,7 +358,7 @@ fn select_any_available_tool(
     }
 
     anyhow::bail!(
-        "No tools available. Install at least one tool (codex, claude-code, opencode, gemini-cli)."
+        "No tools available. Install at least one supported routing tool (codex, claude-code, opencode)."
     )
 }
 

--- a/crates/cli-sub-agent/src/cli_common.rs
+++ b/crates/cli-sub-agent/src/cli_common.rs
@@ -40,6 +40,26 @@ pub(crate) fn validate_return_to(value: &str) -> std::result::Result<String, Str
         .map_err(|e| e.to_string())
 }
 
+pub(crate) fn parse_cli_tool_name(
+    tool: &str,
+) -> std::result::Result<csa_core::types::ToolName, String> {
+    if csa_core::types::is_removed_tool_name(tool) {
+        return Err(csa_core::types::removed_tool_error(tool));
+    }
+    match tool {
+        "opencode" => Ok(csa_core::types::ToolName::Opencode),
+        "codex" => Ok(csa_core::types::ToolName::Codex),
+        "claude-code" => Ok(csa_core::types::ToolName::ClaudeCode),
+        "openai-compat" => Ok(csa_core::types::ToolName::OpenaiCompat),
+        "antigravity-cli" => Ok(csa_core::types::ToolName::AntigravityCli),
+        "claude" => Ok(csa_core::types::ToolName::ClaudeCode),
+        "antigravity" => Ok(csa_core::types::ToolName::AntigravityCli),
+        _ => Err(format!(
+            "unknown tool '{tool}'. Valid values: opencode, codex, claude-code, openai-compat, antigravity-cli"
+        )),
+    }
+}
+
 pub(crate) fn parse_model_spec_arg(spec: &str) -> std::result::Result<String, String> {
     let (value, warning) = parse_model_spec_arg_with_warning(spec)?;
     if let Some(warning) = warning {
@@ -63,6 +83,9 @@ pub(crate) fn parse_model_spec_arg_with_warning(
         return Err(format!(
             "Invalid model spec '{spec}': tool/provider/model/thinking_budget segments cannot be empty"
         ));
+    }
+    if csa_core::types::is_removed_tool_name(&parsed.tool) {
+        return Err(csa_core::types::removed_tool_error(&parsed.tool));
     }
 
     match parsed.validate_with_catalog(&known_tools) {
@@ -90,7 +113,7 @@ pub(crate) fn parse_spec_path_arg(spec: &str) -> std::result::Result<String, Str
 
 #[cfg(test)]
 mod tests {
-    use super::parse_model_spec_arg_with_warning;
+    use super::{parse_cli_tool_name, parse_model_spec_arg_with_warning};
 
     #[test]
     fn parse_model_spec_arg_warns_and_passes_unknown_model() {
@@ -120,5 +143,23 @@ mod tests {
             .expect_err("empty tool should remain malformed");
 
         assert!(err.contains("segments cannot be empty"), "{err}");
+    }
+
+    #[test]
+    fn parse_model_spec_arg_rejects_removed_gemini_cli() {
+        let err =
+            parse_model_spec_arg_with_warning("gemini-cli/google/gemini-3-pro/xhigh").unwrap_err();
+
+        assert!(err.contains("no longer supported"), "{err}");
+        assert!(err.contains("discontinued"), "{err}");
+        assert!(err.contains("antigravity-cli"), "{err}");
+    }
+
+    #[test]
+    fn parse_cli_tool_name_rejects_removed_gemini_cli() {
+        let err = parse_cli_tool_name("gemini-cli").unwrap_err();
+
+        assert!(err.contains("no longer supported"), "{err}");
+        assert!(err.contains("provider is discontinued"), "{err}");
     }
 }

--- a/crates/cli-sub-agent/src/cli_plan.rs
+++ b/crates/cli-sub-agent/src/cli_plan.rs
@@ -4,7 +4,7 @@
 use clap::Subcommand;
 use csa_core::types::ToolName;
 
-use super::parse_model_spec_arg;
+use super::{parse_cli_tool_name, parse_model_spec_arg};
 
 #[derive(Subcommand)]
 pub enum PlanCommands {
@@ -30,7 +30,7 @@ pub enum PlanCommands {
         issue: Option<u64>,
 
         /// Override tool for all CSA steps (ignores tier routing)
-        #[arg(long)]
+        #[arg(long, value_parser = parse_cli_tool_name)]
         tool: Option<ToolName>,
 
         /// Override model spec for all CSA steps (tool/provider/model/thinking format)

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use clap::{ArgGroup, ValueEnum};
 use csa_core::types::{ToolArg, ToolName};
 
-use super::{Commands, parse_model_spec_arg, parse_spec_path_arg};
+use super::{Commands, parse_cli_tool_name, parse_model_spec_arg, parse_spec_path_arg};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
@@ -50,7 +50,7 @@ pub struct ReviewArgs {
     /// Unlike `csa run`, explicit --tool keeps failover enabled; use --no-failover to fail fast.
     /// Combine with --tier to use that tier's model/thinking for the selected tool.
     /// Combine with --force-ignore-tier-setting to bypass tiers entirely.
-    #[arg(long)]
+    #[arg(long, value_parser = parse_cli_tool_name)]
     pub tool: Option<ToolName>,
     /// Autonomous mode flag (REQUIRED for root callers)
     #[arg(long, value_name = "BOOL")]
@@ -82,7 +82,7 @@ pub struct ReviewArgs {
     pub thinking: Option<String>,
 
     /// Disable automatic retry/failover on transient errors (cross-tool 429 failover,
-    /// same-tool ACP crash retry, Gemini rate-limit/quota retry phases, debate outer
+    /// same-tool ACP crash retry, provider rate-limit/quota retry phases, debate outer
     /// retry loop). Useful with --model-spec to pin an exact selection and fail fast.
     #[arg(long)]
     pub no_failover: bool,
@@ -490,7 +490,7 @@ pub struct DebateArgs {
     pub thinking: Option<String>,
 
     /// Disable automatic retry/failover on transient errors (cross-tool 429 failover,
-    /// same-tool ACP crash retry, Gemini rate-limit/quota retry phases, debate outer
+    /// same-tool ACP crash retry, provider rate-limit/quota retry phases, debate outer
     /// retry loop). Useful with --model-spec to pin an exact selection and fail fast.
     #[arg(long)]
     pub no_failover: bool,

--- a/crates/cli-sub-agent/src/cli_session.rs
+++ b/crates/cli-sub-agent/src/cli_session.rs
@@ -49,7 +49,7 @@ pub enum SessionCommands {
         show_version: bool,
     },
 
-    /// Compress session context (gemini-cli: /compress, others: /compact)
+    /// Compress session context
     Compress {
         /// Session ULID or prefix (positional alternative to --session)
         #[arg(conflicts_with = "session")]

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -194,7 +194,6 @@ max_recursion_depth = 5
 # liveness_dead_seconds = 600
 #
 # [resources.initial_estimates]
-# gemini-cli = 150
 # opencode = 500
 # codex = 800
 # claude-code = 1200
@@ -218,12 +217,6 @@ max_recursion_depth = 5
 # enabled = true
 # suppress_notify = true
 # setting_sources = ["project"]    # load only project-level settings
-#
-# [tools.gemini-cli]
-# enabled = true
-# suppress_notify = true
-# [tools.gemini-cli.restrictions]
-# allow_edit_existing_files = false
 #
 # [tools.opencode]
 # enabled = true

--- a/crates/cli-sub-agent/src/config_cmds_tests.rs
+++ b/crates/cli-sub-agent/src/config_cmds_tests.rs
@@ -30,13 +30,7 @@ impl Drop for EnvVarGuard {
 }
 
 fn write_global_config(contents: &str) -> std::path::PathBuf {
-    // Mirror every production read path. Both `GlobalConfig::load()` and
-    // `ProjectConfig::load()` resolve the user-level config via
-    // `paths::config_dir().join("config.toml")`, so the test fixture must
-    // populate whatever that resolver returns for the current environment.
-    // Also populate `GlobalConfig::config_path()` (the canonical write path)
-    // so production code and tests agree on which bytes they see on
-    // platforms where the read and write resolvers can disagree.
+    // Mirror both production read and write paths for user-level config.
     let read_path =
         csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
     std::fs::create_dir_all(read_path.parent().expect("user config dir")).unwrap();
@@ -202,7 +196,12 @@ fn resolve_effective_execution_key_uses_compile_default_when_no_config_exists() 
 
 #[test]
 fn resolve_effective_execution_key_prefers_project_override() {
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let dir = tempfile::tempdir().unwrap();
+    let config_root = dir.path().join("xdg-config");
+    std::fs::create_dir_all(&config_root).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", dir.path());
+    let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
     let csa_dir = dir.path().join(".csa");
     std::fs::create_dir_all(&csa_dir).unwrap();
     std::fs::write(

--- a/crates/cli-sub-agent/src/debate_cmd_dry_run_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_dry_run_tests.rs
@@ -28,10 +28,10 @@ fn debate_cli_parses_dry_run_flag() {
 
 #[test]
 fn debate_explicit_tool_keeps_failover_enabled_by_default() {
-    let args = parse_debate_args(&["csa", "debate", "--tool", "gemini-cli", "question"]);
+    let args = parse_debate_args(&["csa", "debate", "--tool", "codex", "question"]);
     assert!(matches!(
         args.tool,
-        Some(ToolArg::Specific(ToolName::GeminiCli))
+        Some(ToolArg::Specific(ToolName::Codex))
     ));
     assert!(!args.no_failover);
 }

--- a/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_exact_tests.rs
@@ -912,7 +912,7 @@ fn debate_finalize_non_success_omits_after_final_disabled_tier_spec() {
     .unwrap();
     let config: csa_config::ProjectConfig = toml::from_str(
         r#"
-[tools.gemini-cli]
+[tools.opencode]
 enabled = false
 
 [tools.claude-code]
@@ -924,7 +924,7 @@ enabled = false
 [tiers.quality]
 description = "quality"
 models = [
-  "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+  "opencode/openai/gpt-5/xhigh",
   "claude-code/anthropic/claude-sonnet/high",
   "codex/openai/gpt-5/high",
 ]
@@ -978,7 +978,7 @@ Summary: Needs changes from terminal non-success verdict.
         .expect("saved result");
     let persisted_chain = saved.fallback_chain.expect("fallback_chain should persist");
     assert_eq!(persisted_chain.len(), 1);
-    assert_eq!(persisted_chain[0].tool, "gemini-cli");
+    assert_eq!(persisted_chain[0].tool, "opencode");
     assert_eq!(persisted_chain[0].skip_reason, "disabled");
     assert!(
         persisted_chain.iter().all(|attempt| attempt.tool != "codex"),

--- a/crates/cli-sub-agent/src/debate_cmd_execute_tier_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_execute_tier_tests.rs
@@ -36,22 +36,22 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
     let bin_dir = project_dir.path().join("bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
 
-    let gemini_invocation_log = project_dir.path().join("gemini-invocations.log");
     let codex_invocation_log = project_dir.path().join("codex-invocations.log");
-    let gemini_invocation_log_str = gemini_invocation_log.display().to_string();
+    let opencode_invocation_log = project_dir.path().join("opencode-invocations.log");
     let codex_invocation_log_str = codex_invocation_log.display().to_string();
+    let opencode_invocation_log_str = opencode_invocation_log.display().to_string();
 
     for (binary, body) in [
         (
-            "gemini",
+            "codex",
             format!(
-                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gemini-cli 1.0.0\\n'\n  exit 0\nfi\ncount=0\nif [ -f \"{gemini_invocation_log_str}\" ]; then\n  count=$(wc -l < \"{gemini_invocation_log_str}\")\nfi\nnext=$((count + 1))\nprintf 'attempt-%s\\n' \"$next\" >> \"{gemini_invocation_log_str}\"\nif [ \"$next\" -eq 1 ]; then\n  printf \"reason: 'QUOTA_EXHAUSTED'\\n\" >&2\n  exit 1\nfi\nprintf '%s\\n' 'Verdict: APPROVE' 'Confidence: high' 'Summary: Debate succeeded via second gemini tier candidate.' '- Fallback stayed within the gemini whitelist.'\n"
+                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex-cli 1.0.0\\n'\n  exit 0\nfi\ncount=0\nif [ -f \"{codex_invocation_log_str}\" ]; then\n  count=$(wc -l < \"{codex_invocation_log_str}\")\nfi\nnext=$((count + 1))\nprintf 'attempt-%s\\n' \"$next\" >> \"{codex_invocation_log_str}\"\nif [ \"$next\" -eq 1 ]; then\n  printf 'codex_429_retry_exhausted: temporary codex 429 rate limit persisted after 3 retries\\n' >&2\n  exit 1\nfi\nprintf '%s\\n' 'Verdict: APPROVE' 'Confidence: high' 'Summary: Debate succeeded via second codex tier candidate.' '- Fallback stayed within the codex preference.'\n"
             ),
         ),
         (
-            "codex-acp",
+            "opencode",
             format!(
-                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'codex-acp 1.0.0\\n'\n  exit 0\nfi\nprintf 'codex should not be invoked\\n' >> \"{codex_invocation_log_str}\"\nexit 1\n"
+                "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'opencode 1.0.0\\n'\n  exit 0\nfi\nprintf 'opencode should not be invoked\\n' >> \"{opencode_invocation_log_str}\"\nexit 1\n"
             ),
         ),
     ] {
@@ -68,7 +68,7 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
     let _available_guard =
         EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
 
-    let mut config = project_config_with_enabled_tools(&["codex", "gemini-cli"]);
+    let mut config = project_config_with_enabled_tools(&["codex", "opencode"]);
     config.review = Some(csa_config::ReviewConfig {
         gate_command: Some("true".to_string()),
         ..Default::default()
@@ -78,9 +78,9 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
         csa_config::config::TierConfig {
             description: "quality".to_string(),
             models: vec![
-                "gemini-cli/google/gemini-3.1-pro-preview/medium".to_string(),
-                "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
+                "codex/openai/gpt-5.4/medium".to_string(),
                 "codex/openai/gpt-5/high".to_string(),
+                "opencode/openai/gpt-5/high".to_string(),
             ],
             strategy: csa_config::TierStrategy::default(),
             token_budget: None,
@@ -94,7 +94,7 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
         project_dir.path(),
         Some("debate explicit-tool tier fallback"),
         None,
-        Some("gemini-cli"),
+        Some("codex"),
     )
     .unwrap();
 
@@ -105,7 +105,7 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
         "--cd",
         &cd,
         "--tool",
-        "gemini-cli",
+        "codex",
         "--tier",
         "quality",
         "--session",
@@ -120,14 +120,14 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
         &crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV,
     )
     .await
-    .expect("explicit gemini debate tier fallback should succeed");
+    .expect("explicit codex debate tier fallback should succeed");
     assert_eq!(exit_code, 0);
 
-    let gemini_invocations = std::fs::read_to_string(&gemini_invocation_log).unwrap();
-    assert_eq!(gemini_invocations.lines().count(), 2);
+    let codex_invocations = std::fs::read_to_string(&codex_invocation_log).unwrap();
+    assert_eq!(codex_invocations.lines().count(), 2);
     assert!(
-        !codex_invocation_log.exists(),
-        "codex should not be invoked because the preferred gemini fallback succeeds first"
+        !opencode_invocation_log.exists(),
+        "opencode should not be invoked because the preferred codex fallback succeeds first"
     );
 
     let session_dir =
@@ -140,16 +140,16 @@ async fn execute_debate_advances_tier_fallback_when_explicit_tool_and_tier() {
     assert_eq!(parsed["verdict"], "APPROVE");
     assert_eq!(
         parsed["summary"],
-        "Debate succeeded via second gemini tier candidate."
+        "Debate succeeded via second codex tier candidate."
     );
     assert!(parsed["failure_reason"].is_null());
 
     let result = csa_session::load_result(project_dir.path(), &session.meta_session_id)
         .unwrap()
         .expect("result.toml should exist");
-    assert_eq!(result.tool, "gemini-cli");
+    assert_eq!(result.tool, "codex");
     assert_eq!(
         result.summary,
-        "Debate succeeded via second gemini tier candidate."
+        "Debate succeeded via second codex tier candidate."
     );
 }

--- a/crates/cli-sub-agent/src/debate_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_resolve.rs
@@ -389,7 +389,7 @@ fn resolve_debate_tool_from_selection(
     if let Some(tool_name) = selection.as_single() {
         let tool = crate::run_helpers::parse_tool_name(tool_name).map_err(|_| {
             anyhow::anyhow!(
-                "Invalid [debate].tool value '{tool_name}'. Supported values: auto, gemini-cli, opencode, codex, claude-code."
+                "Invalid [debate].tool value '{tool_name}'. Supported values: auto, opencode, codex, claude-code."
             )
         })?;
         // Verify the tool is enabled in the project config
@@ -456,7 +456,7 @@ fn select_auto_debate_tool(
     let parent_str = parent_tool?;
     let parent_tool_name = crate::run_helpers::parse_tool_name(parent_str).ok()?;
     let enabled_tools: Vec<_> = if let Some(cfg) = project_config {
-        let tools: Vec<_> = csa_config::global::all_known_tools()
+        let tools: Vec<_> = csa_config::global::routing_candidate_tools()
             .iter()
             .filter(|t| cfg.is_tool_auto_selectable(t.as_str()))
             .filter(|t| {
@@ -467,7 +467,7 @@ fn select_auto_debate_tool(
             .collect();
         csa_config::global::sort_tools_by_effective_priority(&tools, project_config, global_config)
     } else {
-        let all = csa_config::global::all_known_tools();
+        let all = csa_config::global::routing_candidate_tools();
         let tools: Vec<_> = all
             .iter()
             .filter(|t| {
@@ -504,6 +504,7 @@ fn resolve_same_model_fallback(
     // but only if the configured runtime binary is actually available.
     if let Some(parent_str) = parent_tool
         && let Ok(tool) = crate::run_helpers::parse_tool_name(parent_str)
+        && csa_config::global::routing_candidate_tools().contains(&tool)
     {
         let enabled = project_config
             .map(|cfg| cfg.is_tool_enabled(tool.as_str()))
@@ -517,13 +518,13 @@ fn resolve_same_model_fallback(
 
     // No usable parent tool — select the first enabled tool from project config
     let candidates: Vec<_> = if let Some(cfg) = project_config {
-        csa_config::global::all_known_tools()
+        csa_config::global::routing_candidate_tools()
             .iter()
             .filter(|t| cfg.is_tool_enabled(t.as_str()))
             .copied()
             .collect()
     } else {
-        csa_config::global::all_known_tools().to_vec()
+        csa_config::global::routing_candidate_tools().to_vec()
     };
     if let Some(tool) = candidates.iter().find(|t| {
         crate::run_helpers::is_tool_binary_available_for_config(t.as_str(), project_config)
@@ -552,10 +553,10 @@ Supported auto mapping: claude-code <-> codex\n\n\
 Choose one:\n\
 1) Global config (user-level): {global_path}\n\
    [debate]\n\
-   tool = \"codex\"  # or \"claude-code\", \"opencode\", \"gemini-cli\"\n\
+   tool = \"codex\"  # or \"claude-code\", \"opencode\"\n\
 2) Project config override: {project_path}\n\
    [debate]\n\
-   tool = \"codex\"  # or \"claude-code\", \"opencode\", \"gemini-cli\"\n\
+   tool = \"codex\"  # or \"claude-code\", \"opencode\"\n\
 3) CLI override: csa debate --sa-mode <true|false> --tool codex\n\n\
 Reason: CSA enforces heterogeneity in auto mode and will not fall back."
     )

--- a/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests_tail.rs
@@ -397,12 +397,12 @@ async fn handle_debate_rejects_direct_tool_tier_before_session_creation() {
     unsafe {
         std::env::remove_var("CSA_SESSION_ID");
     }
-    let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    let mut config = project_config_with_enabled_tools(&["opencode", "codex"]);
     config.tiers.insert(
         "default".to_string(),
         csa_config::config::TierConfig {
             description: "Test tier".to_string(),
-            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            models: vec!["opencode/openai/gpt-5/xhigh".to_string()],
             strategy: csa_config::TierStrategy::default(),
             token_budget: None,
             max_turns: None,
@@ -464,9 +464,9 @@ async fn handle_debate_marks_unavailable_when_all_tier_models_fail() {
 
     {
         let (binary, version, stderr_line) = (
-            "gemini",
-            "gemini-cli 1.0.0",
-            "reason: 'QUOTA_EXHAUSTED'; monthly spending cap reached",
+            "codex",
+            "codex-cli 1.0.0",
+            "codex_429_retry_exhausted: temporary codex 429 rate limit persisted after 3 retries",
         );
         let path = bin_dir.join(binary);
         std::fs::write(
@@ -487,7 +487,7 @@ async fn handle_debate_marks_unavailable_when_all_tier_models_fail() {
     let _available_guard =
         EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
 
-    let mut config = project_config_with_enabled_tools(&["gemini-cli"]);
+    let mut config = project_config_with_enabled_tools(&["codex"]);
     config.review = Some(csa_config::ReviewConfig {
         gate_command: Some("true".to_string()),
         ..Default::default()
@@ -497,9 +497,9 @@ async fn handle_debate_marks_unavailable_when_all_tier_models_fail() {
         csa_config::config::TierConfig {
             description: "quality".to_string(),
             models: vec![
-                "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
-                "gemini-cli/google/gemini-3.1-pro/high".to_string(),
-                "gemini-cli/google/gemini-2.5-pro/medium".to_string(),
+                "codex/openai/gpt-5.4/xhigh".to_string(),
+                "codex/openai/gpt-5/high".to_string(),
+                "codex/openai/gpt-5/medium".to_string(),
             ],
             strategy: csa_config::TierStrategy::default(),
             token_budget: None,
@@ -555,11 +555,9 @@ async fn handle_debate_marks_unavailable_when_all_tier_models_fail() {
     assert_eq!(parsed["decision"], "unavailable");
     assert_eq!(parsed["verdict"], "UNAVAILABLE");
     let failure_reason = parsed["failure_reason"].as_str().expect("failure_reason");
-    assert!(
-        failure_reason.contains("gemini-cli/google/gemini-3.1-pro-preview/xhigh=QUOTA_EXHAUSTED")
-    );
-    assert!(failure_reason.contains("gemini-cli/google/gemini-3.1-pro/high=QUOTA_EXHAUSTED"));
-    assert!(failure_reason.contains("gemini-cli/google/gemini-2.5-pro/medium=QUOTA_EXHAUSTED"));
+    assert!(failure_reason.contains("codex/openai/gpt-5.4/xhigh="));
+    assert!(failure_reason.contains("codex/openai/gpt-5/high="));
+    assert!(failure_reason.contains("codex/openai/gpt-5/medium="));
 }
 
 #[cfg(unix)]
@@ -568,7 +566,7 @@ async fn tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier
     let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.lock().await;
     let _available_guard =
         EnvVarGuard::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
-    let mut config = project_config_with_enabled_tools(&["codex", "gemini-cli"]);
+    let mut config = project_config_with_enabled_tools(&["codex", "opencode"]);
     config.tools.get_mut("codex").unwrap().transport = Some(csa_config::TransportKind::Cli);
     config.tiers.insert(
         "quality".to_string(),
@@ -577,7 +575,7 @@ async fn tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier
             models: vec![
                 "codex/openai/gpt-5.4/medium".to_string(),
                 "codex/openai/gpt-5/high".to_string(),
-                "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
+                "opencode/openai/gpt-5/xhigh".to_string(),
             ],
             strategy: csa_config::TierStrategy::default(),
             token_budget: None,
@@ -603,8 +601,8 @@ async fn tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier
             ),
             (ToolName::Codex, Some("codex/openai/gpt-5/high".to_string())),
             (
-                ToolName::GeminiCli,
-                Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string()),
+                ToolName::Opencode,
+                Some("opencode/openai/gpt-5/xhigh".to_string()),
             ),
         ]
     );

--- a/crates/cli-sub-agent/src/debate_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tier_tests.rs
@@ -105,8 +105,8 @@ fn test_debate_blocks_direct_tool_when_tiers_configured() {
     let global = GlobalConfig::default();
     let cfg = debate_config_with_tier(
         "default",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     let result = resolve_debate_tool(
         Some(ToolName::Codex),
@@ -141,8 +141,8 @@ fn test_debate_allows_tier_flag() {
     let global = GlobalConfig::default();
     let cfg = debate_config_with_tier(
         "quality",
-        vec!["gemini-cli/google/gemini-3.1-pro-preview/xhigh"],
-        &["gemini-cli"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode"],
     );
     let result = resolve_debate_tool(
         None,
@@ -161,12 +161,9 @@ fn test_debate_allows_tier_flag() {
         result.unwrap_err()
     );
     let (tool, mode, model_spec) = result.unwrap();
-    assert_eq!(tool, ToolName::GeminiCli);
+    assert_eq!(tool, ToolName::Opencode);
     assert_eq!(mode, DebateMode::Heterogeneous);
-    assert_eq!(
-        model_spec.as_deref(),
-        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh")
-    );
+    assert_eq!(model_spec.as_deref(), Some("opencode/openai/gpt-5/xhigh"));
 }
 
 #[test]
@@ -176,11 +173,11 @@ fn test_debate_tool_plus_tier_resolves_requested_tool_from_tier() {
     let cfg = debate_config_with_tier(
         "quality",
         vec![
-            "gemini-cli/google/default/xhigh",
+            "opencode/openai/gpt-5/xhigh",
             "codex/openai/gpt-5.4/high",
             "claude-code/anthropic/sonnet-4.6/xhigh",
         ],
-        &["gemini-cli", "codex", "claude-code"],
+        &["opencode", "codex", "claude-code"],
     );
     let result = resolve_debate_tool(
         Some(ToolName::Codex),
@@ -211,8 +208,8 @@ fn test_debate_tool_plus_tier_rejects_tool_missing_from_tier() {
     let global = GlobalConfig::default();
     let cfg = debate_config_with_tier(
         "quality",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     // Since #1994, non-candidate --tool pins fail fast instead of selecting another tier tool.
     let err = resolve_debate_tool(
@@ -240,8 +237,8 @@ fn test_debate_tier_preference_mismatch_uses_full_tier() {
     let global = GlobalConfig::default();
     let cfg = debate_config_with_whitelist(
         "quality",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
         &["codex"],
     );
     let result = resolve_debate_tool(
@@ -257,12 +254,9 @@ fn test_debate_tier_preference_mismatch_uses_full_tier() {
     );
 
     let (tool, mode, model_spec) = result.expect("absent preferred tool should not hard-fail");
-    assert_eq!(tool, ToolName::GeminiCli);
+    assert_eq!(tool, ToolName::Opencode);
     assert_eq!(mode, DebateMode::Heterogeneous);
-    assert_eq!(
-        model_spec.as_deref(),
-        Some("gemini-cli/google/default/xhigh")
-    );
+    assert_eq!(model_spec.as_deref(), Some("opencode/openai/gpt-5/xhigh"));
 }
 
 #[test]
@@ -271,11 +265,8 @@ fn debate_resolution_prefers_configured_tool_without_narrowing_fallbacks() {
     let global = GlobalConfig::default();
     let cfg = debate_config_with_single_tool_whitelist(
         "quality",
-        vec![
-            "gemini-cli/google/default/xhigh",
-            "codex/openai/gpt-5.4/high",
-        ],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh", "codex/openai/gpt-5.4/high"],
+        &["opencode", "codex"],
         "codex",
     );
 
@@ -304,11 +295,8 @@ fn debate_resolution_require_heterogeneous_passes_with_preference_plus_fallbacks
     global.debate.require_heterogeneous = true;
     let cfg = debate_config_with_single_tool_whitelist(
         "quality",
-        vec![
-            "gemini-cli/google/default/xhigh",
-            "codex/openai/gpt-5.4/high",
-        ],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh", "codex/openai/gpt-5.4/high"],
+        &["opencode", "codex"],
         "codex",
     );
 
@@ -336,11 +324,8 @@ fn debate_resolution_passes_when_panel_stays_heterogeneous() {
     let global = GlobalConfig::default();
     let cfg = debate_config_with_tier(
         "quality",
-        vec![
-            "gemini-cli/google/default/xhigh",
-            "codex/openai/gpt-5.4/high",
-        ],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh", "codex/openai/gpt-5.4/high"],
+        &["opencode", "codex"],
     );
 
     let result = resolve_debate_tool(
@@ -356,9 +341,9 @@ fn debate_resolution_passes_when_panel_stays_heterogeneous() {
     )
     .expect("heterogeneous panel should resolve");
 
-    assert_eq!(result.0, ToolName::GeminiCli);
+    assert_eq!(result.0, ToolName::Opencode);
     assert_eq!(result.1, DebateMode::Heterogeneous);
-    assert_eq!(result.2.as_deref(), Some("gemini-cli/google/default/xhigh"));
+    assert_eq!(result.2.as_deref(), Some("opencode/openai/gpt-5/xhigh"));
 }
 
 #[test]
@@ -366,8 +351,8 @@ fn test_debate_force_ignore_tier_allows_direct_tool() {
     let global = GlobalConfig::default();
     let cfg = debate_config_with_tier(
         "default",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     let result = resolve_debate_tool(
         Some(ToolName::Codex),
@@ -395,11 +380,8 @@ fn test_debate_tool_plus_tier_and_force_ignore_errors_on_conflict() {
     let global = GlobalConfig::default();
     let cfg = debate_config_with_tier(
         "quality",
-        vec![
-            "gemini-cli/google/default/xhigh",
-            "codex/openai/gpt-5.4/xhigh",
-        ],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh", "codex/openai/gpt-5.4/xhigh"],
+        &["opencode", "codex"],
     );
     let result = resolve_debate_tool(
         Some(ToolName::Codex),
@@ -455,8 +437,8 @@ fn test_debate_tier_alias_resolves() {
     let global = GlobalConfig::default();
     let mut cfg = debate_config_with_tier(
         "quality",
-        vec!["gemini-cli/google/gemini-3.1-pro-preview/xhigh"],
-        &["gemini-cli"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode"],
     );
     cfg.tier_mapping
         .insert("security_audit".to_string(), "quality".to_string());
@@ -478,10 +460,7 @@ fn test_debate_tier_alias_resolves() {
         result.unwrap_err()
     );
     let (tool, mode, model_spec) = result.unwrap();
-    assert_eq!(tool, ToolName::GeminiCli);
+    assert_eq!(tool, ToolName::Opencode);
     assert_eq!(mode, DebateMode::Heterogeneous);
-    assert_eq!(
-        model_spec.as_deref(),
-        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh")
-    );
+    assert_eq!(model_spec.as_deref(), Some("opencode/openai/gpt-5/xhigh"));
 }

--- a/crates/cli-sub-agent/src/doctor_routing.rs
+++ b/crates/cli-sub-agent/src/doctor_routing.rs
@@ -8,13 +8,7 @@ use csa_config::{GlobalConfig, ProjectConfig, TierStrategy};
 use csa_core::types::OutputFormat;
 use std::{env, fmt::Write as _, path::Path};
 
-const BUILTIN_TOOLS: &[&str] = &[
-    "gemini-cli",
-    "opencode",
-    "codex",
-    "claude-code",
-    "antigravity-cli",
-];
+const BUILTIN_TOOLS: &[&str] = &["opencode", "codex", "claude-code"];
 
 /// Map tool name (from model spec) to its executable binary name.
 fn tool_exe_name(tool: &str, config: &ProjectConfig) -> String {
@@ -707,15 +701,15 @@ mod tests {
         let user_config_path = ProjectConfig::user_config_path().expect("resolve user config path");
         std::fs::create_dir_all(user_config_path.parent().expect("user config dir"))
             .expect("create user config dir");
-        // Use gemini-cli + acp as the still-invalid combination after #1128 flipped
-        // codex CLI to a legal value. gemini-cli has no ACP transport, so the merge
+        // Use opencode + acp as the still-invalid combination after #1128 flipped
+        // codex CLI to a legal value. opencode has no ACP transport, so the merge
         // still produces a validation error tagged on the offending key. The invalid
         // value lives in USER config; project config stays valid so the project view
         // remains Valid in isolation.
         std::fs::write(
             &user_config_path,
             r#"
-[tools.gemini-cli]
+[tools.opencode]
 transport = "acp"
 "#,
         )
@@ -724,7 +718,7 @@ transport = "acp"
         write_project_config(
             td.path(),
             r#"
-[tools.gemini-cli]
+[tools.opencode]
 transport = "auto"
 
 [tiers.tier-1]
@@ -752,7 +746,7 @@ default = "tier-1"
         assert!(
             report.diagnostics[0]
                 .message
-                .contains("tools.gemini-cli.transport"),
+                .contains("tools.opencode.transport"),
             "diagnostic should surface the merged-config key: {:?}",
             report.diagnostics[0]
         );
@@ -761,7 +755,7 @@ default = "tier-1"
             "text output should surface the effective-config diagnostic: {rendered}"
         );
         assert!(
-            rendered.contains("Built-in tools: gemini-cli, opencode, codex, claude-code"),
+            rendered.contains("Built-in tools: opencode, codex, claude-code"),
             "text output should keep best-effort routing context: {rendered}"
         );
         assert!(
@@ -782,7 +776,7 @@ default = "tier-1"
             json["diagnostics"][0]["message"]
                 .as_str()
                 .expect("routing json diagnostic message")
-                .contains("tools.gemini-cli.transport"),
+                .contains("tools.opencode.transport"),
             "json output should surface the merged-config key: {json}"
         );
         assert_eq!(json["context"]["vcs_backend"], serde_json::json!("git"));

--- a/crates/cli-sub-agent/src/doctor_tests.rs
+++ b/crates/cli-sub-agent/src/doctor_tests.rs
@@ -368,7 +368,7 @@ fn explicit_claude_code_cli_transport_reports_json_transport_details() {
 }
 
 /// Doctor must surface transport validation errors with the offending key path.
-/// Uses gemini-cli + ACP (still rejected post-#1128) because the original
+/// Uses opencode + ACP (still rejected post-#1128) because the original
 /// codex+cli rejection became obsolete after the codex CLI default flip.
 #[test]
 fn doctor_load_rejects_invalid_tool_transport_override() {
@@ -376,7 +376,7 @@ fn doctor_load_rejects_invalid_tool_transport_override() {
     write_project_config(
         td.path(),
         r#"
-[tools.gemini-cli]
+[tools.opencode]
 transport = "acp"
 "#,
     );
@@ -385,7 +385,7 @@ transport = "acp"
     let message = format!("{err:#}");
 
     assert!(
-        message.contains("tools.gemini-cli.transport"),
+        message.contains("tools.opencode.transport"),
         "doctor should surface the exact config key: {message}"
     );
     assert!(
@@ -472,15 +472,15 @@ fn doctor_project_config_display_ignores_invalid_user_global_config() {
     let user_config_path = ProjectConfig::user_config_path().expect("resolve user config path");
     std::fs::create_dir_all(user_config_path.parent().expect("user config dir"))
         .expect("create user config dir");
-    // gemini-cli + acp is the still-invalid combination after #1128 flipped
-    // codex CLI to a legal transport. gemini-cli has no ACP transport, so the
+    // opencode + acp is the still-invalid combination after #1128 flipped
+    // codex CLI to a legal transport. opencode has no ACP transport, so the
     // merge still produces a validation error tagged on the offending key.
     // The invalid value lives in USER config; project config stays valid so
     // doctor still reports `.csa/config.toml` as Valid in isolation.
     std::fs::write(
         &user_config_path,
         r#"
-[tools.gemini-cli]
+[tools.opencode]
 transport = "acp"
 "#,
     )
@@ -489,14 +489,14 @@ transport = "acp"
     write_project_config(
         td.path(),
         r#"
-[tools.gemini-cli]
+[tools.opencode]
 transport = "auto"
 "#,
     );
 
     let merged_error = ProjectConfig::load(td.path()).expect_err("merged load should fail");
     assert!(
-        format!("{merged_error:#}").contains("tools.gemini-cli.transport"),
+        format!("{merged_error:#}").contains("tools.opencode.transport"),
         "test fixture should exercise an invalid user-level transport override: {merged_error}"
     );
 
@@ -629,15 +629,15 @@ fn doctor_text_reports_invalid_effective_config() {
     let user_config_path = ProjectConfig::user_config_path().expect("resolve user config path");
     std::fs::create_dir_all(user_config_path.parent().expect("user config dir"))
         .expect("create user config dir");
-    // gemini-cli + acp is the still-invalid combination after #1128 flipped
-    // codex CLI to a legal transport. gemini-cli has no ACP transport, so the
+    // opencode + acp is the still-invalid combination after #1128 flipped
+    // codex CLI to a legal transport. opencode has no ACP transport, so the
     // merge still produces a validation error tagged on the offending key.
     // The invalid value lives in USER config; project config stays valid so
     // doctor still reports `.csa/config.toml` as Valid in isolation.
     std::fs::write(
         &user_config_path,
         r#"
-[tools.gemini-cli]
+[tools.opencode]
 transport = "acp"
 "#,
     )
@@ -646,7 +646,7 @@ transport = "acp"
     write_project_config(
         td.path(),
         r#"
-[tools.gemini-cli]
+[tools.opencode]
 transport = "auto"
 "#,
     );
@@ -669,7 +669,7 @@ transport = "auto"
         "doctor text should surface the invalid effective-config branch: {rendered}"
     );
     assert!(
-        rendered.contains("tools.gemini-cli.transport"),
+        rendered.contains("tools.opencode.transport"),
         "doctor text should surface the exact merged-config key: {rendered}"
     );
     assert!(
@@ -695,15 +695,15 @@ fn doctor_json_reports_invalid_effective_config() {
     let user_config_path = ProjectConfig::user_config_path().expect("resolve user config path");
     std::fs::create_dir_all(user_config_path.parent().expect("user config dir"))
         .expect("create user config dir");
-    // gemini-cli + acp is the still-invalid combination after #1128 flipped
-    // codex CLI to a legal transport. gemini-cli has no ACP transport, so the
+    // opencode + acp is the still-invalid combination after #1128 flipped
+    // codex CLI to a legal transport. opencode has no ACP transport, so the
     // merge still produces a validation error tagged on the offending key.
     // The invalid value lives in USER config; project config stays valid so
     // doctor still reports `.csa/config.toml` as Valid in isolation.
     std::fs::write(
         &user_config_path,
         r#"
-[tools.gemini-cli]
+[tools.opencode]
 transport = "acp"
 "#,
     )
@@ -712,7 +712,7 @@ transport = "acp"
     write_project_config(
         td.path(),
         r#"
-[tools.gemini-cli]
+[tools.opencode]
 transport = "auto"
 "#,
     );
@@ -729,7 +729,7 @@ transport = "auto"
     assert_eq!(report["config"]["valid"], serde_json::json!(true));
     assert_eq!(effective["valid"], serde_json::json!(false));
     assert!(
-        effective_error.contains("tools.gemini-cli.transport"),
+        effective_error.contains("tools.opencode.transport"),
         "doctor JSON should surface the exact merged-config key: {effective_error}"
     );
     assert!(

--- a/crates/cli-sub-agent/src/error_hints.rs
+++ b/crates/cli-sub-agent/src/error_hints.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use anyhow::Error;
 use csa_core::error::AppError;
 
-const HINT_INSTALL_GEMINI: &str = "hint: install gemini-cli: npm install -g @google/gemini-cli";
+const HINT_REMOVED_GEMINI: &str = "hint: gemini-cli support has been removed because the provider is discontinued; use codex or claude-code instead";
 const HINT_INSTALL_CODEX: &str = "hint: install codex CLI: npm install -g @openai/codex";
 const HINT_INSTALL_CODEX_ACP: &str =
     "hint: install codex ACP adapter: npm install -g @zed-industries/codex-acp";
@@ -22,7 +22,7 @@ const HINT_SESSION_NOT_FOUND: &str = "hint: list available sessions with 'csa se
 const HINT_CONFIG_ERROR: &str =
     "hint: validate config with 'csa config validate' or reinitialize with 'csa init'";
 const HINT_SKILL_NOT_FOUND: &str = "hint: list runnable skills with 'csa skill list' or install one with 'csa skill install <repo>'";
-const HINT_GEMINI_RUNTIME_HOME: &str = "hint: Gemini ACP needs a writable runtime home; current builds pin TMPDIR to a writable sandbox temp dir (private /tmp in bwrap, session tmp elsewhere) and seed under CSA session state, but older builds may still need re-run with TMPDIR=/tmp";
+const HINT_GEMINI_RUNTIME_HOME: &str = HINT_REMOVED_GEMINI;
 const LEFTHOOK_CORE_HOOKSPATH_CONFLICT: &str = "core.hooksPath is set locally";
 const HINT_LEFTHOOK_CORE_HOOKSPATH_CONFLICT: &str = "hint: lefthook blocked git commit because core.hooksPath is set locally. Staged work may be uncommitted. Run `git config --unset-all --local core.hooksPath`, then rerun the commit or continue the session.";
 const SANDBOX_FS_DENIAL_MARKERS: [&str; 7] = [
@@ -71,7 +71,7 @@ pub fn suggest_fix(err: &Error) -> Option<String> {
 
     if has_not_installed_or_not_found {
         if chain_text.contains("gemini") {
-            return Some(HINT_INSTALL_GEMINI.to_string());
+            return Some(HINT_REMOVED_GEMINI.to_string());
         }
         if chain_text.contains("codex-acp") {
             return Some(HINT_INSTALL_CODEX_ACP.to_string());
@@ -235,7 +235,7 @@ fn tool_install_hint(tool_name: &str) -> Option<&'static str> {
         return Some(HINT_INSTALL_CODEX_ACP);
     }
     if tool.contains("gemini") {
-        return Some(HINT_INSTALL_GEMINI);
+        return Some(HINT_REMOVED_GEMINI);
     }
     if tool.contains("codex") {
         return Some(HINT_INSTALL_CODEX);
@@ -256,7 +256,9 @@ mod tests {
     #[test]
     fn test_tool_not_installed_gemini() {
         let err = Error::new(AppError::ToolNotInstalled("gemini-cli".into()));
-        assert_eq!(suggest_fix(&err).as_deref(), Some(HINT_INSTALL_GEMINI));
+        let hint = suggest_fix(&err).expect("removed gemini should produce a hint");
+        assert!(hint.contains("support has been removed"), "{hint}");
+        assert!(!hint.contains("npm install"), "{hint}");
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/failover_trace.rs
+++ b/crates/cli-sub-agent/src/failover_trace.rs
@@ -170,7 +170,7 @@ fn exclusion_attempt(exclusion: &TierModelExclusion) -> FallbackAttempt {
 /// flag the scheduler already computed.
 #[derive(Debug, Clone)]
 pub(crate) struct AttemptFailure {
-    /// Full model spec (e.g. `gemini-cli/google/gemini-3.1-pro-preview/xhigh`).
+    /// Full model spec (e.g. `codex/openai/gpt-5.5/xhigh`).
     pub(crate) model_spec: String,
     /// Normalized failover reason (e.g. the scheduler's `"QUOTA_EXHAUSTED"`).
     pub(crate) reason: String,

--- a/crates/cli-sub-agent/src/mcp_server.rs
+++ b/crates/cli-sub-agent/src/mcp_server.rs
@@ -220,7 +220,7 @@ fn get_tools() -> Vec<McpToolDef> {
                 "properties": {
                     "tool": {
                         "type": "string",
-                        "description": "Tool to use (gemini-cli, opencode, codex, claude-code). With tier, this is a soft preference before remaining tier fallbacks."
+                        "description": "Tool to use (opencode, codex, claude-code). With tier, this is a soft preference before remaining tier fallbacks."
                     },
                     "prompt": {
                         "type": "string",

--- a/crates/cli-sub-agent/src/mcp_server_run_tool.rs
+++ b/crates/cli-sub-agent/src/mcp_server_run_tool.rs
@@ -332,7 +332,9 @@ pub(super) fn resolve_mcp_model_pin(
 /// Parse tool name from string.
 pub(super) fn parse_tool_name(tool_str: &str) -> Result<ToolName> {
     match tool_str {
-        "gemini-cli" => Ok(ToolName::GeminiCli),
+        "gemini-cli" | "gemini" => {
+            anyhow::bail!("{}", csa_core::types::removed_tool_error("gemini-cli"))
+        }
         "opencode" => Ok(ToolName::Opencode),
         "codex" => Ok(ToolName::Codex),
         "claude-code" => Ok(ToolName::ClaudeCode),

--- a/crates/cli-sub-agent/src/mcp_server_tests.rs
+++ b/crates/cli-sub-agent/src/mcp_server_tests.rs
@@ -149,10 +149,6 @@ fn seed_completed_session(
 #[test]
 fn mcp_parse_tool_name_all_valid_tools() {
     assert!(matches!(
-        parse_tool_name("gemini-cli").unwrap(),
-        ToolName::GeminiCli
-    ));
-    assert!(matches!(
         parse_tool_name("opencode").unwrap(),
         ToolName::Opencode
     ));
@@ -161,6 +157,8 @@ fn mcp_parse_tool_name_all_valid_tools() {
         parse_tool_name("claude-code").unwrap(),
         ToolName::ClaudeCode
     ));
+    let err = parse_tool_name("gemini-cli").unwrap_err();
+    assert!(err.to_string().contains("no longer supported"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -104,7 +104,7 @@ fn load_and_validate_within_depth_returns_some() {
 }
 
 /// Pipeline must surface transport validation errors with the offending key path.
-/// Uses gemini-cli + ACP because it is still rejected post-#1128 (gemini-cli has
+/// Uses opencode + ACP because it is still rejected post-#1128 (gemini-cli has
 /// no ACP transport). The original codex+cli rejection became obsolete after the
 /// codex CLI default flip (#760 / #1128).
 #[test]
@@ -116,7 +116,7 @@ fn load_and_validate_rejects_invalid_tool_transport_override() {
     fs::write(
         config_dir.join("config.toml"),
         r#"
-[tools.gemini-cli]
+[tools.opencode]
 transport = "acp"
 "#,
     )
@@ -126,7 +126,7 @@ transport = "acp"
     let message = format!("{err:#}");
 
     assert!(
-        message.contains("tools.gemini-cli.transport"),
+        message.contains("tools.opencode.transport"),
         "pipeline should surface the exact config key: {message}"
     );
     assert!(

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_mktd_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_mktd_tests.rs
@@ -76,6 +76,7 @@ fn prepare_plan_session(project_root: &Path, description: &str) -> (String, Path
 #[tokio::test]
 async fn daemon_child_failed_mktd_persist_result_surfaces_validation_detail() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
+    let _user_config_env = crate::test_env_lock::isolate_user_config_locked(temp.path()).await;
     let project_root = temp.path().join("repo");
     std::fs::create_dir_all(&project_root).expect("repo dir should be created");
     init_plan_test_repo(&project_root);
@@ -152,6 +153,7 @@ on_fail = "abort"
 #[tokio::test]
 async fn daemon_child_failed_mktd_result_surfaces_underlying_command_failure() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
+    let _user_config_env = crate::test_env_lock::isolate_user_config_locked(temp.path()).await;
     let project_root = temp.path().join("repo");
     std::fs::create_dir_all(&project_root).expect("repo dir should be created");
     init_plan_test_repo(&project_root);

--- a/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon_tests.rs
@@ -1,7 +1,6 @@
-//! Tests for `plan_cmd_daemon`.
-
 use super::*;
 use crate::plan_cmd::PlanRunArgs;
+use crate::test_env_lock::isolate_user_config_locked as iso;
 use std::process::Command;
 
 fn make_args() -> PlanRunArgs {
@@ -114,7 +113,8 @@ fn describe_unknown_when_no_source_provided() {
 
 #[tokio::test]
 async fn daemon_child_failed_plan_writes_structured_failure_output() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let _user_config_env = iso(temp.path()).await;
     let project_root = temp.path().join("repo");
     std::fs::create_dir_all(&project_root).expect("repo dir should be created");
     init_plan_test_repo(&project_root);
@@ -174,7 +174,8 @@ on_fail = "abort"
 
 #[tokio::test]
 async fn daemon_child_failed_pr_bot_preserves_weave_lock_after_snapshot() {
-    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let _user_config_env = iso(temp.path()).await;
     let project_root = temp.path().join("repo");
     std::fs::create_dir_all(&project_root).expect("repo dir should be created");
     init_plan_test_repo(&project_root);

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -223,7 +223,7 @@ fn is_argument_list_too_long(error: &std::io::Error) -> bool {
     error.raw_os_error() == Some(libc::E2BIG)
 }
 
-/// Execute a step via CSA tool (codex, claude-code, gemini-cli, opencode).
+/// Execute a step via CSA tool (codex, claude-code, opencode).
 ///
 /// Stale forwarded session strategy: fallback to a fresh session (approach B).
 /// Rationale: token reuse is an optimization, while workflow completion is

--- a/crates/cli-sub-agent/src/plan_cmd_override_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_override_tests.rs
@@ -13,7 +13,6 @@ fn resolve_step_tool_all_explicit_tools() {
         ("await-user", false),  // AwaitUser
         ("claude-code", false), // CsaTool
         ("codex", false),       // CsaTool
-        ("gemini-cli", false),  // CsaTool
         ("opencode", false),    // CsaTool
         ("weave", false),       // WeaveInclude (not CsaTool, not DirectBash)
     ];
@@ -507,7 +506,7 @@ fn resolve_step_tool_respects_tool_override() {
     let step = PlanStep {
         id: 1,
         title: "test step".to_string(),
-        tool: Some("gemini-cli".to_string()), // Step explicitly asks for gemini-cli
+        tool: Some("opencode".to_string()), // Step explicitly asks for opencode
         tier: None,
         prompt: "test prompt".to_string(),
         depends_on: vec![],
@@ -518,17 +517,17 @@ fn resolve_step_tool_respects_tool_override() {
         workspace_access: None,
     };
 
-    // Without override: should resolve to gemini-cli as specified in step.tool
+    // Without override: should resolve to opencode as specified in step.tool
     let target_no_override = resolve_step_tool(&step, None, None, None).unwrap();
     assert!(matches!(
         target_no_override,
         StepTarget::CsaTool {
-            tool_name: ToolName::GeminiCli,
+            tool_name: ToolName::Opencode,
             ..
         }
     ));
 
-    // With tool override: should use codex instead of gemini-cli
+    // With tool override: should use codex instead of opencode
     let tool_override = ToolName::Codex;
     let target_with_override = resolve_step_tool(&step, None, Some(&tool_override), None).unwrap();
     assert!(matches!(
@@ -547,7 +546,7 @@ fn resolve_step_tool_respects_model_spec_override() {
     let step = PlanStep {
         id: 1,
         title: "test step".to_string(),
-        tool: Some("gemini-cli".to_string()),
+        tool: Some("opencode".to_string()),
         tier: None,
         prompt: "test prompt".to_string(),
         depends_on: vec![],
@@ -588,7 +587,7 @@ fn resolve_step_tool_model_spec_override_bypasses_step_tier() {
 
     let config: csa_config::ProjectConfig = toml::from_str(
         r#"
-[tools.gemini-cli]
+[tools.opencode]
 enabled = true
 
 [tools.codex]
@@ -596,7 +595,7 @@ enabled = true
 
 [tiers.review]
 description = "review"
-models = ["gemini-cli/google/gemini-2.5-pro/high"]
+models = ["opencode/google/gemini-2.5-pro/high"]
 "#,
     )
     .unwrap();
@@ -636,12 +635,12 @@ models = ["gemini-cli/google/gemini-2.5-pro/high"]
 fn resolve_step_tool_interpolates_plan_tier_variable() {
     let config: csa_config::ProjectConfig = toml::from_str(
         r#"
-[tools.gemini-cli]
+[tools.opencode]
 enabled = true
 
 [tiers.tier-plan]
 description = "planning"
-models = ["gemini-cli/google/gemini-2.5-pro/high"]
+models = ["opencode/google/gemini-2.5-pro/high"]
 "#,
     )
     .unwrap();
@@ -681,10 +680,10 @@ models = ["gemini-cli/google/gemini-2.5-pro/high"]
             model_spec,
             tier_name,
         } => {
-            assert_eq!(tool_name, ToolName::GeminiCli);
+            assert_eq!(tool_name, ToolName::Opencode);
             assert_eq!(
                 model_spec.as_deref(),
-                Some("gemini-cli/google/gemini-2.5-pro/high")
+                Some("opencode/google/gemini-2.5-pro/high")
             );
             assert_eq!(tier_name.as_deref(), Some("tier-plan"));
         }

--- a/crates/cli-sub-agent/src/plan_cmd_step_target.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_step_target.rs
@@ -79,7 +79,9 @@ pub(crate) fn resolve_step_tool(
             "note" => return Ok(StepTarget::Note),
             "manual" => return Ok(StepTarget::Manual),
             "await-user" => return Ok(StepTarget::AwaitUser),
-            "gemini-cli" => return Ok(StepTarget::csa(ToolName::GeminiCli, None)),
+            "gemini-cli" | "gemini" => {
+                bail!("{}", csa_core::types::removed_tool_error("gemini-cli"))
+            }
             "antigravity-cli" => return Ok(StepTarget::csa(ToolName::AntigravityCli, None)),
             "opencode" => return Ok(StepTarget::csa(ToolName::Opencode, None)),
             "codex" => return Ok(StepTarget::csa(ToolName::Codex, None)),
@@ -92,7 +94,7 @@ pub(crate) fn resolve_step_tool(
             }
             "weave" => return Ok(StepTarget::WeaveInclude),
             other => bail!(
-                "Unknown tool '{}' in step {} ('{}'). Known: bash, note, manual, await-user, gemini-cli, opencode, codex, claude-code, csa, weave",
+                "Unknown tool '{}' in step {} ('{}'). Known: bash, note, manual, await-user, opencode, codex, claude-code, csa, weave",
                 other,
                 step.id,
                 step.title
@@ -201,7 +203,7 @@ fn is_deterministic_step_tool(explicit_tool: Option<&str>) -> bool {
 
 fn parse_tool_name(tool: &str) -> Result<ToolName> {
     match tool {
-        "gemini-cli" => Ok(ToolName::GeminiCli),
+        "gemini-cli" | "gemini" => bail!("{}", csa_core::types::removed_tool_error("gemini-cli")),
         "opencode" => Ok(ToolName::Opencode),
         "codex" => Ok(ToolName::Codex),
         "claude-code" => Ok(ToolName::ClaudeCode),

--- a/crates/cli-sub-agent/src/plan_cmd_tests_manual_handoff.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_manual_handoff.rs
@@ -1,6 +1,6 @@
 use super::*;
+use crate::test_env_lock::{TEST_ENV_LOCK, isolate_user_config};
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::{Arc, Barrier};
 use weave::compiler::{ExecutionPlan, FailAction, PlanStep, plan_from_toml};
 
@@ -175,6 +175,8 @@ async fn execute_plan_stops_after_manual_handoff() {
 #[tokio::test]
 async fn handle_plan_run_complete_manual_step_continues_after_pending_handoff() {
     let tmp = tempfile::tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let _user_config_env = isolate_user_config(tmp.path());
     let workflow_path = write_manual_handoff_workflow(tmp.path());
 
     handle_plan_run(plan_run_args(tmp.path(), &workflow_path))
@@ -217,6 +219,8 @@ async fn handle_plan_run_complete_manual_step_continues_after_pending_handoff() 
 #[tokio::test]
 async fn handle_plan_run_concurrent_complete_manual_step_runs_post_manual_steps_once() {
     let tmp = tempfile::tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let _user_config_env = isolate_user_config(tmp.path());
     let workflow_path = write_manual_handoff_append_workflow(tmp.path());
 
     handle_plan_run(plan_run_args(tmp.path(), &workflow_path))
@@ -284,6 +288,8 @@ async fn handle_plan_run_concurrent_complete_manual_step_runs_post_manual_steps_
 #[tokio::test]
 async fn handle_plan_run_complete_manual_step_accepts_zero_step_id() {
     let tmp = tempfile::tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let _user_config_env = isolate_user_config(tmp.path());
     let workflow_path = write_manual_handoff_workflow_with_manual_step_id(tmp.path(), 0);
 
     handle_plan_run(plan_run_args(tmp.path(), &workflow_path))
@@ -314,6 +320,8 @@ async fn handle_plan_run_complete_manual_step_accepts_zero_step_id() {
 #[tokio::test]
 async fn complete_manual_step_rejects_non_pending_step_id() {
     let tmp = tempfile::tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let _user_config_env = isolate_user_config(tmp.path());
     let workflow_path = write_manual_handoff_workflow(tmp.path());
     let plan = plan_from_toml(&std::fs::read_to_string(&workflow_path).unwrap()).unwrap();
 

--- a/crates/cli-sub-agent/src/review_cmd_execute_issue2409_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_issue2409_tests.rs
@@ -35,7 +35,7 @@ fn issue_2409_review_tier_filters_codex_o3_before_candidate_selection() {
     let config = config_with_review_tier(
         &["codex", "claude-code"],
         &[
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "opencode/openai/gpt-5/xhigh",
             "codex/openai/o3/medium",
             "claude-code/anthropic/claude-sonnet-4-20250514/none",
         ],
@@ -86,7 +86,7 @@ fn issue_2409_review_tier_filters_codex_o3_before_candidate_selection() {
         &[],
     );
     assert_eq!(chain.len(), 2);
-    assert_eq!(chain[0].tool, "gemini-cli");
+    assert_eq!(chain[0].tool, "opencode");
     assert_eq!(chain[0].skip_reason, "disabled");
     assert_eq!(chain[1].tool, "codex");
     assert_eq!(
@@ -103,10 +103,7 @@ fn issue_2409_review_tier_without_compatible_model_errors_before_provider_select
         ScopedTestEnvVar::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
     let config = config_with_review_tier(
         &["codex"],
-        &[
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-            "codex/openai/o3/medium",
-        ],
+        &["opencode/openai/gpt-5/xhigh", "codex/openai/o3/medium"],
     );
     let global = GlobalConfig::default();
 
@@ -125,7 +122,7 @@ fn issue_2409_review_tier_without_compatible_model_errors_before_provider_select
     let message = err.to_string();
     assert!(message.contains("none of its tools are currently available"));
     assert!(
-        message.contains("gemini-cli/google/gemini-3.1-pro-preview/xhigh=disabled"),
+        message.contains("opencode/openai/gpt-5/xhigh=disabled"),
         "{message}"
     );
     assert!(

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_1958_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_1958_tests.rs
@@ -129,7 +129,7 @@ async fn execute_review_falls_back_from_gemini_status_400_to_codex() {
         .expect("result fallback_chain");
     assert_eq!(fallback_chain.len(), 1);
     assert_eq!(fallback_chain[0].tool, "gemini-cli");
-    assert_eq!(fallback_chain[0].skip_reason, "attempted-and-errored");
+    assert_eq!(fallback_chain[0].skip_reason, "malformed-spec");
     assert!(!fallback_chain[0].quota_exhausted);
 }
 
@@ -236,8 +236,8 @@ async fn execute_review_falls_back_from_gemini_quota_exhausted_to_codex() {
         fallback_chain[0].model_spec.as_deref(),
         Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh")
     );
-    assert_eq!(fallback_chain[0].skip_reason, "oauth-quota");
-    assert!(fallback_chain[0].quota_exhausted);
+    assert_eq!(fallback_chain[0].skip_reason, "malformed-spec");
+    assert!(!fallback_chain[0].quota_exhausted);
 }
 
 #[cfg(unix)]
@@ -362,7 +362,7 @@ async fn execute_review_falls_back_from_gemini_status_400_transport_error_to_cod
         fallback_chain[0].model_spec.as_deref(),
         Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh")
     );
-    assert_eq!(fallback_chain[0].skip_reason, "attempted-and-errored");
+    assert_eq!(fallback_chain[0].skip_reason, "malformed-spec");
     assert!(!fallback_chain[0].quota_exhausted);
 
     let gemini_sessions = csa_session::list_sessions(project_dir.path(), Some(&["gemini-cli"]))

--- a/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_tier_tests.rs
@@ -266,7 +266,7 @@ async fn execute_review_falls_back_to_next_tier_model_and_persists_routing_metad
 
 #[cfg(unix)]
 #[tokio::test]
-async fn execute_review_falls_back_from_gemini_manual_auth_to_codex_and_persists_routing_chain() {
+async fn execute_review_skips_removed_gemini_spec_to_codex_and_persists_routing_chain() {
     use std::os::unix::fs::PermissionsExt;
 
     if which::which("bwrap").is_err() {
@@ -320,7 +320,7 @@ async fn execute_review_falls_back_from_gemini_manual_auth_to_codex_and_persists
         Some("quality".to_string()),
         true,
         None,
-        "review: manual-auth-tier-fallback-success".to_string(),
+        "review: removed-gemini-tier-fallback-success".to_string(),
         project_dir.path(),
         Some(&config),
         &global,
@@ -342,7 +342,7 @@ async fn execute_review_falls_back_from_gemini_manual_auth_to_codex_and_persists
         Some(false),
     )
     .await
-    .expect("manual-auth tier fallback should succeed");
+    .expect("removed gemini tier fallback should reach codex");
 
     assert_eq!(result.executed_tool, ToolName::Codex);
     assert_eq!(
@@ -364,7 +364,7 @@ async fn execute_review_falls_back_from_gemini_manual_auth_to_codex_and_persists
     assert_eq!(persisted.fallback_tool.as_deref(), Some("codex"));
     assert!(
         persisted.fallback_reason.is_none(),
-        "legacy fallback_reason stays quota-only; auth provenance lives in fallback_chain"
+        "legacy fallback_reason stays quota-only; removed-spec provenance lives in fallback_chain"
     );
     let fallback_chain = persisted
         .fallback_chain
@@ -376,7 +376,7 @@ async fn execute_review_falls_back_from_gemini_manual_auth_to_codex_and_persists
         fallback_chain[0].model_spec.as_deref(),
         Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh")
     );
-    assert_eq!(fallback_chain[0].skip_reason, "auth_unavailable");
+    assert_eq!(fallback_chain[0].skip_reason, "malformed-spec");
     assert!(!fallback_chain[0].quota_exhausted);
 
     let routing_json =
@@ -388,7 +388,7 @@ async fn execute_review_falls_back_from_gemini_manual_auth_to_codex_and_persists
         .expect("routing fallback_chain array");
     assert_eq!(routing_chain.len(), 1);
     assert_eq!(routing_chain[0]["tool"], "gemini-cli");
-    assert_eq!(routing_chain[0]["skip_reason"], "auth_unavailable");
+    assert_eq!(routing_chain[0]["skip_reason"], "malformed-spec");
     assert_eq!(routing_chain[0]["quota_exhausted"], false);
 }
 
@@ -649,7 +649,7 @@ async fn execute_review_marks_unavailable_when_all_tier_models_fail() {
 
 #[cfg(unix)]
 #[tokio::test]
-async fn execute_review_manual_auth_then_codex_unavailable_stays_unavailable() {
+async fn execute_review_removed_gemini_then_codex_unavailable_stays_unavailable() {
     use std::os::unix::fs::PermissionsExt;
 
     if which::which("bwrap").is_err() {
@@ -705,7 +705,7 @@ async fn execute_review_manual_auth_then_codex_unavailable_stays_unavailable() {
         Some("quality".to_string()),
         true,
         None,
-        "review: manual-auth-tier-all-failed".to_string(),
+        "review: removed-gemini-tier-all-failed".to_string(),
         project_dir.path(),
         Some(&config),
         &global,
@@ -738,12 +738,8 @@ async fn execute_review_manual_auth_then_codex_unavailable_stays_unavailable() {
     assert!(result.routed_to.is_none());
     assert_ne!(result.execution.execution.exit_code, 0);
     let primary_failure = result.primary_failure.as_deref().expect("primary_failure");
-    assert!(primary_failure.contains("auth_unavailable"));
     assert!(primary_failure.contains("HTTP 401"));
     let failure_reason = result.failure_reason.as_deref().expect("failure_reason");
-    assert!(
-        failure_reason.contains("gemini-cli/google/gemini-3.1-pro-preview/xhigh=auth_unavailable")
-    );
     assert!(failure_reason.contains("codex/openai/gpt-5.4/high=HTTP 401"));
 
     let session_dir =
@@ -758,7 +754,7 @@ async fn execute_review_manual_auth_then_codex_unavailable_stays_unavailable() {
         .expect("routing fallback_chain array");
     assert_eq!(routing_chain.len(), 2);
     assert_eq!(routing_chain[0]["tool"], "gemini-cli");
-    assert_eq!(routing_chain[0]["skip_reason"], "auth_unavailable");
+    assert_eq!(routing_chain[0]["skip_reason"], "malformed-spec");
     assert_eq!(routing_chain[0]["quota_exhausted"], false);
     assert_eq!(routing_chain[1]["tool"], "codex");
     assert_eq!(routing_chain[1]["skip_reason"], "attempted-and-errored");

--- a/crates/cli-sub-agent/src/review_cmd_output_diagnostics.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_diagnostics.rs
@@ -37,7 +37,7 @@ pub(in crate::review_cmd) fn print_reviewer_outcomes(outcomes: &[ReviewerOutcome
 }
 
 /// Detect known tool-level diagnostic messages that indicate the review tool
-/// failed to actually perform a review (e.g., gemini-cli MCP connectivity issues).
+/// failed to actually perform a review.
 ///
 /// Checks both stdout and stderr for known failure patterns.
 /// Returns a human-readable diagnostic summary when a known pattern is found.
@@ -55,15 +55,15 @@ pub(crate) fn detect_tool_diagnostic(stdout: &str, stderr: &str) -> Option<Strin
 
     if has_quota_issue(stdout) || has_quota_issue(stderr) {
         return Some(
-            "gemini-cli OAuth quota exhausted. Either (a) configure GEMINI_API_KEY in ~/.config/cli-sub-agent/config.toml under [tools.gemini-cli] api_key for automatic retry, or (b) wait for quota reset."
+            "Review provider quota exhausted. Configure a supported provider API key, select a different supported review tool, or wait for quota reset."
                 .to_string(),
         );
     }
 
     if has_mcp_issue(stdout) || has_mcp_issue(stderr) {
         return Some(
-            "gemini-cli MCP init degraded. \
-             Retry with `--force-ignore-tier-setting` + a different `--tool`, \
+            "Review tool MCP init degraded. \
+             Retry with `--force-ignore-tier-setting` + a supported `--tool`, \
              or run `csa doctor` to diagnose unhealthy MCP servers."
                 .to_string(),
         );

--- a/crates/cli-sub-agent/src/review_cmd_output_text.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_text.rs
@@ -180,7 +180,7 @@ const STREAM_START_EVENT_TYPES: &[&str] = &["system", "thread.started", "turn.st
 
 /// Event types that positively identify a JSON streaming transcript (claude-code / codex).
 /// Used to keep [`stream_started_without_terminal_event`] from misclassifying non-streaming
-/// output (gemini-cli / opencode plain text, rate-limit event blobs) as an incomplete stream.
+/// output (plain text or rate-limit event blobs) as an incomplete stream.
 const STREAM_EVENT_TYPES: &[&str] = &[
     // claude-code stream-json
     "system",
@@ -206,7 +206,7 @@ const STREAM_EVENT_TYPES: &[&str] = &[
 /// exit code before reclassifying the reviewer as unavailable.
 ///
 /// Conservative by construction: returns `false` unless the output is *recognized* as a
-/// claude-code/codex JSON stream (so plain-text gemini-cli/opencode output is never flagged),
+/// claude-code/codex JSON stream (so plain-text tool output is never flagged),
 /// and `false` as soon as any terminal event is seen (so a completed reviewer that merely
 /// exits non-zero is never flagged).
 pub(in crate::review_cmd) fn stream_started_without_terminal_event(raw_output: &str) -> bool {

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -205,7 +205,7 @@ fn resolve_review_tool_from_selection(
     if let Some(tool_name) = selection.as_single() {
         let tool = crate::run_helpers::parse_tool_name(tool_name).map_err(|_| {
             anyhow::anyhow!(
-                "Invalid [review].tool value '{tool_name}'. Supported values: auto, gemini-cli, opencode, codex, claude-code."
+                "Invalid [review].tool value '{tool_name}'. Supported values: auto, opencode, codex, claude-code."
             )
         })?;
         // Verify the tool is enabled in the project config
@@ -256,7 +256,7 @@ fn select_auto_review_tool(
     let parent_str = parent_tool?;
     let parent_tool_name = crate::run_helpers::parse_tool_name(parent_str).ok()?;
     let enabled_tools: Vec<_> = if let Some(cfg) = project_config {
-        let tools: Vec<_> = csa_config::global::all_known_tools()
+        let tools: Vec<_> = csa_config::global::routing_candidate_tools()
             .iter()
             .filter(|t| cfg.is_tool_auto_selectable(t.as_str()))
             .filter(|t| {
@@ -267,7 +267,7 @@ fn select_auto_review_tool(
             .collect();
         csa_config::global::sort_tools_by_effective_priority(&tools, project_config, global_config)
     } else {
-        let all = csa_config::global::all_known_tools();
+        let all = csa_config::global::routing_candidate_tools();
         let tools: Vec<_> = all
             .iter()
             .filter(|t| {
@@ -300,10 +300,10 @@ Supported auto mapping: claude-code <-> codex\n\n\
 Choose one:\n\
 1) Global config (user-level): {global_path}\n\
    [review]\n\
-   tool = \"codex\"  # or \"claude-code\", \"opencode\", \"gemini-cli\"\n\
+   tool = \"codex\"  # or \"claude-code\", \"opencode\"\n\
 2) Project config override: {project_path}\n\
    [review]\n\
-   tool = \"codex\"  # or \"claude-code\", \"opencode\", \"gemini-cli\"\n\
+   tool = \"codex\"  # or \"claude-code\", \"opencode\"\n\
 3) CLI override: csa review --sa-mode <true|false> --tool codex\n\n\
 Reason: CSA enforces heterogeneity in auto mode and will not fall back."
     )

--- a/crates/cli-sub-agent/src/review_cmd_reviewers_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers_tests.rs
@@ -160,7 +160,7 @@ fn auto_reviewer_selection_uses_all_distinct_tier_tools_up_to_cap() {
     let (_env_lock, _available_guard) = assume_review_tools_available();
     let config = project_config_with_tier(&[
         "codex/openai/gpt-5.4/high",
-        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        "opencode/openai/gpt-5/xhigh",
         "opencode/anthropic/claude-sonnet-4-6/high",
         "claude-code/anthropic/sonnet/xhigh",
     ]);
@@ -176,7 +176,7 @@ fn auto_reviewer_selection_uses_all_distinct_tier_tools_up_to_cap() {
         large_diff_auto_escalation: false,
         explicit_tool: None,
         explicit_model_spec: None,
-        primary_tool: ToolName::GeminiCli,
+        primary_tool: ToolName::Opencode,
         resolved_tier_name: Some("quality"),
         config: Some(&config),
         global_config: &global,
@@ -186,7 +186,7 @@ fn auto_reviewer_selection_uses_all_distinct_tier_tools_up_to_cap() {
     assert_eq!(selection.reviewers, 3);
     assert_eq!(
         selection.selected_tools,
-        vec![ToolName::GeminiCli, ToolName::Codex, ToolName::Opencode]
+        vec![ToolName::Opencode, ToolName::Codex, ToolName::ClaudeCode]
     );
     assert_eq!(distinct_model_family_count(&selection.selected_tools), 3);
 }
@@ -194,10 +194,8 @@ fn auto_reviewer_selection_uses_all_distinct_tier_tools_up_to_cap() {
 #[test]
 fn large_diff_auto_escalation_selects_heterogeneous_reviewers_for_non_range_scope() {
     let (_env_lock, _available_guard) = assume_review_tools_available();
-    let config = project_config_with_tier(&[
-        "codex/openai/gpt-5.4/high",
-        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-    ]);
+    let config =
+        project_config_with_tier(&["codex/openai/gpt-5.4/high", "opencode/openai/gpt-5/xhigh"]);
     let global = GlobalConfig::default();
 
     let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
@@ -221,16 +219,14 @@ fn large_diff_auto_escalation_selects_heterogeneous_reviewers_for_non_range_scop
     assert!(distinct_model_family_count(&selection.selected_tools) >= 2);
     assert_eq!(
         selection.selected_tools,
-        vec![ToolName::Codex, ToolName::GeminiCli]
+        vec![ToolName::Codex, ToolName::Opencode]
     );
 }
 
 fn assert_large_diff_auto_escalation_stays_single_reviewer(fix: bool, session_present: bool) {
     let (_env_lock, _available_guard) = assume_review_tools_available();
-    let config = project_config_with_tier(&[
-        "codex/openai/gpt-5.4/high",
-        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-    ]);
+    let config =
+        project_config_with_tier(&["codex/openai/gpt-5.4/high", "opencode/openai/gpt-5/xhigh"]);
     let global = GlobalConfig::default();
 
     let selection = resolve_effective_reviewer_selection(&AutoReviewerRequest {
@@ -267,10 +263,7 @@ fn large_diff_auto_escalation_keeps_session_on_single_reviewer_path() {
 fn auto_range_reviewer_roster_prefers_review_tool_without_filtering_tier() {
     let (_env_lock, _available_guard) = assume_review_tools_available();
     let config = project_config_with_tier_and_review_tool(
-        &[
-            "codex/openai/gpt-5.4/high",
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-        ],
+        &["codex/openai/gpt-5.4/high", "opencode/openai/gpt-5/xhigh"],
         ToolSelection::Whitelist(vec!["codex".to_string()]),
     );
     let global = GlobalConfig::default();
@@ -288,20 +281,20 @@ fn auto_range_reviewer_roster_prefers_review_tool_without_filtering_tier() {
 
     assert_eq!(
         pool.reviewer_tools,
-        vec![ToolName::Codex, ToolName::GeminiCli]
+        vec![ToolName::Codex, ToolName::Opencode]
     );
     assert!(
         pool.tier_reviewer_specs
             .iter()
-            .any(|resolution| resolution.tool == ToolName::GeminiCli)
+            .any(|resolution| resolution.tool == ToolName::Opencode)
     );
 }
 
 fn assert_auto_execution_uses_selected_heterogeneous_roster(large_diff_auto_escalation: bool) {
     let (_env_lock, _available_guard) = assume_review_tools_available();
     let config = project_config_with_tier(&[
-        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-        "antigravity-cli/google/gemini-3.1-pro-preview/xhigh",
+        "opencode/openai/gpt-5/xhigh",
+        "openai-compat/openai/gpt-5/xhigh",
         "codex/openai/gpt-5.4/high",
     ]);
     let global = GlobalConfig::default();
@@ -315,7 +308,7 @@ fn assert_auto_execution_uses_selected_heterogeneous_roster(large_diff_auto_esca
         large_diff_auto_escalation,
         explicit_tool: None,
         explicit_model_spec: None,
-        primary_tool: ToolName::GeminiCli,
+        primary_tool: ToolName::Opencode,
         resolved_tier_name: Some("quality"),
         config: Some(&config),
         global_config: &global,
@@ -328,18 +321,18 @@ fn assert_auto_execution_uses_selected_heterogeneous_roster(large_diff_auto_esca
         effective.reviewers,
         Some(&selected_tools),
         None,
-        ToolName::GeminiCli,
+        ToolName::Opencode,
         Some("quality"),
         Some(&config),
         &global,
     )
     .expect("auto-selected reviewer roster should resolve for execution");
-    let same_family_pair = [ToolName::GeminiCli, ToolName::AntigravityCli];
+    let same_family_pair = [ToolName::Opencode, ToolName::OpenaiCompat];
     assert_eq!(pool.reviewer_tools, selected_tools);
     assert!(distinct_model_family_count(&pool.reviewer_tools) >= 2);
     assert_eq!(
         &pool.reviewer_tools[..2],
-        [ToolName::GeminiCli, ToolName::Codex].as_slice()
+        [ToolName::Opencode, ToolName::Codex].as_slice()
     );
     assert_ne!(&pool.reviewer_tools[..2], same_family_pair.as_slice());
 }
@@ -353,10 +346,8 @@ fn auto_execution_uses_selected_heterogeneous_reviewer_roster_for_range_and_larg
 #[test]
 fn auto_reviewer_selection_respects_single_flag() {
     let (_env_lock, _available_guard) = assume_review_tools_available();
-    let config = project_config_with_tier(&[
-        "codex/openai/gpt-5.4/high",
-        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-    ]);
+    let config =
+        project_config_with_tier(&["codex/openai/gpt-5.4/high", "opencode/openai/gpt-5/xhigh"]);
     let global = GlobalConfig::default();
 
     let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
@@ -381,10 +372,8 @@ fn auto_reviewer_selection_respects_single_flag() {
 #[test]
 fn auto_reviewer_selection_respects_explicit_reviewer_override() {
     let (_env_lock, _available_guard) = assume_review_tools_available();
-    let config = project_config_with_tier(&[
-        "codex/openai/gpt-5.4/high",
-        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-    ]);
+    let config =
+        project_config_with_tier(&["codex/openai/gpt-5.4/high", "opencode/openai/gpt-5/xhigh"]);
     let global = GlobalConfig::default();
 
     let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
@@ -411,7 +400,7 @@ fn large_diff_auto_escalation_respects_explicit_reviewer_count() {
     let (_env_lock, _available_guard) = assume_review_tools_available();
     let config = project_config_with_tier(&[
         "codex/openai/gpt-5.4/high",
-        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+        "opencode/openai/gpt-5/xhigh",
         "opencode/anthropic/claude-sonnet-4-6/high",
     ]);
     let global = GlobalConfig::default();
@@ -439,10 +428,8 @@ fn large_diff_auto_escalation_respects_explicit_reviewer_count() {
 #[test]
 fn auto_reviewer_selection_respects_explicit_model_spec_override() {
     let (_env_lock, _available_guard) = assume_review_tools_available();
-    let config = project_config_with_tier(&[
-        "codex/openai/gpt-5.4/high",
-        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-    ]);
+    let config =
+        project_config_with_tier(&["codex/openai/gpt-5.4/high", "opencode/openai/gpt-5/xhigh"]);
     let global = GlobalConfig::default();
 
     let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
@@ -454,7 +441,7 @@ fn auto_reviewer_selection_respects_explicit_model_spec_override() {
         scope_is_range: true,
         large_diff_auto_escalation: true,
         explicit_tool: None,
-        explicit_model_spec: Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh"),
+        explicit_model_spec: Some("opencode/openai/gpt-5/xhigh"),
         primary_tool: ToolName::Codex,
         resolved_tier_name: Some("quality"),
         config: Some(&config),
@@ -467,10 +454,8 @@ fn auto_reviewer_selection_respects_explicit_model_spec_override() {
 #[test]
 fn auto_reviewer_selection_respects_explicit_tool_override() {
     let (_env_lock, _available_guard) = assume_review_tools_available();
-    let config = project_config_with_tier(&[
-        "codex/openai/gpt-5.4/high",
-        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-    ]);
+    let config =
+        project_config_with_tier(&["codex/openai/gpt-5.4/high", "opencode/openai/gpt-5/xhigh"]);
     let global = GlobalConfig::default();
 
     let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {
@@ -496,8 +481,8 @@ fn auto_reviewer_selection_respects_explicit_tool_override() {
 fn large_diff_auto_escalation_requires_two_model_families() {
     let (_env_lock, _available_guard) = assume_review_tools_available();
     let config = project_config_with_tier(&[
-        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-        "antigravity-cli/google/gemini-3.1-pro-preview/xhigh",
+        "opencode/openai/gpt-5/xhigh",
+        "openai-compat/openai/gpt-5/xhigh",
     ]);
     let global = GlobalConfig::default();
 
@@ -511,7 +496,7 @@ fn large_diff_auto_escalation_requires_two_model_families() {
         large_diff_auto_escalation: true,
         explicit_tool: None,
         explicit_model_spec: None,
-        primary_tool: ToolName::GeminiCli,
+        primary_tool: ToolName::Opencode,
         resolved_tier_name: Some("quality"),
         config: Some(&config),
         global_config: &global,
@@ -523,10 +508,8 @@ fn large_diff_auto_escalation_requires_two_model_families() {
 #[test]
 fn auto_reviewer_selection_skips_non_range_scope() {
     let (_env_lock, _available_guard) = assume_review_tools_available();
-    let config = project_config_with_tier(&[
-        "codex/openai/gpt-5.4/high",
-        "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-    ]);
+    let config =
+        project_config_with_tier(&["codex/openai/gpt-5.4/high", "opencode/openai/gpt-5/xhigh"]);
     let global = GlobalConfig::default();
 
     let selection = resolve_auto_reviewer_selection(&AutoReviewerRequest {

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -214,7 +214,7 @@ fn build_post_review_output_preserves_existing_directive_without_duplication() {
 #[test]
 fn resolve_review_tool_prefers_cli_override() {
     let global = GlobalConfig::default();
-    let cfg = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    let cfg = project_config_with_enabled_tools(&["opencode", "codex"]);
     let tool = resolve_review_tool(
         Some(ToolName::Codex),
         None,
@@ -234,8 +234,8 @@ fn resolve_review_tool_prefers_cli_override() {
 fn resolve_review_tool_global_auto_prefers_first_heterogeneous_tool() {
     let (_env_lock, _available_guard) = assume_review_tools_available();
     let global = GlobalConfig::default();
-    // Parent=claude-code; first heterogeneous default is gemini-cli.
-    let cfg = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    // Parent=claude-code; supported heterogeneous default follows routing priority.
+    let cfg = project_config_with_enabled_tools(&["codex", "opencode"]);
     let tool = resolve_review_tool(
         None,
         None,
@@ -248,15 +248,15 @@ fn resolve_review_tool_global_auto_prefers_first_heterogeneous_tool() {
         false, // force_ignore_tier_setting
     )
     .unwrap();
-    assert!(matches!(tool.0, ToolName::GeminiCli));
+    assert!(matches!(tool.0, ToolName::Opencode));
 }
 
 #[test]
 fn resolve_review_tool_global_auto_succeeds_with_single_heterogeneous_tool() {
     let (_env_lock, _available_guard) = assume_review_tools_available();
     let global = GlobalConfig::default();
-    // Only gemini-cli enabled — auto-selection should still succeed.
-    let cfg = project_config_with_enabled_tools(&["gemini-cli"]);
+    // Only codex enabled — auto-selection should still succeed from a Claude parent.
+    let cfg = project_config_with_enabled_tools(&["codex"]);
     let tool = resolve_review_tool(
         None,
         None,
@@ -269,7 +269,7 @@ fn resolve_review_tool_global_auto_succeeds_with_single_heterogeneous_tool() {
         false, // force_ignore_tier_setting
     )
     .unwrap();
-    assert!(matches!(tool.0, ToolName::GeminiCli));
+    assert!(matches!(tool.0, ToolName::Codex));
 }
 
 #[test]
@@ -298,7 +298,7 @@ fn resolve_review_tool_errors_without_parent_tool_context() {
 fn resolve_review_tool_errors_on_invalid_explicit_global_tool() {
     let mut global = GlobalConfig::default();
     global.review.tool = csa_config::ToolSelection::Single("invalid-tool".to_string());
-    let cfg = project_config_with_enabled_tools(&["gemini-cli"]);
+    let cfg = project_config_with_enabled_tools(&["codex"]);
     let err = resolve_review_tool(
         None,
         None,
@@ -702,8 +702,8 @@ fn review_cli_parses_allow_fallback_flag() {
 
 #[test]
 fn review_explicit_tool_keeps_failover_enabled_by_default() {
-    let args = parse_review_args(&["csa", "review", "--diff", "--tool", "gemini-cli"]);
-    assert_eq!(args.tool, Some(ToolName::GeminiCli));
+    let args = parse_review_args(&["csa", "review", "--diff", "--tool", "codex"]);
+    assert_eq!(args.tool, Some(ToolName::Codex));
     assert!(!args.no_failover);
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_daemon_pre_exec.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_daemon_pre_exec.rs
@@ -23,12 +23,12 @@ fn install_pattern(project_root: &Path, name: &str) {
 async fn daemon_direct_tool_tier_rejection_persists_pre_exec_result_before_completion() {
     let project_dir = tempfile::tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
-    let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    let mut config = project_config_with_enabled_tools(&["opencode", "codex"]);
     config.tiers.insert(
         "default".to_string(),
         csa_config::config::TierConfig {
             description: "Test tier".to_string(),
-            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            models: vec!["opencode/openai/gpt-5/xhigh".to_string()],
             strategy: csa_config::TierStrategy::default(),
             token_budget: None,
             max_turns: None,

--- a/crates/cli-sub-agent/src/review_cmd_tests_explicit_tool_tier_fallback.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_explicit_tool_tier_fallback.rs
@@ -8,7 +8,7 @@ async fn tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier
         crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV,
         "1",
     );
-    let mut config = project_config_with_enabled_tools(&["codex", "gemini-cli"]);
+    let mut config = project_config_with_enabled_tools(&["codex", "opencode"]);
     config.tools.get_mut("codex").unwrap().transport = Some(csa_config::TransportKind::Cli);
     config.tiers.insert(
         "quality".to_string(),
@@ -17,7 +17,7 @@ async fn tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier
             models: vec![
                 "codex/openai/gpt-5.4/medium".to_string(),
                 "codex/openai/gpt-5/high".to_string(),
-                "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
+                "opencode/openai/gpt-5/xhigh".to_string(),
             ],
             strategy: csa_config::TierStrategy::default(),
             token_budget: None,
@@ -46,8 +46,8 @@ async fn tier_fallback_advances_across_tool_variants_when_explicit_tool_and_tier
                 Some("codex/openai/gpt-5/high".to_string()),
             ),
             (
-                csa_core::types::ToolName::GeminiCli,
-                Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string()),
+                csa_core::types::ToolName::Opencode,
+                Some("opencode/openai/gpt-5/xhigh".to_string()),
             ),
         ]
     );

--- a/crates/cli-sub-agent/src/review_cmd_tests_session_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_session_fix.rs
@@ -113,13 +113,13 @@ fn write_session_result(project_root: &Path, session_id: &str, tool: &str) {
 }
 
 fn review_config_with_quality_tier() -> ProjectConfig {
-    let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    let mut config = project_config_with_enabled_tools(&["opencode", "codex"]);
     config.tiers.insert(
         "quality".to_string(),
         csa_config::config::TierConfig {
             description: "Test quality tier".to_string(),
             models: vec![
-                "gemini-cli/google/default/xhigh".to_string(),
+                "opencode/openai/gpt-5/xhigh".to_string(),
                 "codex/openai/gpt-5.5/xhigh".to_string(),
             ],
             strategy: TierStrategy::default(),
@@ -135,12 +135,12 @@ fn review_config_with_quality_tier() -> ProjectConfig {
 }
 
 fn review_config_with_gemini_only_quality_tier() -> ProjectConfig {
-    let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    let mut config = project_config_with_enabled_tools(&["opencode", "codex"]);
     config.tiers.insert(
         "quality".to_string(),
         csa_config::config::TierConfig {
             description: "Test quality tier".to_string(),
-            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            models: vec!["opencode/openai/gpt-5/xhigh".to_string()],
             strategy: TierStrategy::default(),
             token_budget: None,
             max_turns: None,
@@ -457,7 +457,7 @@ fn review_session_fix_rejects_explicit_tool_mismatch_before_child_session_creati
     let args = parse_session_fix_args(
         project_dir.path(),
         &source.meta_session_id,
-        &["--tool", "gemini-cli"],
+        &["--tool", "opencode"],
     );
 
     let err = validate_session_fix_before_daemon(&args)
@@ -469,7 +469,7 @@ fn review_session_fix_rejects_explicit_tool_mismatch_before_child_session_creati
         "unexpected error: {msg}"
     );
     assert!(
-        msg.contains("explicit --tool 'gemini-cli'"),
+        msg.contains("explicit --tool 'opencode'"),
         "unexpected error: {msg}"
     );
     let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -152,8 +152,8 @@ fn detect_tool_diagnostic_returns_quota_message_for_gemini_429() {
     let result = detect_tool_diagnostic("", stderr);
     assert!(result.is_some());
     let msg = result.unwrap();
-    assert!(msg.contains("OAuth quota exhausted"), "got: {msg}");
-    assert!(msg.contains("GEMINI_API_KEY"), "got: {msg}");
+    assert!(msg.contains("provider quota exhausted"), "got: {msg}");
+    assert!(msg.contains("supported provider API key"), "got: {msg}");
 }
 
 #[test]
@@ -162,7 +162,7 @@ fn detect_tool_diagnostic_prefers_quota_over_mcp_when_both_present() {
     let result = detect_tool_diagnostic("", stderr);
     assert!(result.is_some());
     let msg = result.unwrap();
-    assert!(msg.contains("OAuth quota exhausted"), "got: {msg}");
+    assert!(msg.contains("provider quota exhausted"), "got: {msg}");
     assert!(
         !msg.contains("Run `csa doctor`"),
         "should not emit MCP guidance when quota is root cause; got: {msg}"
@@ -814,12 +814,12 @@ async fn handle_review_fix_clean_initial_persists_no_fix_attempt() {
 async fn handle_review_rejects_direct_tool_tier_before_session_creation() {
     let project_dir = tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
-    let mut config = project_config_with_enabled_tools(&["gemini-cli", "codex"]);
+    let mut config = project_config_with_enabled_tools(&["opencode", "codex"]);
     config.tiers.insert(
         "default".to_string(),
         csa_config::config::TierConfig {
             description: "Test tier".to_string(),
-            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            models: vec!["opencode/openai/gpt-5/xhigh".to_string()],
             strategy: csa_config::TierStrategy::default(),
             token_budget: None,
             max_turns: None,

--- a/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
@@ -111,8 +111,8 @@ fn test_review_blocks_direct_tool_when_tiers_configured() {
     let global = GlobalConfig::default();
     let cfg = review_config_with_tier(
         "default",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     let result = resolve_review_tool(
         Some(ToolName::Codex),
@@ -147,8 +147,8 @@ fn test_review_allows_tier_flag() {
     let global = GlobalConfig::default();
     let cfg = review_config_with_tier(
         "quality",
-        vec!["gemini-cli/google/gemini-3.1-pro-preview/xhigh"],
-        &["gemini-cli"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode"],
     );
     let result = resolve_review_tool(
         None,
@@ -167,11 +167,8 @@ fn test_review_allows_tier_flag() {
         result.unwrap_err()
     );
     let (tool, model_spec) = result.unwrap();
-    assert_eq!(tool, ToolName::GeminiCli);
-    assert_eq!(
-        model_spec.as_deref(),
-        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh")
-    );
+    assert_eq!(tool, ToolName::Opencode);
+    assert_eq!(model_spec.as_deref(), Some("opencode/openai/gpt-5/xhigh"));
 }
 
 #[test]
@@ -179,8 +176,8 @@ fn test_review_legacy_tier_4_hard_selector_suggests_critical_tier() {
     let global = GlobalConfig::default();
     let cfg = review_config_with_tier(
         "tier-4-critical",
-        vec!["gemini-cli/google/gemini-3.1-pro-preview/xhigh"],
-        &["gemini-cli"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode"],
     );
 
     let err = resolve_review_tier_name(Some(&cfg), &global, Some("tier-4-hard"), false, false)
@@ -203,11 +200,11 @@ fn test_review_tool_plus_tier_resolves_requested_tool_from_tier() {
     let cfg = review_config_with_tier(
         "quality",
         vec![
-            "gemini-cli/google/default/xhigh",
+            "opencode/openai/gpt-5/xhigh",
             "codex/openai/gpt-5.4/high",
             "claude-code/anthropic/sonnet-4.6/xhigh",
         ],
-        &["gemini-cli", "codex", "claude-code"],
+        &["opencode", "codex", "claude-code"],
     );
     let result = resolve_review_tool(
         Some(ToolName::Codex),
@@ -237,11 +234,8 @@ fn test_review_tool_plus_tier_force_override_resolves_disabled_requested_tool() 
     let global = GlobalConfig::default();
     let cfg = review_config_with_tier(
         "quality",
-        vec![
-            "gemini-cli/google/default/xhigh",
-            "codex/openai/gpt-5.4/high",
-        ],
-        &["gemini-cli"],
+        vec!["opencode/openai/gpt-5/xhigh", "codex/openai/gpt-5.4/high"],
+        &["opencode"],
     );
     let selection = resolve_review_selection(
         Some(ToolName::Codex),
@@ -271,14 +265,11 @@ fn test_review_tool_plus_tier_keeps_full_tier_failover_chain() {
     let global = GlobalConfig::default();
     let cfg = review_config_with_tier(
         "quality",
-        vec![
-            "gemini-cli/google/default/xhigh",
-            "codex/openai/gpt-5.4/high",
-        ],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh", "codex/openai/gpt-5.4/high"],
+        &["opencode", "codex"],
     );
     let selection = resolve_review_selection(
-        Some(ToolName::GeminiCli),
+        Some(ToolName::Opencode),
         None,
         Some(&cfg),
         &global,
@@ -291,14 +282,14 @@ fn test_review_tool_plus_tier_keeps_full_tier_failover_chain() {
     )
     .expect("tool+tier should resolve requested review tool");
 
-    assert_eq!(selection.tool, ToolName::GeminiCli);
+    assert_eq!(selection.tool, ToolName::Opencode);
     assert_eq!(
         selection.model_spec.as_deref(),
-        Some("gemini-cli/google/default/xhigh")
+        Some("opencode/openai/gpt-5/xhigh")
     );
     assert_eq!(
         selection.tier_preference_order,
-        vec!["gemini-cli"],
+        vec!["opencode"],
         "explicit review --tool chooses the first attempt but must not whitelist away tier fallback"
     );
 }
@@ -309,8 +300,8 @@ fn test_review_tool_plus_tier_rejects_tool_missing_from_tier() {
     let global = GlobalConfig::default();
     let cfg = review_config_with_tier(
         "quality",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     // Since #1994, non-candidate --tool pins fail fast instead of selecting another tier tool.
     let err = resolve_review_tool(
@@ -338,8 +329,8 @@ fn test_review_tier_preference_mismatch_uses_full_tier() {
     let global = GlobalConfig::default();
     let cfg = review_config_with_whitelist(
         "quality",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
         &["codex"],
     );
     let result = resolve_review_tool(
@@ -355,11 +346,8 @@ fn test_review_tier_preference_mismatch_uses_full_tier() {
     );
 
     let (tool, model_spec) = result.expect("absent preferred tool should not hard-fail");
-    assert_eq!(tool, ToolName::GeminiCli);
-    assert_eq!(
-        model_spec.as_deref(),
-        Some("gemini-cli/google/default/xhigh")
-    );
+    assert_eq!(tool, ToolName::Opencode);
+    assert_eq!(model_spec.as_deref(), Some("opencode/openai/gpt-5/xhigh"));
 }
 
 #[test]
@@ -367,8 +355,8 @@ fn test_review_force_ignore_tier_allows_direct_tool() {
     let global = GlobalConfig::default();
     let cfg = review_config_with_tier(
         "default",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     let result = resolve_review_tool(
         Some(ToolName::Codex),
@@ -395,11 +383,8 @@ fn test_review_tool_plus_tier_and_force_ignore_errors_on_conflict() {
     let global = GlobalConfig::default();
     let cfg = review_config_with_tier(
         "quality",
-        vec![
-            "gemini-cli/google/default/xhigh",
-            "codex/openai/gpt-5.4/xhigh",
-        ],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh", "codex/openai/gpt-5.4/xhigh"],
+        &["opencode", "codex"],
     );
     let result = resolve_review_tool(
         Some(ToolName::Codex),
@@ -455,8 +440,8 @@ fn test_review_tier_alias_resolves() {
     let global = GlobalConfig::default();
     let mut cfg = review_config_with_tier(
         "quality",
-        vec!["gemini-cli/google/gemini-3.1-pro-preview/xhigh"],
-        &["gemini-cli"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode"],
     );
     cfg.tier_mapping
         .insert("code_review".to_string(), "quality".to_string());
@@ -478,9 +463,6 @@ fn test_review_tier_alias_resolves() {
         result.unwrap_err()
     );
     let (tool, model_spec) = result.unwrap();
-    assert_eq!(tool, ToolName::GeminiCli);
-    assert_eq!(
-        model_spec.as_deref(),
-        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh")
-    );
+    assert_eq!(tool, ToolName::Opencode);
+    assert_eq!(model_spec.as_deref(), Some("opencode/openai/gpt-5/xhigh"));
 }

--- a/crates/cli-sub-agent/src/review_consensus.rs
+++ b/crates/cli-sub-agent/src/review_consensus.rs
@@ -84,7 +84,7 @@ pub(crate) fn build_reviewer_tools(
     let enabled_tools: Vec<ToolName> = if let Some(tools) = tier_tools {
         tools.to_vec()
     } else if let Some(cfg) = project_config {
-        let tools: Vec<_> = csa_config::global::all_known_tools()
+        let tools: Vec<_> = csa_config::global::routing_candidate_tools()
             .iter()
             .filter(|t| cfg.is_tool_auto_selectable(t.as_str()))
             .filter(|t| reviewer_tool_binary_available(t.as_str(), project_config))
@@ -96,14 +96,14 @@ pub(crate) fn build_reviewer_tools(
             tools
         }
     } else if let Some(gc) = global_config {
-        let available_tools: Vec<_> = csa_config::global::all_known_tools()
+        let available_tools: Vec<_> = csa_config::global::routing_candidate_tools()
             .iter()
             .filter(|t| reviewer_tool_binary_available(t.as_str(), project_config))
             .copied()
             .collect();
         csa_config::global::sort_tools_by_effective_priority(&available_tools, project_config, gc)
     } else {
-        csa_config::global::all_known_tools()
+        csa_config::global::routing_candidate_tools()
             .iter()
             .filter(|t| reviewer_tool_binary_available(t.as_str(), project_config))
             .copied()

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -146,8 +146,8 @@ async fn handle_run_persists_model_spec_tier_bypass_pre_exec_result() {
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let config = run_config_with_tier(
         "default",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     write_project_config(project_dir.path(), &config);
 

--- a/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
@@ -110,8 +110,8 @@ async fn handle_run_persists_result_for_direct_tool_tier_rejection() {
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     let config = run_config_with_tier(
         "default",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     write_project_config(project_dir.path(), &config);
 

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection.rs
@@ -275,7 +275,7 @@ fn collect_enabled_tools(
     model_hint: Option<&str>,
 ) -> Vec<ToolName> {
     if let Some(cfg) = config {
-        let tools: Vec<_> = csa_config::global::all_known_tools()
+        let tools: Vec<_> = csa_config::global::routing_candidate_tools()
             .iter()
             .filter(|t| {
                 let extra_env = global_config

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -178,7 +178,7 @@ pub(crate) fn validate_model_spec_tier_conflict(
 /// Returns true when `--tier` is specified without an explicit `--tool`.
 ///
 /// Auto-routing in this case may silently select the wrong tool for the task
-/// (e.g., gemini-cli with allow_edit=false for write tasks).
+/// (e.g., an explicit-only or read-only tool for write tasks).
 pub(crate) fn tier_without_tool_should_warn(tier: Option<&str>, tool_explicitly_set: bool) -> bool {
     tier.is_some() && !tool_explicitly_set
 }
@@ -191,11 +191,11 @@ pub(crate) fn warn_if_tier_without_tool(tier: Option<&str>, tool_explicitly_set:
         tracing::warn!(
             tier = tier.unwrap_or(""),
             "--tier without --tool uses auto-routing; \
-             specify --tool auto|claude-code|codex|gemini-cli to control tool selection"
+             specify --tool auto|claude-code|codex|opencode to control tool selection"
         );
         eprintln!(
             "warning: --tier without --tool uses auto-routing; \
-             specify --tool auto|claude-code|codex|gemini-cli to control tool selection"
+             specify --tool auto|claude-code|codex|opencode to control tool selection"
         );
     }
 }
@@ -456,7 +456,7 @@ pub(crate) fn resolve_tool_and_model(
 
     // Case 3: no tool/model_spec; use tiers, or --force any enabled runtime.
     if force {
-        for tool in csa_config::global::all_known_tools() {
+        for tool in csa_config::global::routing_candidate_tools() {
             let name = tool.as_str();
             let enabled = config.is_none_or(|cfg| cfg.is_tool_enabled(name));
             let extra_env = runtime_env_for_tool(name);
@@ -473,8 +473,8 @@ pub(crate) fn resolve_tool_and_model(
             }
         }
         anyhow::bail!(
-            "No installed and enabled tools found. Install at least one tool \
-             (gemini-cli, opencode, codex, claude-code) or check enabled status."
+            "No installed and enabled tools found. Install at least one supported routing tool \
+             (opencode, codex, claude-code) or check enabled status."
         );
     }
 
@@ -521,7 +521,7 @@ pub(crate) fn resolve_tool_and_model(
     if let Some(cfg) = config
         && cfg.tiers.is_empty()
     {
-        for tool in csa_config::global::all_known_tools() {
+        for tool in csa_config::global::routing_candidate_tools() {
             let name = tool.as_str();
             let extra_env = runtime_env_for_tool(name);
             if cfg.is_tool_auto_selectable(name)

--- a/crates/cli-sub-agent/src/run_helpers_basics.rs
+++ b/crates/cli-sub-agent/src/run_helpers_basics.rs
@@ -12,7 +12,7 @@ pub(crate) fn is_compress_command(prompt: &str) -> bool {
 /// Parse a tool name string to ToolName enum.
 pub(crate) fn parse_tool_name(name: &str) -> Result<ToolName> {
     match name {
-        "gemini-cli" => Ok(ToolName::GeminiCli),
+        "gemini-cli" | "gemini" => anyhow::bail!("{}", csa_core::types::removed_tool_error(name)),
         "opencode" => Ok(ToolName::Opencode),
         "codex" => Ok(ToolName::Codex),
         "claude-code" => Ok(ToolName::ClaudeCode),

--- a/crates/cli-sub-agent/src/run_helpers_compound_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_compound_tier_tests.rs
@@ -20,7 +20,7 @@ fn fixture(tool_aliases: HashMap<String, String>) -> ProjectConfig {
             name.to_string(),
             TierConfig {
                 description: "test".to_string(),
-                models: vec!["gemini-cli/google/default/xhigh".to_string()],
+                models: vec!["codex/openai/gpt-5.4/high".to_string()],
                 strategy: TierStrategy::default(),
                 token_budget: None,
                 max_turns: None,
@@ -82,10 +82,10 @@ fn compound_selector_parses_multi_hyphen_tool_suffix() {
 fn compound_selector_parses_builtin_alias_suffix() {
     let cfg = fixture(HashMap::new());
     let (tier, tool) =
-        apply_compound_tier_selector(Some("tier-4-critical-gemini".to_string()), None, Some(&cfg))
+        apply_compound_tier_selector(Some("tier-4-critical-claude".to_string()), None, Some(&cfg))
             .expect("compound parse should succeed");
     assert_eq!(tier.as_deref(), Some("tier-4-critical"));
-    assert_eq!(tool, Some(ToolName::GeminiCli));
+    assert_eq!(tool, Some(ToolName::ClaudeCode));
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn compound_selector_errors_on_tool_conflict() {
     let cfg = fixture(HashMap::new());
     let err = apply_compound_tier_selector(
         Some("tier-4-critical-codex".to_string()),
-        Some(ToolName::GeminiCli),
+        Some(ToolName::Opencode),
         Some(&cfg),
     )
     .expect_err("conflicting --tool should error");
@@ -121,7 +121,7 @@ fn compound_selector_errors_on_tool_conflict() {
     let msg = format!("{err:#}");
     assert!(msg.contains("tier-4-critical-codex"), "msg: {msg}");
     assert!(msg.contains("codex"), "msg: {msg}");
-    assert!(msg.contains("gemini-cli"), "msg: {msg}");
+    assert!(msg.contains("opencode"), "msg: {msg}");
 }
 
 #[test]
@@ -201,7 +201,7 @@ fn compound_selector_arg_errors_on_specific_conflict() {
     let cfg = fixture(HashMap::new());
     let err = apply_compound_tier_selector_arg(
         Some("tier-4-critical-codex".to_string()),
-        Some(ToolArg::Specific(ToolName::GeminiCli)),
+        Some(ToolArg::Specific(ToolName::Opencode)),
         Some(&cfg),
     )
     .expect_err("Specific(other) should error");

--- a/crates/cli-sub-agent/src/run_helpers_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tests.rs
@@ -539,10 +539,6 @@ fn is_compress_command_partial_match_rejected() {
 fn parse_tool_name_all_valid() {
     use super::parse_tool_name;
     assert!(matches!(
-        parse_tool_name("gemini-cli").unwrap(),
-        ToolName::GeminiCli
-    ));
-    assert!(matches!(
         parse_tool_name("opencode").unwrap(),
         ToolName::Opencode
     ));
@@ -551,6 +547,14 @@ fn parse_tool_name_all_valid() {
         parse_tool_name("claude-code").unwrap(),
         ToolName::ClaudeCode
     ));
+}
+
+#[test]
+fn parse_tool_name_rejects_removed_gemini_cli() {
+    let err = super::parse_tool_name("gemini-cli").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("no longer supported"), "{msg}");
+    assert!(msg.contains("provider is discontinued"), "{msg}");
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/run_helpers_tier_force_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_force_tests.rs
@@ -87,7 +87,7 @@ fn tier_bypass_gate_rejects_model_spec_and_force_by_default() {
         "tier-4-critical".to_string(),
         csa_config::TierConfig {
             description: "critical".to_string(),
-            models: vec!["gemini-cli/google/pro/high".to_string()],
+            models: vec!["opencode/openai/gpt-5/high".to_string()],
             strategy: Default::default(),
             token_budget: None,
             max_turns: None,
@@ -360,8 +360,8 @@ fn resolve_tool_and_model_force_ignore_tier_bypassed_when_model_spec_provided() 
 fn resolve_tool_and_model_allows_model_spec_when_global_tier_bypass_opted_in() {
     let cfg = config_with_tier(
         "tier-1",
-        vec!["gemini-cli/google/gemini-3.1-pro-preview/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     let global = GlobalConfig {
         tier_policy: csa_config::TierPolicyConfig {
@@ -402,8 +402,8 @@ fn resolve_tool_and_model_uses_inherited_model_spec_when_gate_default() {
     let _guard = assume_tier_tools_available();
     let cfg = config_with_tier(
         "tier-1",
-        vec!["gemini-cli/google/gemini-3.1-pro-preview/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     let global = GlobalConfig::default();
     let inherited_spec = "codex/openai/gpt-5.5/xhigh";
@@ -468,13 +468,13 @@ fn collect_preferred_tier_models_honors_preference_array_order() {
     let cfg = config_with_tier(
         "quality",
         vec![
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "opencode/openai/gpt-5/xhigh",
             "codex/openai/gpt-5.4/high",
             "claude-code/anthropic/sonnet-4.5/high",
         ],
-        &["gemini-cli", "codex", "claude-code"],
+        &["opencode", "codex", "claude-code"],
     );
-    let preference_order = vec!["codex".to_string(), "gemini-cli".to_string()];
+    let preference_order = vec!["codex".to_string(), "opencode".to_string()];
 
     let candidates = super::collect_preferred_tier_models("quality", &cfg, &preference_order, &[]);
     let specs: Vec<&str> = candidates
@@ -486,7 +486,7 @@ fn collect_preferred_tier_models_honors_preference_array_order() {
         specs,
         vec![
             "codex/openai/gpt-5.4/high",
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "opencode/openai/gpt-5/xhigh",
             "claude-code/anthropic/sonnet-4.5/high",
         ]
     );

--- a/crates/cli-sub-agent/src/run_helpers_tier_resolution.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_resolution.rs
@@ -73,6 +73,14 @@ pub(crate) fn evaluate_tier_models_with_global_config(
             });
             continue;
         }
+        if !csa_config::global::routing_candidate_tools().contains(&tool) {
+            excluded.push(TierModelExclusion {
+                model_spec: spec.clone(),
+                tool: Some(tool),
+                kind: FailoverSkipKind::Disabled,
+            });
+            continue;
+        }
         if !config.is_tool_enabled(tool_str) {
             excluded.push(TierModelExclusion {
                 model_spec: spec.clone(),
@@ -254,6 +262,17 @@ pub(crate) fn resolve_preferred_tool_from_tier_with_global_config(
     if !config.tiers.contains_key(tier_name) {
         anyhow::bail!("Tier '{}' not found.", tier_name);
     }
+    for preferred_tool in preference_order {
+        if let Ok(tool) = parse_tool_name(preferred_tool)
+            && !csa_config::global::routing_candidate_tools().contains(&tool)
+        {
+            anyhow::bail!(
+                "--tool {preferred_tool} is explicit-only and is not eligible for tier routing \
+                 or general fallback. For low-risk read-only exploration, omit --tier and use \
+                 --force-ignore-tier-setting with a complete explicit model selection."
+            );
+        }
+    }
     let (available, excluded) =
         evaluate_tier_models_with_global_config(tier_name, config, global_config, skip_specs);
 
@@ -413,8 +432,8 @@ mod tests {
             "claude-code",
             &[
                 TierToolResolution {
-                    tool: ToolName::GeminiCli,
-                    model_spec: "gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string(),
+                    tool: ToolName::Opencode,
+                    model_spec: "opencode/openrouter/qwen/qwen3-coder/xhigh".to_string(),
                 },
                 TierToolResolution {
                     tool: ToolName::Codex,
@@ -427,11 +446,8 @@ mod tests {
         assert!(warning.starts_with("warning:"), "{warning}");
         assert!(warning.contains("--tool claude-code ignored"), "{warning}");
         assert!(warning.contains("tier 'tier-4-critical'"), "{warning}");
-        assert!(
-            warning.contains("candidates: gemini-cli, codex"),
-            "{warning}"
-        );
-        assert!(warning.contains("proceeding with gemini-cli"), "{warning}");
+        assert!(warning.contains("candidates: opencode, codex"), "{warning}");
+        assert!(warning.contains("proceeding with opencode"), "{warning}");
     }
 
     #[test]
@@ -454,12 +470,12 @@ mod tests {
         use crate::review_cmd::tests::project_config_with_enabled_tools;
         use csa_config::{TierStrategy, config::TierConfig};
 
-        let mut config = project_config_with_enabled_tools(&["gemini-cli"]);
+        let mut config = project_config_with_enabled_tools(&["codex"]);
         config.tiers.insert(
             "test-tier".to_string(),
             TierConfig {
                 description: "test".to_string(),
-                models: vec!["gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string()],
+                models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
                 strategy: TierStrategy::default(),
                 token_budget: None,
                 max_turns: None,

--- a/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
@@ -222,11 +222,7 @@ pub(super) fn config_with_tier(
 
 #[test]
 fn resolve_tool_from_tier_returns_none_for_missing_tier() {
-    let cfg = config_with_tier(
-        "tier-1",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli"],
-    );
+    let cfg = config_with_tier("tier-1", vec!["opencode/openai/gpt-5/xhigh"], &["opencode"]);
     let result = super::resolve_tool_from_tier("nonexistent-tier", &cfg, None, &[], &[]);
     assert!(result.is_none());
 }
@@ -236,33 +232,33 @@ fn resolve_tool_from_tier_returns_first_available_when_no_parent() {
     let _tool_availability = assume_tier_tools_available();
     let cfg = config_with_tier(
         "test-tier",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode"],
     );
     let result = super::resolve_tool_from_tier("test-tier", &cfg, None, &[], &[]);
     assert!(result.is_some());
     let res = result.unwrap();
-    assert_eq!(res.tool, ToolName::GeminiCli);
-    assert_eq!(res.model_spec, "gemini-cli/google/default/xhigh");
+    assert_eq!(res.tool, ToolName::Opencode);
+    assert_eq!(res.model_spec, "opencode/openai/gpt-5/xhigh");
 }
 
 #[test]
 fn resolve_tool_from_tier_prefers_heterogeneous() {
     let _tool_availability = assume_tier_tools_available();
-    // Parent=claude-code(Anthropic), tier has gemini-cli+claude-code; prefer gemini for heterogeneity.
+    // Parent=claude-code(Anthropic), tier has opencode+claude-code; prefer opencode for heterogeneity.
     let cfg = config_with_tier(
         "test-tier",
         vec![
             "claude-code/anthropic/default/xhigh",
-            "gemini-cli/google/default/xhigh",
+            "opencode/openai/gpt-5/xhigh",
         ],
-        &["claude-code", "gemini-cli"],
+        &["claude-code", "opencode"],
     );
     let result = super::resolve_tool_from_tier("test-tier", &cfg, Some("claude-code"), &[], &[]);
     assert!(result.is_some());
     let res = result.unwrap();
-    assert_eq!(res.tool, ToolName::GeminiCli);
-    assert_eq!(res.model_spec, "gemini-cli/google/default/xhigh");
+    assert_eq!(res.tool, ToolName::Opencode);
+    assert_eq!(res.model_spec, "opencode/openai/gpt-5/xhigh");
 }
 
 #[test]
@@ -284,11 +280,11 @@ fn resolve_tool_from_tier_falls_back_to_same_family_when_no_heterogeneous() {
 #[test]
 fn resolve_tool_from_tier_skips_disabled_tools() {
     let _tool_availability = assume_tier_tools_available();
-    // gemini-cli is disabled, only claude-code is enabled.
+    // opencode is disabled, only claude-code is enabled.
     let cfg = config_with_tier(
         "test-tier",
         vec![
-            "gemini-cli/google/default/xhigh",
+            "opencode/openai/gpt-5/xhigh",
             "claude-code/anthropic/default/xhigh",
         ],
         &["claude-code"],
@@ -305,7 +301,7 @@ fn resolve_tool_from_tier_returns_none_when_all_disabled() {
     // All tools in tier are disabled.
     let cfg = config_with_tier(
         "test-tier",
-        vec!["gemini-cli/google/default/xhigh"],
+        vec!["opencode/openai/gpt-5/xhigh"],
         &[], // no enabled tools
     );
     let result = super::resolve_tool_from_tier("test-tier", &cfg, None, &[], &[]);
@@ -317,17 +313,17 @@ fn resolve_tool_from_tier_returns_none_when_all_disabled() {
 #[test]
 fn resolve_preferred_tool_from_tier_fails_fast_on_disabled_pinned_candidate() {
     let _tool_availability = assume_tier_tools_available();
-    // claude-code IS a tier candidate but is disabled in config; gemini-cli is
+    // claude-code IS a tier candidate but is disabled in config; opencode is
     // the enabled tier default. An explicit `--tool claude-code` pin must error
-    // instead of silently falling through to gemini-cli (#1836). Resolution is
+    // instead of silently falling through to opencode (#1836). Resolution is
     // upstream of failover, so this fail-fast fires regardless of --no-failover.
     let cfg = config_with_tier(
         "tier-4-critical",
         vec![
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "opencode/openai/gpt-5/xhigh",
             "claude-code/anthropic/default/xhigh",
         ],
-        &["gemini-cli"], // claude-code disabled
+        &["opencode"], // claude-code disabled
     );
     let preference_order = vec!["claude-code".to_string()];
     let result = super::resolve_preferred_tool_from_tier(
@@ -350,16 +346,13 @@ fn resolve_preferred_tool_from_tier_fails_fast_on_disabled_pinned_candidate() {
 #[test]
 fn resolve_preferred_tool_from_tier_soft_reorders_enabled_candidate() {
     let _tool_availability = assume_tier_tools_available();
-    // gemini-cli is the tier default, but the user pins the ENABLED candidate
+    // opencode is the tier default, but the user pins the ENABLED candidate
     // codex; the soft-reorder must surface codex without error (#1749 preserved,
     // regression guard — the disabled fail-fast must not catch enabled pins).
     let cfg = config_with_tier(
         "tier-4-critical",
-        vec![
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-            "codex/openai/gpt-5.5/xhigh",
-        ],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh", "codex/openai/gpt-5.5/xhigh"],
+        &["opencode", "codex"],
     );
     let preference_order = vec!["codex".to_string()];
     let resolution = super::resolve_preferred_tool_from_tier(
@@ -381,8 +374,8 @@ fn resolve_preferred_tool_from_tier_rejects_non_candidate_pin() {
     // pins fail fast instead of silently substituting a different tool.
     let cfg = config_with_tier(
         "tier-4-critical",
-        vec!["gemini-cli/google/gemini-3.1-pro-preview/xhigh"],
-        &["gemini-cli", "opencode"],
+        vec!["codex/openai/gpt-5.5/xhigh"],
+        &["opencode", "codex"],
     );
     let preference_order = vec!["opencode".to_string()];
     let err = super::resolve_preferred_tool_from_tier(
@@ -409,10 +402,10 @@ fn resolve_tool_and_model_fails_fast_on_disabled_pinned_tier_candidate() {
     let cfg = config_with_tier(
         "tier-4-critical",
         vec![
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "opencode/openai/gpt-5/xhigh",
             "claude-code/anthropic/default/xhigh",
         ],
-        &["gemini-cli"], // claude-code disabled
+        &["opencode"], // claude-code disabled
     );
     let result = super::resolve_tool_and_model(super::RoutingRequest {
         tool: Some(ToolName::ClaudeCode),
@@ -433,11 +426,11 @@ fn resolve_tool_and_model_fails_fast_on_disabled_pinned_tier_candidate() {
 fn resolve_tool_and_model_blocks_direct_tool_when_tiers_configured() {
     let cfg = config_with_tier(
         "default",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode"],
     );
     let result = super::resolve_tool_and_model(super::RoutingRequest {
-        tool: Some(ToolName::GeminiCli),
+        tool: Some(ToolName::Opencode),
         config: Some(&cfg),
         ..super::RoutingRequest::new(std::path::Path::new("/tmp"))
     });
@@ -462,8 +455,8 @@ fn resolve_tool_and_model_blocks_direct_tool_when_tiers_configured() {
 fn resolve_tool_and_model_rejects_unconfigured_model_spec_when_tiers_configured() {
     let cfg = config_with_tier(
         "default",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     let result = super::resolve_tool_and_model(super::RoutingRequest {
         model_spec: Some("codex/openai/gpt-5.4/high"),
@@ -483,7 +476,7 @@ fn resolve_tool_and_model_allows_configured_model_spec_when_tiers_configured() {
     let cfg = config_with_tier(
         "default",
         vec!["codex/openai/gpt-5.5/high"],
-        &["gemini-cli", "codex"],
+        &["opencode", "codex"],
     );
     let result = super::resolve_tool_and_model(super::RoutingRequest {
         model_spec: Some("codex/openai/gpt-5.5/high"),
@@ -506,8 +499,8 @@ fn resolve_tool_and_model_allows_configured_model_spec_when_tiers_configured() {
 fn resolve_tool_and_model_blocks_direct_model_alone_when_tiers_configured() {
     let cfg = config_with_tier(
         "default",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode"],
     );
     let result = super::resolve_tool_and_model(super::RoutingRequest {
         model: Some("custom-model"), // --model provided
@@ -527,8 +520,8 @@ fn resolve_tool_and_model_blocks_direct_model_alone_when_tiers_configured() {
 fn resolve_tool_and_model_blocks_direct_thinking_alone_when_tiers_configured() {
     let cfg = config_with_tier(
         "default",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode"],
     );
     let result = super::resolve_tool_and_model(super::RoutingRequest {
         thinking: Some("low"),
@@ -548,8 +541,8 @@ fn resolve_tool_and_model_blocks_direct_thinking_alone_when_tiers_configured() {
 fn resolve_tool_and_model_force_ignore_tier_allows_direct_tool() {
     let cfg = config_with_tier(
         "default",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     let result = super::resolve_tool_and_model(super::RoutingRequest {
         tool: Some(ToolName::Codex),
@@ -569,8 +562,8 @@ fn resolve_tool_and_model_force_ignore_tier_allows_direct_tool() {
 fn resolve_tool_and_model_force_override_user_config_does_not_bypass_tiers() {
     let cfg = config_with_tier(
         "default",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
     let result = super::resolve_tool_and_model(super::RoutingRequest {
         tool: Some(ToolName::Codex),
@@ -636,8 +629,8 @@ fn resolve_tool_and_model_tier_flag_resolves_from_tier() {
     let _tool_availability = assume_tier_tools_available();
     let cfg = config_with_tier(
         "quality",
-        vec!["gemini-cli/google/gemini-3.1-pro-preview/xhigh"],
-        &["gemini-cli"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode"],
     );
     let result = super::resolve_tool_and_model(super::RoutingRequest {
         config: Some(&cfg),
@@ -650,11 +643,8 @@ fn resolve_tool_and_model_tier_flag_resolves_from_tier() {
         result.unwrap_err()
     );
     let (tool, model_spec, _) = result.unwrap();
-    assert_eq!(tool, ToolName::GeminiCli);
-    assert_eq!(
-        model_spec.as_deref(),
-        Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh")
-    );
+    assert_eq!(tool, ToolName::Opencode);
+    assert_eq!(model_spec.as_deref(), Some("opencode/openai/gpt-5/xhigh"));
 }
 
 #[test]
@@ -662,8 +652,8 @@ fn resolve_tool_and_model_tier_shorthand_resolves_from_tier() {
     let _tool_availability = assume_tier_tools_available();
     let cfg = config_with_tier(
         "tier-4-critical",
-        vec!["gemini-cli/google/gemini-3.1-pro-preview/xhigh"],
-        &["gemini-cli"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode"],
     );
 
     for selector in ["tier4", "tier-4"] {
@@ -678,11 +668,8 @@ fn resolve_tool_and_model_tier_shorthand_resolves_from_tier() {
             result.unwrap_err()
         );
         let (tool, model_spec, _) = result.unwrap();
-        assert_eq!(tool, ToolName::GeminiCli);
-        assert_eq!(
-            model_spec.as_deref(),
-            Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh")
-        );
+        assert_eq!(tool, ToolName::Opencode);
+        assert_eq!(model_spec.as_deref(), Some("opencode/openai/gpt-5/xhigh"));
     }
 }
 
@@ -692,11 +679,11 @@ fn resolve_tool_and_model_tier_with_tool_resolves_requested_tool_from_tier() {
     let cfg = config_with_tier(
         "tier-4-critical",
         vec![
-            "gemini-cli/google/default/xhigh",
+            "opencode/openai/gpt-5/xhigh",
             "codex/openai/gpt-5.4/xhigh",
             "claude-code/anthropic/sonnet-4.6/xhigh",
         ],
-        &["gemini-cli", "codex", "claude-code"],
+        &["opencode", "codex", "claude-code"],
     );
     let result = super::resolve_tool_and_model(super::RoutingRequest {
         tool: Some(ToolName::Codex),
@@ -720,10 +707,10 @@ fn resolve_tool_and_model_tier_with_tool_rejects_missing_tool_candidate() {
     let cfg = config_with_tier(
         "quality",
         vec![
-            "gemini-cli/google/default/xhigh",
+            "opencode/openai/gpt-5/xhigh",
             "claude-code/anthropic/sonnet-4.6/xhigh",
         ],
-        &["gemini-cli", "codex", "claude-code"],
+        &["opencode", "codex", "claude-code"],
     );
     let err = super::resolve_tool_and_model(super::RoutingRequest {
         tool: Some(ToolName::Codex),
@@ -744,8 +731,8 @@ fn resolve_tool_and_model_tier_ignores_auto_resolved_tool_hint() {
     let _tool_availability = assume_tier_tools_available();
     let cfg = config_with_tier(
         "quality",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
 
     let result = super::resolve_tool_and_model(super::RoutingRequest {
@@ -762,19 +749,16 @@ fn resolve_tool_and_model_tier_ignores_auto_resolved_tool_hint() {
         result.unwrap_err()
     );
     let (tool, model_spec, _) = result.unwrap();
-    assert_eq!(tool, ToolName::GeminiCli);
-    assert_eq!(
-        model_spec.as_deref(),
-        Some("gemini-cli/google/default/xhigh")
-    );
+    assert_eq!(tool, ToolName::Opencode);
+    assert_eq!(model_spec.as_deref(), Some("opencode/openai/gpt-5/xhigh"));
 }
 
 #[test]
 fn resolve_tool_and_model_tier_with_tool_and_force_ignore_errors_on_conflict() {
     let cfg = config_with_tier(
         "quality",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli", "codex"],
+        vec!["opencode/openai/gpt-5/xhigh"],
+        &["opencode", "codex"],
     );
 
     let result = super::resolve_tool_and_model(super::RoutingRequest {
@@ -803,11 +787,7 @@ fn resolve_tool_and_model_tier_with_tool_and_force_ignore_errors_on_conflict() {
 #[test]
 fn resolve_tool_and_model_tier_alias_resolves_correctly() {
     let _tool_availability = assume_tier_tools_available();
-    let mut cfg = config_with_tier(
-        "tier1",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli"],
-    );
+    let mut cfg = config_with_tier("tier1", vec!["opencode/openai/gpt-5/xhigh"], &["opencode"]);
     cfg.tier_mapping
         .insert("default".to_string(), "tier1".to_string());
 
@@ -822,20 +802,13 @@ fn resolve_tool_and_model_tier_alias_resolves_correctly() {
         result.unwrap_err()
     );
     let (tool, model_spec, _) = result.unwrap();
-    assert_eq!(tool, ToolName::GeminiCli);
-    assert_eq!(
-        model_spec.as_deref(),
-        Some("gemini-cli/google/default/xhigh")
-    );
+    assert_eq!(tool, ToolName::Opencode);
+    assert_eq!(model_spec.as_deref(), Some("opencode/openai/gpt-5/xhigh"));
 }
 
 #[test]
 fn resolve_tool_and_model_invalid_tier_selector_includes_aliases_in_error() {
-    let mut cfg = config_with_tier(
-        "tier1",
-        vec!["gemini-cli/google/default/xhigh"],
-        &["gemini-cli"],
-    );
+    let mut cfg = config_with_tier("tier1", vec!["opencode/openai/gpt-5/xhigh"], &["opencode"]);
     cfg.tier_mapping
         .insert("alias1".to_string(), "tier1".to_string());
 

--- a/crates/cli-sub-agent/src/session_cmds_compress.rs
+++ b/crates/cli-sub-agent/src/session_cmds_compress.rs
@@ -16,8 +16,12 @@ pub(crate) fn handle_session_compress(session: String, cd: Option<String>) -> Re
         .max_by_key(|(_, state)| &state.updated_at)
         .ok_or_else(|| anyhow::anyhow!("Session '{resolved_id}' has no tool history"))?;
 
+    if csa_core::types::is_removed_tool_name(tool_name) {
+        anyhow::bail!("{}", csa_core::types::removed_tool_error(tool_name));
+    }
+
     let compress_cmd = match tool_name.as_str() {
-        "gemini-cli" | "antigravity-cli" => "/compress",
+        "antigravity-cli" => "/compress",
         _ => "/compact",
     };
 

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -194,7 +194,7 @@ pub(crate) fn render_wait_result_summary(
 }
 
 /// Render the per-tool failover chain as a single line for the wait summary,
-/// e.g. `gemini-cli: rate-limit-429; antigravity-cli: disabled; codex: disabled
+/// e.g. `opencode: rate-limit-429; antigravity-cli: disabled; codex: disabled
 /// → claude-code` (#1714). Returns `None` when no failover was recorded.
 fn format_failover_chain_label(
     session_dir: &Path,

--- a/crates/cli-sub-agent/src/test_env_lock.rs
+++ b/crates/cli-sub-agent/src/test_env_lock.rs
@@ -1,5 +1,6 @@
 // NOTE #1858: #[path]-included by tests; no `crate::`, no binary-only methods (dead_code).
 use std::ffi::OsString;
+use std::path::Path;
 use std::sync::{Arc, LazyLock};
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
@@ -42,6 +43,35 @@ impl ScopedEnvVarRestore {
         // private per-module env locks are forbidden because env is process-wide.
         unsafe { std::env::remove_var(key) };
         Self { key, original }
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn isolate_user_config(
+    project_root: &Path,
+) -> (ScopedEnvVarRestore, ScopedEnvVarRestore) {
+    let config_home = project_root.join("xdg-config");
+    std::fs::create_dir_all(&config_home).expect("test config home should be created");
+    let home_guard = ScopedEnvVarRestore::set("HOME", project_root);
+    let config_guard = ScopedEnvVarRestore::set("XDG_CONFIG_HOME", &config_home);
+    (home_guard, config_guard)
+}
+
+#[allow(dead_code)]
+pub(crate) struct ScopedUserConfigIsolation {
+    _config_guard: ScopedEnvVarRestore,
+    _home_guard: ScopedEnvVarRestore,
+    _lock: OwnedMutexGuard<()>,
+}
+
+#[allow(dead_code)]
+pub(crate) async fn isolate_user_config_locked(project_root: &Path) -> ScopedUserConfigIsolation {
+    let lock = TEST_ENV_LOCK.clone().lock_owned().await;
+    let (home_guard, config_guard) = isolate_user_config(project_root);
+    ScopedUserConfigIsolation {
+        _config_guard: config_guard,
+        _home_guard: home_guard,
+        _lock: lock,
     }
 }
 

--- a/crates/cli-sub-agent/src/tier_model_fallback.rs
+++ b/crates/cli-sub-agent/src/tier_model_fallback.rs
@@ -169,7 +169,7 @@ fn ordered_global_candidates(
     };
 
     for tool in csa_config::global::sort_tools_by_effective_priority(
-        csa_config::global::all_known_tools(),
+        csa_config::global::routing_candidate_tools(),
         config,
         global_config,
     ) {

--- a/crates/cli-sub-agent/src/tier_model_fallback_tests.rs
+++ b/crates/cli-sub-agent/src/tier_model_fallback_tests.rs
@@ -101,10 +101,10 @@ fn tier_fallback_prefers_original_tool_then_keeps_full_tier() {
         "quality",
         &[
             "codex/openai/gpt-5.4/high",
-            "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
+            "opencode/openai/gpt-5/xhigh",
             "claude-code/anthropic/sonnet-4.6/xhigh",
         ],
-        &["codex", "gemini-cli", "claude-code"],
+        &["codex", "opencode", "claude-code"],
     );
 
     let candidates = ordered_tier_candidates(
@@ -125,8 +125,8 @@ fn tier_fallback_prefers_original_tool_then_keeps_full_tier() {
                 Some("codex/openai/gpt-5.4/high".to_string()),
             ),
             (
-                ToolName::GeminiCli,
-                Some("gemini-cli/google/gemini-3.1-pro-preview/xhigh".to_string()),
+                ToolName::Opencode,
+                Some("opencode/openai/gpt-5/xhigh".to_string()),
             ),
             (
                 ToolName::ClaudeCode,
@@ -143,14 +143,14 @@ fn no_tier_fallback_uses_global_tool_priority() {
         "1",
     );
     let mut global = GlobalConfig::default();
-    global.preferences.tool_priority = vec!["claude-code".to_string(), "gemini-cli".to_string()];
+    global.preferences.tool_priority = vec!["claude-code".to_string(), "opencode".to_string()];
     let candidates =
         ordered_tier_candidates(ToolName::Codex, None, None, None, Some(&global), true, &[]);
 
     assert!(candidates.starts_with(&[
         (ToolName::Codex, None),
         (ToolName::ClaudeCode, None),
-        (ToolName::GeminiCli, None),
+        (ToolName::Opencode, None),
     ]));
 }
 

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -134,8 +134,8 @@ pub struct ProjectConfig {
     pub aliases: HashMap<String, String>,
     /// Tool name aliases: maps short names to canonical tool names.
     ///
-    /// Example: `gem = "gemini-cli"`, `cc = "claude-code"`.
-    /// Built-in aliases (`gemini` → `gemini-cli`, `claude` → `claude-code`)
+    /// Example: `cx = "codex"`, `cc = "claude-code"`.
+    /// Built-in aliases (`claude` → `claude-code`)
     /// are always available without configuration.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub tool_aliases: HashMap<String, String>,
@@ -278,9 +278,9 @@ impl ProjectConfig {
     fn load_from_path(path: &Path) -> Result<Option<Self>> {
         let content = std::fs::read_to_string(path)
             .with_context(|| format!("Failed to read config: {}", path.display()))?;
-        // Check for deprecated keys before deserializing (serde silently ignores them)
         if let Ok(raw) = toml::from_str::<toml::Value>(&content) {
             warn_deprecated_keys(&raw, &path.display().to_string());
+            reject_removed_refs(&raw, path, "")?;
             crate::validate::validate_tool_transport_overrides_in_raw_config(&raw)
                 .with_context(|| format!("Invalid config: {}", path.display()))?;
         }
@@ -296,6 +296,7 @@ impl ProjectConfig {
             .with_context(|| format!("Failed to read config: {}", path.display()))?;
         if let Ok(raw) = toml::from_str::<toml::Value>(&content) {
             warn_deprecated_keys(&raw, &path.display().to_string());
+            reject_removed_refs(&raw, path, "")?;
             reject_project_tier_policy(&raw, &path.display().to_string())
                 .with_context(|| format!("Invalid config: {}", path.display()))?;
             crate::validate::validate_tool_transport_overrides_in_raw_config(&raw)
@@ -326,9 +327,10 @@ impl ProjectConfig {
             format!("Failed to parse project config: {}", overlay_path.display())
         })?;
 
-        // Check for deprecated keys in both configs
         warn_deprecated_keys(&base_val, &base_path.display().to_string());
         warn_deprecated_keys(&overlay_val, &overlay_path.display().to_string());
+        reject_removed_refs(&base_val, base_path, "user ")?;
+        reject_removed_refs(&overlay_val, overlay_path, "project ")?;
         reject_project_tier_policy(&overlay_val, &overlay_path.display().to_string())
             .with_context(|| format!("Invalid project config: {}", overlay_path.display()))?;
         crate::validate::validate_tool_transport_overrides_in_raw_config(&base_val)
@@ -673,14 +675,12 @@ init_timeout_seconds = 120
 # enabled = true
 # codex_auto_trust = false
 # tmux_mode = false
-# [tools.gemini-cli]
-# enabled = true
 # [tiers.tier-1-quick]
 # description = "Quick tasks: fast models"
-# models = ["gemini-cli/google/gemini-2.5-flash/low"]
+# models = ["codex/openai/gpt-5.4/low"]
 # [tiers.tier-2-standard]
 # description = "Standard tasks: balanced models"
-# models = ["codex/openai/gpt-5.4/medium", "gemini-cli/google/gemini-2.5-pro/medium"]
+# models = ["codex/openai/gpt-5.4/medium", "claude-code/anthropic/claude-sonnet-4-5-20250929/medium"]
 # [tiers.tier-3-heavy]
 # description = "Complex tasks: strongest models"
 # models = ["claude-code/anthropic/claude-sonnet-4-5-20250929/high", "codex/openai/gpt-5.5/high"]
@@ -689,10 +689,9 @@ init_timeout_seconds = 120
 # quick = "tier-1-quick"
 # complex = "tier-3-heavy"
 # [aliases]
-# fast = "gemini-cli/google/gemini-2.5-flash/low"
+# fast = "codex/openai/gpt-5.4/low"
 # smart = "codex/openai/gpt-5.5/high"
 # [tool_aliases]
-# gem = "gemini-cli"
 # cc = "claude-code"
 # [hooks]
 # pre_run = "cargo fmt --all"
@@ -707,7 +706,6 @@ init_timeout_seconds = 120
     /// Resolve alias to model spec string.
     ///
     /// If input is an alias key, returns the resolved value.
-    /// Otherwise, returns the input unchanged.
     pub fn resolve_alias(&self, input: &str) -> String {
         self.aliases
             .get(input)
@@ -745,6 +743,11 @@ pub(crate) fn read_optional_toml(path: &Path, source: &str) -> Option<toml::Valu
     }
 }
 
+fn reject_removed_refs(raw: &toml::Value, path: &Path, label: &str) -> Result<()> {
+    crate::validate::reject_removed_gemini_cli_in_raw_config(raw, &path.display().to_string())
+        .with_context(|| format!("Invalid {label}config"))
+}
+
 fn parse_session_wait_memory_warn_mb(raw: &toml::Value) -> Option<u64> {
     let value = raw
         .get("session_wait")
@@ -771,6 +774,9 @@ mod tests;
 #[cfg(test)]
 #[path = "config_tests_github.rs"]
 mod tests_github;
+#[cfg(test)]
+#[path = "config_tests_removed_gemini.rs"]
+mod tests_removed_gemini;
 #[cfg(test)]
 #[path = "config_tests_tail.rs"]
 mod tests_tail;

--- a/crates/csa-config/src/config_filesystem_sandbox.rs
+++ b/crates/csa-config/src/config_filesystem_sandbox.rs
@@ -46,7 +46,7 @@ pub struct FilesystemSandboxConfig {
     pub extra_readable: Vec<PathBuf>,
 
     /// Per-tool writable path overrides.  Keys are canonical tool names
-    /// (e.g. `"claude-code"`, `"gemini-cli"`).
+    /// (e.g. `"claude-code"`, `"codex"`).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub tool_writable_overrides: HashMap<String, Vec<PathBuf>>,
 }

--- a/crates/csa-config/src/config_merge_tests.rs
+++ b/crates/csa-config/src/config_merge_tests.rs
@@ -34,7 +34,7 @@ fn test_merge_tiers_deep_merge() {
         schema_version = 1
         [tiers.tier1]
         description = "User tier 1"
-        models = ["gemini-cli/google/flash/low"]
+        models = ["codex/openai/gpt-5.4-mini/low"]
         [tiers.tier2]
         description = "User tier 2"
         models = ["codex/openai/gpt/medium"]
@@ -116,7 +116,7 @@ fn test_merged_schema_version_defaults_when_both_omit() {
         r#"
         [tiers.tier1]
         description = "User tier"
-        models = ["gemini-cli/google/flash/low"]
+        models = ["codex/openai/gpt-5.4-mini/low"]
     "#,
     )
     .unwrap();
@@ -155,7 +155,7 @@ fn test_merged_schema_version_uses_max_when_explicit() {
         schema_version = 1
         [tiers.tier1]
         description = "User tier"
-        models = ["gemini-cli/google/flash/low"]
+        models = ["codex/openai/gpt-5.4-mini/low"]
     "#,
     )
     .unwrap();
@@ -291,8 +291,8 @@ config_dir = "/tmp/user-gh"
     );
 }
 
-/// Uses gemini-cli + acp as the still-invalid combination after #1128 flipped
-/// codex CLI to a legal value. gemini-cli has no ACP transport.
+/// Uses opencode + acp as the still-invalid combination after #1128 flipped
+/// codex CLI to a legal value. opencode has no ACP transport.
 #[test]
 fn test_invalid_user_transport_override_fails_before_merge() {
     let tmp = tempdir().unwrap();
@@ -303,7 +303,7 @@ fn test_invalid_user_transport_override_fails_before_merge() {
         &user_path,
         r#"
 schema_version = 1
-[tools.gemini-cli]
+[tools.opencode]
 transport = "acp"
 "#,
     )
@@ -313,7 +313,7 @@ transport = "acp"
         &project_path,
         r#"
 schema_version = 1
-[tools.gemini-cli]
+[tools.opencode]
 transport = "auto"
 "#,
     )
@@ -332,13 +332,13 @@ transport = "auto"
         "error should include the user config path: {rendered}"
     );
     assert!(
-        rendered.contains("tools.gemini-cli.transport"),
+        rendered.contains("tools.opencode.transport"),
         "error should surface the invalid user transport key: {rendered}"
     );
 }
 
-/// Uses gemini-cli + acp as the still-invalid combination after #1128 flipped
-/// codex CLI to a legal value. gemini-cli has no ACP transport.
+/// Uses opencode + acp as the still-invalid combination after #1128 flipped
+/// codex CLI to a legal value. opencode has no ACP transport.
 #[test]
 fn test_invalid_project_transport_override_fails_before_merge() {
     let tmp = tempdir().unwrap();
@@ -349,7 +349,7 @@ fn test_invalid_project_transport_override_fails_before_merge() {
         &user_path,
         r#"
 schema_version = 1
-[tools.gemini-cli]
+[tools.opencode]
 transport = "auto"
 "#,
     )
@@ -359,7 +359,7 @@ transport = "auto"
         &project_path,
         r#"
 schema_version = 1
-[tools.gemini-cli]
+[tools.opencode]
 transport = "acp"
 "#,
     )
@@ -378,7 +378,7 @@ transport = "acp"
         "error should include the project config path: {rendered}"
     );
     assert!(
-        rendered.contains("tools.gemini-cli.transport"),
+        rendered.contains("tools.opencode.transport"),
         "error should surface the invalid project transport key: {rendered}"
     );
 }
@@ -536,8 +536,8 @@ liveness_dead_seconds = 120
 
 #[test]
 fn test_global_disable_wins_over_project_enable() {
-    // Global config disables gemini-cli; project config enables it.
-    // After merge, gemini-cli must remain disabled.
+    // Global config disables opencode; project config enables it.
+    // After merge, opencode must remain disabled.
     let tmp = tempfile::tempdir().unwrap();
     let user_path = tmp.path().join("user.toml");
     let project_path = tmp.path().join("project.toml");
@@ -546,7 +546,7 @@ fn test_global_disable_wins_over_project_enable() {
         &user_path,
         r#"
 schema_version = 1
-[tools.gemini-cli]
+[tools.opencode]
 enabled = false
 suppress_notify = true
 [tools.codex]
@@ -560,7 +560,7 @@ suppress_notify = true
         &project_path,
         r#"
 schema_version = 1
-[tools.gemini-cli]
+[tools.opencode]
 enabled = true
 suppress_notify = true
 [tools.codex]
@@ -568,7 +568,7 @@ enabled = true
 suppress_notify = true
 [tiers.tier-1-quick]
 description = "Quick"
-models = ["gemini-cli/google/flash/xhigh"]
+models = ["opencode/openai/gpt-5/xhigh"]
 "#,
     )
     .unwrap();
@@ -577,16 +577,16 @@ models = ["gemini-cli/google/flash/xhigh"]
         .unwrap()
         .expect("Should load merged config");
 
-    // gemini-cli must be disabled (global wins)
+    // opencode must be disabled (global wins)
     assert!(
-        !config.is_tool_enabled("gemini-cli"),
+        !config.is_tool_enabled("opencode"),
         "globally-disabled tool must remain disabled after merge"
     );
     // codex stays enabled (both agree)
     assert!(config.is_tool_enabled("codex"));
-    // gemini-cli must not be auto-selectable
+    // opencode must not be auto-selectable
     assert!(
-        !config.is_tool_auto_selectable("gemini-cli"),
+        !config.is_tool_auto_selectable("opencode"),
         "globally-disabled tool must not be auto-selectable"
     );
 }

--- a/crates/csa-config/src/config_runtime.rs
+++ b/crates/csa-config/src/config_runtime.rs
@@ -54,8 +54,9 @@ fn profile_defaults(profile: ToolResourceProfile) -> ProfileDefaults {
 fn default_memory_max_mb_for_tool(tool: &str) -> Option<u64> {
     match tool {
         "gemini-cli" => {
-            // Gemini CLI workloads are highly variable. A hard 2GB default often
-            // fails in real projects before useful output is produced.
+            // Legacy Gemini-family session records are highly variable. A hard
+            // 2GB default often fails in real projects before useful output is
+            // produced.
             None
         }
         "codex" => {
@@ -80,7 +81,8 @@ fn default_memory_swap_max_mb_for_tool(tool: &str) -> Option<u64> {
 
 fn default_node_heap_limit_mb_for_tool(tool: &str) -> Option<u64> {
     if tool == "gemini-cli" {
-        // Let gemini-cli decide Node heap sizing unless user explicitly pins it.
+        // Let legacy Gemini-family tool records decide Node heap sizing unless
+        // the user explicitly pins it.
         return None;
     }
     match default_profile(tool) {

--- a/crates/csa-config/src/config_tests_removed_gemini.rs
+++ b/crates/csa-config/src/config_tests_removed_gemini.rs
@@ -1,0 +1,95 @@
+use super::*;
+use tempfile::tempdir;
+
+fn load_error(contents: &str) -> String {
+    let dir = tempdir().unwrap();
+    let config_dir = dir.path().join(".csa");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let project_path = config_dir.join("config.toml");
+    std::fs::write(&project_path, contents).unwrap();
+    let err = ProjectConfig::load_with_paths(None, &project_path).unwrap_err();
+    format!("{err:?}")
+}
+
+fn load_ok(contents: &str) {
+    let dir = tempdir().unwrap();
+    let config_dir = dir.path().join(".csa");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let project_path = config_dir.join("config.toml");
+    std::fs::write(&project_path, contents).unwrap();
+    ProjectConfig::load_with_paths(None, &project_path).unwrap();
+}
+
+fn raw_ok(contents: &str) {
+    let raw = toml::from_str::<toml::Value>(contents).unwrap();
+    crate::validate::reject_removed_gemini_cli_in_raw_config(&raw, "test-config").unwrap();
+}
+
+#[test]
+fn load_rejects_removed_gemini_cli_tool_section() {
+    let message = load_error("[tools.gemini-cli]\nenabled = true\n");
+    assert!(message.contains("removed tool reference"), "{message}");
+    assert!(
+        message.contains("gemini-cli integration has been removed"),
+        "{message}"
+    );
+}
+
+#[test]
+fn load_rejects_removed_gemini_cli_tier_model() {
+    let message = load_error(
+        "[tiers.tier-1]\ndescription = \"deprecated\"\nmodels = [\"gemini-cli/google/gemini-3-pro-preview/xhigh\"]\n",
+    );
+    assert!(message.contains("$.tiers.tier-1.models[0]"), "{message}");
+    assert!(
+        message.contains("Do not replace it with antigravity-cli"),
+        "{message}"
+    );
+}
+
+#[test]
+fn load_rejects_removed_gemini_cli_tool_alias() {
+    let message = load_error("[tool_aliases]\ngem = \"gemini-cli\"\n");
+    assert!(message.contains("$.tool_aliases.gem"), "{message}");
+    assert!(message.contains("no longer supported"), "{message}");
+}
+
+#[test]
+fn load_rejects_removed_gemini_review_tool_alias() {
+    let message = load_error("[review]\ntool = \"gemini\"\n");
+    assert!(message.contains("$.review.tool"), "{message}");
+    assert!(message.contains("removed tool reference"), "{message}");
+}
+
+#[test]
+fn raw_scan_rejects_removed_gemini_defaults_tool() {
+    let raw = toml::from_str::<toml::Value>("[defaults]\ntool = \"gemini-cli\"\n").unwrap();
+    let message = crate::validate::reject_removed_gemini_cli_in_raw_config(&raw, "test-config")
+        .unwrap_err()
+        .to_string();
+    assert!(message.contains("$.defaults.tool"), "{message}");
+    assert!(message.contains("removed tool reference"), "{message}");
+}
+
+#[test]
+fn load_allows_removed_gemini_cli_model_alias_key() {
+    load_ok("[aliases]\ngemini-cli = \"codex/openai/gpt-5.5/xhigh\"\n");
+}
+
+#[test]
+fn load_rejects_removed_gemini_cli_model_alias_value() {
+    let message =
+        load_error("[aliases]\nlegacy = \"gemini-cli/google/gemini-3-pro-preview/xhigh\"\n");
+    assert!(message.contains("$.aliases.legacy"), "{message}");
+    assert!(message.contains("removed tool reference"), "{message}");
+}
+
+#[test]
+fn load_allows_unrelated_project_name_gemini() {
+    load_ok("[project]\nname = \"gemini\"\n");
+}
+
+#[test]
+fn raw_scan_allows_unrelated_global_review_gate_name_gemini() {
+    raw_ok("[[review.gates]]\nname = \"gemini\"\ncommand = \"true\"\n");
+}

--- a/crates/csa-config/src/config_tests_tier_selector.rs
+++ b/crates/csa-config/src/config_tests_tier_selector.rs
@@ -9,7 +9,7 @@ fn test_resolve_tier_selector_direct_tier() {
         "tier1".to_string(),
         TierConfig {
             description: "test".to_string(),
-            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
             strategy: TierStrategy::default(),
             token_budget: None,
             max_turns: None,
@@ -54,7 +54,7 @@ fn test_resolve_tier_selector_alias() {
         "tier-2-standard".to_string(),
         TierConfig {
             description: "test".to_string(),
-            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
             strategy: TierStrategy::default(),
             token_budget: None,
             max_turns: None,
@@ -103,7 +103,7 @@ fn test_resolve_tier_selector_direct_wins_on_collision() {
         "default".to_string(),
         TierConfig {
             description: "direct tier".to_string(),
-            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
             strategy: TierStrategy::default(),
             token_budget: None,
             max_turns: None,
@@ -236,7 +236,7 @@ fn test_resolve_tier_selector_prefix_unique() {
             name.to_string(),
             TierConfig {
                 description: "test".to_string(),
-                models: vec!["gemini-cli/google/default/xhigh".to_string()],
+                models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
                 strategy: TierStrategy::default(),
                 token_budget: None,
                 max_turns: None,
@@ -310,7 +310,7 @@ fn test_resolve_tier_selector_prefix_ambiguous() {
             name.to_string(),
             TierConfig {
                 description: "test".to_string(),
-                models: vec!["gemini-cli/google/default/xhigh".to_string()],
+                models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
                 strategy: TierStrategy::default(),
                 token_budget: None,
                 max_turns: None,
@@ -361,7 +361,7 @@ fn test_resolve_tier_selector_exact_wins_over_prefix() {
             name.to_string(),
             TierConfig {
                 description: "test".to_string(),
-                models: vec!["gemini-cli/google/default/xhigh".to_string()],
+                models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
                 strategy: TierStrategy::default(),
                 token_budget: None,
                 max_turns: None,
@@ -413,7 +413,7 @@ fn test_suggest_tier_prefix() {
             name.to_string(),
             TierConfig {
                 description: "test".to_string(),
-                models: vec!["gemini-cli/google/default/xhigh".to_string()],
+                models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
                 strategy: TierStrategy::default(),
                 token_budget: None,
                 max_turns: None,
@@ -464,7 +464,7 @@ fn test_suggest_tier_substring() {
             name.to_string(),
             TierConfig {
                 description: "test".to_string(),
-                models: vec!["gemini-cli/google/default/xhigh".to_string()],
+                models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
                 strategy: TierStrategy::default(),
                 token_budget: None,
                 max_turns: None,
@@ -552,7 +552,7 @@ fn test_resolve_tier_selector_empty_string_rejected() {
         "tier-1-quick".to_string(),
         TierConfig {
             description: "test".to_string(),
-            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
             strategy: TierStrategy::default(),
             token_budget: None,
             max_turns: None,
@@ -602,7 +602,7 @@ fn compound_tier_fixture(tool_aliases: HashMap<String, String>) -> ProjectConfig
             name.to_string(),
             TierConfig {
                 description: "test".to_string(),
-                models: vec!["gemini-cli/google/default/xhigh".to_string()],
+                models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
                 strategy: TierStrategy::default(),
                 token_budget: None,
                 max_turns: None,
@@ -671,13 +671,11 @@ fn test_try_parse_compound_builtin_alias_suffix() {
             csa_core::types::ToolName::ClaudeCode,
         )),
     );
-    // `gemini` → GeminiCli (built-in alias from ToolArg::from_str).
+    // `gemini` was a legacy alias for the removed gemini-cli integration and
+    // must not parse as a tier suffix anymore.
     assert_eq!(
         config.try_parse_compound_tier_tool("tier-4-critical-gemini"),
-        Some((
-            "tier-4-critical".to_string(),
-            csa_core::types::ToolName::GeminiCli,
-        )),
+        None,
     );
 }
 

--- a/crates/csa-config/src/config_tests_tier_selector_legacy.rs
+++ b/crates/csa-config/src/config_tests_tier_selector_legacy.rs
@@ -7,7 +7,7 @@ fn config_with_tier_4_critical() -> ProjectConfig {
         "tier-4-critical".to_string(),
         TierConfig {
             description: "test".to_string(),
-            models: vec!["gemini-cli/google/default/xhigh".to_string()],
+            models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
             strategy: TierStrategy::default(),
             token_budget: None,
             max_turns: None,

--- a/crates/csa-config/src/config_tool.rs
+++ b/crates/csa-config/src/config_tool.rs
@@ -108,7 +108,7 @@ pub struct ToolConfig {
     /// OpenAI-compat only: base URL for the API endpoint (e.g., "http://localhost:8317").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
-    /// API key for authentication. Used by openai-compat and gemini-cli (fallback).
+    /// API key for authentication where supported by the selected provider.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
     /// Per-tool filesystem sandbox overrides. When set, replaces global

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -48,7 +48,7 @@ pub struct GlobalConfig {
     /// MCP hub unix socket for shared proxy mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_proxy_socket: Option<String>,
-    /// Tool name aliases (`gem` → `gemini-cli`). Project-level wins.
+    /// Tool name aliases (`cx` → `codex`). Project-level wins.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub tool_aliases: HashMap<String, String>,
     /// `csa run` behavior defaults; project config overrides through the merged project view.
@@ -322,7 +322,7 @@ pub struct ReviewConfig {
     /// Review tool selection.
     ///
     /// Accepts a single tool name (`"codex"`), `"auto"` for heterogeneous
-    /// auto-selection, or an array of tool names (`["codex", "gemini-cli"]`)
+    /// auto-selection, or an array of tool names (`["codex", "claude-code"]`)
     /// as a whitelist for auto-selection. An empty array is equivalent to `"auto"`.
     #[serde(default)]
     pub tool: ToolSelection,
@@ -346,7 +346,7 @@ pub struct ReviewConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tier: Option<String>,
     /// Default model for `csa review`. Overrides the tool's own default model
-    /// selection (e.g., gemini-cli model steering) without requiring a tier.
+    /// selection without requiring a tier.
     /// Without an active tier: CLI `--model` > this field > tool default.
     /// With an active review tier, the tier model spec remains authoritative unless CLI `--model` is provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -485,7 +485,7 @@ pub struct DebateConfig {
     /// Debate tool selection.
     ///
     /// Accepts a single tool name (`"codex"`), `"auto"` for heterogeneous
-    /// auto-selection, or an array of tool names (`["codex", "gemini-cli"]`)
+    /// auto-selection, or an array of tool names (`["codex", "claude-code"]`)
     /// as a whitelist for auto-selection. An empty array is equivalent to `"auto"`.
     #[serde(default)]
     pub tool: ToolSelection,
@@ -495,7 +495,7 @@ pub struct DebateConfig {
     #[serde(default = "default_debate_timeout_seconds")]
     pub timeout_seconds: u64,
     /// Default model for `csa debate`. Overrides the tool's own default model
-    /// selection (e.g., gemini-cli model steering) without requiring a tier.
+    /// selection without requiring a tier.
     /// Without an active tier: CLI `--model` > this field > tool default.
     /// With an active debate tier, the tier model spec remains authoritative unless CLI `--model` is provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -648,16 +648,20 @@ pub fn select_heterogeneous_tool(
         .copied()
 }
 
-/// Returns all known tool names as a static slice.
+/// Returns all currently supported tool names as a static slice.
 pub fn all_known_tools() -> &'static [ToolName] {
     &[
-        ToolName::GeminiCli,
         ToolName::Opencode,
         ToolName::Codex,
         ToolName::ClaudeCode,
         ToolName::OpenaiCompat,
         ToolName::AntigravityCli,
     ]
+}
+
+/// Returns tools eligible for automatic routing and general fallback.
+pub fn routing_candidate_tools() -> &'static [ToolName] {
+    csa_core::types::ROUTING_CANDIDATE_TOOLS
 }
 
 /// Sort tools by a priority list. Listed tools appear first (in priority order).
@@ -755,12 +759,11 @@ pub struct GlobalToolConfig {
     /// Accepts: low, medium, high, xhigh, max, or a numeric token count.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking_lock: Option<String>,
-    /// API key for fallback authentication. Used when OAuth quota is exhausted
-    /// (e.g., gemini-cli falls back to API key auth after 429 retries fail).
+    /// API key for fallback authentication where supported by the provider.
     /// NOT injected into env by default — only used as a last resort.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
-    /// Allow gemini-cli to continue after disabling unhealthy MCP servers.
+    /// Legacy no-op: retained for backward-compatible config deserialization.
     /// Defaults to true so startup-time MCP degradation is non-fatal.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_degraded_mcp: Option<bool>,

--- a/crates/csa-config/src/global_impl.rs
+++ b/crates/csa-config/src/global_impl.rs
@@ -39,6 +39,13 @@ impl GlobalConfig {
         }
         let content = std::fs::read_to_string(&path)
             .with_context(|| format!("Failed to read global config: {}", path.display()))?;
+        if let Ok(raw) = toml::from_str::<toml::Value>(&content) {
+            crate::validate::reject_removed_gemini_cli_in_raw_config(
+                &raw,
+                &path.display().to_string(),
+            )
+            .with_context(|| format!("Invalid global config: {}", path.display()))?;
+        }
         let config: Self = toml::from_str(&content)
             .with_context(|| format!("Failed to parse global config: {}", path.display()))?;
         Ok(config.sanitized(Some(&path)))
@@ -183,7 +190,7 @@ impl GlobalConfig {
         self.tools.get(tool).and_then(|t| t.api_key.as_deref())
     }
 
-    /// Whether gemini-cli may retry after stripping unhealthy MCP servers.
+    /// Whether a legacy provider may retry after stripping unhealthy MCP servers.
     ///
     /// Missing config defaults to `true` to keep MCP degradation non-fatal.
     pub fn allow_degraded_mcp(&self, tool: &str) -> bool {
@@ -282,7 +289,7 @@ impl GlobalConfig {
 
     /// List all known tool names (from config + static list).
     pub fn all_tool_slots(&self) -> Vec<(&str, u32)> {
-        let static_tools = ["gemini-cli", "opencode", "codex", "claude-code"];
+        let static_tools = ["opencode", "codex", "claude-code"];
         let mut result: Vec<(&str, u32)> = static_tools
             .iter()
             .map(|t| (*t, self.max_concurrent(t)))

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -11,12 +11,6 @@ max_concurrent = 3  # Default max parallel instances per tool
 
 # Per-tool overrides. Uncomment and configure as needed.
 #
-# [tools.gemini-cli]
-# max_concurrent = 5
-# api_key = "AI..."  # Fallback only after quota exhaustion; fresh invocations stay OAuth-first.
-# [tools.gemini-cli.env]
-# CSA_GEMINI_INCLUDE_DIRECTORIES = "/abs/path/one,/abs/path/two"
-#
 # [tools.claude-code]
 # max_concurrent = 1
 # [tools.claude-code.env]
@@ -40,7 +34,7 @@ max_concurrent = 3  # Default max parallel instances per tool
 # Example: prefer Claude Code for worker tasks, then Codex.
 # [preferences]
 # primary_writer_spec = "codex/openai/gpt-5.4/high"
-# tool_priority = ["claude-code", "codex", "gemini-cli", "opencode"]
+# tool_priority = ["claude-code", "codex", "opencode"]
 
 # Optional GitHub CLI auth override for issue workflows.
 # When unset, CSA falls back to ~/.config/gh-aider for issue reads/comments.

--- a/crates/csa-config/src/global_tests_heterogeneous.rs
+++ b/crates/csa-config/src/global_tests_heterogeneous.rs
@@ -114,13 +114,23 @@ task_pool_workers = 4
 #[test]
 fn test_all_known_tools() {
     let tools = all_known_tools();
-    assert_eq!(tools.len(), 6);
-    assert!(tools.contains(&ToolName::GeminiCli));
+    assert_eq!(tools.len(), 5);
+    assert!(!tools.contains(&ToolName::GeminiCli));
     assert!(tools.contains(&ToolName::Opencode));
     assert!(tools.contains(&ToolName::Codex));
     assert!(tools.contains(&ToolName::ClaudeCode));
     assert!(tools.contains(&ToolName::OpenaiCompat));
     assert!(tools.contains(&ToolName::AntigravityCli));
+}
+
+#[test]
+fn test_routing_candidate_tools_exclude_explicit_only_tools() {
+    let tools = routing_candidate_tools();
+    assert!(!tools.contains(&ToolName::GeminiCli));
+    assert!(!tools.contains(&ToolName::AntigravityCli));
+    assert!(tools.contains(&ToolName::Codex));
+    assert!(tools.contains(&ToolName::ClaudeCode));
+    assert!(tools.contains(&ToolName::Opencode));
 }
 
 #[test]
@@ -162,20 +172,19 @@ fn test_all_tool_slots_includes_extra_config_tools() {
     );
 
     let slots = config.all_tool_slots();
-    // 4 static tools + 1 custom = 5
-    assert_eq!(slots.len(), 5);
+    // 3 static routing tools + 1 custom = 4
+    assert_eq!(slots.len(), 4);
     let custom = slots.iter().find(|(t, _)| *t == "custom-tool").unwrap();
     assert_eq!(custom.1, 7);
 }
 
 #[test]
-fn test_all_tool_slots_default_config_has_four_tools() {
+fn test_all_tool_slots_default_config_has_three_tools() {
     let config = GlobalConfig::default();
     let slots = config.all_tool_slots();
-    assert_eq!(slots.len(), 4);
+    assert_eq!(slots.len(), 3);
 
     let names: Vec<&str> = slots.iter().map(|(n, _)| *n).collect();
-    assert!(names.contains(&"gemini-cli"));
     assert!(names.contains(&"opencode"));
     assert!(names.contains(&"codex"));
     assert!(names.contains(&"claude-code"));

--- a/crates/csa-config/src/init.rs
+++ b/crates/csa-config/src/init.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use crate::config::{
     CURRENT_SCHEMA_VERSION, ProjectConfig, ProjectMeta, ResourcesConfig, TierConfig, TierStrategy,
-    ToolConfig, ToolRestrictions,
+    ToolConfig,
 };
 
 /// Load tool names explicitly disabled (`enabled = false`) in the global config.
@@ -47,8 +47,8 @@ pub fn detect_installed_tools() -> Vec<&'static str> {
 /// This avoids relying on the process-global `PATH` environment variable,
 /// making it safe to call from parallel tests.
 fn detect_installed_tools_in_paths(paths: &OsStr) -> Vec<&'static str> {
-    let tools = ["gemini", "opencode", "codex", "claude"];
-    let names = ["gemini-cli", "opencode", "codex", "claude-code"];
+    let tools = ["opencode", "codex", "claude"];
+    let names = ["opencode", "codex", "claude-code"];
     tools
         .iter()
         .zip(names.iter())
@@ -60,14 +60,14 @@ fn detect_installed_tools_in_paths(paths: &OsStr) -> Vec<&'static str> {
 /// Build smart tier configuration based on installed tools.
 ///
 /// Assigns tools to tiers based on their characteristics:
-/// - tier-1-quick: Fast, cheap (gemini-cli flash > codex mini > opencode sonnet > claude-code sonnet)
-/// - tier-2-standard: Balanced (codex frontier > claude-code sonnet > opencode sonnet > gemini-cli pro)
-/// - tier-3-complex: Deep reasoning (claude-code opus > codex frontier > opencode opus > gemini-cli pro)
+/// - tier-1-quick: Fast, cheap (codex mini > opencode sonnet > claude-code sonnet)
+/// - tier-2-standard: Balanced (codex frontier > claude-code sonnet > opencode sonnet)
+/// - tier-3-complex: Deep reasoning (claude-code opus > codex frontier > opencode opus)
 ///
 /// Tools in `globally_disabled` are treated as unavailable even if their binary
 /// is installed, respecting the user's global `enabled = false` settings.
 ///
-/// If no tools are available, falls back to gemini-cli with all tiers disabled.
+/// If no tools are available, falls back to codex specs with all tools disabled.
 fn build_smart_tiers(
     installed: &[&str],
     globally_disabled: &[String],
@@ -79,17 +79,15 @@ fn build_smart_tiers(
         |name: &str| installed.contains(&name) && !globally_disabled.contains(&name.to_string());
 
     // tier-1-quick: Fast, cheap
-    let tier1_model = if has_tool("gemini-cli") {
-        "gemini-cli/google/gemini-3-flash-preview/xhigh"
-    } else if has_tool("codex") {
+    let tier1_model = if has_tool("codex") {
         "codex/openai/gpt-5.4-mini/xhigh"
     } else if has_tool("opencode") {
         "opencode/anthropic/claude-sonnet-4-5-20250929/default"
     } else if has_tool("claude-code") {
         "claude-code/anthropic/claude-sonnet-4-5-20250929/default"
     } else {
-        // Fallback: gemini-cli (will be disabled)
-        "gemini-cli/google/gemini-3-flash-preview/xhigh"
+        // Fallback: codex (will be disabled)
+        "codex/openai/gpt-5.4-mini/xhigh"
     };
 
     tiers.insert(
@@ -111,11 +109,9 @@ fn build_smart_tiers(
         "claude-code/anthropic/claude-sonnet-4-5-20250929/default"
     } else if has_tool("opencode") {
         "opencode/anthropic/claude-sonnet-4-5-20250929/default"
-    } else if has_tool("gemini-cli") {
-        "gemini-cli/google/gemini-3-pro-preview/xhigh"
     } else {
-        // Fallback: gemini-cli (will be disabled)
-        "gemini-cli/google/gemini-3-pro-preview/xhigh"
+        // Fallback: codex (will be disabled)
+        "codex/openai/gpt-5.5/high"
     };
 
     tiers.insert(
@@ -137,11 +133,9 @@ fn build_smart_tiers(
         "codex/openai/gpt-5.5/xhigh"
     } else if has_tool("opencode") {
         "opencode/anthropic/claude-opus-4-6/default"
-    } else if has_tool("gemini-cli") {
-        "gemini-cli/google/gemini-3-pro-preview/xhigh"
     } else {
-        // Fallback: gemini-cli (will be disabled)
-        "gemini-cli/google/gemini-3-pro-preview/xhigh"
+        // Fallback: codex (will be disabled)
+        "codex/openai/gpt-5.5/xhigh"
     };
 
     tiers.insert(
@@ -165,7 +159,7 @@ fn build_smart_tiers(
 /// Returns the generated config.
 pub fn init_project(
     project_root: &Path,
-    non_interactive: bool,
+    _non_interactive: bool,
     minimal: bool,
 ) -> Result<ProjectConfig> {
     let config_path = ProjectConfig::config_path(project_root);
@@ -186,25 +180,7 @@ pub fn init_project(
 
     let mut tools = HashMap::new();
 
-    // gemini-cli has special restrictions
-    if installed.contains(&"gemini-cli") || !non_interactive {
-        let is_usable =
-            installed.contains(&"gemini-cli") && !globally_disabled.contains(&"gemini-cli".into());
-        tools.insert(
-            "gemini-cli".to_string(),
-            ToolConfig {
-                enabled: is_usable,
-                restrictions: Some(ToolRestrictions {
-                    allow_edit_existing_files: false,
-                    allow_write_new_files: true,
-                }),
-                suppress_notify: true,
-                ..Default::default()
-            },
-        );
-    }
-
-    // Other tools with default config
+    // Supported tools with default config
     for tool_name in &["opencode", "codex", "claude-code"] {
         let is_usable =
             installed.contains(tool_name) && !globally_disabled.contains(&tool_name.to_string());

--- a/crates/csa-config/src/init_tests.rs
+++ b/crates/csa-config/src/init_tests.rs
@@ -84,14 +84,14 @@ fn test_detect_installed_tools() {
     // We can't assert specific tools since it depends on the system
     // but we can verify the function returns valid tool names
     for tool in &tools {
-        assert!(["gemini-cli", "opencode", "codex", "claude-code"].contains(tool));
+        assert!(["opencode", "codex", "claude-code"].contains(tool));
     }
 }
 
 #[test]
 fn test_smart_tiers_with_multiple_tools() {
-    // Simulate a system with codex, gemini-cli, and claude-code installed
-    let installed = vec!["codex", "gemini-cli", "claude-code"];
+    // Simulate a system with codex and claude-code installed
+    let installed = vec!["codex", "claude-code"];
     let tiers = build_smart_tiers(&installed, &[]);
 
     // Verify all tiers are created
@@ -100,13 +100,10 @@ fn test_smart_tiers_with_multiple_tools() {
     assert!(tiers.contains_key("tier-2-standard"));
     assert!(tiers.contains_key("tier-3-complex"));
 
-    // tier-1-quick should prefer gemini-cli flash (fast, cheap)
+    // tier-1-quick should prefer fast codex
     let tier1 = tiers.get("tier-1-quick").unwrap();
     assert_eq!(tier1.models.len(), 1);
-    assert_eq!(
-        tier1.models[0],
-        "gemini-cli/google/gemini-3-flash-preview/xhigh"
-    );
+    assert_eq!(tier1.models[0], "codex/openai/gpt-5.4-mini/xhigh");
 
     // tier-2-standard should prefer codex frontier (balanced)
     let tier2 = tiers.get("tier-2-standard").unwrap();
@@ -121,46 +118,38 @@ fn test_smart_tiers_with_multiple_tools() {
         "claude-code/anthropic/claude-opus-4-6/default"
     );
 
-    // Verify tier diversity: different tiers use different tools
-    let tier1_tool = tier1.models[0].split('/').next().unwrap();
-    let tier2_tool = tier2.models[0].split('/').next().unwrap();
+    // Verify complex tier can still choose a different tool.
     let tier3_tool = tier3.models[0].split('/').next().unwrap();
 
     assert_ne!(
-        tier1_tool, tier2_tool,
-        "tier-1 and tier-2 should use different tools"
-    );
-    assert_ne!(
-        tier2_tool, tier3_tool,
-        "tier-2 and tier-3 should use different tools"
+        tier2.models[0].split('/').next().unwrap(),
+        tier3_tool,
+        "tier-2 and tier-3 should use different tools when claude-code is installed"
     );
 }
 
 #[test]
-fn test_smart_tiers_with_only_gemini() {
-    // Simulate a system with only gemini-cli installed
-    let installed = vec!["gemini-cli"];
+fn test_smart_tiers_with_only_codex() {
+    // Simulate a system with only codex installed
+    let installed = vec!["codex"];
     let tiers = build_smart_tiers(&installed, &[]);
 
     // Verify all tiers are created
     assert_eq!(tiers.len(), 3);
 
-    // All tiers should use gemini-cli
+    // All tiers should use codex
     let tier1 = tiers.get("tier-1-quick").unwrap();
-    assert!(tier1.models[0].starts_with("gemini-cli/"));
+    assert!(tier1.models[0].starts_with("codex/"));
 
     let tier2 = tiers.get("tier-2-standard").unwrap();
-    assert!(tier2.models[0].starts_with("gemini-cli/"));
+    assert!(tier2.models[0].starts_with("codex/"));
 
     let tier3 = tiers.get("tier-3-complex").unwrap();
-    assert!(tier3.models[0].starts_with("gemini-cli/"));
+    assert!(tier3.models[0].starts_with("codex/"));
 
-    // tier-1 should use flash variant
-    assert!(tier1.models[0].contains("flash"));
-
-    // tier-2 and tier-3 should use pro variant
-    assert!(tier2.models[0].contains("pro"));
-    assert!(tier3.models[0].contains("pro"));
+    assert!(tier1.models[0].contains("gpt-5.4-mini"));
+    assert!(tier2.models[0].contains("gpt-5.5"));
+    assert!(tier3.models[0].contains("gpt-5.5"));
 }
 
 #[test]
@@ -169,15 +158,15 @@ fn test_smart_tiers_with_no_tools() {
     let installed: Vec<&str> = vec![];
     let tiers = build_smart_tiers(&installed, &[]);
 
-    // Should still create all tiers with gemini-cli fallback
+    // Should still create all tiers with codex fallback
     assert_eq!(tiers.len(), 3);
 
-    // All should fallback to gemini-cli
+    // All should fallback to codex
     for tier_name in &["tier-1-quick", "tier-2-standard", "tier-3-complex"] {
         let tier = tiers.get(*tier_name).unwrap();
         assert!(
-            tier.models[0].starts_with("gemini-cli/"),
-            "Tier {tier_name} should fallback to gemini-cli"
+            tier.models[0].starts_with("codex/"),
+            "Tier {tier_name} should fallback to codex"
         );
     }
 }
@@ -221,7 +210,7 @@ fn test_build_smart_tiers_with_only_codex() {
 
     assert_eq!(tiers.len(), 3);
 
-    // tier-1-quick: codex (no gemini, so codex is first fallback)
+    // tier-1-quick: codex
     let tier1 = tiers.get("tier-1-quick").unwrap();
     assert!(tier1.models[0].starts_with("codex/"));
     assert!(tier1.models[0].contains("gpt-5.4-mini"));
@@ -283,14 +272,14 @@ fn test_build_smart_tiers_with_only_opencode() {
 }
 
 #[test]
-fn test_build_smart_tiers_with_gemini_and_codex() {
+fn test_build_smart_tiers_ignores_removed_gemini_with_codex() {
     let installed = vec!["gemini-cli", "codex"];
     let tiers = build_smart_tiers(&installed, &[]);
 
-    // tier-1-quick should use gemini flash (fastest/cheapest)
+    // tier-1-quick should use codex, not removed gemini-cli
     let tier1 = tiers.get("tier-1-quick").unwrap();
-    assert!(tier1.models[0].starts_with("gemini-cli/"));
-    assert!(tier1.models[0].contains("flash"));
+    assert!(tier1.models[0].starts_with("codex/"));
+    assert!(tier1.models[0].contains("gpt-5.4-mini"));
 
     // tier-2-standard should prefer codex
     let tier2 = tiers.get("tier-2-standard").unwrap();
@@ -304,7 +293,7 @@ fn test_build_smart_tiers_with_gemini_and_codex() {
 
 #[test]
 fn test_build_smart_tiers_each_tier_has_exactly_one_model() {
-    let installed = vec!["gemini-cli", "codex", "claude-code", "opencode"];
+    let installed = vec!["codex", "claude-code", "opencode"];
     let tiers = build_smart_tiers(&installed, &[]);
 
     for (name, tier) in &tiers {
@@ -320,7 +309,7 @@ fn test_build_smart_tiers_each_tier_has_exactly_one_model() {
 
 #[test]
 fn test_build_smart_tiers_descriptions_not_empty() {
-    let installed = vec!["gemini-cli"];
+    let installed = vec!["codex"];
     let tiers = build_smart_tiers(&installed, &[]);
 
     for (name, tier) in &tiers {
@@ -394,10 +383,10 @@ fn test_detect_installed_tools_with_mock_path() {
     let custom_path = std::ffi::OsStr::new(bin_dir.to_str().unwrap());
     let tools = detect_installed_tools_in_paths(custom_path);
 
-    // Should detect gemini-cli and codex (mapped from "gemini" and "codex" executables)
+    // Should detect codex but not removed gemini-cli.
     assert!(
-        tools.contains(&"gemini-cli"),
-        "Should detect gemini-cli from mock 'gemini' executable"
+        !tools.contains(&"gemini-cli"),
+        "Should not detect removed gemini-cli from mock 'gemini' executable"
     );
     assert!(
         tools.contains(&"codex"),
@@ -507,40 +496,40 @@ fn test_update_gitignore_no_trailing_newline() {
 
 #[test]
 fn test_build_smart_tiers_skips_globally_disabled() {
-    // gemini-cli and codex installed, but gemini-cli is globally disabled.
-    let installed = vec!["gemini-cli", "codex", "claude-code"];
-    let disabled = vec!["gemini-cli".to_string()];
+    // opencode and codex installed, but opencode is globally disabled.
+    let installed = vec!["opencode", "codex", "claude-code"];
+    let disabled = vec!["opencode".to_string()];
     let tiers = build_smart_tiers(&installed, &disabled);
 
-    // No tier should contain gemini-cli
+    // No tier should contain opencode
     for (name, tier) in &tiers {
         for model in &tier.models {
             assert!(
-                !model.starts_with("gemini-cli/"),
-                "tier '{name}' should not contain globally-disabled gemini-cli, found: {model}"
+                !model.starts_with("opencode/"),
+                "tier '{name}' should not contain globally-disabled opencode, found: {model}"
             );
         }
     }
 
-    // tier-1-quick should fall back to codex (next preference after gemini-cli)
+    // tier-1-quick should fall back to codex
     let tier1 = tiers.get("tier-1-quick").unwrap();
     assert!(
         tier1.models[0].starts_with("codex/"),
-        "tier-1-quick should use codex when gemini-cli is disabled"
+        "tier-1-quick should use codex when opencode is disabled"
     );
 }
 
 #[test]
 fn test_build_smart_tiers_all_disabled() {
     // All tools installed but all globally disabled.
-    let installed = vec!["gemini-cli", "codex", "claude-code"];
+    let installed = vec!["opencode", "codex", "claude-code"];
     let disabled = vec![
-        "gemini-cli".to_string(),
+        "opencode".to_string(),
         "codex".to_string(),
         "claude-code".to_string(),
     ];
     let tiers = build_smart_tiers(&installed, &disabled);
 
-    // Should fall back to gemini-cli defaults (existing behavior for no tools)
+    // Should fall back to codex defaults (existing behavior for no tools)
     assert_eq!(tiers.len(), 3);
 }

--- a/crates/csa-config/src/tool_selection.rs
+++ b/crates/csa-config/src/tool_selection.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// TOML examples:
 /// ```toml
 /// tool = "codex"                      # Single: always use codex
-/// tool = ["codex", "gemini-cli"]      # Legacy no-tier auto whitelist; active-tier preference order
+/// tool = ["codex", "claude-code"]     # Legacy no-tier auto whitelist; active-tier preference order
 /// tool = []                           # Empty: same as "auto"
 /// ```
 #[derive(Debug, Clone, PartialEq)]
@@ -36,7 +36,7 @@ impl ToolSelection {
     ///
     /// - `Single("auto")` → `None` (no restriction)
     /// - `Single("codex")` → `None` (direct selection, not a filter)
-    /// - `Whitelist(["codex", "gemini-cli"])` → `Some(&["codex", "gemini-cli"])`
+    /// - `Whitelist(["codex", "claude-code"])` → `Some(&["codex", "claude-code"])`
     /// - `Whitelist([])` → `None` (empty = no restriction)
     pub fn whitelist(&self) -> Option<&[String]> {
         match self {
@@ -57,7 +57,7 @@ impl ToolSelection {
     ///
     /// - `Single("auto")` -> empty preference list
     /// - `Single("codex")` -> `["codex"]`
-    /// - `Whitelist(["codex", "gemini-cli"])` -> same ordered list
+    /// - `Whitelist(["codex", "claude-code"])` -> same ordered list
     /// - `Whitelist([])` -> empty preference list
     pub fn preference_order(&self) -> Vec<String> {
         match self {
@@ -167,7 +167,7 @@ mod tests {
 
     #[test]
     fn whitelist_returns_tools() {
-        let sel = ToolSelection::Whitelist(vec!["codex".into(), "gemini-cli".into()]);
+        let sel = ToolSelection::Whitelist(vec!["codex".into(), "claude-code".into()]);
         assert!(!sel.is_auto());
         assert_eq!(sel.whitelist().unwrap().len(), 2);
     }
@@ -180,8 +180,8 @@ mod tests {
 
     #[test]
     fn preference_order_returns_ordered_array() {
-        let sel = ToolSelection::Whitelist(vec!["codex".into(), "gemini-cli".into()]);
-        assert_eq!(sel.preference_order(), vec!["codex", "gemini-cli"]);
+        let sel = ToolSelection::Whitelist(vec!["codex".into(), "claude-code".into()]);
+        assert_eq!(sel.preference_order(), vec!["codex", "claude-code"]);
     }
 
     #[test]
@@ -209,10 +209,10 @@ mod tests {
 
     #[test]
     fn allows_checks_whitelist() {
-        let sel = ToolSelection::Whitelist(vec!["codex".into(), "gemini-cli".into()]);
+        let sel = ToolSelection::Whitelist(vec!["codex".into(), "claude-code".into()]);
         assert!(sel.allows("codex"));
-        assert!(sel.allows("gemini-cli"));
-        assert!(!sel.allows("claude-code"));
+        assert!(sel.allows("claude-code"));
+        assert!(!sel.allows("opencode"));
     }
 
     #[test]
@@ -227,8 +227,8 @@ mod tests {
 
     #[test]
     fn display_whitelist() {
-        let sel = ToolSelection::Whitelist(vec!["codex".into(), "gemini-cli".into()]);
-        assert_eq!(sel.to_string(), "[codex, gemini-cli]");
+        let sel = ToolSelection::Whitelist(vec!["codex".into(), "claude-code".into()]);
+        assert_eq!(sel.to_string(), "[codex, claude-code]");
     }
 
     #[test]
@@ -254,11 +254,11 @@ mod tests {
 
     #[test]
     fn serde_roundtrip_whitelist() {
-        let toml_str = r#"tool = ["codex", "gemini-cli"]"#;
+        let toml_str = r#"tool = ["codex", "claude-code"]"#;
         let parsed: Wrapper = toml::from_str(toml_str).unwrap();
         assert_eq!(
             parsed.tool,
-            ToolSelection::Whitelist(vec!["codex".into(), "gemini-cli".into()])
+            ToolSelection::Whitelist(vec!["codex".into(), "claude-code".into()])
         );
     }
 

--- a/crates/csa-config/src/validate.rs
+++ b/crates/csa-config/src/validate.rs
@@ -6,7 +6,6 @@ use crate::config::{FORK_PREFIX_BUDGET_MAX_TOKENS, FORK_PREFIX_BUDGET_MIN_TOKENS
 use crate::global::ToolSelection;
 
 const KNOWN_TOOLS: &[&str] = &[
-    "gemini-cli",
     "opencode",
     "codex",
     "claude-code",
@@ -78,6 +77,81 @@ pub(crate) fn validate_tool_transport_overrides_in_raw_config(raw: &toml::Value)
     }
 
     Ok(())
+}
+
+pub(crate) fn reject_removed_gemini_cli_in_raw_config(
+    raw: &toml::Value,
+    source: &str,
+) -> Result<()> {
+    reject_removed_gemini_cli_value(raw, source, "$")
+}
+
+fn reject_removed_gemini_cli_value(raw: &toml::Value, source: &str, path: &str) -> Result<()> {
+    match raw {
+        toml::Value::Table(table) => {
+            for (key, value) in table {
+                let child_path = format!("{path}.{key}");
+                if is_semantic_tool_key_table(path) && csa_core::types::is_removed_tool_name(key) {
+                    return Err(removed_gemini_cli_reference_error(source, &child_path, key));
+                }
+                reject_removed_gemini_cli_value(value, source, &child_path)?;
+            }
+        }
+        toml::Value::Array(items) => {
+            for (index, value) in items.iter().enumerate() {
+                reject_removed_gemini_cli_value(value, source, &format!("{path}[{index}]"))?;
+            }
+        }
+        toml::Value::String(value) if is_removed_gemini_cli_config_value(path, value) => {
+            return Err(removed_gemini_cli_reference_error(source, path, value));
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+fn is_semantic_tool_key_table(path: &str) -> bool {
+    matches!(path, "$.tools" | "$.resources.initial_estimates")
+}
+
+fn is_removed_gemini_cli_config_value(path: &str, value: &str) -> bool {
+    if is_semantic_tool_value_path(path) {
+        return csa_core::types::is_removed_tool_name(value);
+    }
+    if is_semantic_model_spec_value_path(path) {
+        return is_removed_gemini_cli_model_spec(value);
+    }
+    false
+}
+
+fn is_semantic_tool_value_path(path: &str) -> bool {
+    matches!(path, "$.defaults.tool" | "$.review.tool" | "$.debate.tool")
+        || path.starts_with("$.review.tool[")
+        || path.starts_with("$.debate.tool[")
+        || path.starts_with("$.tool_aliases.")
+        || path.starts_with("$.preferences.tool_priority[")
+}
+
+fn is_semantic_model_spec_value_path(path: &str) -> bool {
+    path.starts_with("$.aliases.")
+        || path == "$.preferences.primary_writer_spec"
+        || (path.starts_with("$.tiers.") && path.contains(".models["))
+}
+
+fn is_removed_gemini_cli_model_spec(value: &str) -> bool {
+    let tool_part = value.split_once('/').map_or(value, |(tool, _)| tool);
+    csa_core::types::is_removed_tool_name(tool_part)
+}
+
+fn removed_gemini_cli_reference_error(source: &str, path: &str, value: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Invalid config {source}: removed tool reference '{value}' at {path}.\n\
+         {}\n\
+         Action: remove this entry or replace it with codex/claude-code. Do not replace it with \
+         antigravity-cli as a general fallback.",
+        csa_core::types::removed_tool_error("gemini-cli")
+    )
 }
 
 pub(crate) fn validate_tool_transport_overrides(config: &ProjectConfig) -> Result<()> {
@@ -341,25 +415,18 @@ fn transport_key(tool_name: &str) -> String {
 fn validate_tool_selection(tool: &ToolSelection, section: &str) -> Result<()> {
     let single_supported = [
         "auto",
-        "gemini-cli",
         "opencode",
         "codex",
         "claude-code",
         "antigravity-cli",
     ];
-    let whitelist_supported = [
-        "gemini-cli",
-        "opencode",
-        "codex",
-        "claude-code",
-        "antigravity-cli",
-    ];
+    let whitelist_supported = ["opencode", "codex", "claude-code", "antigravity-cli"];
     match tool {
         ToolSelection::Single(s) => {
             if !single_supported.contains(&s.as_str()) {
                 bail!(
                     "Invalid [{section}].tool value '{s}'. \
-                     Supported values: auto, gemini-cli, antigravity-cli, opencode, codex, claude-code."
+                     Supported values: auto, antigravity-cli, opencode, codex, claude-code."
                 );
             }
         }
@@ -368,7 +435,7 @@ fn validate_tool_selection(tool: &ToolSelection, section: &str) -> Result<()> {
                 if !whitelist_supported.contains(&t.as_str()) {
                     bail!(
                         "Invalid tool '{t}' in [{section}].tool array. \
-                         Supported values: gemini-cli, antigravity-cli, opencode, codex, claude-code. \
+                         Supported values: antigravity-cli, opencode, codex, claude-code. \
                          ('auto' is not valid inside a whitelist array)"
                     );
                 }
@@ -482,7 +549,6 @@ fn warn_fork_prefix_budget_out_of_range(config: &ProjectConfig) {
 /// Unknown entries are harmless (sorted to end) but likely indicate a typo.
 fn warn_unknown_tool_priority(config: &ProjectConfig) {
     let known_tools = [
-        "gemini-cli",
         "opencode",
         "codex",
         "claude-code",
@@ -511,6 +577,15 @@ fn validate_model_spec(tier_name: &str, model_spec: &str) -> Result<()> {
 
     // Validate tool name is a known tool
     let tool_part = parts[0];
+    if csa_core::types::is_removed_tool_name(tool_part) {
+        bail!(
+            "Tier '{tier_name}' has model spec '{model_spec}' with removed tool '{}'.\n\
+             {}\n\
+             Action: remove this model from the tier or replace it with a codex/claude-code spec.",
+            tool_part,
+            csa_core::types::removed_tool_error("gemini-cli")
+        );
+    }
     let known_tools: Vec<&str> = crate::global::all_known_tools()
         .iter()
         .map(|t| t.as_str())

--- a/crates/csa-config/src/validate_tests.rs
+++ b/crates/csa-config/src/validate_tests.rs
@@ -21,7 +21,7 @@ fn test_validate_config_succeeds_on_valid() {
         "tier-1-quick".to_string(),
         TierConfig {
             description: "Quick tasks".to_string(),
-            models: vec!["gemini-cli/google/gemini-3-flash-preview/xhigh".to_string()],
+            models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
             strategy: TierStrategy::default(),
 
             token_budget: None,
@@ -320,7 +320,7 @@ fn test_validate_config_fails_on_invalid_tier_mapping() {
         "tier-1-quick".to_string(),
         TierConfig {
             description: "Quick tasks".to_string(),
-            models: vec!["gemini-cli/google/gemini-3-flash-preview/xhigh".to_string()],
+            models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
             strategy: TierStrategy::default(),
 
             token_budget: None,
@@ -453,7 +453,7 @@ fn test_validate_config_accepts_custom_tier_names() {
         "my-custom-tier".to_string(),
         TierConfig {
             description: "Custom tier name".to_string(),
-            models: vec!["gemini-cli/google/gemini-3-flash-preview/xhigh".to_string()],
+            models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
             strategy: TierStrategy::default(),
 
             token_budget: None,

--- a/crates/csa-config/src/validate_tests_tail.rs
+++ b/crates/csa-config/src/validate_tests_tail.rs
@@ -218,7 +218,6 @@ fn test_validate_review_batch_commits_zero_rejected() {
 fn test_validate_all_known_review_tools_accepted() {
     let known = [
         "auto",
-        "gemini-cli",
         "opencode",
         "codex",
         "claude-code",
@@ -273,7 +272,6 @@ fn test_validate_all_known_review_tools_accepted() {
 fn test_validate_all_known_debate_tools_accepted() {
     let known = [
         "auto",
-        "gemini-cli",
         "opencode",
         "codex",
         "claude-code",
@@ -329,13 +327,7 @@ fn test_validate_all_known_tools_accepted() {
     let dir = tempdir().unwrap();
 
     let mut tools = HashMap::new();
-    for name in &[
-        "gemini-cli",
-        "opencode",
-        "codex",
-        "claude-code",
-        "antigravity-cli",
-    ] {
+    for name in &["opencode", "codex", "claude-code", "antigravity-cli"] {
         tools.insert(name.to_string(), ToolConfig::default());
     }
 

--- a/crates/csa-config/src/validate_tests_tiers.rs
+++ b/crates/csa-config/src/validate_tests_tiers.rs
@@ -7,7 +7,7 @@ fn test_validate_multiple_tiers_all_valid() {
         "tier-1-quick".to_string(),
         TierConfig {
             description: "Quick tasks".to_string(),
-            models: vec!["gemini-cli/google/gemini-3-flash-preview/xhigh".to_string()],
+            models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
             strategy: TierStrategy::default(),
 
             token_budget: None,
@@ -87,7 +87,7 @@ fn test_validate_tier_with_multiple_models_all_valid() {
         TierConfig {
             description: "Has multiple models".to_string(),
             models: vec![
-                "gemini-cli/google/gemini-3-flash-preview/xhigh".to_string(),
+                "codex/openai/gpt-5.5/xhigh".to_string(),
                 "codex/openai/gpt-5.4/default".to_string(),
             ],
             strategy: TierStrategy::default(),
@@ -142,7 +142,7 @@ fn test_validate_tier_with_one_bad_model_in_list() {
         TierConfig {
             description: "One good, one bad".to_string(),
             models: vec![
-                "gemini-cli/google/gemini-3-flash-preview/xhigh".to_string(),
+                "codex/openai/gpt-5.5/xhigh".to_string(),
                 "bad-spec".to_string(), // invalid
             ],
             strategy: TierStrategy::default(),
@@ -745,7 +745,7 @@ fn test_validate_review_tier_valid_accepted() {
         "tier-4-critical".to_string(),
         TierConfig {
             description: "Critical tier".to_string(),
-            models: vec!["gemini-cli/google/gemini-3-flash-preview/xhigh".to_string()],
+            models: vec!["codex/openai/gpt-5.5/xhigh".to_string()],
             strategy: TierStrategy::default(),
 
             token_budget: None,

--- a/crates/csa-config/src/validate_tests_transport.rs
+++ b/crates/csa-config/src/validate_tests_transport.rs
@@ -59,24 +59,6 @@ fn validate_tool_transport_matrix_matches_phase_3_contract() {
             expected_message: None,
         },
         Case {
-            tool: "gemini-cli",
-            value: "auto",
-            should_pass: true,
-            expected_message: None,
-        },
-        Case {
-            tool: "gemini-cli",
-            value: "cli",
-            should_pass: true,
-            expected_message: None,
-        },
-        Case {
-            tool: "gemini-cli",
-            value: "acp",
-            should_pass: false,
-            expected_message: Some("gemini-cli does not support ACP transport"),
-        },
-        Case {
             tool: "opencode",
             value: "auto",
             should_pass: true,

--- a/crates/csa-core/src/types.rs
+++ b/crates/csa-core/src/types.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 /// AI tool selection
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
 pub enum ToolName {
+    #[value(skip)]
     GeminiCli,
     Opencode,
     Codex,
@@ -16,13 +17,31 @@ pub enum ToolName {
 }
 
 /// Primary CLI-backed tools surfaced by doctor and default tool listings.
-pub const PRIMARY_TOOL_NAMES: &[&str] = &[
-    "gemini-cli",
-    "opencode",
-    "codex",
-    "claude-code",
-    "antigravity-cli",
+pub const PRIMARY_TOOL_NAMES: &[&str] = &["opencode", "codex", "claude-code"];
+
+/// Tools eligible for general automatic routing and fallback.
+///
+/// `antigravity-cli` is intentionally omitted: it may still be invoked through
+/// explicit low-risk paths, but CSA must not use it as a general fallback for
+/// implementation, review, or long-context work.
+pub const ROUTING_CANDIDATE_TOOLS: &[ToolName] = &[
+    ToolName::Opencode,
+    ToolName::Codex,
+    ToolName::ClaudeCode,
+    ToolName::OpenaiCompat,
 ];
+
+pub fn is_removed_tool_name(name: &str) -> bool {
+    matches!(name, "gemini-cli" | "gemini")
+}
+
+pub fn removed_tool_error(name: &str) -> String {
+    format!(
+        "tool '{name}' is no longer supported: gemini-cli integration has been removed because \
+         the provider is discontinued. Remove it from CLI/config/tier mappings and use codex or \
+         claude-code instead. CSA will not route to antigravity-cli as a general fallback."
+    )
+}
 
 impl ToolName {
     /// Returns the CLI-facing name for this tool
@@ -106,10 +125,12 @@ impl std::fmt::Display for ModelFamily {
 
 /// Resolve the `ModelFamily` (quota-pool / provider grouping) for a CLI tool name.
 ///
-/// Tools that share an upstream provider quota pool — `gemini-cli` and
-/// `antigravity-cli` both consume the Google OAuth quota — map to the same
+/// Tools that share an upstream provider quota pool map to the same
 /// `ModelFamily` so that failover can skip same-provider alternatives after one
 /// of them exhausts the shared quota.
+///
+/// Legacy Gemini-family session records and `antigravity-cli` both consume the
+/// Google/Gemini quota pool.
 pub fn provider_for_tool_name(tool: &str) -> Option<ModelFamily> {
     match tool {
         "gemini-cli" | "antigravity-cli" | "antigravity" | "gemini" => Some(ModelFamily::Gemini),
@@ -125,9 +146,9 @@ pub fn provider_for_tool_name(tool: &str) -> Option<ModelFamily> {
 /// Written to `result.toml` under `[[fallback_chain]]` when failover occurred during `csa run`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FallbackAttempt {
-    /// Tool name that was attempted (e.g. "gemini-cli").
+    /// Tool name that was attempted (e.g. "codex").
     pub tool: String,
-    /// Full model spec that was attempted (e.g. "gemini-cli/google/gemini-3.1-pro-preview/xhigh").
+    /// Full model spec that was attempted (e.g. "codex/openai/gpt-5.5/xhigh").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_spec: Option<String>,
     /// Machine-readable reason the tool was skipped (matched pattern from stderr/stdout).
@@ -158,15 +179,14 @@ impl std::str::FromStr for ToolArg {
         match s {
             "auto" => Ok(Self::Auto),
             "any-available" => Ok(Self::AnyAvailable),
+            "gemini-cli" | "gemini" => Err(removed_tool_error(s)),
             // Canonical tool names
-            "gemini-cli" => Ok(Self::Specific(ToolName::GeminiCli)),
             "opencode" => Ok(Self::Specific(ToolName::Opencode)),
             "codex" => Ok(Self::Specific(ToolName::Codex)),
             "claude-code" => Ok(Self::Specific(ToolName::ClaudeCode)),
             "openai-compat" => Ok(Self::Specific(ToolName::OpenaiCompat)),
             "antigravity-cli" => Ok(Self::Specific(ToolName::AntigravityCli)),
             // Built-in aliases for common short names
-            "gemini" => Ok(Self::Specific(ToolName::GeminiCli)),
             "claude" => Ok(Self::Specific(ToolName::ClaudeCode)),
             "antigravity" => Ok(Self::Specific(ToolName::AntigravityCli)),
             // Unknown string — store for config-based resolution
@@ -191,14 +211,14 @@ impl ToolArg {
                     match resolved {
                         Self::Alias(ref inner) => Err(format!(
                             "tool alias '{alias}' maps to '{inner}' which is not a valid tool \
-                             name. Valid targets: gemini-cli, opencode, codex, claude-code, antigravity-cli"
+                             name. Valid targets: opencode, codex, claude-code, openai-compat, antigravity-cli"
                         )),
                         other => Ok(other),
                     }
                 } else {
                     Err(format!(
                         "unknown tool '{alias}'. Valid values: auto, any-available, \
-                         gemini-cli, opencode, codex, claude-code, openai-compat, antigravity-cli. \
+                         opencode, codex, claude-code, openai-compat, antigravity-cli. \
                          Or define it in [tool_aliases] in config."
                     ))
                 }
@@ -335,12 +355,11 @@ mod tests {
     }
 
     #[test]
-    fn test_tool_arg_from_str_specific_gemini() {
-        let arg = ToolArg::from_str("gemini-cli").unwrap();
-        match arg {
-            ToolArg::Specific(ToolName::GeminiCli) => {}
-            _ => panic!("Expected Specific(GeminiCli)"),
-        }
+    fn test_tool_arg_from_str_rejects_removed_gemini_cli() {
+        let err = ToolArg::from_str("gemini-cli").unwrap_err();
+        assert!(err.contains("no longer supported"), "{err}");
+        assert!(err.contains("discontinued"), "{err}");
+        assert!(err.contains("codex"), "{err}");
     }
 
     #[test]
@@ -359,9 +378,12 @@ mod tests {
     }
 
     #[test]
-    fn test_tool_arg_from_str_builtin_alias_gemini() {
-        let arg = ToolArg::from_str("gemini").unwrap();
-        assert!(matches!(arg, ToolArg::Specific(ToolName::GeminiCli)));
+    fn test_tool_arg_from_str_rejects_removed_gemini_alias() {
+        let err = ToolArg::from_str("gemini").unwrap_err();
+        assert!(
+            err.contains("gemini-cli integration has been removed"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -373,16 +395,25 @@ mod tests {
     #[test]
     fn test_resolve_alias_with_config() {
         let mut aliases = HashMap::new();
-        aliases.insert("gem".to_string(), "gemini-cli".to_string());
+        aliases.insert("router".to_string(), "codex".to_string());
         aliases.insert("cc".to_string(), "claude-code".to_string());
 
-        let arg = ToolArg::from_str("gem").unwrap();
+        let arg = ToolArg::from_str("router").unwrap();
         let resolved = arg.resolve_alias(&aliases).unwrap();
-        assert!(matches!(resolved, ToolArg::Specific(ToolName::GeminiCli)));
+        assert!(matches!(resolved, ToolArg::Specific(ToolName::Codex)));
 
         let arg = ToolArg::from_str("cc").unwrap();
         let resolved = arg.resolve_alias(&aliases).unwrap();
         assert!(matches!(resolved, ToolArg::Specific(ToolName::ClaudeCode)));
+    }
+
+    #[test]
+    fn test_resolve_alias_rejects_removed_gemini_cli_target() {
+        let mut aliases = HashMap::new();
+        aliases.insert("gem".to_string(), "gemini-cli".to_string());
+        let arg = ToolArg::from_str("gem").unwrap();
+        let err = arg.resolve_alias(&aliases).unwrap_err();
+        assert!(err.contains("no longer supported"), "{err}");
     }
 
     #[test]
@@ -409,10 +440,10 @@ mod tests {
     fn test_resolve_alias_chained_builtin() {
         // Config alias pointing to a built-in alias name
         let mut aliases = HashMap::new();
-        aliases.insert("g".to_string(), "gemini".to_string());
-        let arg = ToolArg::from_str("g").unwrap();
+        aliases.insert("c".to_string(), "claude".to_string());
+        let arg = ToolArg::from_str("c").unwrap();
         let resolved = arg.resolve_alias(&aliases).unwrap();
-        assert!(matches!(resolved, ToolArg::Specific(ToolName::GeminiCli)));
+        assert!(matches!(resolved, ToolArg::Specific(ToolName::ClaudeCode)));
     }
 
     #[test]
@@ -498,10 +529,11 @@ mod tests {
         let cases = [
             ToolArg::Auto,
             ToolArg::AnyAvailable,
-            ToolArg::Specific(ToolName::GeminiCli),
             ToolArg::Specific(ToolName::Opencode),
             ToolArg::Specific(ToolName::Codex),
             ToolArg::Specific(ToolName::ClaudeCode),
+            ToolArg::Specific(ToolName::OpenaiCompat),
+            ToolArg::Specific(ToolName::AntigravityCli),
         ];
         for original in &cases {
             let s = original.to_string();

--- a/crates/csa-session/src/manager_result_spillover.rs
+++ b/crates/csa-session/src/manager_result_spillover.rs
@@ -267,8 +267,52 @@ fn upsert_session_artifact(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env::TEST_ENV_LOCK;
     use chrono::Utc;
+    use std::ffi::OsString;
     use tempfile::tempdir;
+
+    struct ScopedUserConfigEnv {
+        original_home: Option<OsString>,
+        original_xdg_config_home: Option<OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl ScopedUserConfigEnv {
+        fn new(project_root: &std::path::Path) -> Self {
+            let lock = TEST_ENV_LOCK.lock().expect("env lock poisoned");
+            let config_home = project_root.join("xdg-config");
+            std::fs::create_dir_all(&config_home).expect("create test config home");
+            let original_home = std::env::var_os("HOME");
+            let original_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
+            // SAFETY: test-scoped env mutation is guarded by TEST_ENV_LOCK.
+            unsafe {
+                std::env::set_var("HOME", project_root);
+                std::env::set_var("XDG_CONFIG_HOME", config_home);
+            }
+            Self {
+                original_home,
+                original_xdg_config_home,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for ScopedUserConfigEnv {
+        fn drop(&mut self) {
+            // SAFETY: test-scoped env restoration is guarded by TEST_ENV_LOCK.
+            unsafe {
+                match self.original_home.take() {
+                    Some(value) => std::env::set_var("HOME", value),
+                    None => std::env::remove_var("HOME"),
+                }
+                match self.original_xdg_config_home.take() {
+                    Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
+                }
+            }
+        }
+    }
 
     #[test]
     fn manager_result_redaction_preserves_toml_datetime_values() {
@@ -564,6 +608,7 @@ mod tests {
     #[test]
     fn resolve_report_spill_threshold_uses_project_config_override() {
         let td = tempdir().expect("tempdir");
+        let _user_config_env = ScopedUserConfigEnv::new(td.path());
         let config_dir = td.path().join(".csa");
         std::fs::create_dir_all(&config_dir).expect("create config dir");
         std::fs::write(

--- a/docs/acp-transport.md
+++ b/docs/acp-transport.md
@@ -31,7 +31,6 @@ context precisely:
 |------|-------------------|----------------|
 | claude-code | ACP (`cli` opt-in) | `claude-code-acp` / `claude` |
 | codex | ACP (`acp` explicit) | `codex-acp` |
-| gemini-cli | CLI only | `gemini` |
 | opencode | CLI only | `opencode` |
 
 The `Transport` trait abstracts both execution modes. `TransportFactory`
@@ -43,7 +42,7 @@ the current build default is ACP, so the default path probes `codex-acp`.
 Config validation accepts codex `auto` and `acp` values without performing a
 binary presence check, and `csa doctor` surfaces missing adapters and install
 hints. Project config still rejects `tools.codex.transport = "cli"` today.
-`gemini-cli` and `opencode` remain direct CLI tools.
+`opencode` remains a direct CLI tool.
 
 To force Claude Code onto the native CLI runtime:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ This creates a tree of independent Unix processes:
 ```
 csa run (depth=0, claude-code)
   +-- csa run (depth=1, codex)          # review sub-agent
-  |   +-- csa run (depth=2, gemini)     # deep analysis
+  |   +-- csa run (depth=2, opencode)   # deep analysis
   +-- csa run (depth=1, codex)          # debate sub-agent
       +-- csa run (depth=2, claude)     # adversary
 ```
@@ -43,12 +43,11 @@ nesting, and makes garbage collection straightforward.
 
 ### Closed Enum for Tools
 
-CSA uses a closed enum (`Executor`) for the four supported tools rather than
+CSA uses a closed enum (`Executor`) for the supported tools rather than
 trait-based polymorphism:
 
 ```rust
 pub enum Executor {
-    GeminiCli { model_override, thinking_budget },
     Opencode  { model_override, agent, thinking_budget },
     Codex     { model_override, thinking_budget },
     ClaudeCode { model_override, thinking_budget },
@@ -68,9 +67,8 @@ than silently degrading.
 
 | Parent Tool | Auto-selected Review Tool |
 |-------------|--------------------------|
-| claude-code | codex or gemini-cli |
-| codex | claude-code or gemini-cli |
-| gemini-cli | claude-code or codex |
+| claude-code | codex |
+| codex | claude-code |
 
 ## Crate Structure
 
@@ -160,7 +158,6 @@ User -> csa run "prompt"
 |------|-----------|----------------|
 | claude-code | ACP by default, CLI opt-in | `claude-code-acp` / `claude` |
 | codex | ACP by default; config currently accepts `auto` / `acp` | `codex-acp` |
-| gemini-cli | CLI only | `gemini` |
 | opencode | CLI only | `opencode` |
 
 The `Transport` trait abstracts both modes. `TransportFactory` routes based
@@ -172,8 +169,8 @@ plus `[tools.codex].transport`; the current build default is ACP, so the
 default path probes `codex-acp`. Config validation currently accepts codex
 `auto` and `acp` without checking whether the adapter binary is installed, and
 `csa doctor` surfaces missing adapters plus install hints. Project config
-still rejects codex `cli` overrides today. `gemini-cli` and `opencode` stay
-on their direct CLI binaries. ACP fallback to Legacy is allowed only during
+still rejects codex `cli` overrides today. `opencode` stays on its direct CLI
+binary. ACP fallback to Legacy is allowed only during
 connection initialization;
 during prompt execution, automatic fallback is forbidden.
 
@@ -218,7 +215,6 @@ All tools run with automatic approvals for non-interactive sub-agent execution:
 
 | Tool | Yolo Flag |
 |------|-----------|
-| gemini-cli | `-y` |
 | codex | `--dangerously-bypass-approvals-and-sandbox` |
 | claude-code | `--dangerously-skip-permissions` |
 | opencode | (non-interactive by design) |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,7 +63,7 @@ csa run --sa-mode false --tier tier-2-standard --tool codex "try codex first, th
 csa run --sa-mode false --tool claude --hint-difficulty quick_question "answer briefly"
 csa run --sa-mode false --auto-route analysis "trace the auth flow"
 csa run --sa-mode false --last "continue where I left off"
-echo "analyze this" | csa run --sa-mode false --tier tier-1-quick --tool gemini-cli
+echo "analyze this" | csa run --sa-mode false --tier tier-1-quick --tool codex
 ```
 
 ## `csa review` -- Code review

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,7 +137,6 @@ through the standard config merge.
 min_free_memory_mb = 4096
 
 [resources.initial_estimates]
-gemini-cli = 1024       # MB, used until P95 data available
 codex = 4096
 opencode = 1536
 claude-code = 4096
@@ -148,9 +147,6 @@ See [Resource Control](resource-control.md) for P95 estimation details.
 ### `[tools.{name}]` -- Tool Configuration
 
 ```toml
-[tools.gemini-cli]
-enabled = true
-
 [tools.codex]
 enabled = true
 transport = "acp"                 # See codex-specific note below
@@ -159,14 +155,15 @@ transport = "acp"                 # See codex-specific note below
 enabled = true
 transport = "auto"                # Accepted: "auto", "acp", or "cli"
 
-[tools.gemini-cli.restrictions]
-allow_edit_existing_files = false    # Inject read-only restriction into prompt
+[tools.opencode]
+enabled = true
+transport = "cli"
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | Boolean | `true` | Whether this tool is available |
-| `transport` | String | tool-specific | Per-tool transport override. `claude-code` accepts `auto`, `acp`, `cli`, and `tmux`; `codex` currently accepts `auto` and `acp`; `gemini-cli`, `antigravity-cli`, and `opencode` accept `auto` and `cli` |
+| `transport` | String | tool-specific | Per-tool transport override. `claude-code` accepts `auto`, `acp`, `cli`, and `tmux`; `codex` currently accepts `auto` and `acp`; `opencode` accepts `auto` and `cli` |
 | `restrictions.allow_edit_existing_files` | Boolean | `true` | Allow modifying existing files |
 
 Unconfigured tools default to enabled with no restrictions. Setting
@@ -183,8 +180,8 @@ Unconfigured tools default to enabled with no restrictions. Setting
   `acp` override probe `codex-acp`. Config validation checks only whether the
   value is legal for codex; missing binaries are surfaced separately by
   `csa doctor`. `cli` remains rejected in project config today.
-- `gemini-cli`, `antigravity-cli`, and `opencode` accept `auto` and `cli`,
-  stay on their direct CLI runtimes, and reject `acp`.
+- `opencode` accepts `auto` and `cli`, stays on its direct CLI runtime, and
+  rejects `acp`.
 
 When you change a tool transport, `csa doctor` reports the active transport
 and probed binary for that tool.
@@ -256,7 +253,7 @@ transport = "acp"
 
 ```toml
 [review]
-tool = "auto"    # or "codex", "claude-code", "gemini-cli", "antigravity-cli", "opencode"
+tool = "auto"    # or "codex", "claude-code", "opencode"
 ```
 
 Overrides the global review tool for this project. In `auto` mode, CSA
@@ -272,7 +269,7 @@ Tiers group models by quality/cost/speed for automatic selection:
 [tiers.tier-1-quick]
 description = "Quick tasks (low thinking budget)"
 models = [
-    "gemini-cli/google/gemini-3-flash-preview/low",
+    "codex/openai/gpt-5.4-mini/low",
     "opencode/google/gemini-2.5-pro/minimal",
 ]
 
@@ -280,7 +277,7 @@ models = [
 description = "Standard development work"
 models = [
     "codex/anthropic/claude-sonnet/medium",
-    "gemini-cli/google/gemini-3-pro-preview/medium",
+    "claude-code/anthropic/claude-sonnet-4-5-20250929/medium",
 ]
 
 [tiers.tier-3-complex]
@@ -319,7 +316,7 @@ then the rest of the tier remains available as fallback in tier order. Use
    `[tier_policy].allow_force_bypass` escape hatch.
 
 `[preferences].tool_priority` therefore reorders a tier's candidates (e.g.
-moving `gemini-cli` to the front) but does **not** override the tier's declared
+moving `codex` to the front) but does **not** override the tier's declared
 candidate set; this reordering behavior is intentional and unchanged (#1848). To
 make a specific model run first regardless of `tool_priority`, place it first in
 the tier's `models` list and select that tier explicitly.
@@ -362,7 +359,7 @@ Shorthand names for frequently used model specs:
 
 ```toml
 [aliases]
-fast = "gemini-cli/google/gemini-3-flash-preview/low"
+fast = "codex/openai/gpt-5.4-mini/low"
 smart = "codex/anthropic/claude-opus/xhigh"
 balanced = "codex/anthropic/claude-sonnet/medium"
 ```
@@ -388,12 +385,12 @@ CSA validates on load:
 
 1. **Model spec format:** Each model must be `tool/provider/model/budget`
 2. **Tier references:** All `tier_mapping` values must reference existing tiers
-3. **Tool names:** Must be one of `gemini-cli`, `antigravity-cli`, `codex`, `opencode`, `claude-code`
+3. **Tool names:** Must be one of `codex`, `opencode`, `claude-code`
 4. **Thinking budget:** Must be `low`, `medium`, `high`, `xhigh`, or a number
 5. **Tool transport overrides:** validated per tool. In particular,
    `[tools.claude-code].transport` accepts `auto`, `acp`, or `cli`;
    `[tools.codex].transport` currently accepts `auto` or `acp` and defaults
-   to ACP; `gemini-cli`, `antigravity-cli`, and `opencode` accept `auto` or `cli`. Missing
+   to ACP; `opencode` accepts `auto` or `cli`. Missing
    runtime binaries are reported by `csa doctor`, not by config-value
    validation.
 
@@ -420,19 +417,14 @@ CSA prints a warning: `Run 'csa migrate' to update`.
 name = "research-analysis"
 max_recursion_depth = 3
 
-[tools.gemini-cli]
-enabled = true
-[tools.gemini-cli.restrictions]
-allow_edit_existing_files = false
-
 [tools.codex]
-enabled = false
+enabled = true
 [tools.claude-code]
 enabled = false
 
 [tiers.analysis]
 description = "Read-only analysis"
-models = ["gemini-cli/google/gemini-3-pro-preview/medium"]
+models = ["codex/openai/gpt-5.4/medium"]
 
 [tier_mapping]
 default = "analysis"
@@ -445,14 +437,14 @@ default = "analysis"
 name = "budget-project"
 
 [tools.codex]
-enabled = false        # Anthropic models disabled
+enabled = true
 [tools.claude-code]
 enabled = false
 
 [tiers.primary]
-description = "Google models only"
+description = "Lower-cost models"
 models = [
-    "gemini-cli/google/gemini-3-flash-preview/low",
+    "codex/openai/gpt-5.4-mini/low",
     "opencode/google/gemini-2.5-pro/medium",
 ]
 

--- a/docs/debate-review.md
+++ b/docs/debate-review.md
@@ -13,9 +13,8 @@ model family**:
 
 | Parent Tool | Auto-selected Tool | Reason |
 |-------------|--------------------|--------|
-| claude-code | codex or gemini-cli | Different model family |
-| codex | claude-code or gemini-cli | Different model family |
-| gemini-cli | claude-code or codex | Different model family |
+| claude-code | codex | Different model family |
+| codex | claude-code | Different model family |
 
 If no heterogeneous tool is available, CSA fails with an explicit error.
 It never silently degrades to the same model.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,6 @@ This guide covers installation, initial setup, and your first CSA commands.
 - At least one supported AI tool installed:
   - [claude-code](https://docs.anthropic.com/en/docs/claude-code) (Anthropic)
   - [codex](https://github.com/openai/codex) (OpenAI)
-  - [gemini-cli](https://github.com/google-gemini/gemini-cli) (Google)
   - [opencode](https://github.com/sst/opencode) (OpenRouter)
 - Git 2.30+
 - Optional: [mise](https://mise.jdx.dev/) for binary version management

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -35,7 +35,7 @@ Configure it in the global CSA config:
 command = "mempal timeline --language en --limit 30"
 enabled = true
 # Optional: only fire for these tool transports. Omit or use [] for all.
-transports = ["codex", "gemini-cli"]
+transports = ["codex", "opencode"]
 timeout_seconds = 10
 ```
 
@@ -44,7 +44,7 @@ timeout_seconds = 10
 | Channel | Name | Description |
 |---------|------|-------------|
 | env | `CSA_SESSION_ID` | CSA session ULID |
-| env | `CSA_TRANSPORT` | Resolved tool name (`codex`, `claude-code`, `gemini-cli`, `opencode`, etc.) |
+| env | `CSA_TRANSPORT` | Resolved tool name (`codex`, `claude-code`, `opencode`, etc.) |
 | env | `CSA_PROJECT_ROOT` | Project root path for the CSA session |
 | env | `CSA_WORKING_DIR` | Working directory where the hook runs |
 | stdin | user prompt | Original user prompt text |
@@ -207,7 +207,7 @@ prompt guards **capture stdout** and append it to the prompt as
 `<prompt-guard>` XML blocks.
 
 This enables "reverse prompt injection" -- reminding tools (including those
-without native hook systems like codex, opencode, gemini-cli) to follow
+without native hook systems like codex or opencode) to follow
 project rules such as branch protection and timely commits.
 
 ### How It Works
@@ -326,7 +326,7 @@ fi
 [hooks.pre_session]
 command = "mempal timeline --language en --limit 30"
 enabled = true
-transports = ["codex", "gemini-cli"]
+transports = ["codex", "opencode"]
 timeout_seconds = 10
 ```
 

--- a/docs/resource-control.md
+++ b/docs/resource-control.md
@@ -94,7 +94,6 @@ per tool in `usage_stats.toml`:
 
 ```toml
 [history]
-gemini-cli = [1024, 1152, 1088, 1920, 1200, ...]
 codex = [2048, 2304, 2176, 2560, ...]
 ```
 
@@ -200,7 +199,6 @@ Until P95 data is available, CSA uses configured initial estimates:
 
 | Tool | Recommended Initial (MB) |
 |------|-------------------------|
-| gemini-cli | 1024 |
 | codex | 4096 |
 | opencode | 1536 |
 | claude-code | 4096 |

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -108,7 +108,6 @@ Send the tool-specific compaction command:
 
 | Tool | Compression Command |
 |------|---------------------|
-| gemini-cli | `/compress` |
 | codex | `/compact` |
 | claude-code | `/compact` |
 | opencode | (not supported) |

--- a/docs/skills-patterns.md
+++ b/docs/skills-patterns.md
@@ -105,7 +105,7 @@ Description of the workflow.
 
 Analyze the codebase for issues.
 
-Tool: gemini-cli
+Tool: codex
 Tier: tier-1-quick
 
 ## Step 2: Fix
@@ -160,7 +160,7 @@ version = "1.0.0"
 
 [[steps]]
 name = "Analyze"
-tool = "gemini-cli"
+tool = "codex"
 tier = "tier-1-quick"
 prompt = "Analyze the codebase for issues."
 

--- a/patterns/dev2merge/skills/dev2merge/SKILL.md
+++ b/patterns/dev2merge/skills/dev2merge/SKILL.md
@@ -88,8 +88,12 @@ Once squashed, the original commits cannot be reconstructed from the default bra
 ### Quick Start
 
 ```bash
-csa plan run patterns/dev2merge/workflow.toml
+csa plan run --sa-mode true patterns/dev2merge/workflow.toml
 ```
+
+Root `plan run` callers must pass explicit `--sa-mode true|false`. Use
+`--sa-mode true` for autonomous agent workflows and `--sa-mode false` only for
+deliberate interactive/human runs.
 
 To drive the pipeline from a specific GitHub issue, pass `--issue <N>`. CSA
 fetches the issue body (using the project's configured `GH_CONFIG_DIR`, falling
@@ -97,7 +101,7 @@ back to default `gh` auth on a permission/not-found error) and injects it as the
 `FEATURE_INPUT` workflow variable that the dev2merge planning step consumes:
 
 ```bash
-csa plan run patterns/dev2merge/workflow.toml --issue 1638
+csa plan run --sa-mode true patterns/dev2merge/workflow.toml --issue 1638
 ```
 
 `--issue <N>` is mutually exclusive with an explicit `--var FEATURE_INPUT=...`:
@@ -112,7 +116,7 @@ When the implementation already exists and is committed on the feature branch
 PR → merge → sync — without re-planning:
 
 ```bash
-csa plan run patterns/dev2merge/workflow.toml --var DEV2MERGE_MODE=resume
+csa plan run --sa-mode true patterns/dev2merge/workflow.toml --var DEV2MERGE_MODE=resume
 ```
 
 `DEV2MERGE_MODE` defaults to `full` (the complete pipeline). `resume` skips

--- a/patterns/pr-bot/references/rebase-clean-history.md
+++ b/patterns/pr-bot/references/rebase-clean-history.md
@@ -41,7 +41,7 @@ Legacy compatibility format accepted by the guard:
 
 ```text
 Review: codex session 01ABC... (status=success, summary=PASS)
-Review: gemini-cli session 01DEF... (status=success, summary=CLEAN)
+Review: claude-code session 01DEF... (status=success, summary=CLEAN)
 ```
 
 `summary=FAIL` (or `verdict=Fail`) blocks compression. A commit with no explicit

--- a/patterns/sa/skills/sa/SKILL.md
+++ b/patterns/sa/skills/sa/SKILL.md
@@ -160,8 +160,9 @@ liveness failure, or direct user instruction.
 
 For codebase exploration (searching code, reading multiple files, understanding architecture),
 Layer 1 and Layer 2 employees **MUST prefer `csa run` over Claude Code's built-in `Agent` tool
-with `subagent_type=Explore`**. CSA tokens (gemini-cli/codex) are significantly cheaper than
-Claude tokens, and CSA tools have larger context windows for processing many files simultaneously.
+with `subagent_type=Explore`** when a supported CSA routing tool is available. Codex and
+OpenCode can be cheaper than Claude tokens, and CSA tools have large context windows for
+processing many files simultaneously.
 Reserve the built-in Explore agent only for quick searches that need <3 queries.
 
 ## Structured Communication Protocol

--- a/skill.md
+++ b/skill.md
@@ -165,7 +165,7 @@ commit-workflow) that automatically inject workflow reminders into every
 csa doctor
 ```
 
-This reports which AI tools (claude-code, codex, gemini-cli, opencode) are
+This reports which AI tools (claude-code, codex, opencode) are
 available and properly configured.
 
 ---
@@ -375,7 +375,7 @@ Create or edit `~/.config/cli-sub-agent/config.toml`:
 ```toml
 # Tool selection priority (first = most preferred)
 [preferences]
-tool_priority = ["claude-code", "codex", "gemini-cli", "opencode"]
+tool_priority = ["claude-code", "codex", "opencode"]
 
 # Review tool (auto = heterogeneous selection)
 [review]
@@ -400,8 +400,8 @@ max_concurrent = 3
 | Setup | Recommended `tool_priority` |
 |-------|-----------------------------|
 | Claude Code + Codex | `["claude-code", "codex"]` |
-| Codex + Gemini CLI | `["codex", "gemini-cli"]` |
-| All tools available | `["claude-code", "codex", "gemini-cli", "opencode"]` |
+| Claude Code + OpenCode | `["claude-code", "opencode"]` |
+| All supported tools available | `["claude-code", "codex", "opencode"]` |
 | Single tool only | Set `[review] tool = "<tool>"` and `[debate] tool = "<tool>"` explicitly |
 
 ---
@@ -500,7 +500,7 @@ csa run --sa-mode false --fork-last "continue"          # Fork most recent sessi
 csa run --sa-mode false --fork-from <ULID> "continue"   # Fork specific session
 csa run --sa-mode false --fork-call "task"              # Fork-call (child returns to parent)
 csa run --sa-mode false --ephemeral "quick task"        # Ephemeral (no project files)
-csa run --sa-mode false --model-spec gemini-cli/google/gemini-2.5-pro/xhigh "task"  # Model spec
+csa run --sa-mode false --model-spec codex/openai/gpt-5.5/xhigh "task"  # Model spec
 csa review --sa-mode false --diff                       # Review uncommitted changes
 csa review --sa-mode false --range main...HEAD          # Review commit range
 csa review --sa-mode false --fix                        # Review-and-fix mode

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1073"
-weave = "0.1.1073"
+csa = "0.1.1074"
+weave = "0.1.1074"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- remove obsolete `gemini-cli` support from CSA routing/config validation
- keep `agy`/`antigravity-cli` limited to explicit low-risk read-only usage instead of treating it as a replacement
- reject removed Gemini tool references in semantic tool/model selectors, including `[defaults].tool`, tool aliases, review/debate tool selectors, tier model specs, and preference tool priority
- preserve non-tool strings such as project names or review gate names containing `gemini`

Closes #2475

## Verification
- `cargo test -p csa-config removed_gemini -- --nocapture` (`10 passed`)
- `just pre-commit-fast`
- `just test` (`6669 tests run: 6669 passed (3 leaky), 3 skipped`)
- clean-tree release rebuild: `csa 0.1.1074 (f985b3bf)`, `weave 0.1.1074 (f985b3bf)`
- exact-head CSA review: session `01KW3CFFQD54MT2DP6CBKVT2ZS`, verdict `PASS/CLEAN` for `main...HEAD` at `f985b3bf761`

## Notes
- Final `main...HEAD` intentionally does not include `.csa/config.toml`; local `.csa` changes were kept uncommitted only to let self-hosted CSA review run without the removed tool entry.
