### PR TITLE
feat(csa): model-aware KV-cache TTL for session wait re-wait cap

### DIFF
--- a/crates/cli-sub-agent/src/cli_session.rs
+++ b/crates/cli-sub-agent/src/cli_session.rs
@@ -293,8 +293,8 @@ pub enum SessionCommands {
     },
 
     /// Wait for a daemon session to report a terminal result.
-    /// Timeout comes from `~/.config/cli-sub-agent/config.toml` `[kv_cache].long_poll_seconds`
-    /// with a legacy 250s fallback when `[kv_cache]` is absent.
+    /// Timeout comes from the caller model provider TTL when detectable, otherwise
+    /// `~/.config/cli-sub-agent/config.toml` `[kv_cache].default_ttl_seconds`.
     ///
     /// Optional memory early-exit: `--memory-warn-mb <N>` (or config
     /// `[session_wait].memory_warn_mb`) samples the watched session's process-tree RSS
@@ -317,6 +317,11 @@ pub enum SessionCommands {
         /// `0` disables the sampler for this wait command.
         #[arg(long)]
         memory_warn_mb: Option<u64>,
+
+        /// Override the auto-detected caller provider for wait TTL selection.
+        /// Accepted values: claude, openai, glm, other.
+        #[arg(long, value_parser = csa_config::parse_model_provider)]
+        model_provider: Option<csa_config::ModelProvider>,
 
         /// Print the full stdout.log content instead of the compact result summary.
         /// Also enabled when CSA_WAIT_VERBOSE=1 is set.

--- a/crates/cli-sub-agent/src/config_cmds.rs
+++ b/crates/cli-sub-agent/src/config_cmds.rs
@@ -259,7 +259,7 @@ max_recursion_depth = 5
 #                                            #          "@<name> review" for others
 # cloud_bot_wait_seconds = 60                # Quiet wait before polling (default: kv_cache.frequent_poll_seconds = 60)
 # cloud_bot_poll_interval_seconds = 30       # Shell helper poll interval during wait script (default: 30)
-# cloud_bot_poll_max_seconds = 240           # Max poll duration after quiet wait (default: kv_cache.long_poll_seconds = 240)
+# cloud_bot_poll_max_seconds = 240           # Max poll duration after quiet wait (default: kv_cache.default_ttl_seconds = 240)
 # merge_strategy = "merge"                   # "merge" | "rebase" (squash is forbidden, default: "merge")
 # delete_branch = false                      # Delete remote branch after merge (default: false)
 

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -1,6 +1,5 @@
 use super::*;
 use chrono::Utc;
-use csa_config::GlobalConfig;
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::time::{Duration, Instant, SystemTime};
@@ -463,8 +462,7 @@ fn check_session_stale_before_wait(
                     Ok(None) => {}           // no result yet
                 }
 
-                let stale_threshold_seconds =
-                    GlobalConfig::resolve_session_wait_long_poll_seconds().saturating_mul(2);
+                let stale_threshold_seconds = wait_behavior.wait_timeout_secs.saturating_mul(2);
                 let now = Utc::now();
                 let elapsed = now.signed_duration_since(session.last_accessed);
 

--- a/crates/cli-sub-agent/src/session_cmds_list.rs
+++ b/crates/cli-sub-agent/src/session_cmds_list.rs
@@ -15,7 +15,7 @@ const NO_LIVE_PID_STATUS: &str = "NoLivePID";
 
 /// Threshold (seconds) after which an `Active`-phase session whose `last_accessed`
 /// has not advanced is considered stale (#1118 part D). The threshold is `2 *
-/// kv_cache.long_poll_seconds` because an alive `csa session wait` re-stamps
+/// kv_cache.default_ttl_seconds` because an alive `csa session wait` re-stamps
 /// `last_accessed` on each long-poll wake; missing two consecutive wakes is a
 /// strong signal that the daemon hung or its child sub-sessions are runaway.
 fn stale_threshold_seconds() -> u64 {
@@ -214,7 +214,7 @@ pub(super) fn resolve_session_status(session: &MetaSessionState) -> String {
             // Stale detection (#1118 part D): the dead-active reconciler above
             // catches sessions whose process has exited; this branch catches
             // sessions whose process is still alive but has not made progress
-            // for >= 2 * kv_cache.long_poll_seconds. These are the runaway
+            // for >= 2 * kv_cache.default_ttl_seconds. These are the runaway
             // sub-sessions from #1118 — surface them as `Stale` so operators
             // can `csa session kill` them instead of fighting the kill path.
             if is_session_stale(session, stale_threshold_seconds(), Utc::now()) {

--- a/crates/cli-sub-agent/src/session_dispatch.rs
+++ b/crates/cli-sub-agent/src/session_dispatch.rs
@@ -8,7 +8,10 @@ use anyhow::Result;
 use crate::cli::SessionCommands;
 use crate::session_cmds;
 use crate::startup_env::StartupSubtreeEnv;
-use csa_config::{GlobalConfig, KvCacheValueSource, ProjectConfig};
+use csa_config::{
+    GlobalConfig, KvCacheValueSource, ModelProvider, ProjectConfig, detect_model_provider,
+    provider_ttl,
+};
 use csa_core::types::OutputFormat;
 
 /// Resolve session ID from positional arg or --session flag.
@@ -178,12 +181,13 @@ pub(crate) fn dispatch(
             session_id,
             session,
             memory_warn_mb,
+            model_provider,
             verbose,
             json,
             cd,
         } => {
             let sid = resolve_session_id(session_id, session)?;
-            let wait_timeout = resolve_daemon_wait_timeout(cd.as_deref());
+            let wait_timeout = resolve_wait_ttl(model_provider, cd.as_deref());
             let resolved_memory_warn_mb =
                 resolve_session_wait_memory_warn_mb(memory_warn_mb, cd.as_deref());
             let output_mode = session_cmds::SessionWaitOutputMode::from_flags(verbose, json);
@@ -237,7 +241,30 @@ pub(crate) fn dispatch(
     Ok(())
 }
 
-/// Resolve the `csa session wait` cap from global KV cache config.
+/// Resolve the `csa session wait` cap from provider-aware KV cache config.
+///
+/// CLI provider override wins over best-effort provider detection. If no provider
+/// can be detected, fall back to the global default TTL and then the deprecated
+/// project/user `session.daemon_wait_seconds` compatibility key.
+fn resolve_wait_ttl(cli_model_provider: Option<ModelProvider>, cd: Option<&str>) -> u64 {
+    if let Some(provider) = cli_model_provider.or_else(detect_model_provider) {
+        let config = match GlobalConfig::load() {
+            Ok(config) => config,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "Failed to load global config while resolving provider wait TTL; using defaults"
+                );
+                GlobalConfig::default()
+            }
+        };
+        return provider_ttl(provider, &config.kv_cache);
+    }
+
+    resolve_daemon_wait_timeout(cd)
+}
+
+/// Resolve the `csa session wait` fallback cap from global KV cache config.
 ///
 /// Use the global KV cache setting when it differs from the documented default.
 /// Deprecated `session.daemon_wait_seconds` remains a compatibility fallback.
@@ -301,15 +328,16 @@ fn read_legacy_session_wait_timeout(path: &std::path::Path, source: &str) -> Opt
         path = %path.display(),
         source,
         timeout,
-        "Using deprecated session.daemon_wait_seconds; migrate to global kv_cache.long_poll_seconds"
+        "Using deprecated session.daemon_wait_seconds; migrate to global kv_cache.default_ttl_seconds"
     );
     Some(timeout)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_daemon_wait_timeout;
+    use super::{resolve_daemon_wait_timeout, resolve_wait_ttl};
     use crate::test_env_lock::TEST_ENV_LOCK;
+    use csa_config::ModelProvider;
 
     struct EnvVarGuard {
         key: &'static str,
@@ -321,6 +349,13 @@ mod tests {
             let original = std::env::var(key).ok();
             // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
             unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+            unsafe { std::env::remove_var(key) };
             Self { key, original }
         }
     }
@@ -342,6 +377,48 @@ mod tests {
             csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
         std::fs::create_dir_all(global_path.parent().expect("config parent")).unwrap();
         std::fs::write(global_path, contents).unwrap();
+    }
+
+    #[test]
+    fn resolve_wait_ttl_uses_cli_model_provider_override() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let config_root = dir.path().join("xdg-config");
+        std::fs::create_dir_all(&config_root).unwrap();
+        let _home_guard = EnvVarGuard::set("HOME", dir.path());
+        let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
+
+        write_user_config(
+            r#"
+[kv_cache]
+default_ttl_seconds = 555
+
+[kv_cache.provider_ttls]
+openai = 1666
+"#,
+        );
+
+        assert_eq!(resolve_wait_ttl(Some(ModelProvider::OpenAI), None), 1666);
+    }
+
+    #[test]
+    fn resolve_wait_ttl_falls_back_to_default_ttl_without_provider() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let config_root = dir.path().join("xdg-config");
+        std::fs::create_dir_all(&config_root).unwrap();
+        let _provider_guard = EnvVarGuard::remove("HERMES_MODEL_PROVIDER");
+        let _home_guard = EnvVarGuard::set("HOME", dir.path());
+        let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
+
+        write_user_config(
+            r#"
+[kv_cache]
+default_ttl_seconds = 555
+"#,
+        );
+
+        assert_eq!(resolve_wait_ttl(None, None), 555);
     }
 
     #[test]

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -660,7 +660,12 @@ stdin_write_timeout_seconds = 30
 termination_grace_period_seconds = 5
 [kv_cache]
 frequent_poll_seconds = 60
-long_poll_seconds = 240
+default_ttl_seconds = 240
+[kv_cache.provider_ttls]
+claude = 3300
+openai = 1700
+glm = 540
+other = 270
 [gc]
 transcript_max_age_days = 30
 transcript_max_size_mb = 500

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 pub use crate::global_env::ExecutionEnvOptions;
 pub use crate::global_kv_cache::{
     DEFAULT_KV_CACHE_FREQUENT_POLL_SECS, DEFAULT_KV_CACHE_LONG_POLL_SECS, KvCacheConfig,
-    KvCacheValueSource, LEGACY_SESSION_WAIT_FALLBACK_SECS, ResolvedKvCacheValue,
+    KvCacheValueSource, LEGACY_SESSION_WAIT_FALLBACK_SECS, ProviderTtls, ResolvedKvCacheValue,
 };
 use crate::mcp::McpServerConfig;
 use crate::memory::MemoryConfig;

--- a/crates/csa-config/src/global_impl.rs
+++ b/crates/csa-config/src/global_impl.rs
@@ -51,10 +51,11 @@ impl GlobalConfig {
         Ok(config.sanitized(Some(&path)))
     }
 
-    /// Resolve the `csa session wait` long-poll cap from the global config.
+    /// Resolve the `csa session wait` fallback TTL from the global config.
     ///
     /// Missing or invalid config falls back to the documented KV cache default.
-    /// Once `[kv_cache]` exists, `long_poll_seconds` still defaults to 240 if omitted.
+    /// Once `[kv_cache]` exists, `default_ttl_seconds` still defaults to 240 if omitted.
+    /// Deprecated `long_poll_seconds` remains a config-file alias.
     pub fn resolve_session_wait_long_poll_seconds() -> u64 {
         Self::resolve_session_wait_long_poll_seconds_with_source().seconds
     }
@@ -120,9 +121,18 @@ impl GlobalConfig {
             return ResolvedKvCacheValue::documented_default();
         };
 
-        match kv_cache.get("long_poll_seconds") {
+        let configured_value = kv_cache
+            .get("default_ttl_seconds")
+            .map(|value| ("kv_cache.default_ttl_seconds", value))
+            .or_else(|| {
+                kv_cache
+                    .get("long_poll_seconds")
+                    .map(|value| ("kv_cache.long_poll_seconds", value))
+            });
+
+        match configured_value {
             None => ResolvedKvCacheValue::section_default(),
-            Some(value) => match value.as_integer() {
+            Some((key, value)) => match value.as_integer() {
                 Some(seconds) if seconds > 0 => match u64::try_from(seconds) {
                     Ok(seconds) => ResolvedKvCacheValue {
                         seconds,
@@ -131,7 +141,7 @@ impl GlobalConfig {
                     Err(_) => {
                         tracing::warn!(
                             path = %path.display(),
-                            key = "kv_cache.long_poll_seconds",
+                            key,
                             value = seconds,
                             fallback = DEFAULT_KV_CACHE_LONG_POLL_SECS,
                             "Ignoring out-of-range KV cache interval; using section default"
@@ -142,7 +152,7 @@ impl GlobalConfig {
                 _ => {
                     tracing::warn!(
                         path = %path.display(),
-                        key = "kv_cache.long_poll_seconds",
+                        key,
                         fallback = DEFAULT_KV_CACHE_LONG_POLL_SECS,
                         "Ignoring invalid KV cache interval; using section default"
                     );

--- a/crates/csa-config/src/global_kv_cache.rs
+++ b/crates/csa-config/src/global_kv_cache.rs
@@ -1,8 +1,12 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::path::Path;
 
 pub const DEFAULT_KV_CACHE_FREQUENT_POLL_SECS: u64 = 60;
 pub const DEFAULT_KV_CACHE_LONG_POLL_SECS: u64 = 240;
+pub const DEFAULT_KV_CACHE_CLAUDE_TTL_SECS: u64 = 3300;
+pub const DEFAULT_KV_CACHE_OPENAI_TTL_SECS: u64 = 1700;
+pub const DEFAULT_KV_CACHE_GLM_TTL_SECS: u64 = 540;
+pub const DEFAULT_KV_CACHE_OTHER_TTL_SECS: u64 = 270;
 pub const LEGACY_SESSION_WAIT_FALLBACK_SECS: u64 = 250;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,13 +39,108 @@ impl ResolvedKvCacheValue {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderTtls {
+    #[serde(default = "default_kv_cache_claude_ttl_seconds")]
+    pub claude: u64,
+    #[serde(default = "default_kv_cache_openai_ttl_seconds")]
+    pub openai: u64,
+    #[serde(default = "default_kv_cache_glm_ttl_seconds")]
+    pub glm: u64,
+    #[serde(default = "default_kv_cache_other_ttl_seconds")]
+    pub other: u64,
+}
+
+impl Default for ProviderTtls {
+    fn default() -> Self {
+        Self {
+            claude: default_kv_cache_claude_ttl_seconds(),
+            openai: default_kv_cache_openai_ttl_seconds(),
+            glm: default_kv_cache_glm_ttl_seconds(),
+            other: default_kv_cache_other_ttl_seconds(),
+        }
+    }
+}
+
+impl ProviderTtls {
+    fn sanitized(mut self, path: Option<&Path>) -> Self {
+        self.claude = sanitize_kv_cache_seconds(
+            self.claude,
+            "kv_cache.provider_ttls.claude",
+            DEFAULT_KV_CACHE_CLAUDE_TTL_SECS,
+            path,
+        );
+        self.openai = sanitize_kv_cache_seconds(
+            self.openai,
+            "kv_cache.provider_ttls.openai",
+            DEFAULT_KV_CACHE_OPENAI_TTL_SECS,
+            path,
+        );
+        self.glm = sanitize_kv_cache_seconds(
+            self.glm,
+            "kv_cache.provider_ttls.glm",
+            DEFAULT_KV_CACHE_GLM_TTL_SECS,
+            path,
+        );
+        self.other = sanitize_kv_cache_seconds(
+            self.other,
+            "kv_cache.provider_ttls.other",
+            DEFAULT_KV_CACHE_OTHER_TTL_SECS,
+            path,
+        );
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct KvCacheConfig {
     /// Poll interval for fast-changing external state such as GitHub bot events.
     #[serde(default = "default_kv_cache_frequent_poll_seconds")]
     pub frequent_poll_seconds: u64,
-    /// Poll interval for long-running background waits that keep the caller KV cache warm.
+    /// Fallback TTL for `csa session wait` when the caller model provider is unknown.
+    #[serde(default = "default_kv_cache_long_poll_seconds")]
+    pub default_ttl_seconds: u64,
+    /// Deprecated alias for `default_ttl_seconds`.
+    ///
+    /// Kept so old config readers and `csa config get kv_cache.long_poll_seconds`
+    /// continue to see the effective fallback TTL.
     #[serde(default = "default_kv_cache_long_poll_seconds")]
     pub long_poll_seconds: u64,
+    /// Provider-specific TTL caps for model-aware `csa session wait` calls.
+    #[serde(default)]
+    pub provider_ttls: ProviderTtls,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawKvCacheConfig {
+    #[serde(default)]
+    frequent_poll_seconds: Option<u64>,
+    #[serde(default)]
+    default_ttl_seconds: Option<u64>,
+    #[serde(default)]
+    long_poll_seconds: Option<u64>,
+    #[serde(default)]
+    provider_ttls: ProviderTtls,
+}
+
+impl<'de> Deserialize<'de> for KvCacheConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = RawKvCacheConfig::deserialize(deserializer)?;
+        let default_ttl_seconds = raw
+            .default_ttl_seconds
+            .or(raw.long_poll_seconds)
+            .unwrap_or_else(default_kv_cache_long_poll_seconds);
+        Ok(Self {
+            frequent_poll_seconds: raw
+                .frequent_poll_seconds
+                .unwrap_or_else(default_kv_cache_frequent_poll_seconds),
+            default_ttl_seconds,
+            long_poll_seconds: default_ttl_seconds,
+            provider_ttls: raw.provider_ttls,
+        })
+    }
 }
 
 fn default_kv_cache_frequent_poll_seconds() -> u64 {
@@ -52,11 +151,30 @@ fn default_kv_cache_long_poll_seconds() -> u64 {
     DEFAULT_KV_CACHE_LONG_POLL_SECS
 }
 
+fn default_kv_cache_claude_ttl_seconds() -> u64 {
+    DEFAULT_KV_CACHE_CLAUDE_TTL_SECS
+}
+
+fn default_kv_cache_openai_ttl_seconds() -> u64 {
+    DEFAULT_KV_CACHE_OPENAI_TTL_SECS
+}
+
+fn default_kv_cache_glm_ttl_seconds() -> u64 {
+    DEFAULT_KV_CACHE_GLM_TTL_SECS
+}
+
+fn default_kv_cache_other_ttl_seconds() -> u64 {
+    DEFAULT_KV_CACHE_OTHER_TTL_SECS
+}
+
 impl Default for KvCacheConfig {
     fn default() -> Self {
+        let default_ttl_seconds = default_kv_cache_long_poll_seconds();
         Self {
             frequent_poll_seconds: default_kv_cache_frequent_poll_seconds(),
-            long_poll_seconds: default_kv_cache_long_poll_seconds(),
+            default_ttl_seconds,
+            long_poll_seconds: default_ttl_seconds,
+            provider_ttls: ProviderTtls::default(),
         }
     }
 }
@@ -70,11 +188,13 @@ impl KvCacheConfig {
             path,
         );
         self.long_poll_seconds = sanitize_kv_cache_seconds(
-            self.long_poll_seconds,
-            "kv_cache.long_poll_seconds",
+            self.default_ttl_seconds,
+            "kv_cache.default_ttl_seconds",
             DEFAULT_KV_CACHE_LONG_POLL_SECS,
             path,
         );
+        self.default_ttl_seconds = self.long_poll_seconds;
+        self.provider_ttls = self.provider_ttls.sanitized(path);
         self
     }
 }
@@ -98,4 +218,43 @@ fn sanitize_kv_cache_seconds(value: u64, key: &str, default: u64, path: Option<&
         ),
     }
     default
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{KvCacheConfig, ProviderTtls};
+
+    #[test]
+    fn kv_cache_defaults_include_provider_ttls() {
+        let config = KvCacheConfig::default();
+
+        assert_eq!(config.default_ttl_seconds, 240);
+        assert_eq!(config.long_poll_seconds, 240);
+        assert_eq!(config.provider_ttls.claude, 3300);
+        assert_eq!(config.provider_ttls.openai, 1700);
+        assert_eq!(config.provider_ttls.glm, 540);
+        assert_eq!(config.provider_ttls.other, 270);
+    }
+
+    #[test]
+    fn kv_cache_defaults_parse_when_section_omitted() {
+        let config: KvCacheConfig = toml::from_str("").unwrap();
+
+        assert_eq!(config.default_ttl_seconds, 240);
+        assert_eq!(config.long_poll_seconds, 240);
+        assert_eq!(config.provider_ttls, ProviderTtls::default());
+    }
+
+    #[test]
+    fn legacy_long_poll_seconds_still_works() {
+        let config: KvCacheConfig = toml::from_str(
+            r#"
+long_poll_seconds = 999
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.default_ttl_seconds, 999);
+        assert_eq!(config.long_poll_seconds, 999);
+    }
 }

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -95,11 +95,17 @@ task_pool_workers = 1
 
 # KV cache-aware polling defaults.
 # `frequent_poll_seconds`: fast external state (GitHub API, bot responses).
-# `long_poll_seconds`: long waits that return control before the caller cache goes cold.
-# Max-tier Opus users can raise `long_poll_seconds` to 3000 (~50 min on a 1h TTL).
+# `default_ttl_seconds`: fallback when caller model provider detection is unavailable.
+# `long_poll_seconds` is a deprecated alias for `default_ttl_seconds`.
 [kv_cache]
 frequent_poll_seconds = 60
-long_poll_seconds = 240
+default_ttl_seconds = 240
+
+[kv_cache.provider_ttls]
+claude = 3300
+openai = 1700
+glm = 540
+other = 270
 
 # Parent-tool caller hints.
 # Codex callers should prefer the CSA MCP `csa_session_wait` tool with a long

--- a/crates/csa-config/src/lib.rs
+++ b/crates/csa-config/src/lib.rs
@@ -26,6 +26,7 @@ pub mod migrate;
 pub mod paths;
 pub mod project_profile;
 mod project_prune;
+pub mod provider_detection;
 pub mod tool_selection;
 pub mod validate;
 pub mod weave_lock;
@@ -52,9 +53,9 @@ pub use global::{
     AiConfigSymlinkCheckConfig, DEFAULT_KV_CACHE_FREQUENT_POLL_SECS,
     DEFAULT_KV_CACHE_LONG_POLL_SECS, ExecutionEnvOptions, ExperimentalConfig, GateMode, GateStep,
     GithubConfig, GlobalConfig, GlobalHooksConfig, GlobalMcpConfig, KvCacheConfig,
-    KvCacheValueSource, LEGACY_SESSION_WAIT_FALLBACK_SECS, PreflightConfig, ResolvedKvCacheValue,
-    ReviewConfig, SessionWaitConfig, StateDirConfig, StateDirOnExceed, TierPolicyConfig,
-    ToolSelection,
+    KvCacheValueSource, LEGACY_SESSION_WAIT_FALLBACK_SECS, PreflightConfig, ProviderTtls,
+    ResolvedKvCacheValue, ReviewConfig, SessionWaitConfig, StateDirConfig, StateDirOnExceed,
+    TierPolicyConfig, ToolSelection,
 };
 pub use global_caller_hints::{
     CallerHintsConfig, DEFAULT_CODEX_SESSION_WAIT_MCP_INTERNAL_TIMEOUT_SEC,
@@ -66,5 +67,8 @@ pub use memory::{MemoryBackend, MemoryConfig, MemoryEphemeralConfig, MemoryLlmCo
 pub use migrate::{Migration, MigrationRegistry, MigrationStep, Version, default_registry};
 pub use paths::{APP_NAME, LEGACY_APP_NAME};
 pub use project_profile::{ProjectProfile, detect_project_profile};
+pub use provider_detection::{
+    ModelProvider, detect_model_provider, parse_model_provider, provider_ttl,
+};
 pub use validate::validate_config;
 pub use weave_lock::{VersionCheckResult, WeaveLock, check_version};

--- a/crates/csa-config/src/provider_detection.rs
+++ b/crates/csa-config/src/provider_detection.rs
@@ -1,0 +1,228 @@
+use std::path::{Path, PathBuf};
+
+use crate::global::{DEFAULT_KV_CACHE_LONG_POLL_SECS, KvCacheConfig};
+
+const HERMES_MODEL_PROVIDER_ENV: &str = "HERMES_MODEL_PROVIDER";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelProvider {
+    Claude,
+    OpenAI,
+    Glm,
+    Other,
+}
+
+impl ModelProvider {
+    fn from_hermes_value(value: &str) -> Option<Self> {
+        let normalized = normalize_provider_name(value);
+        if normalized.is_empty() {
+            return None;
+        }
+        Some(match normalized.as_str() {
+            "anthropic" | "claude" => Self::Claude,
+            "openai" => Self::OpenAI,
+            "zai" | "zhipu" | "zhipuai" | "glm" => Self::Glm,
+            _ => Self::Other,
+        })
+    }
+}
+
+pub fn parse_model_provider(value: &str) -> Result<ModelProvider, String> {
+    let normalized = normalize_provider_name(value);
+    match normalized.as_str() {
+        "anthropic" | "claude" => Ok(ModelProvider::Claude),
+        "openai" => Ok(ModelProvider::OpenAI),
+        "zai" | "zhipu" | "zhipuai" | "glm" => Ok(ModelProvider::Glm),
+        "other" => Ok(ModelProvider::Other),
+        _ => Err(format!(
+            "unsupported model provider '{value}'; expected claude, openai, glm, or other"
+        )),
+    }
+}
+
+pub fn detect_model_provider() -> Option<ModelProvider> {
+    detect_model_provider_from_env().or_else(detect_model_provider_from_hermes_config)
+}
+
+pub fn provider_ttl(provider: ModelProvider, config: &KvCacheConfig) -> u64 {
+    let provider_seconds = match provider {
+        ModelProvider::Claude => config.provider_ttls.claude,
+        ModelProvider::OpenAI => config.provider_ttls.openai,
+        ModelProvider::Glm => config.provider_ttls.glm,
+        ModelProvider::Other => config.provider_ttls.other,
+    };
+    if provider_seconds > 0 {
+        provider_seconds
+    } else {
+        fallback_default_ttl(config)
+    }
+}
+
+fn detect_model_provider_from_env() -> Option<ModelProvider> {
+    std::env::var(HERMES_MODEL_PROVIDER_ENV)
+        .ok()
+        .and_then(|value| ModelProvider::from_hermes_value(&value))
+}
+
+fn detect_model_provider_from_hermes_config() -> Option<ModelProvider> {
+    detect_model_provider_from_hermes_config_path(&default_hermes_config_path()?)
+}
+
+fn default_hermes_config_path() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".hermes/config.yaml"))
+}
+
+fn detect_model_provider_from_hermes_config_path(path: &Path) -> Option<ModelProvider> {
+    let content = std::fs::read_to_string(path).ok()?;
+    parse_model_provider_from_hermes_config(&content)
+}
+
+fn parse_model_provider_from_hermes_config(content: &str) -> Option<ModelProvider> {
+    let mut model_indent = None;
+
+    for raw_line in content.lines() {
+        let line = raw_line.trim_end();
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let indent = line.len().saturating_sub(trimmed.len());
+        if model_indent.is_some_and(|base| indent <= base) {
+            model_indent = None;
+        }
+
+        let Some((key, value)) = yaml_key_value(trimmed) else {
+            continue;
+        };
+        if key == "model.provider" {
+            return ModelProvider::from_hermes_value(value);
+        }
+        if key == "model" && value.is_empty() {
+            model_indent = Some(indent);
+            continue;
+        }
+        if model_indent.is_some() && key == "provider" {
+            return ModelProvider::from_hermes_value(value);
+        }
+    }
+
+    None
+}
+
+fn yaml_key_value(line: &str) -> Option<(&str, &str)> {
+    let (key, value) = line.split_once(':')?;
+    Some((key.trim(), trim_yaml_scalar(value)))
+}
+
+fn trim_yaml_scalar(value: &str) -> &str {
+    value
+        .split('#')
+        .next()
+        .unwrap_or(value)
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+}
+
+fn normalize_provider_name(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .to_ascii_lowercase()
+}
+
+fn fallback_default_ttl(config: &KvCacheConfig) -> u64 {
+    if config.default_ttl_seconds > 0 {
+        config.default_ttl_seconds
+    } else if config.long_poll_seconds > 0 {
+        config.long_poll_seconds
+    } else {
+        DEFAULT_KV_CACHE_LONG_POLL_SECS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: test-scoped env mutation is reverted in Drop.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: test-scoped env mutation is reverted in Drop.
+            unsafe { std::env::remove_var(key) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: test-scoped env mutation is reverted in Drop.
+            unsafe {
+                match self.original.as_deref() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn detect_model_provider_from_env() {
+        let _guard = EnvVarGuard::set(HERMES_MODEL_PROVIDER_ENV, "zhipuai");
+
+        assert_eq!(detect_model_provider(), Some(ModelProvider::Glm));
+    }
+
+    #[test]
+    #[serial]
+    fn detect_model_provider_from_hermes_config() {
+        let _provider_guard = EnvVarGuard::remove(HERMES_MODEL_PROVIDER_ENV);
+        let home = tempfile::tempdir().unwrap();
+        let _home_guard = EnvVarGuard::set("HOME", home.path());
+        let hermes_dir = home.path().join(".hermes");
+        std::fs::create_dir_all(&hermes_dir).unwrap();
+        std::fs::write(
+            hermes_dir.join("config.yaml"),
+            r#"
+model:
+  provider: anthropic
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(detect_model_provider(), Some(ModelProvider::Claude));
+    }
+
+    #[test]
+    fn provider_ttl_uses_correct_configured_value() {
+        let mut config = KvCacheConfig::default();
+        config.provider_ttls.openai = 1800;
+
+        assert_eq!(provider_ttl(ModelProvider::OpenAI, &config), 1800);
+    }
+
+    #[test]
+    fn provider_ttl_falls_back_to_default() {
+        let mut config = KvCacheConfig::default();
+        config.default_ttl_seconds = 123;
+        config.provider_ttls.glm = 0;
+
+        assert_eq!(provider_ttl(ModelProvider::Glm, &config), 123);
+    }
+}


### PR DESCRIPTION
Fixes #2523

## Summary

`csa session wait` now auto-detects the caller model provider and selects the appropriate KV-cache re-wait cap:

- **Auto-detection chain:** `HERMES_MODEL_PROVIDER` env var → `~/.hermes/config.yaml` → `model.provider` → fallback to default TTL
- **Provider mapping:** `zai`/`zhipu` → glm (540s), `anthropic` → claude (3300s), `openai` → openai (1700s), unknown → other (270s)
- **Config keys:** `[kv_cache].default_ttl_seconds`, `[kv_cache.provider_ttls]` (per-provider overrides)
- **CLI flag:** `--model-provider` optional manual override
- **Legacy compat:** `long_poll_seconds` still works as alias for `default_ttl_seconds`
- **Best-effort:** detection failure never breaks the session — falls back to default TTL

**Verified in production:** After merge, wait cap immediately changed from 240s → 540s for the glm/zai provider.

## Review

1-round tier-4-critical CSA-Codex review. Final verdict: PASS (session `01KWAQN48P2S1T3W46QHM5WT2K`).

**12 files changed, 524 insertions, 32 deletions.**