### PR TITLE
fix(review): keep verdict artifacts, summaries, and fix routes consistent (#2516)

### DIFF
--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -74,6 +74,7 @@ mod review_cmd;
 mod review_consensus;
 mod review_context;
 mod review_design_anchor;
+mod review_failure_context;
 mod review_findings;
 mod review_gate;
 mod review_prior_rounds;

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -25,6 +25,8 @@ use tracing::{debug, error, warn};
 pub(crate) mod output;
 pub(crate) use output::clean_detection::detect_bounded_clean_verdict_token;
 use output::{is_worktree_submodule, persist_review_result_exit_code};
+#[path = "review_cmd_artifact_consistency.rs"]
+mod artifact_consistency;
 #[path = "review_cmd_artifact_parse.rs"]
 mod artifact_parse;
 #[path = "review_cmd_bug_class.rs"]
@@ -65,6 +67,8 @@ pub(crate) mod preflight;
 mod prior_rounds;
 #[path = "review_cmd_prose_findings.rs"]
 mod prose_findings;
+#[path = "review_cmd_prose_resolution.rs"]
+mod prose_resolution;
 #[path = "review_cmd_resolve.rs"]
 mod resolve;
 #[path = "review_cmd_result.rs"]

--- a/crates/cli-sub-agent/src/review_cmd_artifact_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_artifact_consistency.rs
@@ -1,0 +1,16 @@
+use std::{fs, path::Path};
+
+use anyhow::{Context, Result};
+use csa_session::FindingsFile;
+
+pub(super) fn review_findings_toml_has_findings(session_dir: &Path) -> Result<bool> {
+    let findings_path = session_dir.join("output").join("findings.toml");
+    if !findings_path.is_file() {
+        return Ok(false);
+    }
+    let raw = fs::read_to_string(&findings_path)
+        .with_context(|| format!("failed to read {}", findings_path.display()))?;
+    let findings: FindingsFile = toml::from_str(&raw)
+        .with_context(|| format!("failed to parse {}", findings_path.display()))?;
+    Ok(!findings.findings.is_empty())
+}

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
+use super::artifact_consistency::review_findings_toml_has_findings;
 use crate::cli::ReviewArgs;
 use anyhow::{Context, Result};
 use csa_session::state::{MetaSessionState, ReviewSessionMeta};
@@ -629,6 +630,9 @@ fn review_session_acceptance_status(
     if accepted && has_review_severity_counts(&acceptance_artifact.severity_counts) {
         accepted = false;
     }
+    if accepted && review_findings_toml_has_findings(session_dir)? {
+        accepted = false;
+    }
     debug!(
         session_id = %acceptance_meta.session_id,
         meta_decision = %acceptance_meta.decision,
@@ -693,6 +697,10 @@ mod compound_legacy_tests;
 #[cfg(test)]
 #[path = "review_cmd_check_verdict_2425.rs"]
 mod review_cmd_check_verdict_2425;
+
+#[cfg(test)]
+#[path = "review_cmd_check_verdict_2516_tests.rs"]
+mod issue_2516_tests;
 
 #[cfg(test)]
 #[path = "review_cmd_check_verdict_tests.rs"]

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_2516_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_2516_tests.rs
@@ -1,0 +1,98 @@
+use super::*;
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+use chrono::Utc;
+use csa_core::types::ReviewDecision;
+use csa_core::vcs::{VcsIdentity, VcsKind};
+use csa_session::state::ReviewSessionMeta;
+use csa_session::{
+    FindingsFile, ReviewFinding, ReviewFindingFileRange, ReviewVerdictArtifact, Severity,
+};
+use tempfile::TempDir;
+
+#[test]
+fn issue_2516_check_verdict_rejects_pass_json_with_findings_toml() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let temp = TempDir::new().unwrap();
+    let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", temp.path().join("state"));
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    let branch = "feature";
+    let head_sha = "abcdef1234567890";
+    let mut session = csa_session::create_session_fresh(&project, Some("review"), None, None)
+        .expect("create session");
+    session.branch = Some(branch.to_string());
+    session.git_head_at_creation = Some(head_sha.to_string());
+    session.vcs_identity = Some(VcsIdentity {
+        vcs_kind: VcsKind::Git,
+        commit_id: Some(head_sha.to_string()),
+        change_id: None,
+        short_id: Some(short_sha(head_sha).to_string()),
+        ref_name: Some(branch.to_string()),
+        op_id: None,
+    });
+    csa_session::save_session(&session).expect("save session");
+    let session_dir = csa_session::get_session_dir(&project, &session.meta_session_id).unwrap();
+    let meta = ReviewSessionMeta {
+        session_id: session.meta_session_id.clone(),
+        head_sha: head_sha.to_string(),
+        decision: ReviewDecision::Pass.as_str().to_string(),
+        verdict: "CLEAN".to_string(),
+        status_reason: None,
+        routed_to: None,
+        primary_failure: None,
+        failure_reason: None,
+        tool: "codex".to_string(),
+        scope: REQUIRED_FULL_DIFF_SCOPE.to_string(),
+        exit_code: 0,
+        fix_attempted: false,
+        fix_rounds: 0,
+        review_iterations: 1,
+        timestamp: Utc::now(),
+        diff_fingerprint: None,
+        review_mode: None,
+        fix_convergence: None,
+    };
+    csa_session::state::write_review_meta(&session_dir, &meta).expect("write review meta");
+    csa_session::write_review_verdict(
+        &session_dir,
+        &ReviewVerdictArtifact::from_parts(
+            session.meta_session_id.clone(),
+            ReviewDecision::Pass,
+            "CLEAN",
+            &[],
+            Vec::new(),
+        ),
+    )
+    .expect("write verdict");
+    csa_session::write_findings_toml(
+        &session_dir,
+        &FindingsFile {
+            findings: vec![ReviewFinding {
+                id: "F1".to_string(),
+                severity: Severity::High,
+                file_ranges: vec![ReviewFindingFileRange {
+                    path: "src/lib.rs".to_string(),
+                    start: 7,
+                    end: None,
+                }],
+                is_regression_of_commit: None,
+                suggested_test_scenario: None,
+                description: "contradictory blocking finding".to_string(),
+            }],
+        },
+    )
+    .expect("write findings.toml");
+
+    let found = check_review_verdict_for_target(
+        &project,
+        branch,
+        head_sha,
+        REQUIRED_FULL_DIFF_SCOPE,
+        None,
+        None,
+    )
+    .expect("check verdict should run");
+
+    assert!(found.is_none());
+}

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -245,6 +245,23 @@ fn derive_review_verdict_artifact(
             {
                 return Ok(artifact);
             }
+            // #2516 fail-closed: even non-blocking (low-only) JSON findings must
+            // not be silently dropped by the synthetic-empty fast path.
+            if let Some(json_counts) =
+                json_severity_counts_if_present(session_dir, zero_severity_counts)?
+                && !severity_counts_are_zero(&json_counts)
+            {
+                let decision = derive_decision_from_severity_counts(
+                    &json_counts,
+                    false,
+                    None,
+                    ReviewDecision::from_str(&meta.decision).ok(),
+                    || Ok(prose_signals.blocking_summary),
+                    || review_contains_prose_clean_conclusion(session_dir),
+                    || review_contains_prose_fail_conclusion(session_dir),
+                )?;
+                return Ok(verdict_from_meta(meta, decision, json_counts));
+            }
             synthetic_empty_findings_counts = Some(raw_severity_counts.clone());
             // Synthetic-empty + no blocking JSON → fall through to full.md chain.
             debug!(

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_clean_2425_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_clean_2425_tests.rs
@@ -377,6 +377,89 @@ fn issue_2425_prior_finding_fixed_prose_does_not_create_blocking_finding() {
 }
 
 #[test]
+fn issue_2516_pass_remediation_evidence_paths_do_not_flip_to_fail() {
+    let session_id = "01TEST2516PASSEVIDENCE";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-2516-pass-remediation-evidence", session_id);
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nVerdict: PASS\n<!-- CSA:SECTION:summary:END -->\n\n<!-- CSA:SECTION:details -->\nThe prior high finding is fixed. No blocking findings remain.\n\nVerification:\n- crates/cli-sub-agent/src/review_cmd_output_consistency.rs:139 confirms the remediation path.\n- crates/cli-sub-agent/src/review_cmd_check_verdict.rs:601 verifies exact-head acceptance.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist clean review sections");
+
+    let mut meta = make_review_meta(session_id);
+    meta.decision = ReviewDecision::Uncertain.as_str().to_string();
+    meta.verdict = "UNCERTAIN".to_string();
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_output_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    let findings = read_output_findings(&session_dir);
+    assert!(
+        findings.findings.is_empty(),
+        "positive verification path bullets must not become blocking findings"
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_2516_synthetic_empty_with_low_json_counts_fails_closed() {
+    use crate::review_cmd::persist_review_sidecars_if_session_exists;
+    let session_id = "01TEST2516SYNLOWJS0";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-2516-synthetic-low-json", session_id);
+    initialize_git_project(&project_root);
+
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nFAIL: one low-severity finding.\n<!-- CSA:SECTION:summary:END -->\n\n<!-- CSA:SECTION:details -->\nNo blocking findings.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist clean review sections");
+
+    let mut meta = make_review_meta(session_id);
+    meta.decision = ReviewDecision::Fail.as_str().to_string();
+    meta.verdict = "HAS_ISSUES".to_string();
+    meta.scope = "diff".to_string();
+
+    // Create synthetic-empty findings.toml + marker to trigger the synthetic-empty path
+    let output_dir = session_dir.join("output");
+    fs::create_dir_all(&output_dir).expect("create output dir");
+    fs::write(output_dir.join("findings.toml"), "").expect("write empty findings.toml");
+    fs::write(output_dir.join(".findings.toml.synthetic"), "").expect("write synthetic marker");
+
+    // Persist a review-findings.json with a low-only finding at session_dir root
+    let json_content = serde_json::json!({
+        "findings": [{
+            "severity": "low",
+            "fid": "L1",
+            "file": "src/lib.rs",
+            "line": 1,
+            "rule_id": "rule.low",
+            "summary": "low severity test finding",
+            "engine": "codex"
+        }],
+        "severity_summary": { "critical": 0, "high": 0, "medium": 0, "low": 1 },
+        "overall_risk": "low"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_string(&json_content).expect("serialize artifact json"),
+    )
+    .expect("write review-findings.json");
+
+    let exit = persist_review_sidecars_if_session_exists(&project_root, &meta, Some(session_id))
+        .expect("sidecars should persist");
+
+    // Even with a synthetic-empty findings.toml, low-only JSON counts should fail closed
+    assert_ne!(exit, 0, "low-only JSON counts must fail closed, not pass");
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn issue_2425_uncertain_crash_evidence_does_not_recover_to_pass() {
     let session_id = "01TEST2425CRASHUNCERT0";
     let (_env_lock, project_root, session_dir) =

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -1,5 +1,8 @@
 use std::collections::BTreeMap;
 
+use super::prose_resolution::{
+    finding_text_describes_resolved_issue, review_signal_describes_resolved_issue,
+};
 use csa_session::{FindingsFile, ReviewFinding, ReviewFindingFileRange, Severity};
 
 pub(in crate::review_cmd) fn findings_file_from_prose(text: &str) -> Option<FindingsFile> {
@@ -309,6 +312,9 @@ fn parse_bracketed_finding(body: &str) -> Option<ParsedProseFinding> {
     rest = rest
         .trim_start_matches(|ch: char| ch == ':' || ch == '-' || ch.is_whitespace())
         .trim_start();
+    if finding_text_describes_resolved_issue(rest) {
+        return None;
+    }
     Some(ParsedProseFinding {
         severity,
         file_range: parse_embedded_file_range(rest),
@@ -330,6 +336,9 @@ fn parse_severity_prefixed_finding(
     let severity = severity_from_label(label).or_else(|| leading_severity_from_title(label))?;
     let rest = rest.trim();
     if severity_prefixed_rest_is_zero_count(rest) {
+        return None;
+    }
+    if finding_text_describes_resolved_issue(&format!("{label}: {rest}")) {
         return None;
     }
     if let Some((file_range, description)) = parse_leading_file_range(rest) {
@@ -536,6 +545,9 @@ fn blocking_review_clause_has_signal(clause: &str) -> bool {
         if review_issue_noun_is_followed_by_zero_count(&tokens, noun_index) {
             continue;
         }
+        if review_signal_describes_resolved_issue(&tokens, index, noun_index) {
+            continue;
+        }
         return true;
     }
 
@@ -568,6 +580,9 @@ fn severe_review_clause_has_signal(clause: &str) -> bool {
             continue;
         };
         if review_issue_noun_is_followed_by_zero_count(&tokens, noun_index) {
+            continue;
+        }
+        if review_signal_describes_resolved_issue(&tokens, index, noun_index) {
             continue;
         }
         return true;

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
@@ -87,3 +87,71 @@ fn severity_prefixed_bullet_with_description_still_becomes_prose_finding() {
     assert_eq!(findings.len(), 1);
     assert_eq!(findings[0].severity, Severity::High);
 }
+
+#[test]
+fn issue_2516_resolved_high_finding_prose_is_not_blocking_signal() {
+    assert!(!contains_blocking_review_signal(
+        "The prior high finding is fixed and no blocking findings remain."
+    ));
+    assert!(contains_blocking_review_signal(
+        "One high severity finding remains in the review output parser."
+    ));
+}
+
+#[test]
+fn issue_2516_positive_verification_paths_do_not_become_medium_findings() {
+    let findings = extract_review_findings_from_prose(
+        r#"PASS: no blocking findings remain.
+Verification:
+- crates/cli-sub-agent/src/review_cmd_output.rs:139 confirms the prior high finding is fixed.
+- tests/review.rs:42 verifies the remediation path.
+"#,
+    );
+
+    assert!(
+        findings.is_empty(),
+        "positive verification path bullets must not become findings: {findings:?}"
+    );
+}
+
+#[test]
+fn issue_2516_no_longer_describes_regression_not_resolution() {
+    use super::finding_text_describes_resolved_issue;
+
+    assert!(
+        !finding_text_describes_resolved_issue("crates/foo.rs:42 no longer validates user input"),
+        "'no longer validates' is a regression description, not a resolution"
+    );
+    assert!(
+        !finding_text_describes_resolved_issue("crates/foo.rs:42 no longer checks for overflow"),
+        "'no longer checks' is a regression description, not a resolution"
+    );
+    assert!(
+        finding_text_describes_resolved_issue(
+            "The prior high finding is addressed and no longer present"
+        ),
+        "'no longer present' after a resolution word should be classified as resolved"
+    );
+}
+
+#[test]
+fn issue_2516_mixed_resolution_and_active_problem_stays_blocking() {
+    use super::review_signal_describes_resolved_issue;
+
+    let tokens: Vec<String> = "fixed high finding still remains"
+        .split_whitespace()
+        .map(str::to_string)
+        .collect();
+    let signal_index = tokens
+        .iter()
+        .position(|t| t == "fixed")
+        .expect("find signal token");
+    let noun_index = tokens
+        .iter()
+        .position(|t| t == "finding")
+        .expect("find noun token");
+    assert!(
+        !review_signal_describes_resolved_issue(&tokens, signal_index, noun_index),
+        "sentence with 'still remains' must not be classified as resolved"
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_prose_resolution.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_resolution.rs
@@ -1,0 +1,110 @@
+const RESOLUTION_WORDS: &[&str] = &[
+    "addressed",
+    "cleared",
+    "closed",
+    "corrected",
+    "eliminated",
+    "fixed",
+    "gone",
+    "mitigated",
+    "removed",
+    "repaired",
+    "resolved",
+    "verified",
+];
+const REQUIRED_FIX_WORDS: &[&str] = &[
+    "must", "need", "needed", "needs", "require", "required", "requires", "should",
+];
+const ACTIVE_PROBLEM_WORDS: &[&str] = &[
+    "allow",
+    "allows",
+    "can",
+    "cannot",
+    "could",
+    "fail",
+    "failed",
+    "failure",
+    "incorrect",
+    "leak",
+    "missing",
+    "omit",
+    "omits",
+    "omitted",
+    "panic",
+    "race",
+    "regression",
+    "remain",
+    "remaining",
+    "remains",
+    "risk",
+    "still",
+    "unsafe",
+    "wrong",
+];
+
+pub(super) fn review_signal_describes_resolved_issue(
+    tokens: &[String],
+    signal_index: usize,
+    noun_index: usize,
+) -> bool {
+    let start = signal_index.saturating_sub(3);
+    let end = tokens.len().min(noun_index + 8);
+    // #2516: If the window contains a non-negated active-problem word,
+    // the signal describes a live problem, not a resolution.
+    // "no blocking findings remain" is fine because "remain" is negated by "no".
+    if (start..end).any(|index| active_problem_token_is_non_negated(tokens, index)) {
+        return false;
+    }
+    (start..end).any(|index| resolution_token_applies(tokens, index))
+}
+
+fn active_problem_token_is_non_negated(tokens: &[String], index: usize) -> bool {
+    let Some(token) = tokens.get(index) else {
+        return false;
+    };
+    if !ACTIVE_PROBLEM_WORDS.contains(&token.as_str()) {
+        return false;
+    }
+    // Check preceding 3 tokens for negation words
+    !tokens[..index]
+        .iter()
+        .rev()
+        .take(3)
+        .any(|candidate| matches!(candidate.as_str(), "no" | "not" | "never" | "without"))
+}
+
+pub(super) fn finding_text_describes_resolved_issue(text: &str) -> bool {
+    let tokens = review_signal_tokens(text);
+    if tokens
+        .iter()
+        .any(|token| ACTIVE_PROBLEM_WORDS.contains(&token.as_str()))
+    {
+        return false;
+    }
+    tokens
+        .iter()
+        .enumerate()
+        .any(|(index, _)| resolution_token_applies(&tokens, index))
+}
+
+fn resolution_token_applies(tokens: &[String], index: usize) -> bool {
+    let Some(token) = tokens.get(index) else {
+        return false;
+    };
+    RESOLUTION_WORDS.contains(&token.as_str())
+        && !resolution_token_is_negated_or_required(tokens, index)
+}
+
+fn resolution_token_is_negated_or_required(tokens: &[String], index: usize) -> bool {
+    tokens[..index].iter().rev().take(3).any(|candidate| {
+        matches!(candidate.as_str(), "not" | "never" | "unresolved")
+            || REQUIRED_FIX_WORDS.contains(&candidate.as_str())
+    })
+}
+
+fn review_signal_tokens(text: &str) -> Vec<String> {
+    text.split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect()
+}

--- a/crates/cli-sub-agent/src/review_failure_context.rs
+++ b/crates/cli-sub-agent/src/review_failure_context.rs
@@ -1,0 +1,575 @@
+use std::path::Path;
+use std::sync::OnceLock;
+
+use csa_core::types::ReviewDecision;
+use csa_session::{FindingsFile, ReviewFinding, ReviewVerdictArtifact, Severity};
+use regex::{Captures, Regex};
+
+const ARTIFACT_GENERATION_FINDING_ID: &str = "artifact-generation-001";
+const TITLE_MAX_CHARS: usize = 180;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReviewFailureContext {
+    pub(crate) first_finding: Option<ReviewFailureFinding>,
+    pub(crate) diagnostic: Option<String>,
+    pub(crate) fix_route: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReviewFailureFinding {
+    pub(crate) severity: Severity,
+    pub(crate) category: String,
+    pub(crate) location: String,
+    pub(crate) title: String,
+}
+
+pub(crate) fn review_failure_context_lines(session_dir: &Path) -> Vec<String> {
+    let Some(context) = review_failure_context(session_dir) else {
+        return Vec::new();
+    };
+    let mut lines = Vec::new();
+    if let Some(finding) = context.first_finding {
+        lines.push(format!(
+            "First finding: severity={} category={} location={} title={}",
+            severity_label(&finding.severity),
+            finding.category,
+            finding.location,
+            finding.title
+        ));
+    }
+    if let Some(diagnostic) = context.diagnostic {
+        lines.push(format!("Review diagnostic: {diagnostic}"));
+    }
+    lines.push(format!("Fix route: {}", context.fix_route));
+    lines
+}
+
+pub(crate) fn print(session_dir: &Path) {
+    for line in review_failure_context_lines(session_dir) {
+        println!("{line}");
+    }
+}
+
+pub(crate) fn review_failure_context_json(session_dir: &Path) -> Option<serde_json::Value> {
+    let context = review_failure_context(session_dir)?;
+    let first_finding = context.first_finding.map(|finding| {
+        serde_json::json!({
+            "severity": severity_label(&finding.severity),
+            "category": finding.category,
+            "location": finding.location,
+            "title": finding.title,
+        })
+    });
+    Some(serde_json::json!({
+        "first_finding": first_finding,
+        "diagnostic": context.diagnostic,
+        "fix_route": context.fix_route,
+    }))
+}
+
+pub(crate) fn insert_json(payload: &mut serde_json::Value, session_dir: &Path) {
+    if let Some(context) = review_failure_context_json(session_dir) {
+        payload["review_failure_context"] = context;
+    }
+}
+
+fn review_failure_context(session_dir: &Path) -> Option<ReviewFailureContext> {
+    let artifact = read_review_verdict_artifact(session_dir)?;
+    if artifact.decision != ReviewDecision::Fail {
+        return None;
+    }
+    let findings = read_findings_file(session_dir).unwrap_or_default();
+    let first_finding = findings
+        .findings
+        .iter()
+        .find(|finding| !is_artifact_generation_placeholder(finding))
+        .map(review_failure_finding);
+    let diagnostic = if first_finding.is_none() {
+        artifact
+            .failure_reason
+            .as_deref()
+            .map(compact_diagnostic)
+            .or_else(|| Some("review-output parser/internal consistency failure".to_string()))
+    } else {
+        None
+    };
+    Some(ReviewFailureContext {
+        first_finding,
+        diagnostic,
+        fix_route: fix_route_label(session_dir, &artifact.session_id),
+    })
+}
+
+fn read_review_verdict_artifact(session_dir: &Path) -> Option<ReviewVerdictArtifact> {
+    let raw =
+        std::fs::read_to_string(session_dir.join("output").join("review-verdict.json")).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn read_findings_file(session_dir: &Path) -> Option<FindingsFile> {
+    let raw = std::fs::read_to_string(session_dir.join("output").join("findings.toml")).ok()?;
+    toml::from_str(&raw).ok()
+}
+
+fn review_failure_finding(finding: &ReviewFinding) -> ReviewFailureFinding {
+    ReviewFailureFinding {
+        severity: finding.severity.clone(),
+        category: finding_category(finding),
+        location: finding_location(finding),
+        title: finding_title(finding),
+    }
+}
+
+fn finding_category(finding: &ReviewFinding) -> String {
+    let description = finding.description.trim_start();
+    if let Some(rest) = description.strip_prefix('[')
+        && let Some(end) = rest.find(']')
+    {
+        let category = rest[..end].trim();
+        if !category.is_empty() {
+            return sanitize_finding_text(category, 48);
+        }
+    }
+    "review".to_string()
+}
+
+fn sanitize_finding_text(raw: &str, max_chars: usize) -> String {
+    let text = csa_session::redact_text_content(raw);
+    let text = relativize_absolute_paths(&text);
+    clip(text.trim(), max_chars)
+}
+
+fn finding_location(finding: &ReviewFinding) -> String {
+    let Some(range) = finding.file_ranges.first() else {
+        return "unscoped".to_string();
+    };
+    let sanitized_path = sanitize_finding_text(&range.path, 256);
+    let start = range.start;
+    match range.end {
+        Some(end) if end != start => format!("{sanitized_path}:{start}-{end}"),
+        _ => format!("{sanitized_path}:{start}"),
+    }
+}
+
+fn finding_title(finding: &ReviewFinding) -> String {
+    let mut title = finding.description.trim();
+    if let Some(rest) = title.strip_prefix('[')
+        && let Some(end) = rest.find(']')
+    {
+        title = rest[end + 1..].trim_start_matches([':', '-', ' ']).trim();
+    }
+    sanitize_finding_text(title, TITLE_MAX_CHARS)
+}
+
+fn absolute_path_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(
+            r#"(?x)
+                (?P<prefix>^|[\s"'`(<\[])
+                (?P<path>
+                    /[^\s"'`<>()\[\]{}]+
+                    |
+                    [A-Za-z]:\\[^\s"'`<>()\[\]{}]+
+                )
+            "#,
+        )
+        .expect("absolute path redaction regex must compile")
+    })
+}
+
+fn relativize_absolute_paths(text: &str) -> String {
+    absolute_path_pattern()
+        .replace_all(text, |captures: &Captures<'_>| {
+            let prefix = captures.name("prefix").map_or("", |value| value.as_str());
+            let path = captures.name("path").map_or("", |value| value.as_str());
+            format!("{prefix}{}", relativize_absolute_path(path))
+        })
+        .into_owned()
+}
+
+fn relativize_absolute_path(path: &str) -> String {
+    let (path, trailing_punctuation) = split_trailing_path_punctuation(path);
+    let (path, line_suffix) = split_line_suffix(path);
+    let normalized = path.replace('\\', "/");
+    let relative = strip_current_dir_prefix(&normalized)
+        .or_else(|| strip_env_home_prefix(&normalized))
+        .or_else(|| strip_common_home_prefix(&normalized))
+        .unwrap_or_else(|| strip_absolute_prefix(&normalized));
+    format!("{relative}{line_suffix}{trailing_punctuation}")
+}
+
+fn split_trailing_path_punctuation(path: &str) -> (&str, &str) {
+    let mut end = path.len();
+    while let Some(ch) = path[..end].chars().next_back() {
+        if matches!(ch, ',' | ';' | '.') {
+            end -= ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    (&path[..end], &path[end..])
+}
+
+fn split_line_suffix(path: &str) -> (&str, &str) {
+    let Some((head, tail)) = path.rsplit_once(':') else {
+        return (path, "");
+    };
+    if is_line_suffix(tail) {
+        (head, &path[head.len()..])
+    } else {
+        (path, "")
+    }
+}
+
+fn is_line_suffix(value: &str) -> bool {
+    let Some((start, end)) = value.split_once('-') else {
+        return !value.is_empty() && value.chars().all(|ch| ch.is_ascii_digit());
+    };
+    !start.is_empty()
+        && !end.is_empty()
+        && start.chars().all(|ch| ch.is_ascii_digit())
+        && end.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn strip_current_dir_prefix(path: &str) -> Option<String> {
+    let current_dir = std::env::current_dir().ok()?;
+    strip_path_prefix(path, &current_dir)
+}
+
+fn strip_env_home_prefix(path: &str) -> Option<String> {
+    let home = std::env::var_os("HOME")?;
+    strip_path_prefix(path, Path::new(&home))
+}
+
+fn strip_path_prefix(path: &str, prefix: &Path) -> Option<String> {
+    let prefix = prefix.to_string_lossy().replace('\\', "/");
+    let rest = path.strip_prefix(&prefix)?;
+    let rest = rest.strip_prefix('/')?;
+    if rest.is_empty() {
+        None
+    } else {
+        Some(rest.to_string())
+    }
+}
+
+fn strip_common_home_prefix(path: &str) -> Option<String> {
+    ["/home/", "/Users/"].into_iter().find_map(|prefix| {
+        let rest = path.strip_prefix(prefix)?;
+        let (_, relative) = rest.split_once('/')?;
+        if relative.is_empty() {
+            None
+        } else {
+            Some(relative.to_string())
+        }
+    })
+}
+
+fn strip_absolute_prefix(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix('/') {
+        return rest.to_string();
+    }
+    if path.len() > 3
+        && path.as_bytes()[1] == b':'
+        && path.as_bytes()[2] == b'/'
+        && path.as_bytes()[0].is_ascii_alphabetic()
+    {
+        return path[3..].to_string();
+    }
+    path.to_string()
+}
+
+fn is_artifact_generation_placeholder(finding: &ReviewFinding) -> bool {
+    finding.id == ARTIFACT_GENERATION_FINDING_ID
+}
+
+fn fix_route_label(session_dir: &Path, session_id: &str) -> String {
+    if session_is_retired(session_dir) {
+        return "review session is retired/immutable; start a fresh fix from the finding, then run a new exact-head review before push/PR".to_string();
+    }
+
+    let Some(value) = read_suggestion_toml(session_dir) else {
+        return format!(
+            "exact --fix-finding route unavailable (missing output/suggestion.toml); use `csa review --session {session_id} --fix` or start a new fix session, then run a fresh exact-head review"
+        );
+    };
+    let suggestion = value.get("suggestion");
+    let action = suggestion
+        .and_then(|value| value.get("action"))
+        .and_then(toml::Value::as_str)
+        .unwrap_or_default();
+    if action != "confirm_then_fix_finding" {
+        return format!(
+            "exact --fix-finding route unavailable (suggestion action '{action}'); use `csa review --session {session_id} --fix` or start a new fix session, then run a fresh exact-head review"
+        );
+    }
+    let command = suggestion
+        .and_then(|value| value.get("command_template"))
+        .and_then(toml::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            format!("csa review --fix-finding --session {session_id} --prompt-file <path>")
+        });
+    format!("confirm the finding, then run `{command}`; next review must be a fresh session")
+}
+
+fn read_suggestion_toml(session_dir: &Path) -> Option<toml::Value> {
+    let raw = std::fs::read_to_string(session_dir.join("output").join("suggestion.toml")).ok()?;
+    toml::from_str(&raw).ok()
+}
+
+fn session_is_retired(session_dir: &Path) -> bool {
+    let raw = std::fs::read_to_string(session_dir.join("state.toml")).ok();
+    let Some(raw) = raw else {
+        return false;
+    };
+    let Ok(value) = toml::from_str::<toml::Value>(&raw) else {
+        return false;
+    };
+    value
+        .get("phase")
+        .and_then(toml::Value::as_str)
+        .is_some_and(|phase| phase.eq_ignore_ascii_case("retired"))
+}
+
+fn compact_diagnostic(reason: &str) -> String {
+    let reason = csa_session::redact_text_content(reason);
+    let reason = clip(reason.trim(), 180);
+    if reason.is_empty() {
+        "review-output parser/internal consistency failure".to_string()
+    } else {
+        format!("review-output parser/internal consistency failure ({reason})")
+    }
+}
+
+fn severity_label(severity: &Severity) -> &'static str {
+    match severity {
+        Severity::Critical => "CRITICAL",
+        Severity::High => "HIGH",
+        Severity::Medium => "MEDIUM",
+        Severity::Low => "LOW",
+    }
+}
+
+fn clip(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut clipped = value
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    clipped.push_str("...");
+    clipped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use csa_session::{ReviewFindingFileRange, write_findings_toml, write_review_verdict};
+
+    #[test]
+    fn failure_context_renders_first_finding_and_exact_fix_route() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let artifact = ReviewVerdictArtifact::from_parts(
+            "01TESTFAILCTX",
+            ReviewDecision::Fail,
+            "HAS_ISSUES",
+            &[],
+            Vec::new(),
+        );
+        write_review_verdict(temp.path(), &artifact).expect("write verdict");
+        write_findings_toml(
+            temp.path(),
+            &FindingsFile {
+                findings: vec![ReviewFinding {
+                    id: "F1".to_string(),
+                    severity: Severity::High,
+                    file_ranges: vec![ReviewFindingFileRange {
+                        path: "src/lib.rs".to_string(),
+                        start: 42,
+                        end: None,
+                    }],
+                    is_regression_of_commit: None,
+                    suggested_test_scenario: None,
+                    description: "[correctness] parser accepts stale PASS evidence".to_string(),
+                }],
+            },
+        )
+        .expect("write findings");
+        std::fs::write(
+            temp.path().join("output").join("suggestion.toml"),
+            "[suggestion]\naction = \"confirm_then_fix_finding\"\ncommand_template = \"csa review --fix-finding --session 01TESTFAILCTX --prompt-file <path>\"\n",
+        )
+        .expect("write suggestion");
+
+        let lines = review_failure_context_lines(temp.path());
+
+        assert!(lines.iter().any(|line| line.contains("severity=HIGH")));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("category=correctness"))
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("location=src/lib.rs:42"))
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("csa review --fix-finding --session 01TESTFAILCTX"))
+        );
+    }
+
+    #[test]
+    fn failure_context_points_retired_session_to_fresh_fix_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut artifact = ReviewVerdictArtifact::from_parts(
+            "01TESTRETIREDCTX",
+            ReviewDecision::Fail,
+            "HAS_ISSUES",
+            &[],
+            Vec::new(),
+        );
+        artifact.failure_reason = Some("fail_verdict_empty_findings_artifact".to_string());
+        write_review_verdict(temp.path(), &artifact).expect("write verdict");
+        std::fs::write(temp.path().join("state.toml"), "phase = \"retired\"\n")
+            .expect("write state");
+
+        let lines = review_failure_context_lines(temp.path());
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("review-output parser/internal consistency failure"))
+        );
+        assert!(lines.iter().any(|line| line.contains("retired/immutable")));
+        assert!(lines.iter().all(|line| !line.contains("pr-bot")));
+    }
+
+    #[test]
+    fn issue_2516_finding_title_redacts_embedded_credential() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_failed_review_context(
+            temp.path(),
+            "[security] command leaks OPENAI_API_KEY=providerfixture12345 into logs",
+        );
+
+        let title = json_finding_title(temp.path());
+
+        assert!(title.contains("[REDACTED]"));
+        assert!(!title.contains("providerfixture12345"));
+    }
+
+    #[test]
+    fn issue_2516_finding_title_shortens_absolute_paths_to_relative_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let current_dir = std::env::current_dir().expect("current dir");
+        let absolute_path = current_dir
+            .join("crates/cli-sub-agent/src/review_failure_context.rs")
+            .display()
+            .to_string();
+        write_failed_review_context(
+            temp.path(),
+            &format!("[security] leaked path {absolute_path}:144 in review output"),
+        );
+
+        let title = json_finding_title(temp.path());
+
+        assert_eq!(
+            title,
+            "leaked path crates/cli-sub-agent/src/review_failure_context.rs:144 in review output"
+        );
+        assert!(!title.contains(&current_dir.display().to_string()));
+        assert!(!title.contains("/home/"));
+    }
+
+    #[test]
+    fn issue_2516_normal_finding_title_passes_through_unchanged() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_failed_review_context(
+            temp.path(),
+            "[correctness] parser accepts stale PASS evidence",
+        );
+
+        let title = json_finding_title(temp.path());
+
+        assert_eq!(title, "parser accepts stale PASS evidence");
+    }
+
+    #[test]
+    fn issue_2516_terminal_and_json_titles_use_same_sanitized_value() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let current_dir = std::env::current_dir().expect("current dir");
+        let absolute_path = current_dir
+            .join("crates/cli-sub-agent/src/review_failure_context.rs")
+            .display()
+            .to_string();
+        write_failed_review_context(
+            temp.path(),
+            &format!(
+                "[security] leaked OPENAI_API_KEY=providerfixture12345 at {absolute_path}:144"
+            ),
+        );
+
+        let terminal_title = terminal_finding_title(temp.path());
+        let json_title = json_finding_title(temp.path());
+
+        assert_eq!(terminal_title, json_title);
+        assert_eq!(
+            json_title,
+            "leaked [REDACTED] at crates/cli-sub-agent/src/review_failure_context.rs:144"
+        );
+    }
+
+    fn write_failed_review_context(session_dir: &Path, description: &str) {
+        let artifact = ReviewVerdictArtifact::from_parts(
+            "01TESTISSUE2516",
+            ReviewDecision::Fail,
+            "HAS_ISSUES",
+            &[],
+            Vec::new(),
+        );
+        write_review_verdict(session_dir, &artifact).expect("write verdict");
+        write_findings_toml(
+            session_dir,
+            &FindingsFile {
+                findings: vec![ReviewFinding {
+                    id: "F1".to_string(),
+                    severity: Severity::High,
+                    file_ranges: vec![ReviewFindingFileRange {
+                        path: "src/lib.rs".to_string(),
+                        start: 42,
+                        end: None,
+                    }],
+                    is_regression_of_commit: None,
+                    suggested_test_scenario: None,
+                    description: description.to_string(),
+                }],
+            },
+        )
+        .expect("write findings");
+    }
+
+    fn json_finding_title(session_dir: &Path) -> String {
+        review_failure_context_json(session_dir)
+            .expect("review failure context")
+            .pointer("/first_finding/title")
+            .and_then(serde_json::Value::as_str)
+            .expect("json finding title")
+            .to_string()
+    }
+
+    fn terminal_finding_title(session_dir: &Path) -> String {
+        let line = review_failure_context_lines(session_dir)
+            .into_iter()
+            .find(|line| line.starts_with("First finding:"))
+            .expect("terminal finding line");
+        line.split_once(" title=")
+            .map(|(_, title)| title.to_string())
+            .expect("terminal finding title")
+    }
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -135,6 +135,9 @@ pub(crate) fn render_wait_result_summary(
     if let Some(verdict) = review_label::read_review_verdict_label(session_dir, result) {
         lines.push(format!("Review verdict: {verdict}"));
     }
+    lines.extend(crate::review_failure_context::review_failure_context_lines(
+        session_dir,
+    ));
 
     if let Some(reason) =
         crate::session_unavailable_reason::review_unavailable_reason_label(session_dir)
@@ -281,6 +284,7 @@ fn render_wait_result_json(
         "elapsed_seconds": wait_elapsed_seconds(result),
         "tokens": tokens,
         "review_verdict": review_label::read_review_verdict_label(session_dir, result),
+        "review_failure_context": crate::review_failure_context::review_failure_context_json(session_dir),
         "unavailable_reason": crate::session_unavailable_reason::review_unavailable_reason_label(session_dir),
         "failover": format_failover_chain_label(session_dir, result),
         "kill_hint": result.kill_hint.as_deref(),
@@ -612,6 +616,9 @@ fn render_wait_output_log(raw: &[u8], truncated: bool) -> Option<String> {
 #[cfg(test)]
 #[path = "session_cmds_daemon_wait_summary_2425.rs"]
 mod session_cmds_daemon_wait_summary_2425;
+#[cfg(test)]
+#[path = "session_cmds_daemon_wait_summary_2516_tests.rs"]
+mod session_cmds_daemon_wait_summary_2516_tests;
 #[cfg(test)]
 #[path = "session_cmds_daemon_wait_summary_tests.rs"]
 mod session_cmds_daemon_wait_summary_tests;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_2516_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_2516_tests.rs
@@ -1,0 +1,75 @@
+use super::*;
+use chrono::Utc;
+
+#[test]
+fn issue_2516_fail_wait_summary_includes_first_finding_and_fix_route() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let output_dir = temp.path().join("output");
+    std::fs::create_dir_all(&output_dir).expect("output dir should be created");
+    std::fs::write(
+        output_dir.join("review-verdict.json"),
+        r#"{"schema_version":1,"session_id":"01TEST2516FAILSUMMARY","timestamp":"2026-04-01T00:00:00Z","decision":"fail","verdict_legacy":"HAS_ISSUES","severity_counts":{"critical":0,"high":1,"medium":0,"low":0},"prior_round_refs":[]}"#,
+    )
+    .expect("review verdict should be written");
+    std::fs::write(
+        output_dir.join("findings.toml"),
+        r#"[[findings]]
+id = "F1"
+severity = "high"
+description = "[correctness] parser accepts positive verification prose as a finding"
+
+[[findings.file_ranges]]
+path = "src/lib.rs"
+start = 42
+"#,
+    )
+    .expect("findings.toml should be written");
+    std::fs::write(
+        output_dir.join("suggestion.toml"),
+        "[suggestion]\naction = \"confirm_then_fix_finding\"\ncommand_template = \"csa review --fix-finding --session 01TEST2516FAILSUMMARY --prompt-file <path>\"\n",
+    )
+    .expect("suggestion.toml should be written");
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        post_exec_gate: None,
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "FAIL".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TEST2516FAILSUMMARY", &result);
+
+    assert!(summary.contains("Review verdict: FAIL"), "{summary}");
+    assert!(
+        summary.contains("First finding: severity=HIGH"),
+        "{summary}"
+    );
+    assert!(summary.contains("category=correctness"), "{summary}");
+    assert!(summary.contains("location=src/lib.rs:42"), "{summary}");
+    assert!(
+        summary.contains("csa review --fix-finding --session 01TEST2516FAILSUMMARY"),
+        "{summary}"
+    );
+    assert!(!summary.contains("pr-bot"), "{summary}");
+
+    let rendered = render_wait_result_json(temp.path(), "01TEST2516FAILSUMMARY", &result)
+        .expect("wait result JSON should render");
+    let value: serde_json::Value =
+        serde_json::from_str(&rendered).expect("wait result JSON should parse");
+    assert_eq!(
+        value["review_failure_context"]["first_finding"]["severity"],
+        "HIGH"
+    );
+    assert!(
+        value["review_failure_context"]["fix_route"]
+            .as_str()
+            .unwrap()
+            .contains("--fix-finding")
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_result_display.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_display.rs
@@ -5,6 +5,15 @@ use std::fs;
 use std::path::Path;
 
 use super::{StructuredOutputOpts, TranscriptSummary};
+use crate::memory_soft_limit_recovery_display::format_memory_soft_limit_recovery_lines;
+use crate::require_commit_recovery_display::format_require_commit_recovery_lines;
+use crate::review_failure_context as rfc;
+use crate::session_display_alias;
+use crate::session_provider_quota::{
+    ProviderQuotaDisplay, provider_quota_display_for_result, provider_quota_display_for_session_dir,
+};
+use crate::session_summary_text::{enrich_review_summary, human_session_summary};
+use crate::session_unavailable_reason::review_unavailable_reason_label;
 use crate::token_usage_display::{display_total_tokens, token_usage_json_value};
 
 #[path = "session_cmds_result_post_exec_gate.rs"]
@@ -49,10 +58,9 @@ pub(super) fn display_result_text(
     token_usage: Option<&TokenUsage>,
 ) {
     let envelope = &result.envelope;
-    let provider_quota =
-        crate::session_provider_quota::provider_quota_display_for_result(session_dir, envelope);
+    let provider_quota = provider_quota_display_for_result(session_dir, envelope);
     println!("Session: {session_id}");
-    for line in crate::session_display_alias::text_lines(session_dir, session_id) {
+    for line in session_display_alias::text_lines(session_dir, session_id) {
         println!("{line}");
     }
     println!("Status:  {}", envelope.status);
@@ -73,12 +81,11 @@ pub(super) fn display_result_text(
     if let Some(summary) = display_summary {
         println!("Summary: {summary}");
     }
+    rfc::print(session_dir);
     if let (true, Some(provider_quota)) = (used_provider_quota, provider_quota.as_ref()) {
         println!("Hint: {}", provider_quota.hint);
     }
-    if let Some(reason) =
-        crate::session_unavailable_reason::review_unavailable_reason_label(session_dir)
-    {
+    if let Some(reason) = review_unavailable_reason_label(session_dir) {
         println!("Unavailable reason: {reason}");
     }
     if let Some(kill_hint) = envelope.kill_hint.as_deref() {
@@ -88,18 +95,12 @@ pub(super) fn display_result_text(
         println!("Kill diagnostics: {}", format_kill_diagnostics(diagnostics));
     }
     if let Some(recovery) = envelope.require_commit_recovery.as_ref() {
-        for line in
-            crate::require_commit_recovery_display::format_require_commit_recovery_lines(recovery)
-        {
+        for line in format_require_commit_recovery_lines(recovery) {
             println!("{line}");
         }
     }
     if let Some(recovery) = envelope.memory_soft_limit_recovery.as_ref() {
-        for line in
-            crate::memory_soft_limit_recovery_display::format_memory_soft_limit_recovery_lines(
-                recovery,
-            )
-        {
+        for line in format_memory_soft_limit_recovery_lines(recovery) {
             println!("{line}");
         }
     }
@@ -267,22 +268,21 @@ pub(super) fn build_result_json_payload_with_identity(
 ) -> Result<serde_json::Value> {
     let mut payload =
         build_result_json_payload(result, transcript_summary, review_meta, token_usage)?;
-    crate::session_display_alias::apply_json_identity(&mut payload, session_dir, session_id);
+    session_display_alias::apply_json_identity(&mut payload, session_dir, session_id);
+    rfc::insert_json(&mut payload, session_dir);
     Ok(payload)
 }
 
 fn result_display_summary(
     session_dir: &Path,
     envelope: &csa_session::SessionResult,
-    provider_quota: Option<&crate::session_provider_quota::ProviderQuotaDisplay>,
+    provider_quota: Option<&ProviderQuotaDisplay>,
 ) -> Option<String> {
     if let Some(report) = envelope.post_exec_gate.as_ref() {
         return Some(csa_session::post_exec_gate_failure_summary(report));
     }
-    if let Some(summary) =
-        crate::session_summary_text::human_session_summary(session_dir, &envelope.summary).map(
-            |summary| crate::session_summary_text::enrich_review_summary(session_dir, &summary),
-        )
+    if let Some(summary) = human_session_summary(session_dir, &envelope.summary)
+        .map(|summary| enrich_review_summary(session_dir, &summary))
     {
         return Some(summary);
     }
@@ -354,8 +354,7 @@ const FALLBACK_LINES: usize = 20;
 
 /// Display a bounded pre-exec result artifact without falling back to raw logs.
 pub(super) fn display_pre_exec_summary_if_present(session_dir: &Path, json: bool) -> Result<bool> {
-    let unavailable_reason =
-        crate::session_unavailable_reason::review_unavailable_reason_label(session_dir);
+    let unavailable_reason = review_unavailable_reason_label(session_dir);
     pre_exec_summary::display_if_present(session_dir, unavailable_reason.as_deref(), json)
 }
 
@@ -387,11 +386,9 @@ pub(super) fn display_summary_section(
     session_id: &str,
     json: bool,
 ) -> Result<()> {
-    let unavailable_reason =
-        crate::session_unavailable_reason::review_unavailable_reason_label(session_dir);
+    let unavailable_reason = review_unavailable_reason_label(session_dir);
     let post_exec_gate = load_structured_post_exec_gate_report(session_dir);
-    let provider_quota =
-        crate::session_provider_quota::provider_quota_display_for_session_dir(session_dir);
+    let provider_quota = provider_quota_display_for_session_dir(session_dir);
     let (section_id, content) = match csa_session::read_section(session_dir, "summary")? {
         Some(content) => ("summary", content),
         None => match csa_session::read_section(session_dir, "full")? {
@@ -466,7 +463,7 @@ fn display_gate_summary_override(
 }
 
 fn display_provider_quota_summary(
-    provider_quota: &crate::session_provider_quota::ProviderQuotaDisplay,
+    provider_quota: &ProviderQuotaDisplay,
     unavailable_reason: Option<String>,
     json: bool,
 ) -> Result<()> {
@@ -488,11 +485,8 @@ fn display_provider_quota_summary(
 }
 
 fn display_summary_fallback(session_dir: &Path, session_id: &str, json: bool) -> Result<()> {
-    let unavailable_reason =
-        crate::session_unavailable_reason::review_unavailable_reason_label(session_dir);
-    if let Some(provider_quota) =
-        crate::session_provider_quota::provider_quota_display_for_session_dir(session_dir)
-    {
+    let unavailable_reason = review_unavailable_reason_label(session_dir);
+    if let Some(provider_quota) = provider_quota_display_for_session_dir(session_dir) {
         return display_provider_quota_summary(&provider_quota, unavailable_reason, json);
     }
     let output_log = session_dir.join("output.log");


### PR DESCRIPTION
Closes #2516

## Summary

Review verdict artifacts, summaries, and fix routes are now consistent across terminal and JSON surfaces.

Key changes:
- **Failure-context sanitization**: All finding output fields (title, category, location) sanitized via shared `sanitize_finding_text()` before terminal/JSON exposure
- **Prose resolution filter**: Removed unreliable `"no longer"` heuristic; added non-negated active-problem guard to `review_signal_describes_resolved_issue`
- **Synthetic-empty fail-closed**: Checks JSON for any severity counts (not just blocking), preventing low-only findings from being silently dropped
- **Verdict artifact consistency**: Markers, summaries, and fix routes kept consistent across all output surfaces

## Tests

48 focused tests pass. 7-iteration tier4 CSA-Codex review loop completed. Final verdict: PASS.