### PR TITLE
fix(csa): make pre-exec memory admission retryable with feasibility guidance (#2512)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "chrono",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "chrono",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "axum",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "chrono",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "chrono",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1081"
+version = "0.1.1082"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1081"
+version = "0.1.1082"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/no_provider_launch.rs
+++ b/crates/cli-sub-agent/src/no_provider_launch.rs
@@ -10,6 +10,8 @@ use crate::resource_admission_soft_limit::MemorySoftLimitAdmissionError;
 use crate::run_resource_overrides::RunResourceOverrides;
 
 pub(crate) const HOST_MEMORY_ADMISSION_REASON: &str = "host_memory_admission";
+const CLI_MEMORY_MAX_MIN_MB: u64 = 256;
+const PREFERRED_RETRY_RESERVE_MB: u64 = 6_000;
 
 pub(crate) struct NoProviderLaunchContext<'a> {
     pub(crate) session: &'a MetaSessionState,
@@ -56,19 +58,60 @@ fn from_host_memory_admission(
     ctx: NoProviderLaunchContext<'_>,
     error: &MemoryAdmissionError,
 ) -> NoProviderLaunchDiagnostic {
-    let effective_memory_max_mb = error.projected_spawn_mb.or_else(|| {
-        ctx.resource_overrides
-            .resolve_memory_max_mb(ctx.config, ctx.tool_name)
-    });
+    let memory = host_memory_diagnostic_memory(
+        ctx.task_type,
+        ctx.tool_name,
+        ctx.config,
+        ctx.resource_overrides,
+        error,
+    );
+    let guidance = host_memory_guidance(ctx.task_type, ctx.tool_name, &memory);
+
+    base_diagnostic(
+        &ctx,
+        role_from_task_type(ctx.task_type),
+        error.kind.denial_class(),
+        memory,
+        guidance,
+    )
+}
+
+pub(crate) fn host_memory_guidance_from_error(
+    task_type: Option<&str>,
+    tool_name: &str,
+    config: Option<&ProjectConfig>,
+    resource_overrides: RunResourceOverrides,
+    error: &Error,
+) -> Option<Vec<String>> {
+    let host_memory = error.downcast_ref::<MemoryAdmissionError>()?;
+    let memory = host_memory_diagnostic_memory(
+        task_type,
+        tool_name,
+        config,
+        resource_overrides,
+        host_memory,
+    );
+    Some(host_memory_guidance(task_type, tool_name, &memory))
+}
+
+fn host_memory_diagnostic_memory(
+    task_type: Option<&str>,
+    tool_name: &str,
+    config: Option<&ProjectConfig>,
+    resource_overrides: RunResourceOverrides,
+    error: &MemoryAdmissionError,
+) -> NoProviderLaunchMemoryDiagnostic {
+    let effective_memory_max_mb = error
+        .projected_spawn_mb
+        .or_else(|| resource_overrides.resolve_memory_max_mb(config, tool_name));
     let soft_limit_percent = effective_memory_max_mb.map(|_| {
-        ctx.config
+        config
             .and_then(|cfg| cfg.resources.soft_limit_percent)
             .unwrap_or(memory_policy::DEFAULT_SOFT_LIMIT_PERCENT)
     });
     let required_floor_mb =
         crate::resource_admission_soft_limit::codex_soft_limit_required_floor_mb(
-            ctx.task_type,
-            ctx.tool_name,
+            task_type, tool_name,
         );
     let required_memory_max_mb =
         required_floor_mb
@@ -79,8 +122,16 @@ fn from_host_memory_admission(
     let soft_threshold_mb = effective_memory_max_mb
         .zip(soft_limit_percent)
         .and_then(|(cap, percent)| memory_policy::soft_limit_threshold_mb(cap, percent));
+    let retry_lower_bound_mb = Some(host_memory_retry_lower_bound_mb(required_memory_max_mb));
+    let retry_feasible = retry_lower_bound_mb.zip(error.retry_combined_upper_mb).map(
+        |(lower_bound, upper_bound)| {
+            lower_bound <= upper_bound
+                || reserve_delta_retry(memory_available(error), lower_bound, error)
+                    .is_some_and(|retry| lower_bound <= retry.adjusted_upper_mb)
+        },
+    );
 
-    let memory = NoProviderLaunchMemoryDiagnostic {
+    NoProviderLaunchMemoryDiagnostic {
         effective_memory_max_mb,
         soft_limit_percent,
         soft_threshold_mb,
@@ -94,16 +145,12 @@ fn from_host_memory_admission(
         active_session_projected_mb: error.active_session_projected_mb,
         active_session_count: error.active_session_count,
         sampled_session_count: error.sampled_session_count,
-    };
-    let guidance = host_memory_guidance(ctx.task_type, ctx.tool_name, &memory);
-
-    base_diagnostic(
-        &ctx,
-        role_from_task_type(ctx.task_type),
-        error.kind.denial_class(),
-        memory,
-        guidance,
-    )
+        retry_physical_upper_mb: error.retry_physical_upper_mb,
+        retry_active_session_upper_mb: error.retry_active_session_upper_mb,
+        retry_combined_upper_mb: error.retry_combined_upper_mb,
+        retry_lower_bound_mb,
+        retry_feasible,
+    }
 }
 
 fn base_diagnostic(
@@ -144,17 +191,14 @@ fn host_memory_guidance(
     tool_name: &str,
     memory: &NoProviderLaunchMemoryDiagnostic,
 ) -> Vec<String> {
+    let feasibility = host_memory_retry_feasibility(tool_name, memory);
     match role_from_task_type(task_type) {
         "reviewer" => {
             let mut guidance = vec![
                 "Host memory admission failed before the reviewer provider launched; this is infrastructure no-verdict, not PASS/FAIL.".to_string(),
                 "Host admission uses physical MemAvailable only; swap/combined memory is diagnostic and is not counted because launching a reviewer into swap can still OOM or terminate before a verdict.".to_string(),
             ];
-            if let Some(retry) = suggested_host_memory_retry(tool_name, memory) {
-                guidance.push(retry);
-            } else {
-                guidance.push("Retry the same cap with a lower --min-free-memory-mb only when the host reserve is intentionally conservative; otherwise wait/free memory or use another configured reviewer.".to_string());
-            }
+            guidance.push(feasibility);
             guidance.push(
                 "If no reviewer fallback runs, fail closed and use native/manual review after one bounded retry."
                     .to_string(),
@@ -164,69 +208,195 @@ fn host_memory_guidance(
         "writer" => vec![
             "Host memory admission failed before the writer provider launched; no provider-side worktree mutation occurred.".to_string(),
             "Host admission uses physical MemAvailable only; swap/combined memory is diagnostic and is not counted toward the pre-spawn gate.".to_string(),
-            "Lower only the reserve when safe, wait/free memory, or reduce the projected spawn cap without dropping below the role soft-limit floor.".to_string(),
+            feasibility,
             "For dirty-work recovery, avoid repeated CSA retries in the same memory envelope; after one same-class retry, switch to documented recovery/manual fallback.".to_string(),
         ],
         _ => vec![
             "Host memory admission failed before the provider launched; retry after freeing memory or lowering only safe resource overrides.".to_string(),
+            feasibility,
         ],
     }
 }
 
-fn suggested_host_memory_retry(
-    tool_name: &str,
-    memory: &NoProviderLaunchMemoryDiagnostic,
-) -> Option<String> {
-    let required_cap_mb = memory.required_memory_max_mb?;
-    let required_floor_mb = memory.required_floor_mb?;
-    let soft_limit_percent = memory.soft_limit_percent?;
-    let available_mb = memory.available_memory_mb?;
-    let current_reserve_mb = memory.reserve_mb.unwrap_or(0);
-    let current_upper_mb = available_mb.saturating_sub(current_reserve_mb);
-    let suggested_soft_threshold_mb =
-        memory_policy::soft_limit_threshold_mb(required_cap_mb, soft_limit_percent)?;
-    if suggested_soft_threshold_mb < required_floor_mb || available_mb <= required_cap_mb {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReserveDeltaRetry {
+    reserve_mb: u64,
+    adjusted_upper_mb: u64,
+}
+
+fn host_memory_retry_lower_bound_mb(required_memory_max_mb: Option<u64>) -> u64 {
+    required_memory_max_mb.unwrap_or(CLI_MEMORY_MAX_MIN_MB)
+}
+
+fn memory_available(error: &MemoryAdmissionError) -> u64 {
+    error.available_phys_mb
+}
+
+fn reserve_delta_retry(
+    available_mb: u64,
+    lower_bound_mb: u64,
+    error: &MemoryAdmissionError,
+) -> Option<ReserveDeltaRetry> {
+    let active_upper_mb = error.retry_active_session_upper_mb.unwrap_or(u64::MAX);
+    reserve_delta_retry_from_bounds(
+        available_mb,
+        error.reserve_mb,
+        active_upper_mb,
+        lower_bound_mb,
+    )
+}
+
+fn reserve_delta_retry_from_bounds(
+    available_mb: u64,
+    current_reserve_mb: u64,
+    active_upper_mb: u64,
+    lower_bound_mb: u64,
+) -> Option<ReserveDeltaRetry> {
+    if active_upper_mb < lower_bound_mb {
         return None;
     }
-
-    if required_cap_mb <= current_upper_mb {
-        let host_required_mb = required_cap_mb.saturating_add(current_reserve_mb);
-        return Some(format!(
-            "Suggested bounded retry for {tool_name}: --memory-max-mb {required_cap_mb} \
-             (current retry window is {required_cap_mb}..={current_upper_mb}MB with \
-             min_free_memory_mb={current_reserve_mb}; soft_limit_percent={soft_limit_percent} \
-             gives soft threshold {suggested_soft_threshold_mb}MB >= required floor \
-             {required_floor_mb}MB; host required {host_required_mb}MB <= physical \
-             available {available_mb}MB)."
-        ));
-    }
-
-    let max_reserve_mb = available_mb.saturating_sub(required_cap_mb);
+    let max_reserve_mb = available_mb.checked_sub(lower_bound_mb)?;
     if max_reserve_mb == 0 {
         return None;
     }
-    let preferred_reserve_mb = current_reserve_mb.clamp(1, 6_000);
-    let suggested_reserve_mb = if max_reserve_mb >= preferred_reserve_mb {
-        preferred_reserve_mb
-    } else {
-        max_reserve_mb
-    };
-    let suggested_upper_mb = available_mb.saturating_sub(suggested_reserve_mb);
-    let host_required_mb = required_cap_mb.saturating_add(suggested_reserve_mb);
-    if host_required_mb > available_mb {
-        return None;
+    let preferred_reserve_mb = current_reserve_mb.clamp(1, PREFERRED_RETRY_RESERVE_MB);
+    let reserve_mb = preferred_reserve_mb.min(max_reserve_mb);
+    let adjusted_upper_mb = available_mb.saturating_sub(reserve_mb).min(active_upper_mb);
+    (lower_bound_mb <= adjusted_upper_mb).then_some(ReserveDeltaRetry {
+        reserve_mb,
+        adjusted_upper_mb,
+    })
+}
+
+fn host_memory_retry_feasibility(
+    tool_name: &str,
+    memory: &NoProviderLaunchMemoryDiagnostic,
+) -> String {
+    let lower_bound_mb = memory
+        .retry_lower_bound_mb
+        .unwrap_or_else(|| host_memory_retry_lower_bound_mb(memory.required_memory_max_mb));
+    let current_upper_mb = memory
+        .retry_combined_upper_mb
+        .or_else(|| {
+            memory
+                .available_memory_mb
+                .zip(memory.reserve_mb)
+                .map(|(available_mb, reserve_mb)| {
+                    let physical_upper_mb = available_mb.saturating_sub(reserve_mb);
+                    memory
+                        .retry_active_session_upper_mb
+                        .map_or(physical_upper_mb, |active_upper| {
+                            physical_upper_mb.min(active_upper)
+                        })
+                })
+        })
+        .unwrap_or(0);
+    let physical_upper_mb = memory
+        .retry_physical_upper_mb
+        .or_else(|| {
+            memory
+                .available_memory_mb
+                .zip(memory.reserve_mb)
+                .map(|(available_mb, reserve_mb)| available_mb.saturating_sub(reserve_mb))
+        })
+        .unwrap_or(current_upper_mb);
+    let active_upper_mb = memory.retry_active_session_upper_mb;
+    let current_reserve_mb = memory.reserve_mb.unwrap_or(0);
+    let current_cap_mb = memory.effective_memory_max_mb.or(memory.projected_spawn_mb);
+    let lower_reason = retry_lower_bound_reason(memory);
+    let bounds = format_retry_bounds(
+        lower_bound_mb,
+        current_upper_mb,
+        physical_upper_mb,
+        active_upper_mb,
+        current_cap_mb,
+        current_reserve_mb,
+        lower_reason,
+    );
+    if lower_bound_mb <= current_upper_mb {
+        let host_required_mb = lower_bound_mb.saturating_add(current_reserve_mb);
+        return format!(
+            "Retry feasibility: feasible now. {bounds} Retry command delta: add \
+             --memory-max-mb {lower_bound_mb} to the same CSA invocation; for \
+             dev2merge/mktd child steps, add the same flag to csa plan run or the \
+             workflow's child csa run/review step. Config delta: set \
+             tools.{tool_name}.memory_max_mb = {lower_bound_mb} or \
+             resources.memory_max_mb = {lower_bound_mb}. host_required={host_required_mb}MB."
+        );
     }
 
-    Some(format!(
-        "Suggested bounded retry for {tool_name}: --memory-max-mb {required_cap_mb} \
-         --min-free-memory-mb {suggested_reserve_mb} (no cap satisfies the current \
-         retry window because required lower bound {required_cap_mb}MB > current \
-         upper bound {current_upper_mb}MB at min_free_memory_mb={current_reserve_mb}; \
-         lowering reserve opens retry window {required_cap_mb}..={suggested_upper_mb}MB; \
-         soft_limit_percent={soft_limit_percent} gives soft threshold \
-         {suggested_soft_threshold_mb}MB >= required floor {required_floor_mb}MB; \
-         host required {host_required_mb}MB <= physical available {available_mb}MB)."
-    ))
+    let available_mb = memory.available_memory_mb.unwrap_or(0);
+    let active_upper_for_retry = active_upper_mb.unwrap_or(u64::MAX);
+    if let Some(retry) = reserve_delta_retry_from_bounds(
+        available_mb,
+        current_reserve_mb,
+        active_upper_for_retry,
+        lower_bound_mb,
+    ) {
+        let host_required_mb = lower_bound_mb.saturating_add(retry.reserve_mb);
+        return format!(
+            "Retry feasibility: feasible with reserve delta. {bounds} Current reserve has no \
+             valid window because lower_bound={lower_bound_mb}MB > current_upper={current_upper_mb}MB; \
+             lowering reserve opens retry_window={lower_bound_mb}..={adjusted_upper}MB. \
+             Retry command delta: add --memory-max-mb {lower_bound_mb} \
+             --min-free-memory-mb {reserve_mb} to the same CSA invocation; for dev2merge/mktd \
+             child steps, add the same flags to csa plan run or the workflow's child csa \
+             run/review step. Config delta: set tools.{tool_name}.memory_max_mb = \
+             {lower_bound_mb} and resources.min_free_memory_mb = {reserve_mb}. \
+             host_required={host_required_mb}MB <= physical_available={available_mb}MB.",
+            adjusted_upper = retry.adjusted_upper_mb,
+            reserve_mb = retry.reserve_mb,
+        );
+    }
+
+    let blocker = if active_upper_for_retry < lower_bound_mb {
+        format!(
+            "active-session upper {active_upper_for_retry}MB is below lower_bound={lower_bound_mb}MB; wait for active CSA sessions to finish or use a different configured tool"
+        )
+    } else if available_mb < lower_bound_mb {
+        format!(
+            "physical MemAvailable {available_mb}MB is below lower_bound={lower_bound_mb}MB even with reserve=0; free host memory or use a lower-floor tool"
+        )
+    } else {
+        format!(
+            "no positive reserve can satisfy lower_bound={lower_bound_mb}MB and upper_bound={current_upper_mb}MB"
+        )
+    };
+    format!(
+        "Retry feasibility: infeasible. {bounds} No feasible retry window exists \
+         because {blocker}. Do not retry with another memory_max_mb inside this \
+         envelope; wait/free memory, reduce active CSA-session pressure, or switch tool/config."
+    )
+}
+
+fn retry_lower_bound_reason(memory: &NoProviderLaunchMemoryDiagnostic) -> &'static str {
+    if memory.required_memory_max_mb.is_some() {
+        "role/tool soft-limit floor"
+    } else {
+        "CLI minimum"
+    }
+}
+
+fn format_retry_bounds(
+    lower_bound_mb: u64,
+    current_upper_mb: u64,
+    physical_upper_mb: u64,
+    active_upper_mb: Option<u64>,
+    current_cap_mb: Option<u64>,
+    current_reserve_mb: u64,
+    lower_reason: &str,
+) -> String {
+    let active_upper = active_upper_mb
+        .map(|upper| format!("{upper}MB"))
+        .unwrap_or_else(|| "unknown".to_string());
+    let current_cap = current_cap_mb
+        .map(|cap| format!("{cap}MB"))
+        .unwrap_or_else(|| "unknown".to_string());
+    format!(
+        "lower_bound={lower_bound_mb}MB ({lower_reason}); current_upper={current_upper_mb}MB \
+         (physical/reserve upper={physical_upper_mb}MB, active-session upper={active_upper}); \
+         current_projected_spawn_cap={current_cap}; current_min_free_memory_mb={current_reserve_mb}."
+    )
 }
 
 pub(crate) fn enrich_review_diagnostic(
@@ -257,6 +427,11 @@ mod tests {
             available_memory_mb: Some(17_033),
             required_available_mb: Some(19_000),
             projected_spawn_mb: Some(10_000),
+            retry_physical_upper_mb: Some(8_033),
+            retry_active_session_upper_mb: Some(16_000),
+            retry_combined_upper_mb: Some(8_033),
+            retry_lower_bound_mb: Some(9_103),
+            retry_feasible: Some(true),
             ..Default::default()
         };
 
@@ -265,10 +440,12 @@ mod tests {
 
         assert!(joined.contains("physical MemAvailable only"));
         assert!(joined.contains("swap/combined memory is diagnostic"));
+        assert!(joined.contains("Retry feasibility: feasible with reserve delta"));
         assert!(joined.contains("--memory-max-mb 9103 --min-free-memory-mb 6000"));
-        assert!(joined.contains("required lower bound 9103MB > current upper bound 8033MB"));
-        assert!(joined.contains("soft threshold 8192MB >= required floor 8192MB"));
-        assert!(joined.contains("host required 15103MB <= physical available 17033MB"));
+        assert!(joined.contains("lower_bound=9103MB > current_upper=8033MB"));
+        assert!(joined.contains("lowering reserve opens retry_window=9103..=11033MB"));
+        assert!(joined.contains("host_required=15103MB <= physical_available=17033MB"));
+        assert!(joined.contains("csa plan run"));
     }
 
     #[test]
@@ -283,6 +460,11 @@ mod tests {
             available_memory_mb: Some(9_296),
             required_available_mb: Some(10_256),
             projected_spawn_mb: Some(10_000),
+            retry_physical_upper_mb: Some(9_040),
+            retry_active_session_upper_mb: Some(12_000),
+            retry_combined_upper_mb: Some(9_040),
+            retry_lower_bound_mb: Some(9_103),
+            retry_feasible: Some(true),
             ..Default::default()
         };
 
@@ -290,8 +472,36 @@ mod tests {
         let joined = guidance.join("\n");
 
         assert!(joined.contains("--memory-max-mb 9103 --min-free-memory-mb 193"));
-        assert!(joined.contains("required lower bound 9103MB > current upper bound 9040MB"));
-        assert!(joined.contains("lowering reserve opens retry window 9103..=9103MB"));
-        assert!(joined.contains("host required 9296MB <= physical available 9296MB"));
+        assert!(joined.contains("lower_bound=9103MB > current_upper=9040MB"));
+        assert!(joined.contains("lowering reserve opens retry_window=9103..=9103MB"));
+        assert!(joined.contains("host_required=9296MB <= physical_available=9296MB"));
+    }
+
+    #[test]
+    fn host_memory_reviewer_guidance_reports_active_pressure_infeasible() {
+        let memory = NoProviderLaunchMemoryDiagnostic {
+            effective_memory_max_mb: Some(10_000),
+            soft_limit_percent: Some(90),
+            soft_threshold_mb: Some(9_000),
+            required_floor_mb: Some(8_192),
+            required_memory_max_mb: Some(9_103),
+            reserve_mb: Some(1_000),
+            available_memory_mb: Some(20_000),
+            required_available_mb: Some(11_000),
+            projected_spawn_mb: Some(10_000),
+            retry_physical_upper_mb: Some(19_000),
+            retry_active_session_upper_mb: Some(8_000),
+            retry_combined_upper_mb: Some(8_000),
+            retry_lower_bound_mb: Some(9_103),
+            retry_feasible: Some(false),
+            ..Default::default()
+        };
+
+        let guidance = host_memory_guidance(Some("reviewer_sub_session"), "codex", &memory);
+        let joined = guidance.join("\n");
+
+        assert!(joined.contains("Retry feasibility: infeasible"));
+        assert!(joined.contains("active-session upper 8000MB is below lower_bound=9103MB"));
+        assert!(joined.contains("Do not retry with another memory_max_mb"));
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -357,6 +357,7 @@ async fn low_memory_pre_spawn_failure_sets_termination_reason() {
     assert_eq!(result.status, "failure");
     assert!(result.summary.starts_with("pre-exec:"));
     assert!(result.summary.contains("CSA: low memory"));
+    assert!(result.summary.contains("Retry feasibility:"));
     assert!(
         result
             .artifacts
@@ -382,6 +383,14 @@ async fn low_memory_pre_spawn_failure_sets_termination_reason() {
         Some(config.resources.min_free_memory_mb)
     );
     assert_eq!(no_provider.memory.effective_memory_max_mb, Some(1024));
+    assert_eq!(no_provider.memory.retry_lower_bound_mb, Some(256));
+    assert!(no_provider.memory.retry_combined_upper_mb.is_some());
+    assert!(
+        no_provider
+            .guidance
+            .iter()
+            .any(|item| item.contains("Retry feasibility:"))
+    );
 }
 
 #[tokio::test]

--- a/crates/cli-sub-agent/src/review_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_preflight.rs
@@ -249,7 +249,25 @@ fn validate_host_memory_before_session(
         REVIEW_PREFLIGHT_SESSION_ID,
         projected_spawn_mb,
     );
-    resource_guard.check_availability_with_admission(tool.as_str(), Some(admission))
+    resource_guard
+        .check_availability_with_admission(tool.as_str(), Some(admission))
+        .map_err(|err| {
+            let guidance = crate::no_provider_launch::host_memory_guidance_from_error(
+                Some(REVIEWER_SUB_SESSION_TASK_TYPE),
+                tool.as_str(),
+                project_config,
+                resource_overrides,
+                &err,
+            );
+            if let Some(guidance) = guidance {
+                err.context(format!(
+                    "host memory retry guidance:\n- {}",
+                    guidance.join("\n- ")
+                ))
+            } else {
+                err
+            }
+        })
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
@@ -137,6 +137,8 @@ fn review_host_memory_admission_is_rejected_before_session_creation() {
     let msg = format!("{err:#}");
     assert!(msg.contains("CSA: low memory"), "{msg}");
     assert!(msg.contains("review preflight for tool 'codex'"), "{msg}");
+    assert!(msg.contains("host memory retry guidance"), "{msg}");
+    assert!(msg.contains("Retry feasibility:"), "{msg}");
     let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
     assert!(
         sessions.is_empty(),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_review_label.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_review_label.rs
@@ -47,7 +47,10 @@ pub(super) fn read_review_verdict_label(
             && let Some(primary_failure) = artifact.primary_failure.as_deref()
             && !primary_failure.trim().is_empty()
         {
-            return Some(format!("UNAVAILABLE ({})", primary_failure.trim()));
+            let redacted = csa_session::redact_text_content(primary_failure.trim());
+            let compacted = super::compact_wait_summary_text(&redacted);
+            let label = compacted.unwrap_or_else(|| redacted.clone());
+            return Some(format!("UNAVAILABLE ({label})"));
         }
         let normalized = normalize_review_verdict_label(artifact.decision.as_str(), result);
         if matches!(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -235,7 +235,8 @@ fn format_failover_chain_label(
             && let Some(primary_failure) = artifact.primary_failure.as_deref()
             && !primary_failure.trim().is_empty()
         {
-            return Some(primary_failure.trim().to_string());
+            let redacted = csa_session::redact_text_content(primary_failure.trim());
+            return Some(redacted);
         }
     }
 

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_unavailable_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_unavailable_tests.rs
@@ -85,3 +85,48 @@ fn compact_summary_omits_provider_usage_reason_for_auth_only_unavailable() {
     assert!(!summary.contains("Unavailable reason:"));
     assert!(!summary.contains(fake_value));
 }
+
+#[test]
+fn issue_2512_unavailable_primary_failure_is_redacted_in_label_and_failover() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let api_field = concat!("api", "_", "key");
+    let fake_value = concat!("sk", "-", "sec", "...", "6789");
+    write_review_verdict(
+        temp.path(),
+        format!(
+            r#"{{"schema_version":1,"session_id":"01TEST2512REDACT","timestamp":"2026-06-29T00:00:00Z","decision":"unavailable","verdict_legacy":"UNAVAILABLE","severity_counts":{{"critical":0,"high":0,"medium":0,"low":0}},"primary_failure":"host memory admission denied; {api_field}={fake_value}","failure_reason":"infrastructure_unavailable","prior_round_refs":[]}}"#
+        ),
+    );
+    let now = Utc::now();
+    let result = csa_session::SessionResult {
+        post_exec_gate: None,
+        status: "failed".to_string(),
+        exit_code: 1,
+        summary: "review unavailable".to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(65),
+        events_count: 0,
+        artifacts: Vec::new(),
+        fallback_chain: Some(vec![csa_core::types::FallbackAttempt {
+            tool: "codex".into(),
+            model_spec: None,
+            skip_reason: "memory admission denied".into(),
+            quota_exhausted: false,
+            timestamp: now,
+        }]),
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TEST2512REDACT", &result);
+
+    // The credential must never appear in the output
+    assert!(
+        !summary.contains(fake_value),
+        "primary_failure credential leaked into wait summary: {summary}"
+    );
+    assert!(summary.contains("[REDACTED]"), "expected redaction marker");
+}

--- a/crates/csa-resource/src/guard.rs
+++ b/crates/csa-resource/src/guard.rs
@@ -36,6 +36,17 @@ pub struct SpawnMemoryAdmission {
     pub sampled_session_count: u64,
 }
 
+/// Upper-bound inputs for a retry after host-memory admission denial.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryAdmissionRetryBounds {
+    /// Upper bound from physical MemAvailable after preserving the configured reserve.
+    pub physical_upper_mb: u64,
+    /// Upper bound from already-active CSA session pressure, when total RAM is known.
+    pub active_session_upper_mb: Option<u64>,
+    /// Effective upper bound that satisfies both physical and active-session gates.
+    pub combined_upper_mb: u64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryAdmissionKind {
     Reserve,
@@ -66,6 +77,9 @@ pub struct MemoryAdmissionError {
     pub active_session_projected_mb: Option<u64>,
     pub active_session_count: Option<u64>,
     pub sampled_session_count: Option<u64>,
+    pub retry_physical_upper_mb: Option<u64>,
+    pub retry_active_session_upper_mb: Option<u64>,
+    pub retry_combined_upper_mb: Option<u64>,
 }
 
 impl MemoryAdmissionError {
@@ -84,6 +98,11 @@ impl MemoryAdmissionError {
             active_session_projected_mb: snapshot.active_session_projected_mb,
             active_session_count: snapshot.active_session_count,
             sampled_session_count: snapshot.sampled_session_count,
+            retry_physical_upper_mb: snapshot.retry_bounds.map(|bounds| bounds.physical_upper_mb),
+            retry_active_session_upper_mb: snapshot
+                .retry_bounds
+                .and_then(|bounds| bounds.active_session_upper_mb),
+            retry_combined_upper_mb: snapshot.retry_bounds.map(|bounds| bounds.combined_upper_mb),
         }
     }
 }
@@ -109,6 +128,7 @@ struct MemoryAdmissionSnapshot {
     active_session_projected_mb: Option<u64>,
     active_session_count: Option<u64>,
     sampled_session_count: Option<u64>,
+    retry_bounds: Option<MemoryAdmissionRetryBounds>,
 }
 
 /// Guards resource availability before launching tools.
@@ -220,21 +240,47 @@ fn evaluate_memory_availability(
     reserve_mb: u64,
     admission: Option<SpawnMemoryAdmission>,
 ) -> Result<()> {
+    let admission_retry = admission.map(|admission| {
+        let retry_bounds = retry_bounds_for(available_phys_mb, total_ram_mb, reserve_mb, admission);
+        (
+            admission,
+            retry_bounds,
+            format_retry_upper_bound(retry_bounds),
+        )
+    });
     let base_snapshot = MemoryAdmissionSnapshot {
         available_phys_mb,
         available_swap_mb,
         available_combined_mb,
         total_ram_mb,
         reserve_mb,
+        projected_spawn_mb: admission.map(|admission| admission.projected_spawn_mb),
+        active_session_rss_mb: admission.map(|admission| admission.active_session_rss_mb),
+        active_session_projected_mb: admission
+            .map(|admission| admission.active_session_projected_mb),
+        active_session_count: admission.map(|admission| admission.active_session_count),
+        sampled_session_count: admission.map(|admission| admission.sampled_session_count),
+        retry_bounds: admission_retry
+            .as_ref()
+            .map(|(_, retry_bounds, _)| *retry_bounds),
         ..Default::default()
     };
 
     if available_phys_mb < reserve_mb {
+        let retry_note = admission_retry
+            .as_ref()
+            .map(|(_, _, note)| {
+                format!(
+                    " Pre-exec memory admission is infrastructure/session-unavailable before \
+                     provider launch, not a product/test/review failure. {note}"
+                )
+            })
+            .unwrap_or_default();
         let message = format!(
             "CSA: low memory — available={available_phys_mb}MB < required={reserve_mb}MB. \
              Refusing to spawn tool scopes. actual_available_mb={available_phys_mb} \
              required_mb={reserve_mb} physical_available_mb={available_phys_mb} \
-             swap_available_mb={available_swap_mb} combined_available_mb={available_combined_mb}"
+             swap_available_mb={available_swap_mb} combined_available_mb={available_combined_mb}{retry_note}"
         );
         eprintln!("{message}");
         let error = MemoryAdmissionError::new(
@@ -265,19 +311,20 @@ fn evaluate_memory_availability(
         );
     }
 
-    if let Some(admission) = admission
+    if let Some((admission, retry_bounds, retry_note)) = admission_retry
         && admission.projected_spawn_mb > 0
     {
         let required_available_mb = reserve_mb.saturating_add(admission.projected_spawn_mb);
         if available_phys_mb < required_available_mb {
-            let host_cap_upper_mb = available_phys_mb.saturating_sub(reserve_mb);
             let message = format!(
                 "CSA: host memory admission denied — available={available_phys_mb}MB < \
                  required={required_available_mb}MB (reserve={reserve_mb}MB + \
                  projected_spawn={projected_spawn_mb}MB). active_sessions={active_sessions} \
                  sampled_sessions={sampled_sessions} active_session_rss_mb={active_rss} \
                  active_session_projected_mb={active_projected} swap_available_mb={available_swap_mb} \
-                 combined_available_mb={available_combined_mb}",
+                 combined_available_mb={available_combined_mb}. Pre-exec memory admission is \
+                 infrastructure/session-unavailable before provider launch, not a \
+                 product/test/review failure. {retry_note}",
                 projected_spawn_mb = admission.projected_spawn_mb,
                 active_sessions = admission.active_session_count,
                 sampled_sessions = admission.sampled_session_count,
@@ -292,10 +339,9 @@ fn evaluate_memory_availability(
                      MemAvailable only; swap and combined memory are reported for diagnostics but \
                      do not satisfy this pre-spawn gate. For one csa run, pass \
                      --memory-max-mb <MB> to lower projected_spawn or --min-free-memory-mb <MB> \
-                     to lower the reserve. Current host-only retry upper bound is \
-                     memory_max_mb <= {host_cap_upper_mb}MB with reserve={reserve_mb}MB; \
-                     role-specific soft-limit lower bounds may require a higher cap, so choose \
-                     a value inside both bounds or free memory/lower reserve. Persistent config \
+                     to lower the reserve. Choose a memory_max_mb inside the printed retry \
+                     upper bound and the role/tool soft-limit floor; if no such window exists, \
+                     wait/free memory or reduce active CSA-session pressure. Persistent config \
                      keys: resources.memory_max_mb, tools.<tool>.memory_max_mb, \
                      resources.min_free_memory_mb."
                 ),
@@ -307,6 +353,7 @@ fn evaluate_memory_availability(
                     active_session_projected_mb: Some(admission.active_session_projected_mb),
                     active_session_count: Some(admission.active_session_count),
                     sampled_session_count: Some(admission.sampled_session_count),
+                    retry_bounds: Some(retry_bounds),
                     ..base_snapshot
                 },
             );
@@ -324,7 +371,9 @@ fn evaluate_memory_availability(
                  > host_safe_limit={host_safe_limit_mb}MB ({safe_num}/{safe_den} of total_ram={total_ram_mb}MB). \
                  active_sessions={active_sessions} sampled_sessions={sampled_sessions} \
                  active_session_rss_mb={active_rss} active_session_projected_mb={active_projected} \
-                 projected_spawn_mb={projected_spawn_mb} available_mb={available_phys_mb}",
+                 projected_spawn_mb={projected_spawn_mb} available_mb={available_phys_mb}. \
+                 Pre-exec memory admission is infrastructure/session-unavailable before provider \
+                 launch, not a product/test/review failure. {retry_note}",
                 safe_num = ACTIVE_SESSION_SAFE_FRACTION_NUM,
                 safe_den = ACTIVE_SESSION_SAFE_FRACTION_DEN,
                 active_sessions = admission.active_session_count,
@@ -338,7 +387,10 @@ fn evaluate_memory_availability(
                 format!(
                     "{message}. CSA is refusing to launch work that could collectively exhaust host RAM. \
                      For one csa run, pass --memory-max-mb <MB> to lower projected_spawn. \
-                     Persistent config keys: resources.memory_max_mb or tools.<tool>.memory_max_mb."
+                     Choose a memory_max_mb inside the printed retry upper bound and the \
+                     role/tool soft-limit floor; if no such window exists, wait for active CSA \
+                     sessions to finish or use a different configured tool. Persistent config \
+                     keys: resources.memory_max_mb or tools.<tool>.memory_max_mb."
                 ),
                 MemoryAdmissionKind::ActiveSession,
                 MemoryAdmissionSnapshot {
@@ -348,6 +400,7 @@ fn evaluate_memory_availability(
                     active_session_projected_mb: Some(admission.active_session_projected_mb),
                     active_session_count: Some(admission.active_session_count),
                     sampled_session_count: Some(admission.sampled_session_count),
+                    retry_bounds: Some(retry_bounds),
                     ..base_snapshot
                 },
             );
@@ -377,219 +430,49 @@ fn evaluate_memory_availability(
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+fn retry_bounds_for(
+    available_phys_mb: u64,
+    total_ram_mb: u64,
+    reserve_mb: u64,
+    admission: SpawnMemoryAdmission,
+) -> MemoryAdmissionRetryBounds {
+    let physical_upper_mb = available_phys_mb.saturating_sub(reserve_mb);
+    let active_session_upper_mb = active_session_retry_upper_mb(total_ram_mb, admission);
+    let combined_upper_mb = active_session_upper_mb.map_or(physical_upper_mb, |active_upper| {
+        physical_upper_mb.min(active_upper)
+    });
 
-    #[test]
-    fn test_resource_guard_new_default_limits() {
-        let limits = ResourceLimits::default();
-        let _guard = ResourceGuard::new(limits);
-        assert_eq!(ResourceLimits::default().min_free_memory_mb, 4096);
-    }
-
-    #[test]
-    fn test_check_availability_succeeds_with_enough_memory() {
-        let limits = ResourceLimits {
-            min_free_memory_mb: 1,
-        };
-        let mut guard = ResourceGuard::new(limits);
-        let result = guard.check_availability("test_tool");
-        // 1 MB reserve — any running system has this.
-        assert!(result.is_ok(), "check_availability failed: {result:?}");
-    }
-
-    #[test]
-    fn test_check_availability_fails_with_impossible_limits() {
-        let limits = ResourceLimits {
-            min_free_memory_mb: u64::MAX / 2,
-        };
-        let mut guard = ResourceGuard::new(limits);
-        let result = guard.check_availability("any_tool");
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("CSA: low memory"),
-            "Expected memory error, got: {err_msg}"
-        );
-    }
-
-    #[test]
-    fn test_check_availability_simple_threshold() {
-        // Verify the simple threshold: available_mem + available_swap >= reserve
-        // With reserve = 2 MB, any system should pass.
-        let limits = ResourceLimits {
-            min_free_memory_mb: 2,
-        };
-        let mut guard = ResourceGuard::new(limits);
-        let result = guard.check_availability("threshold_tool");
-        assert!(
-            result.is_ok(),
-            "2 MB reserve should pass on any system: {result:?}",
-        );
-    }
-
-    #[test]
-    fn test_check_availability_reports_swap_without_requiring_it() {
-        // With a very small reserve, the check must pass even if
-        // swap is present. The hard gate is based on physical MemAvailable.
-        let limits = ResourceLimits {
-            min_free_memory_mb: 1,
-        };
-        let mut guard = ResourceGuard::new(limits);
-
-        // Refresh and verify the host reports physical memory.
-        guard.sys.refresh_memory();
-        let phys = guard.sys.available_memory() / 1024 / 1024;
-        let swap = guard.sys.free_swap() / 1024 / 1024;
-
-        let result = guard.check_availability("swap_tool");
-        assert!(
-            result.is_ok(),
-            "physical {phys} MB with swap {swap} MB should be >= 1 MB"
-        );
-    }
-
-    // --- Pure function tests (deterministic, no sysinfo dependency) ---
-
-    #[test]
-    fn test_evaluate_hard_block_when_available_below_reserve() {
-        let result =
-            evaluate_memory_availability("test_tool", 3000, 1000, 4000, 32_000, 4096, None);
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(
-            msg.contains("CSA: low memory"),
-            "Expected hard block, got: {msg}"
-        );
-        assert!(
-            msg.contains("actual_available_mb=3000"),
-            "Should show available: {msg}"
-        );
-        assert!(
-            msg.contains("required_mb=4096"),
-            "Should show reserve: {msg}"
-        );
-        assert!(msg.contains("--min-free-memory-mb <MB>"));
-    }
-
-    #[test]
-    fn test_evaluate_warning_when_available_between_100_and_150_percent() {
-        // reserve=4096, 150% = 6144. available=5000 is between 4096..6144.
-        let result =
-            evaluate_memory_availability("test_tool", 5000, 1000, 6000, 32_000, 4096, None);
-        // Should succeed (warning only, no error).
-        assert!(result.is_ok(), "Should warn but not block: {result:?}");
-    }
-
-    #[test]
-    fn test_evaluate_blocks_when_memavailable_below_reserve_even_with_swap() {
-        let result =
-            evaluate_memory_availability("test_tool", 3900, 4096, 7996, 32_000, 4096, None);
-        assert!(
-            result.is_err(),
-            "swap must not satisfy min_free_memory_mb when MemAvailable is low"
-        );
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("actual_available_mb=3900"));
-        assert!(msg.contains("swap_available_mb=4096"));
-        assert!(msg.contains("combined_available_mb=7996"));
-    }
-
-    #[test]
-    fn test_evaluate_no_warning_when_available_above_150_percent() {
-        // reserve=4096, 150% = 6144. available=7000 is above 6144.
-        let result =
-            evaluate_memory_availability("test_tool", 7000, 1000, 8000, 32_000, 4096, None);
-        assert!(result.is_ok(), "Should pass without warning: {result:?}");
-    }
-
-    #[test]
-    fn test_evaluate_exact_boundary_at_reserve() {
-        // Exactly at reserve — should pass (not strictly less than).
-        let result =
-            evaluate_memory_availability("test_tool", 4096, 1096, 5192, 32_000, 4096, None);
-        assert!(result.is_ok(), "Exact reserve should pass: {result:?}");
-    }
-
-    #[test]
-    fn test_evaluate_exact_boundary_at_warning_threshold() {
-        // reserve=4096, 150% = 6144. available=6144 is exactly at warning threshold.
-        let result =
-            evaluate_memory_availability("test_tool", 6144, 1144, 7288, 32_000, 4096, None);
-        // 6144 is NOT < 6144, so no warning.
-        assert!(
-            result.is_ok(),
-            "Exact warning threshold should pass: {result:?}"
-        );
-    }
-
-    #[test]
-    fn test_evaluate_blocks_when_spawn_projection_exceeds_available_headroom() {
-        let admission = SpawnMemoryAdmission {
-            projected_spawn_mb: 8192,
-            active_session_rss_mb: 2048,
-            active_session_projected_mb: 4096,
-            active_session_count: 1,
-            sampled_session_count: 1,
-        };
-
-        let result =
-            evaluate_memory_availability("codex", 10_000, 0, 10_000, 32_000, 4096, Some(admission));
-
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("host memory admission denied"));
-        assert!(msg.contains("projected_spawn=8192MB"));
-        assert!(msg.contains("Host admission uses physical MemAvailable only"));
-        assert!(msg.contains("swap and combined memory are reported for diagnostics"));
-        assert!(msg.contains("--memory-max-mb <MB>"));
-        assert!(msg.contains("--min-free-memory-mb <MB>"));
-        assert!(msg.contains("memory_max_mb <= 5904MB"));
-        assert!(msg.contains("tools.<tool>.memory_max_mb"));
-    }
-
-    #[test]
-    fn test_evaluate_blocks_when_active_projection_exceeds_host_safe_limit() {
-        let admission = SpawnMemoryAdmission {
-            projected_spawn_mb: 8192,
-            active_session_rss_mb: 16_000,
-            active_session_projected_mb: 20_000,
-            active_session_count: 3,
-            sampled_session_count: 2,
-        };
-
-        let result =
-            evaluate_memory_availability("codex", 20_000, 0, 20_000, 32_000, 4096, Some(admission));
-
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("active-session memory admission denied"));
-        assert!(msg.contains("projected_active=28192MB"));
-        assert!(msg.contains("--memory-max-mb <MB>"));
-        assert!(msg.contains("resources.memory_max_mb"));
-    }
-
-    #[test]
-    fn test_evaluate_allows_safe_spawn_projection() {
-        let admission = SpawnMemoryAdmission {
-            projected_spawn_mb: 4096,
-            active_session_rss_mb: 2048,
-            active_session_projected_mb: 4096,
-            active_session_count: 1,
-            sampled_session_count: 1,
-        };
-
-        let result = evaluate_memory_availability(
-            "claude-code",
-            12_000,
-            0,
-            12_000,
-            32_000,
-            4096,
-            Some(admission),
-        );
-
-        assert!(result.is_ok(), "safe projection should pass: {result:?}");
+    MemoryAdmissionRetryBounds {
+        physical_upper_mb,
+        active_session_upper_mb,
+        combined_upper_mb,
     }
 }
+
+fn active_session_retry_upper_mb(
+    total_ram_mb: u64,
+    admission: SpawnMemoryAdmission,
+) -> Option<u64> {
+    let host_safe_limit_mb = total_ram_mb.saturating_mul(ACTIVE_SESSION_SAFE_FRACTION_NUM)
+        / ACTIVE_SESSION_SAFE_FRACTION_DEN;
+    (host_safe_limit_mb > 0)
+        .then(|| host_safe_limit_mb.saturating_sub(admission.active_session_projected_mb))
+}
+
+fn format_retry_upper_bound(bounds: MemoryAdmissionRetryBounds) -> String {
+    let active_upper = bounds
+        .active_session_upper_mb
+        .map(|upper| format!("{upper}MB"))
+        .unwrap_or_else(|| "unknown".to_string());
+    format!(
+        "Retry upper bound: memory_max_mb <= {combined}MB \
+         (physical/reserve upper={physical}MB; active-session upper={active}).",
+        combined = bounds.combined_upper_mb,
+        physical = bounds.physical_upper_mb,
+        active = active_upper,
+    )
+}
+
+#[cfg(test)]
+#[path = "guard_tests.rs"]
+mod tests;

--- a/crates/csa-resource/src/guard_tests.rs
+++ b/crates/csa-resource/src/guard_tests.rs
@@ -1,0 +1,210 @@
+use super::*;
+
+#[test]
+fn test_resource_guard_new_default_limits() {
+    let limits = ResourceLimits::default();
+    let _guard = ResourceGuard::new(limits);
+    assert_eq!(ResourceLimits::default().min_free_memory_mb, 4096);
+}
+
+#[test]
+fn test_check_availability_succeeds_with_enough_memory() {
+    let limits = ResourceLimits {
+        min_free_memory_mb: 1,
+    };
+    let mut guard = ResourceGuard::new(limits);
+    let result = guard.check_availability("test_tool");
+    // 1 MB reserve: any running system has this.
+    assert!(result.is_ok(), "check_availability failed: {result:?}");
+}
+
+#[test]
+fn test_check_availability_fails_with_impossible_limits() {
+    let limits = ResourceLimits {
+        min_free_memory_mb: u64::MAX / 2,
+    };
+    let mut guard = ResourceGuard::new(limits);
+    let result = guard.check_availability("any_tool");
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("CSA: low memory"),
+        "Expected memory error, got: {err_msg}"
+    );
+}
+
+#[test]
+fn test_check_availability_simple_threshold() {
+    let limits = ResourceLimits {
+        min_free_memory_mb: 2,
+    };
+    let mut guard = ResourceGuard::new(limits);
+    let result = guard.check_availability("threshold_tool");
+    assert!(
+        result.is_ok(),
+        "2 MB reserve should pass on any system: {result:?}",
+    );
+}
+
+#[test]
+fn test_check_availability_reports_swap_without_requiring_it() {
+    let limits = ResourceLimits {
+        min_free_memory_mb: 1,
+    };
+    let mut guard = ResourceGuard::new(limits);
+
+    guard.sys.refresh_memory();
+    let phys = guard.sys.available_memory() / 1024 / 1024;
+    let swap = guard.sys.free_swap() / 1024 / 1024;
+
+    let result = guard.check_availability("swap_tool");
+    assert!(
+        result.is_ok(),
+        "physical {phys} MB with swap {swap} MB should be >= 1 MB"
+    );
+}
+
+#[test]
+fn test_evaluate_hard_block_when_available_below_reserve() {
+    let result = evaluate_memory_availability("test_tool", 3000, 1000, 4000, 32_000, 4096, None);
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("CSA: low memory"),
+        "Expected hard block, got: {msg}"
+    );
+    assert!(
+        msg.contains("actual_available_mb=3000"),
+        "Should show available: {msg}"
+    );
+    assert!(
+        msg.contains("required_mb=4096"),
+        "Should show reserve: {msg}"
+    );
+    assert!(msg.contains("--min-free-memory-mb <MB>"));
+}
+
+#[test]
+fn test_evaluate_warning_when_available_between_100_and_150_percent() {
+    let result = evaluate_memory_availability("test_tool", 5000, 1000, 6000, 32_000, 4096, None);
+    assert!(result.is_ok(), "Should warn but not block: {result:?}");
+}
+
+#[test]
+fn test_evaluate_blocks_when_memavailable_below_reserve_even_with_swap() {
+    let result = evaluate_memory_availability("test_tool", 3900, 4096, 7996, 32_000, 4096, None);
+    assert!(
+        result.is_err(),
+        "swap must not satisfy min_free_memory_mb when MemAvailable is low"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(msg.contains("actual_available_mb=3900"));
+    assert!(msg.contains("swap_available_mb=4096"));
+    assert!(msg.contains("combined_available_mb=7996"));
+}
+
+#[test]
+fn test_evaluate_no_warning_when_available_above_150_percent() {
+    let result = evaluate_memory_availability("test_tool", 7000, 1000, 8000, 32_000, 4096, None);
+    assert!(result.is_ok(), "Should pass without warning: {result:?}");
+}
+
+#[test]
+fn test_evaluate_exact_boundary_at_reserve() {
+    let result = evaluate_memory_availability("test_tool", 4096, 1096, 5192, 32_000, 4096, None);
+    assert!(result.is_ok(), "Exact reserve should pass: {result:?}");
+}
+
+#[test]
+fn test_evaluate_exact_boundary_at_warning_threshold() {
+    let result = evaluate_memory_availability("test_tool", 6144, 1144, 7288, 32_000, 4096, None);
+    assert!(
+        result.is_ok(),
+        "Exact warning threshold should pass: {result:?}"
+    );
+}
+
+#[test]
+fn test_evaluate_blocks_when_spawn_projection_exceeds_available_headroom() {
+    let admission = SpawnMemoryAdmission {
+        projected_spawn_mb: 8192,
+        active_session_rss_mb: 2048,
+        active_session_projected_mb: 4096,
+        active_session_count: 1,
+        sampled_session_count: 1,
+    };
+
+    let result =
+        evaluate_memory_availability("codex", 10_000, 0, 10_000, 32_000, 4096, Some(admission));
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let admission_error = err
+        .downcast_ref::<MemoryAdmissionError>()
+        .expect("memory admission error");
+    assert_eq!(admission_error.retry_physical_upper_mb, Some(5904));
+    assert_eq!(admission_error.retry_active_session_upper_mb, Some(19_904));
+    assert_eq!(admission_error.retry_combined_upper_mb, Some(5904));
+    let msg = err.to_string();
+    assert!(msg.contains("host memory admission denied"));
+    assert!(msg.contains("projected_spawn=8192MB"));
+    assert!(msg.contains("infrastructure/session-unavailable"));
+    assert!(msg.contains("Host admission uses physical MemAvailable only"));
+    assert!(msg.contains("swap and combined memory are reported for diagnostics"));
+    assert!(msg.contains("--memory-max-mb <MB>"));
+    assert!(msg.contains("--min-free-memory-mb <MB>"));
+    assert!(msg.contains("Retry upper bound: memory_max_mb <= 5904MB"));
+    assert!(msg.contains("tools.<tool>.memory_max_mb"));
+}
+
+#[test]
+fn test_evaluate_blocks_when_active_projection_exceeds_host_safe_limit() {
+    let admission = SpawnMemoryAdmission {
+        projected_spawn_mb: 8192,
+        active_session_rss_mb: 16_000,
+        active_session_projected_mb: 20_000,
+        active_session_count: 3,
+        sampled_session_count: 2,
+    };
+
+    let result =
+        evaluate_memory_availability("codex", 20_000, 0, 20_000, 32_000, 4096, Some(admission));
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let admission_error = err
+        .downcast_ref::<MemoryAdmissionError>()
+        .expect("memory admission error");
+    assert_eq!(admission_error.retry_physical_upper_mb, Some(15_904));
+    assert_eq!(admission_error.retry_active_session_upper_mb, Some(4000));
+    assert_eq!(admission_error.retry_combined_upper_mb, Some(4000));
+    let msg = err.to_string();
+    assert!(msg.contains("active-session memory admission denied"));
+    assert!(msg.contains("projected_active=28192MB"));
+    assert!(msg.contains("Retry upper bound: memory_max_mb <= 4000MB"));
+    assert!(msg.contains("--memory-max-mb <MB>"));
+    assert!(msg.contains("resources.memory_max_mb"));
+}
+
+#[test]
+fn test_evaluate_allows_safe_spawn_projection() {
+    let admission = SpawnMemoryAdmission {
+        projected_spawn_mb: 4096,
+        active_session_rss_mb: 2048,
+        active_session_projected_mb: 4096,
+        active_session_count: 1,
+        sampled_session_count: 1,
+    };
+
+    let result = evaluate_memory_availability(
+        "claude-code",
+        12_000,
+        0,
+        12_000,
+        32_000,
+        4096,
+        Some(admission),
+    );
+
+    assert!(result.is_ok(), "safe projection should pass: {result:?}");
+}

--- a/crates/csa-resource/src/lib.rs
+++ b/crates/csa-resource/src/lib.rs
@@ -23,7 +23,8 @@ pub use cgroup::{
 };
 pub use filesystem_sandbox::{FilesystemCapability, detect_filesystem_capability};
 pub use guard::{
-    MemoryAdmissionError, MemoryAdmissionKind, ResourceGuard, ResourceLimits, SpawnMemoryAdmission,
+    MemoryAdmissionError, MemoryAdmissionKind, MemoryAdmissionRetryBounds, ResourceGuard,
+    ResourceLimits, SpawnMemoryAdmission,
 };
 pub use isolation_plan::{EnforcementMode, IsolationPlan, IsolationPlanBuilder};
 pub use landlock::apply_landlock_rules;

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -331,6 +331,16 @@ pub struct NoProviderLaunchMemoryDiagnostic {
     pub active_session_count: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sampled_session_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_physical_upper_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_active_session_upper_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_combined_upper_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_lower_bound_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_feasible: Option<bool>,
 }
 
 pub fn write_no_provider_launch_diagnostic(

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1081"
-weave = "0.1.1081"
+csa = "0.1.1082"
+weave = "0.1.1082"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
Closes #2512

## Summary

Pre-exec memory admission failures are now classified as infrastructure/session-unavailable with actionable retry guidance.

Key changes:
- **Feasibility computation**: Combines physical MemAvailable/reserve upper bound, active CSA-session pressure, role/tool projected-spawn cap, and writer/reviewer soft-limit floor into a single feasibility result
- **Retry guidance**: When a feasible retry window exists, outputs exact command/config delta (e.g. `--memory-max-mb N`)
- **Infeasible detection**: When upper bound < lower bound, clearly states retry is infeasible
- **All caller paths**: run, review, review --fix-finding, and dev2merge/mktd child spawn all surface retry guidance
- **Redaction hardening**: primary_failure in wait label and failover summary paths now goes through redact_text_content + compact_wait_summary_text

## Tests

- New guard_tests.rs (210 lines) for csa-resource feasibility computation
- Regression test for primary_failure redaction in unavailable wait summary path
- 5-iteration tier4 CSA-Codex review completed. Final verdict: PASS.