### PR TITLE
fix(csa): make memory-soft-limit exits resumable and non-destructive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2939,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/cli-sub-agent/src/memory_soft_limit_recovery_display.rs
+++ b/crates/cli-sub-agent/src/memory_soft_limit_recovery_display.rs
@@ -1,4 +1,8 @@
+use std::borrow::Cow;
 use std::path::Path;
+
+const CONTINUATION_PROMPT_PLACEHOLDER: &str = "CONTINUATION_PROMPT.md";
+const COMMIT_ONLY_RETRY_PROFILE: &str = "lightweight_commit_only_recovery";
 
 pub(crate) fn format_memory_soft_limit_recovery_lines(
     diagnostic: &csa_session::MemorySoftLimitRecoveryDiagnostic,
@@ -46,6 +50,40 @@ pub(crate) fn format_memory_soft_limit_recovery_lines(
     lines
 }
 
+pub(crate) fn format_memory_soft_limit_recovery_lines_for_session(
+    session_id: &str,
+    diagnostic: &csa_session::MemorySoftLimitRecoveryDiagnostic,
+    kill_diagnostics: Option<&csa_session::KillDiagnosticReport>,
+) -> Vec<String> {
+    let mut lines = format_memory_soft_limit_recovery_lines(diagnostic);
+    let guidance =
+        build_memory_soft_limit_recovery_guidance(session_id, diagnostic, kill_diagnostics);
+    lines.push(format!(
+        "Continuation command: {}",
+        guidance.continuation_command
+    ));
+    lines.push(format!(
+        "Continuation prompt guidance: {}",
+        guidance.continuation_prompt
+    ));
+    lines.push(format!("Retry guidance: {}", guidance.retry_guidance));
+    lines
+}
+
+pub(crate) fn format_memory_soft_limit_recovery_lines_for_display_session(
+    session_dir: &Path,
+    display_session_id: &str,
+    diagnostic: &csa_session::MemorySoftLimitRecoveryDiagnostic,
+    kill_diagnostics: Option<&csa_session::KillDiagnosticReport>,
+) -> Vec<String> {
+    let session_id = continuation_guidance_session_id(session_dir, display_session_id);
+    format_memory_soft_limit_recovery_lines_for_session(
+        session_id.as_ref(),
+        diagnostic,
+        kill_diagnostics,
+    )
+}
+
 pub(crate) fn format_memory_soft_limit_context_lines(session_dir: &Path) -> Vec<String> {
     let mut context = vec![format!(
         "Recovery context: session_dir={}",
@@ -63,6 +101,53 @@ pub(crate) fn format_memory_soft_limit_context_lines(session_dir: &Path) -> Vec<
     context
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MemorySoftLimitRecoveryGuidance {
+    pub(crate) continuation_command: String,
+    pub(crate) continuation_prompt: String,
+    pub(crate) retry_guidance: String,
+}
+
+impl MemorySoftLimitRecoveryGuidance {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "continuation_command": self.continuation_command,
+            "continuation_prompt": self.continuation_prompt,
+            "retry_guidance": self.retry_guidance,
+        })
+    }
+}
+
+pub(crate) fn build_memory_soft_limit_recovery_guidance(
+    session_id: &str,
+    diagnostic: &csa_session::MemorySoftLimitRecoveryDiagnostic,
+    kill_diagnostics: Option<&csa_session::KillDiagnosticReport>,
+) -> MemorySoftLimitRecoveryGuidance {
+    let mut args = vec![
+        "csa".to_string(),
+        "run".to_string(),
+        "--fork-from".to_string(),
+        shell_token(session_id),
+    ];
+    if diagnostic.dirty_worktree {
+        args.push("--require-commit".to_string());
+    }
+    args.push("--build-jobs".to_string());
+    args.push("1".to_string());
+    if let Some(memory_max_mb) = retry_memory_max_mb(kill_diagnostics, diagnostic) {
+        args.push("--memory-max-mb".to_string());
+        args.push(memory_max_mb.to_string());
+    }
+    args.push("--prompt-file".to_string());
+    args.push(CONTINUATION_PROMPT_PLACEHOLDER.to_string());
+
+    MemorySoftLimitRecoveryGuidance {
+        continuation_command: args.join(" "),
+        continuation_prompt: continuation_prompt_guidance(diagnostic),
+        retry_guidance: retry_guidance(kill_diagnostics, diagnostic),
+    }
+}
+
 fn recovery_recipe_lines(
     diagnostic: &csa_session::MemorySoftLimitRecoveryDiagnostic,
 ) -> Vec<String> {
@@ -77,7 +162,7 @@ fn recovery_recipe_lines(
         "Recovery recipe: inspect git status --short before acting; preserve staged and unstaged changes, and do not discard or reset this worktree.".to_string(),
         "Status note: two-letter entries such as MM mean staged and unstaged changes are both present for the same path.".to_string(),
     ];
-    if diagnostic.retry_profile.as_deref() == Some("lightweight_commit_only_recovery") {
+    if diagnostic.retry_profile.as_deref() == Some(COMMIT_ONLY_RETRY_PROFILE) {
         lines.push(
             "Retry shape: use a lighter commit-only/require-commit recovery after inspection, or rerun with a feasible memory_max_mb/reserve.".to_string(),
         );
@@ -87,6 +172,109 @@ fn recovery_recipe_lines(
         );
     }
     lines
+}
+
+fn continuation_prompt_guidance(
+    diagnostic: &csa_session::MemorySoftLimitRecoveryDiagnostic,
+) -> String {
+    if diagnostic.dirty_worktree {
+        return "Inspect git status --short, git diff, and git diff --staged; preserve existing staged and unstaged work; finish or commit only the salvaged partial work; do not restart from scratch.".to_string();
+    }
+    if diagnostic.commit_created {
+        return "Inspect the recorded HEAD commit and continue only if that commit does not satisfy the original task.".to_string();
+    }
+    "Continue the original task from the prior session context with reduced parallelism or a higher feasible memory cap.".to_string()
+}
+
+fn retry_guidance(
+    kill_diagnostics: Option<&csa_session::KillDiagnosticReport>,
+    diagnostic: &csa_session::MemorySoftLimitRecoveryDiagnostic,
+) -> String {
+    let memory_context = memory_retry_context(kill_diagnostics);
+    if diagnostic.retry_profile.as_deref() == Some(COMMIT_ONLY_RETRY_PROFILE) {
+        return format!(
+            "Use the fork-from command for low-RSS commit-only salvage first; avoid blind retry under the same memory cap. {memory_context}"
+        );
+    }
+    format!(
+        "Avoid blind retry under the same memory cap; use lower parallelism and only raise memory_max_mb when host RAM/reserve makes it safe. {memory_context}"
+    )
+}
+
+fn memory_retry_context(kill_diagnostics: Option<&csa_session::KillDiagnosticReport>) -> String {
+    let Some(kill_diagnostics) = kill_diagnostics else {
+        return "No structured cap sample was available.".to_string();
+    };
+    let mut parts = Vec::new();
+    if let Some(current_mb) = kill_diagnostics.current_mb {
+        parts.push(format!("current_mb={current_mb}"));
+    }
+    if let Some(threshold_mb) = kill_diagnostics.threshold_mb {
+        parts.push(format!("threshold_mb={threshold_mb}"));
+    }
+    if let Some(memory_max_mb) = kill_diagnostics.memory_max_mb {
+        parts.push(format!("memory_max_mb={memory_max_mb}"));
+    }
+    if let Some(soft_limit_percent) = kill_diagnostics.soft_limit_percent {
+        parts.push(format!("soft_limit_percent={soft_limit_percent}"));
+    }
+    if parts.is_empty() {
+        "No structured cap sample was available.".to_string()
+    } else {
+        format!("Observed {}.", parts.join(", "))
+    }
+}
+
+fn retry_memory_max_mb(
+    kill_diagnostics: Option<&csa_session::KillDiagnosticReport>,
+    diagnostic: &csa_session::MemorySoftLimitRecoveryDiagnostic,
+) -> Option<u64> {
+    if diagnostic.retry_profile.as_deref() == Some(COMMIT_ONLY_RETRY_PROFILE) {
+        return None;
+    }
+    let report = kill_diagnostics?;
+    let current = report.current_mb?;
+    let percent = u64::from(report.soft_limit_percent?);
+    if percent == 0 {
+        return None;
+    }
+    let minimum = current.saturating_mul(100).div_ceil(percent);
+    let suggested = minimum.saturating_add(512);
+    match report.memory_max_mb {
+        Some(cap) if suggested <= cap => None,
+        _ => Some(suggested),
+    }
+}
+
+pub(crate) fn build_memory_soft_limit_recovery_guidance_for_display_session(
+    session_dir: &Path,
+    display_session_id: &str,
+    diagnostic: &csa_session::MemorySoftLimitRecoveryDiagnostic,
+    kill_diagnostics: Option<&csa_session::KillDiagnosticReport>,
+) -> MemorySoftLimitRecoveryGuidance {
+    let session_id = continuation_guidance_session_id(session_dir, display_session_id);
+    build_memory_soft_limit_recovery_guidance(session_id.as_ref(), diagnostic, kill_diagnostics)
+}
+
+fn continuation_guidance_session_id<'a>(
+    session_dir: &'a Path,
+    display_session_id: &'a str,
+) -> Cow<'a, str> {
+    crate::session_display_alias::alias_for_display_session(session_dir, display_session_id)
+        .map_or(Cow::Borrowed(display_session_id), |alias| {
+            Cow::Owned(alias.target_session_id)
+        })
+}
+
+fn shell_token(value: &str) -> String {
+    let safe = !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'/'));
+    if safe {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', r"'\''"))
 }
 
 fn clean_recovery_recipe(diagnostic: &csa_session::MemorySoftLimitRecoveryDiagnostic) -> String {
@@ -207,6 +395,96 @@ mod tests {
         assert!(!rendered.contains("git checkout --"));
         assert!(!rendered.contains("git stash"));
         assert!(!rendered.contains("git clean"));
+    }
+
+    #[test]
+    fn session_recovery_lines_include_fork_from_command_and_retry_context() {
+        let diagnostic = csa_session::MemorySoftLimitRecoveryDiagnostic {
+            outcome: "dirty_or_staged_changes".to_string(),
+            commit_created: false,
+            dirty_worktree: true,
+            changed_paths: vec!["crates/verbatim-daemon/src/main.rs".to_string()],
+            changed_paths_truncated: 0,
+            git_status_short: vec!["MM crates/verbatim-daemon/src/main.rs".to_string()],
+            git_status_short_truncated: 0,
+            head_oid: None,
+            head_summary: None,
+            suggested_recovery_action:
+                "inspect_git_status_preserve_staged_unstaged_then_retry_lightweight_commit_recovery"
+                    .to_string(),
+            retry_profile: Some("lightweight_commit_only_recovery".to_string()),
+        };
+        let kill = csa_session::KillDiagnosticReport {
+            source: "memory_soft_limit".to_string(),
+            signal: Some(15),
+            current_mb: Some(9626),
+            threshold_mb: Some(9000),
+            memory_max_mb: Some(10000),
+            soft_limit_percent: Some(90),
+            scope_name: Some("csa-codex-01KW641KP78VR43SCKJVN6HGDN.scope".to_string()),
+        };
+
+        let rendered = format_memory_soft_limit_recovery_lines_for_session(
+            "01KW641KP78VR43SCKJVN6HGDN",
+            &diagnostic,
+            Some(&kill),
+        )
+        .join("\n");
+
+        assert!(rendered.contains(
+            "Continuation command: csa run --fork-from 01KW641KP78VR43SCKJVN6HGDN --require-commit --build-jobs 1 --prompt-file CONTINUATION_PROMPT.md"
+        ));
+        assert!(rendered.contains("preserve existing staged and unstaged work"));
+        assert!(rendered.contains("low-RSS commit-only salvage"));
+        assert!(rendered.contains("avoid blind retry under the same memory cap"));
+        assert!(rendered.contains("current_mb=9626"));
+        assert!(rendered.contains("threshold_mb=9000"));
+        assert!(rendered.contains("memory_max_mb=10000"));
+        assert!(rendered.contains("soft_limit_percent=90"));
+        assert!(!rendered.contains("git reset --hard"));
+        assert!(!rendered.contains("git checkout --"));
+        assert!(!rendered.contains("git stash"));
+        assert!(!rendered.contains("git clean"));
+    }
+
+    #[test]
+    fn non_commit_only_recovery_command_suggests_higher_feasible_cap() {
+        let diagnostic = csa_session::MemorySoftLimitRecoveryDiagnostic {
+            outcome: "no_tracked_repo_side_effects".to_string(),
+            commit_created: false,
+            dirty_worktree: false,
+            changed_paths: Vec::new(),
+            changed_paths_truncated: 0,
+            git_status_short: Vec::new(),
+            git_status_short_truncated: 0,
+            head_oid: None,
+            head_summary: None,
+            suggested_recovery_action: "rerun_with_more_memory_or_reduce_parallelism".to_string(),
+            retry_profile: None,
+        };
+        let kill = csa_session::KillDiagnosticReport {
+            source: "memory_soft_limit".to_string(),
+            signal: Some(15),
+            current_mb: Some(9626),
+            threshold_mb: Some(9000),
+            memory_max_mb: Some(10000),
+            soft_limit_percent: Some(90),
+            scope_name: None,
+        };
+
+        let guidance = build_memory_soft_limit_recovery_guidance(
+            "01KW641KP78VR43SCKJVN6HGDN",
+            &diagnostic,
+            Some(&kill),
+        );
+
+        assert!(guidance.continuation_command.contains("--build-jobs 1"));
+        assert!(
+            guidance
+                .continuation_command
+                .contains("--memory-max-mb 11208")
+        );
+        assert!(guidance.retry_guidance.contains("lower parallelism"));
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/review_cmd_post_review.rs
+++ b/crates/cli-sub-agent/src/review_cmd_post_review.rs
@@ -122,7 +122,7 @@ pub(super) fn build_review_failure_suggestion(
     }
 
     let command_template =
-        format!("csa review --fix-finding --session {session_id} --prompt-file <path>");
+        format!("csa review --fix-finding --session {session_id} --prompt-file FIX_PROMPT.md");
     let suggestion = ReviewSuggestionFile {
         suggestion: ReviewFailureSuggestion {
             action: CONFIRM_THEN_FIX_FINDING_ACTION,
@@ -248,7 +248,8 @@ pub(super) fn suggest_review_failure_fix(
 }
 
 pub(super) fn build_review_failure_caller_hint(session_id: &str) -> String {
-    let command = format!("csa review --fix-finding --session {session_id} --prompt-file <path>");
+    let command =
+        format!("csa review --fix-finding --session {session_id} --prompt-file FIX_PROMPT.md");
     let escaped_command = crate::daemon_caller_hints::escape_structured_comment_attr(&command);
     format!(
         "<!-- CSA:CALLER_HINT action=\"review_confirm_fix_finding\" \
@@ -318,7 +319,7 @@ mod tests {
 
         assert_eq!(
             rendered,
-            "[suggestion]\naction = \"confirm_then_fix_finding\"\nsession_id = \"01HREVIEWSESSION0000000000\"\nrequires_confirmation = true\ncommand_template = \"csa review --fix-finding --session 01HREVIEWSESSION0000000000 --prompt-file <path>\"\nhint = \"Confirm the review finding is not a false positive, then run --fix-finding. The fix pass resumes the reviewer session for KV-cache reuse; use a NEW review session for the next review round.\"\ntool = \"codex\"\nmodel_spec = \"codex/openai/gpt-5.5/xhigh\"\nprovider_session_id = \"provider-123\"\n"
+            "[suggestion]\naction = \"confirm_then_fix_finding\"\nsession_id = \"01HREVIEWSESSION0000000000\"\nrequires_confirmation = true\ncommand_template = \"csa review --fix-finding --session 01HREVIEWSESSION0000000000 --prompt-file FIX_PROMPT.md\"\nhint = \"Confirm the review finding is not a false positive, then run --fix-finding. The fix pass resumes the reviewer session for KV-cache reuse; use a NEW review session for the next review round.\"\ntool = \"codex\"\nmodel_spec = \"codex/openai/gpt-5.5/xhigh\"\nprovider_session_id = \"provider-123\"\n"
         );
     }
 

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
@@ -115,6 +115,18 @@ Verification:
 }
 
 #[test]
+fn issue_2440_verified_word_does_not_trigger_resolution() {
+    use super::finding_text_describes_resolved_issue;
+
+    assert!(
+        !finding_text_describes_resolved_issue(
+            "High: verified reviewer-auth credential disclosure in summary"
+        ),
+        "'verified' in an active finding title is not explicit resolution language"
+    );
+}
+
+#[test]
 fn issue_2516_no_longer_describes_regression_not_resolution() {
     use super::finding_text_describes_resolved_issue;
 

--- a/crates/cli-sub-agent/src/review_cmd_prose_resolution.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_resolution.rs
@@ -1,4 +1,6 @@
-const RESOLUTION_WORDS: &[&str] = &[
+// Keep this to resolved-state predicates; verification verbs are ambiguous in
+// active finding titles unless the surrounding prose states the issue is fixed.
+const RESOLUTION_STATE_WORDS: &[&str] = &[
     "addressed",
     "cleared",
     "closed",
@@ -10,7 +12,9 @@ const RESOLUTION_WORDS: &[&str] = &[
     "removed",
     "repaired",
     "resolved",
-    "verified",
+];
+const RESOLUTION_AUXILIARY_WORDS: &[&str] = &[
+    "am", "are", "be", "been", "being", "had", "has", "have", "is", "was", "were",
 ];
 const REQUIRED_FIX_WORDS: &[&str] = &[
     "must", "need", "needed", "needs", "require", "required", "requires", "should",
@@ -91,8 +95,29 @@ fn resolution_token_applies(tokens: &[String], index: usize) -> bool {
     let Some(token) = tokens.get(index) else {
         return false;
     };
-    RESOLUTION_WORDS.contains(&token.as_str())
+    RESOLUTION_STATE_WORDS.contains(&token.as_str())
         && !resolution_token_is_negated_or_required(tokens, index)
+        && resolution_token_has_explicit_state_context(tokens, index)
+}
+
+fn resolution_token_has_explicit_state_context(tokens: &[String], index: usize) -> bool {
+    resolution_token_has_auxiliary(tokens, index)
+        || token_before(tokens, index).is_some_and(|token| token == "as")
+}
+
+fn resolution_token_has_auxiliary(tokens: &[String], index: usize) -> bool {
+    tokens[..index]
+        .iter()
+        .rev()
+        .take(3)
+        .any(|candidate| RESOLUTION_AUXILIARY_WORDS.contains(&candidate.as_str()))
+}
+
+fn token_before(tokens: &[String], index: usize) -> Option<&str> {
+    index
+        .checked_sub(1)
+        .and_then(|previous| tokens.get(previous))
+        .map(String::as_str)
 }
 
 fn resolution_token_is_negated_or_required(tokens: &[String], index: usize) -> bool {

--- a/crates/cli-sub-agent/src/review_failure_context.rs
+++ b/crates/cli-sub-agent/src/review_failure_context.rs
@@ -309,7 +309,7 @@ fn fix_route_label(session_dir: &Path, session_id: &str) -> String {
         .filter(|value| !value.trim().is_empty())
         .map(str::to_string)
         .unwrap_or_else(|| {
-            format!("csa review --fix-finding --session {session_id} --prompt-file <path>")
+            format!("csa review --fix-finding --session {session_id} --prompt-file FIX_PROMPT.md")
         });
     format!("confirm the finding, then run `{command}`; next review must be a fresh session")
 }
@@ -400,7 +400,7 @@ mod tests {
         .expect("write findings");
         std::fs::write(
             temp.path().join("output").join("suggestion.toml"),
-            "[suggestion]\naction = \"confirm_then_fix_finding\"\ncommand_template = \"csa review --fix-finding --session 01TESTFAILCTX --prompt-file <path>\"\n",
+            "[suggestion]\naction = \"confirm_then_fix_finding\"\ncommand_template = \"csa review --fix-finding --session 01TESTFAILCTX --prompt-file FIX_PROMPT.md\"\n",
         )
         .expect("write suggestion");
 

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_memory_soft_limit_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_memory_soft_limit_tests.rs
@@ -250,6 +250,93 @@ fn memory_soft_limit_require_commit_with_mm_status_records_commit_only_recovery(
     );
 }
 
+#[test]
+fn memory_soft_limit_require_commit_with_staged_work_fails_closed_for_writer() {
+    let temp = init_repo_with_initial_commit();
+    let root = temp.path();
+    let session = csa_session::create_session(root, Some("run"), None, Some("codex"))
+        .expect("session should be created");
+    let mut session_result = session_result("signal", 143);
+    session_result.summary = "CSA diagnostic: signal kill hint: memory soft limit".to_string();
+    session_result.kill_hint = Some("memory_soft_limit".to_string());
+    session_result.kill_diagnostics = Some(csa_session::KillDiagnosticReport {
+        source: "memory_soft_limit".to_string(),
+        signal: Some(15),
+        current_mb: Some(9626),
+        threshold_mb: Some(9000),
+        memory_max_mb: Some(10000),
+        soft_limit_percent: Some(90),
+        scope_name: Some("csa-codex-01KW641KP78VR43SCKJVN6HGDN.scope".to_string()),
+    });
+    csa_session::save_result(root, &session.meta_session_id, &session_result)
+        .expect("result should be saved");
+    std::fs::write(root.join("seed.txt"), "seed\nstaged only\n").expect("staged file");
+    run_git(root, &["add", "seed.txt"]);
+    let changed_paths = vec!["seed.txt".to_string()];
+    let mut execution = csa_process::ExecutionResult {
+        exit_code: 143,
+        summary: "memory soft limit".to_string(),
+        ..Default::default()
+    };
+
+    record_writer_uncommitted_changes_with_config(
+        root,
+        Some(&session.meta_session_id),
+        &mut execution,
+        WriterUncommittedRecord {
+            sa_mode: false,
+            require_commit: true,
+            changed_paths: Some(&changed_paths),
+            commit_created: Some(false),
+            large_diff_config: &RunLargeDiffWarningConfig::default(),
+        },
+    );
+
+    let loaded = csa_session::load_result(root, &session.meta_session_id)
+        .expect("load result")
+        .expect("result should exist");
+    assert_eq!(execution.exit_code, 1);
+    assert_eq!(
+        execution.csa_gate_failure.as_deref(),
+        Some("writer-uncommitted")
+    );
+    assert_eq!(loaded.status, "failure");
+    assert_eq!(loaded.exit_code, 1);
+    let require_commit_recovery = loaded
+        .require_commit_recovery
+        .as_ref()
+        .expect("require-commit recovery should be recorded");
+    assert_eq!(require_commit_recovery.termination_status, "signal");
+    assert_eq!(require_commit_recovery.exit_code, 143);
+    assert_eq!(require_commit_recovery.termination_signal, Some(15));
+    assert_eq!(
+        require_commit_recovery.kill_hint.as_deref(),
+        Some("memory_soft_limit")
+    );
+    assert!(require_commit_recovery.dirty_worktree);
+    assert_eq!(
+        require_commit_recovery.changed_paths,
+        vec!["seed.txt".to_string()]
+    );
+    let memory_recovery = loaded
+        .memory_soft_limit_recovery
+        .as_ref()
+        .expect("memory recovery should be recorded");
+    assert_eq!(memory_recovery.outcome, MEMORY_SOFT_LIMIT_DIRTY_OUTCOME);
+    assert_eq!(
+        memory_recovery.git_status_short,
+        vec!["M  seed.txt".to_string()]
+    );
+    assert_eq!(
+        memory_recovery.suggested_recovery_action,
+        MEMORY_SOFT_LIMIT_REQUIRE_COMMIT_DIRTY_ACTION
+    );
+    assert_eq!(
+        memory_recovery.retry_profile.as_deref(),
+        Some(MEMORY_SOFT_LIMIT_COMMIT_ONLY_RETRY_PROFILE)
+    );
+}
+
 fn session_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
     let now = chrono::Utc::now();
     csa_session::SessionResult {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -171,8 +171,11 @@ pub(crate) fn render_wait_result_summary(
             );
         }
         lines.extend(
-            crate::memory_soft_limit_recovery_display::format_memory_soft_limit_recovery_lines(
+            crate::memory_soft_limit_recovery_display::format_memory_soft_limit_recovery_lines_for_display_session(
+                session_dir,
+                session_id,
                 recovery,
+                result.kill_diagnostics.as_ref(),
             ),
         );
     }
@@ -292,6 +295,14 @@ fn render_wait_result_json(
         "kill_diagnostics": result.kill_diagnostics.as_ref(),
         "require_commit_recovery": result.require_commit_recovery.as_ref(),
         "memory_soft_limit_recovery": result.memory_soft_limit_recovery.as_ref(),
+        "memory_soft_limit_recovery_guidance": result.memory_soft_limit_recovery.as_ref().map(|recovery| {
+            crate::memory_soft_limit_recovery_display::build_memory_soft_limit_recovery_guidance_for_display_session(
+                session_dir,
+                session_id,
+                recovery,
+                result.kill_diagnostics.as_ref(),
+            ).to_json()
+        }),
         "fix_finding_recovery": crate::session_fix_finding_recovery::read_recovery_sidecar(session_dir),
         "post_exec_gate": result.post_exec_gate.as_ref(),
         "large_diff_warning": result.large_diff_warning.as_ref(),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_2516_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_2516_tests.rs
@@ -26,7 +26,7 @@ start = 42
     .expect("findings.toml should be written");
     std::fs::write(
         output_dir.join("suggestion.toml"),
-        "[suggestion]\naction = \"confirm_then_fix_finding\"\ncommand_template = \"csa review --fix-finding --session 01TEST2516FAILSUMMARY --prompt-file <path>\"\n",
+        "[suggestion]\naction = \"confirm_then_fix_finding\"\ncommand_template = \"csa review --fix-finding --session 01TEST2516FAILSUMMARY --prompt-file FIX_PROMPT.md\"\n",
     )
     .expect("suggestion.toml should be written");
     let now = Utc::now();

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_kill_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_kill_tests.rs
@@ -181,6 +181,12 @@ last_accessed = "2026-06-01T00:00:00Z"
     assert!(summary.contains("soft_limit_percent=90"));
     assert!(summary.contains("MM crates/verbatim-daemon/src/main.rs"));
     assert!(summary.contains("Retry profile: lightweight_commit_only_recovery"));
+    assert!(summary.contains(
+        "Continuation command: csa run --fork-from 01KW641KP78VR43SCKJVN6HGDN --require-commit --build-jobs 1 --prompt-file CONTINUATION_PROMPT.md"
+    ));
+    assert!(summary.contains("preserve existing staged and unstaged work"));
+    assert!(summary.contains("low-RSS commit-only salvage"));
+    assert!(summary.contains("avoid blind retry under the same memory cap"));
     assert!(summary.contains("git status --short"));
     assert!(summary.contains("preserve staged and unstaged changes"));
     assert!(summary.contains("lighter commit-only/require-commit recovery"));
@@ -188,4 +194,28 @@ last_accessed = "2026-06-01T00:00:00Z"
     assert!(!summary.contains("git checkout --"));
     assert!(!summary.contains("git stash"));
     assert!(!summary.contains("git clean"));
+
+    let rendered = render_wait_result_json(&session_dir, "01KW641KP78VR43SCKJVN6HGDN", &result)
+        .expect("wait result JSON should render");
+    let value: serde_json::Value =
+        serde_json::from_str(&rendered).expect("wait result JSON should parse");
+    assert_eq!(value["status"], "failure");
+    assert_eq!(value["exit_code"], 1);
+    assert_eq!(
+        value["require_commit_recovery"]["termination_status"],
+        "signal"
+    );
+    assert_eq!(
+        value["memory_soft_limit_recovery"]["git_status_short"][0],
+        "MM crates/verbatim-daemon/src/main.rs"
+    );
+    assert_eq!(
+        value["memory_soft_limit_recovery_guidance"]["continuation_command"],
+        "csa run --fork-from 01KW641KP78VR43SCKJVN6HGDN --require-commit --build-jobs 1 --prompt-file CONTINUATION_PROMPT.md"
+    );
+    assert!(
+        value["memory_soft_limit_recovery_guidance"]["retry_guidance"]
+            .as_str()
+            .is_some_and(|text| text.contains("avoid blind retry under the same memory cap"))
+    );
 }

--- a/crates/cli-sub-agent/src/session_cmds_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result.rs
@@ -14,6 +14,8 @@ use crate::session_cmds::{
 mod artifacts;
 #[path = "session_cmds_result_display.rs"]
 mod display;
+#[path = "session_cmds_result_memory_soft_limit.rs"]
+mod memory_soft_limit_result_display;
 #[path = "session_cmds_result_tool_output.rs"]
 mod tool_output;
 
@@ -395,6 +397,8 @@ use display::{
     gate_summary_employee_section, load_structured_post_exec_gate_report,
     render_result_sidecar_for_text, render_token_usage_lines, structured_sections_with_gate_first,
 };
+#[cfg(test)]
+use memory_soft_limit_result_display::lines;
 pub(crate) use tool_output::handle_session_tool_output;
 
 #[cfg(test)]
@@ -403,6 +407,9 @@ mod identity_tests;
 #[cfg(test)]
 #[path = "session_cmds_result_post_exec_gate_tests.rs"]
 mod post_exec_gate_tests;
+#[cfg(test)]
+#[path = "session_cmds_result_display_tests.rs"]
+mod session_cmds_result_display_tests;
 #[cfg(test)]
 #[path = "session_cmds_result_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/session_cmds_result_display.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_display.rs
@@ -4,8 +4,8 @@ use csa_session::{SessionResultView, TokenUsage};
 use std::fs;
 use std::path::Path;
 
+use super::memory_soft_limit_result_display::{insert, lines};
 use super::{StructuredOutputOpts, TranscriptSummary};
-use crate::memory_soft_limit_recovery_display::format_memory_soft_limit_recovery_lines;
 use crate::require_commit_recovery_display::format_require_commit_recovery_lines;
 use crate::review_failure_context as rfc;
 use crate::session_display_alias;
@@ -100,7 +100,7 @@ pub(super) fn display_result_text(
         }
     }
     if let Some(recovery) = envelope.memory_soft_limit_recovery.as_ref() {
-        for line in format_memory_soft_limit_recovery_lines(recovery) {
+        for line in lines(session_id, session_dir, envelope, recovery) {
             println!("{line}");
         }
     }
@@ -269,6 +269,7 @@ pub(super) fn build_result_json_payload_with_identity(
     let mut payload =
         build_result_json_payload(result, transcript_summary, review_meta, token_usage)?;
     session_display_alias::apply_json_identity(&mut payload, session_dir, session_id);
+    insert(&mut payload, session_id, session_dir, &result.envelope);
     rfc::insert_json(&mut payload, session_dir);
     Ok(payload)
 }
@@ -358,7 +359,6 @@ pub(super) fn display_pre_exec_summary_if_present(session_dir: &Path, json: bool
     pre_exec_summary::display_if_present(session_dir, unavailable_reason.as_deref(), json)
 }
 
-/// Display structured output sections based on the requested mode.
 pub(super) fn display_structured_output(
     session_dir: &Path,
     session_id: &str,

--- a/crates/cli-sub-agent/src/session_cmds_result_display_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_display_tests.rs
@@ -1,0 +1,148 @@
+use super::{build_result_json_payload_with_identity, lines};
+use csa_session::SessionResultView;
+
+const SESSION_ID: &str = "01KW641KP78VR43SCKJVN6HGDN";
+const CONTINUATION_COMMAND: &str = "csa run --fork-from 01KW641KP78VR43SCKJVN6HGDN --require-commit --build-jobs 1 --memory-max-mb 11208 --prompt-file CONTINUATION_PROMPT.md";
+
+#[test]
+fn issue_2440_session_result_shows_memory_soft_limit_guidance() {
+    let result = memory_soft_limit_result();
+    let recovery = result
+        .envelope
+        .memory_soft_limit_recovery
+        .as_ref()
+        .expect("memory soft-limit recovery diagnostic");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let rendered = lines(SESSION_ID, temp.path(), &result.envelope, recovery).join("\n");
+
+    assert!(rendered.contains(
+        "Memory-soft-limit recovery: outcome=dirty_or_staged_changes dirty_worktree=true"
+    ));
+    assert!(rendered.contains(&format!("Continuation command: {CONTINUATION_COMMAND}")));
+    assert!(rendered.contains("Continuation prompt guidance: Inspect git status --short"));
+    assert!(rendered.contains("Retry guidance: Avoid blind retry under the same memory cap"));
+    assert!(rendered.contains("current_mb=9626"));
+
+    let payload =
+        build_result_json_payload_with_identity(SESSION_ID, temp.path(), &result, None, None, None)
+            .expect("result payload");
+
+    assert_eq!(
+        payload["memory_soft_limit_recovery_guidance"]["continuation_command"],
+        CONTINUATION_COMMAND
+    );
+    assert!(
+        payload["memory_soft_limit_recovery_guidance"]["continuation_prompt"]
+            .as_str()
+            .expect("continuation prompt")
+            .contains("preserve existing staged and unstaged work")
+    );
+    assert!(
+        payload["memory_soft_limit_recovery_guidance"]["retry_guidance"]
+            .as_str()
+            .expect("retry guidance")
+            .contains("current_mb=9626")
+    );
+}
+
+mod session_cmds_result_memory_soft_limit {
+    use super::*;
+
+    #[test]
+    fn issue_2440_continuation_guidance_uses_worker_session_id() {
+        let result = memory_soft_limit_result();
+        let recovery = result
+            .envelope
+            .memory_soft_limit_recovery
+            .as_ref()
+            .expect("memory soft-limit recovery diagnostic");
+        let temp = tempfile::tempdir().expect("tempdir");
+        let wrapper_id = csa_session::new_session_id();
+        let worker_id = csa_session::new_session_id();
+        let worker_dir = temp.path().join(&worker_id);
+        std::fs::create_dir_all(&worker_dir).expect("worker session dir");
+        let expected_command = CONTINUATION_COMMAND.replace(SESSION_ID, &worker_id);
+
+        let rendered = lines(&wrapper_id, &worker_dir, &result.envelope, recovery).join("\n");
+
+        assert!(rendered.contains(&format!("Continuation command: {expected_command}")));
+        assert!(
+            !rendered.contains(&format!("--fork-from {wrapper_id}")),
+            "continuation guidance must not resume the wrapper session: {rendered}"
+        );
+
+        let payload = build_result_json_payload_with_identity(
+            &wrapper_id,
+            &worker_dir,
+            &result,
+            None,
+            None,
+            None,
+        )
+        .expect("result payload");
+
+        assert_eq!(payload["session_id"].as_str(), Some(wrapper_id.as_str()));
+        assert_eq!(
+            payload["target_session_id"].as_str(),
+            Some(worker_id.as_str())
+        );
+        assert_eq!(
+            payload["memory_soft_limit_recovery_guidance"]["continuation_command"],
+            expected_command.as_str()
+        );
+        assert_ne!(
+            payload["memory_soft_limit_recovery_guidance"]["continuation_command"]
+                .as_str()
+                .expect("continuation command"),
+            CONTINUATION_COMMAND.replace(SESSION_ID, &wrapper_id)
+        );
+    }
+}
+
+fn memory_soft_limit_result() -> SessionResultView {
+    let now = chrono::Utc::now();
+    SessionResultView {
+        envelope: csa_session::SessionResult {
+            post_exec_gate: None,
+            status: "signal".to_string(),
+            exit_code: 143,
+            summary: "CSA diagnostic: signal kill hint: memory soft limit".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now,
+            events_count: 0,
+            artifacts: Vec::new(),
+            kill_hint: Some("memory_soft_limit".to_string()),
+            kill_diagnostics: Some(csa_session::KillDiagnosticReport {
+                source: "memory_soft_limit".to_string(),
+                signal: Some(15),
+                current_mb: Some(9626),
+                threshold_mb: Some(9000),
+                memory_max_mb: Some(10000),
+                soft_limit_percent: Some(90),
+                scope_name: Some("csa-codex-01KTEST.scope".to_string()),
+            }),
+            memory_soft_limit_recovery: Some(csa_session::MemorySoftLimitRecoveryDiagnostic {
+                outcome: "dirty_or_staged_changes".to_string(),
+                commit_created: false,
+                dirty_worktree: true,
+                changed_paths: vec!["src/lib.rs".to_string()],
+                changed_paths_truncated: 0,
+                git_status_short: vec![" M src/lib.rs".to_string()],
+                git_status_short_truncated: 0,
+                head_oid: None,
+                head_summary: None,
+                suggested_recovery_action:
+                    "inspect_git_status_preserve_changes_then_rerun_with_memory_headroom"
+                        .to_string(),
+                retry_profile: None,
+            }),
+            ..Default::default()
+        },
+        manager_sidecar: None,
+        legacy_sidecar: None,
+    }
+}

--- a/crates/cli-sub-agent/src/session_cmds_result_memory_soft_limit.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_memory_soft_limit.rs
@@ -1,0 +1,38 @@
+use crate::memory_soft_limit_recovery_display::{
+    build_memory_soft_limit_recovery_guidance_for_display_session,
+    format_memory_soft_limit_recovery_lines_for_display_session,
+};
+use std::path::Path;
+
+pub(super) fn lines(
+    session_id: &str,
+    session_dir: &Path,
+    envelope: &csa_session::SessionResult,
+    recovery: &csa_session::MemorySoftLimitRecoveryDiagnostic,
+) -> Vec<String> {
+    format_memory_soft_limit_recovery_lines_for_display_session(
+        session_dir,
+        session_id,
+        recovery,
+        envelope.kill_diagnostics.as_ref(),
+    )
+}
+
+pub(super) fn insert(
+    payload: &mut serde_json::Value,
+    session_id: &str,
+    session_dir: &Path,
+    envelope: &csa_session::SessionResult,
+) {
+    let Some(recovery) = envelope.memory_soft_limit_recovery.as_ref() else {
+        return;
+    };
+    payload["memory_soft_limit_recovery_guidance"] =
+        build_memory_soft_limit_recovery_guidance_for_display_session(
+            session_dir,
+            session_id,
+            recovery,
+            envelope.kill_diagnostics.as_ref(),
+        )
+        .to_json();
+}

--- a/crates/cli-sub-agent/src/session_observability.rs
+++ b/crates/cli-sub-agent/src/session_observability.rs
@@ -92,7 +92,9 @@ pub(crate) fn refresh_and_repair_result_from_dir(
     if gate::infer_post_exec_gate_failure_from_log(session_dir, &result_path, &mut result)? {
         changed = true;
     }
-    if review_verdict::sync_clean_pass_result_status_from_sidecars(session_dir, &mut result)? {
+    if !force_review_failure
+        && review_verdict::sync_clean_pass_result_status_from_sidecars(session_dir, &mut result)?
+    {
         changed = true;
     }
 
@@ -148,7 +150,9 @@ pub(crate) fn enrich_result_from_session_dir(
     if gate::infer_post_exec_gate_failure_from_log(session_dir, &result_path, result)? {
         changed = true;
     }
-    if review_verdict::sync_clean_pass_result_status_from_sidecars(session_dir, result)? {
+    if !force_review_failure
+        && review_verdict::sync_clean_pass_result_status_from_sidecars(session_dir, result)?
+    {
         changed = true;
     }
 

--- a/crates/cli-sub-agent/src/session_observability_result_artifact_tests.rs
+++ b/crates/cli-sub-agent/src/session_observability_result_artifact_tests.rs
@@ -244,6 +244,94 @@ fn refresh_and_repair_result_from_dir_ignores_stale_gate_failure_log_for_unrelat
 }
 
 #[test]
+fn issue_2440_clean_pass_repair_does_not_override_summary_gate() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let _state_guard =
+        crate::test_env_lock::ScopedTestEnvVar::set("XDG_STATE_HOME", temp.path().join("state"));
+    let project_root = temp.path().join("project");
+    fs::create_dir_all(&project_root).expect("create project");
+    let session = csa_session::create_session(
+        &project_root,
+        Some("issue 2440 clean pass repair regression"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir =
+        csa_session::get_session_dir(&project_root, &session_id).expect("session dir");
+    let output_dir = session_dir.join("output");
+    fs::create_dir_all(&output_dir).expect("create output dir");
+
+    let summary = "No blocking findings in `main...HEAD`.\nHigh-severity: 1 finding remains in `crates/cli-sub-agent/src/session_observability.rs`.";
+    fs::write(output_dir.join("summary.md"), summary).expect("write summary");
+    let now = chrono::Utc::now();
+    csa_session::write_review_meta(
+        &session_dir,
+        &csa_session::ReviewSessionMeta {
+            session_id: session_id.clone(),
+            head_sha: "issue-2440-head".to_string(),
+            decision: csa_core::types::ReviewDecision::Pass.as_str().to_string(),
+            verdict: "CLEAN".to_string(),
+            review_mode: None,
+            status_reason: None,
+            routed_to: None,
+            primary_failure: None,
+            failure_reason: None,
+            tool: "codex".to_string(),
+            scope: "range:main...HEAD".to_string(),
+            exit_code: 0,
+            fix_attempted: false,
+            fix_rounds: 0,
+            review_iterations: 1,
+            timestamp: now,
+            diff_fingerprint: None,
+            fix_convergence: None,
+        },
+    )
+    .expect("write review meta");
+    csa_session::write_review_verdict(
+        &session_dir,
+        &csa_session::ReviewVerdictArtifact::from_parts(
+            session_id.clone(),
+            csa_core::types::ReviewDecision::Pass,
+            "CLEAN",
+            &[],
+            vec![],
+        ),
+    )
+    .expect("write pass verdict artifact");
+    csa_session::save_result(
+        &project_root,
+        &session_id,
+        &SessionResult {
+            status: SessionResult::status_from_exit_code(1),
+            exit_code: 1,
+            summary: summary.to_string(),
+            tool: "codex".to_string(),
+            started_at: now,
+            completed_at: now,
+            ..Default::default()
+        },
+    )
+    .expect("save failing result");
+
+    let refreshed = refresh_and_repair_result_from_dir(&session_dir)
+        .expect("refresh result")
+        .expect("result should exist");
+
+    assert_eq!(refreshed.exit_code, 1);
+    assert_eq!(refreshed.status, SessionResult::status_from_exit_code(1));
+    let persisted: SessionResult = toml::from_str(
+        &fs::read_to_string(session_dir.join(csa_session::result::RESULT_FILE_NAME))
+            .expect("read persisted result"),
+    )
+    .expect("parse persisted result");
+    assert_eq!(persisted.exit_code, 1);
+    assert_eq!(persisted.status, SessionResult::status_from_exit_code(1));
+}
+
+#[test]
 fn enrich_result_from_session_dir_ignores_stale_gate_failure_log_for_unrelated_failure() {
     let fixture = create_stale_gate_log_failure_fixture();
     let mut result = csa_session::load_result(&fixture.project_root, &fixture.session_id)

--- a/crates/csa-mcp-hub/Cargo.toml
+++ b/crates/csa-mcp-hub/Cargo.toml
@@ -25,8 +25,8 @@ toml.workspace = true
 sha2.workspace = true
 axum = "0.8"
 tokio-util = "0.7"
-rmcp = { version = "=1.2.0", optional = true, features = ["server", "client", "transport-child-process", "transport-async-rw", "transport-streamable-http-server"] }
-rmcp-macros = { version = "=1.2.0", optional = true }
+rmcp = { version = "=1.4.0", optional = true, features = ["server", "client", "transport-child-process", "transport-async-rw", "transport-streamable-http-server"] }
+rmcp-macros = { version = "=1.4.0", optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/csa-mcp-hub/src/serve.rs
+++ b/crates/csa-mcp-hub/src/serve.rs
@@ -160,12 +160,10 @@ impl HttpEndpoint {
                 move || Ok(hub_service.clone())
             },
             session_manager,
-            StreamableHttpServerConfig {
-                cancellation_token: shutdown.clone(),
-                stateful_mode: false,
-                sse_keep_alive: None,
-                ..Default::default()
-            },
+            StreamableHttpServerConfig::default()
+                .with_cancellation_token(shutdown.clone())
+                .with_stateful_mode(false)
+                .with_sse_keep_alive(None),
         );
 
         let app = axum::Router::new()


### PR DESCRIPTION
Fixes #2440

## Summary

Makes memory-soft-limit (OOM-adjacent) session exits resumable and non-destructive:
- Recovery guidance now generates a valid `csa run --fork-from` command using the **worker session id** (not resume-wrapper id)
- Continuation commands use shell-safe filenames (`CONTINUATION_PROMPT.md`, `FIX_PROMPT.md`) instead of shell-unsafe `<placeholder>` metacharacters
- `csa session result` now renders memory-soft-limit continuation guidance (matching `csa session wait`)
- Clean-pass result repair respects the human-summary failed gate (no override when blocking evidence exists)
- Prose-resolution filter is negation-aware and does not misclassify `verified`/`confirmed` as resolution signals for active findings

## Review

7-round tier-4-critical CSA-Codex review completed. Final verdict: PASS (session `01KWA8TC7GEYY92ZKJF7WT61QF`).