### PR TITLE
fix(plan): make dev2merge outcomes side-effect-aware, actionable, and fail-fast

### DIFF
--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -39,6 +39,9 @@ use plan_cmd_exec::{extract_bash_code_block, truncate};
 #[path = "plan_cmd_flow.rs"]
 mod plan_cmd_flow;
 
+#[path = "plan_cmd_repo.rs"]
+mod plan_cmd_repo;
+
 #[path = "plan_cmd_failure.rs"]
 pub(crate) mod plan_cmd_failure;
 
@@ -61,6 +64,7 @@ pub(crate) use plan_cmd_assignment::{
     extract_output_assignment_markers, is_assignment_marker_key, should_inject_assignment_markers,
 };
 pub(crate) use plan_cmd_flow::shell_escape_for_command;
+pub(crate) use plan_cmd_repo::detect_effective_repo;
 #[cfg(test)]
 pub(crate) use plan_cmd_steps::resolve_step_tool;
 use plan_cmd_steps::{PlanRunContext, execute_plan_with_journal};
@@ -92,45 +96,6 @@ pub(crate) const FEATURE_INPUT_VAR: &str = "FEATURE_INPUT";
 /// Workflow variable containing the numeric issue number from
 /// `csa plan run --issue <N>`.
 pub(crate) const ISSUE_NUMBER_VAR: &str = "ISSUE_NUMBER";
-
-fn detect_effective_repo(project_root: &Path) -> Option<String> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(project_root)
-        .args(["config", "--get", "remote.origin.url"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if raw.is_empty() {
-        return None;
-    }
-    // Strip credentials from HTTPS/SSH URLs (e.g. https://user:token@github.com/repo)
-    let sanitized = if let Some(pos) = raw.find("://") {
-        let (scheme, rest) = raw.split_at(pos + 3);
-        if let Some(at_pos) = rest.find('@') {
-            format!("{}{}", scheme, &rest[at_pos + 1..])
-        } else {
-            raw
-        }
-    } else {
-        raw
-    };
-
-    let trimmed = sanitized.trim_end_matches(".git");
-    if let Some(rest) = trimmed.strip_prefix("git@github.com:") {
-        return Some(rest.to_string());
-    }
-    if let Some(rest) = trimmed.strip_prefix("https://github.com/") {
-        return Some(rest.to_string());
-    }
-    if let Some(rest) = trimmed.strip_prefix("ssh://git@github.com/") {
-        return Some(rest.to_string());
-    }
-    Some(trimmed.to_string())
-}
 
 /// Resolve a workflow TOML path from either a file path or a pattern name.
 fn resolve_workflow_path(
@@ -448,7 +413,11 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<PlanRunOutcome>
             "Workflow '{}' paused for manual handoff. Complete the requested main-agent action, then resume with `{}`.",
             plan.name, resume_cmd
         );
-        return Ok(PlanRunOutcome::default());
+        return Ok(PlanRunOutcome {
+            completion_summary: Some(format!(
+                "workflow paused for manual handoff; next_action={resume_cmd}"
+            )),
+        });
     }
 
     if journal.status == "awaiting-user" {
@@ -458,7 +427,12 @@ pub(crate) async fn handle_plan_run(args: PlanRunArgs) -> Result<PlanRunOutcome>
             "Workflow '{}' is awaiting user action. Re-run the workflow from the beginning after the requested remediation is complete.",
             plan.name
         );
-        return Ok(PlanRunOutcome::default());
+        return Ok(PlanRunOutcome {
+            completion_summary: Some(
+                "workflow awaiting user action; next_action=rerun after requested remediation"
+                    .to_string(),
+            ),
+        });
     }
 
     // 9. Warn about unsupported skips (loop_var)

--- a/crates/cli-sub-agent/src/plan_cmd_completion.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_completion.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
 use super::StepResult;
-use super::plan_cmd_failure::{PlanFailureError, PlanFailureReport};
+use super::plan_cmd_failure::PlanFailureError;
 
 #[path = "plan_cmd_pr_bot_completion.rs"]
 mod pr_bot_completion;
@@ -13,10 +14,13 @@ pub(crate) use pr_bot_completion::{
     PrBotFailureSideEffectInput, verify_pr_bot_failure_side_effects,
 };
 
-const DEV2MERGE_WORKFLOW_NAME: &str = "dev2merge";
-const DEV2MERGE_VERIFY_STEP_ID: usize = 18;
-const DEV2MERGE_ALREADY_RESOLVED_STEP_ID: usize = 0;
-const DEV2MERGE_PUBLISH_STEPS: [usize; 5] = [13, 14, 15, 16, 17];
+#[path = "plan_cmd_dev2merge_completion.rs"]
+mod dev2merge_completion;
+#[cfg(test)]
+use dev2merge_completion::{
+    Dev2MergeCompletionFacts, Dev2MergeObservedState, dev2merge_success_summary,
+    evaluate_dev2merge_completion, step_completed_successfully,
+};
 
 pub(crate) struct PlanCompletionInput<'a> {
     pub(crate) workflow_name: &'a str,
@@ -31,19 +35,12 @@ pub(crate) struct PlanCompletionInput<'a> {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PlanCompletionSnapshot {
     initial_branch: Option<String>,
+    initial_head: Option<String>,
 }
 
 impl PlanCompletionSnapshot {
     pub(crate) fn capture(workflow_name: &str, project_root: &Path) -> Self {
-        if workflow_name != DEV2MERGE_WORKFLOW_NAME {
-            return Self::default();
-        }
-        Self {
-            initial_branch: git_stdout(project_root, &["branch", "--show-current"])
-                .ok()
-                .map(|value| value.trim().to_string())
-                .filter(|value| !value.is_empty() && value != "HEAD"),
-        }
+        dev2merge_completion::capture_snapshot(workflow_name, project_root)
     }
 }
 
@@ -123,372 +120,10 @@ pub(crate) fn verify_plan_completion(
     if pr_bot_completion::is_pr_bot_workflow(input.workflow_name) {
         return pr_bot_completion::verify_pr_bot_completion(input);
     }
-    if input.workflow_name != DEV2MERGE_WORKFLOW_NAME {
-        return Ok(None);
+    if input.workflow_name == dev2merge_completion::DEV2MERGE_WORKFLOW_NAME {
+        return dev2merge_completion::verify_plan_completion(input);
     }
-    let facts = Dev2MergeCompletionFacts::from_input(&input);
-    if !facts.publish_started {
-        if facts.already_resolved_skip {
-            return Ok(Some(
-                "dev2merge: already-resolved check declared an explicit no-op".to_string(),
-            ));
-        }
-        return Err(Box::new(dev2merge_lifecycle_not_started_failure_report(
-            input.workflow_name,
-            input.workflow_path,
-            &facts,
-        )));
-    }
-
-    let observed = observe_dev2merge_state(input.project_root, &facts);
-    let failures = evaluate_dev2merge_completion(&facts, &observed);
-    if failures.is_empty() {
-        let pr = facts
-            .pr_number
-            .as_deref()
-            .map(|value| format!("PR #{value} is MERGED"))
-            .unwrap_or_else(|| "publish side effects are complete".to_string());
-        let branch = facts
-            .branch
-            .as_deref()
-            .map(|value| format!(" for branch {value}"))
-            .unwrap_or_default();
-        return Ok(Some(format!("dev2merge{branch}: {pr}")));
-    }
-
-    Err(Box::new(dev2merge_completion_failure_report(
-        input.workflow_name,
-        input.workflow_path,
-        failures,
-    )))
-}
-
-#[derive(Debug, Clone, Default)]
-struct Dev2MergeCompletionFacts {
-    dev2merge_skip: bool,
-    already_resolved_skip: bool,
-    publish_started: bool,
-    push_gate_completed: bool,
-    review_verdict_completed: bool,
-    pr_completed: bool,
-    pr_bot_completed: bool,
-    post_merge_sync_completed: bool,
-    branch: Option<String>,
-    pr_number: Option<String>,
-    pr_bot_done_marker: Option<PathBuf>,
-}
-
-impl Dev2MergeCompletionFacts {
-    fn from_input(input: &PlanCompletionInput<'_>) -> Self {
-        let dev2merge_skip = truthy(input.vars.get("DEV2MERGE_SKIP"));
-        let already_resolved_skip =
-            dev2merge_skip && already_resolved_step_declared_skip(input.results);
-        let step_completed = |step_id| {
-            step_completed_successfully(
-                input.results,
-                input.completed_steps,
-                dev2merge_skip,
-                step_id,
-            )
-        };
-        let publish_started = DEV2MERGE_PUBLISH_STEPS.into_iter().any(&step_completed);
-        let branch = input
-            .snapshot
-            .initial_branch
-            .clone()
-            .or_else(|| non_empty_var(input.vars, "WORKFLOW_BRANCH"))
-            .or_else(|| non_empty_var(input.vars, "BRANCH"));
-        let pr_number = non_empty_var(input.vars, "PR_NUMBER")
-            .filter(|value| value.chars().all(|ch| ch.is_ascii_digit()));
-        let pr_bot_done_marker = non_empty_var(input.vars, "PR_BOT_DONE_MARKER").map(PathBuf::from);
-
-        Self {
-            dev2merge_skip,
-            already_resolved_skip,
-            publish_started,
-            push_gate_completed: step_completed(13),
-            review_verdict_completed: step_completed(14),
-            pr_completed: step_completed(15),
-            pr_bot_completed: step_completed(16),
-            post_merge_sync_completed: step_completed(17),
-            branch,
-            pr_number,
-            pr_bot_done_marker,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-struct Dev2MergeObservedState {
-    pr_bot_marker_exists: Option<bool>,
-    pr_state: Option<String>,
-    pr_state_error: Option<String>,
-}
-
-fn observe_dev2merge_state(
-    project_root: &Path,
-    facts: &Dev2MergeCompletionFacts,
-) -> Dev2MergeObservedState {
-    let pr_bot_marker_exists = facts
-        .pr_bot_done_marker
-        .as_ref()
-        .map(|path| resolve_observed_path(project_root, path).is_file());
-    let (pr_state, pr_state_error) = match facts.pr_number.as_deref() {
-        Some(pr_number) => match command_stdout(
-            project_root,
-            "gh",
-            &["pr", "view", pr_number, "--json", "state", "-q", ".state"],
-        ) {
-            Ok(value) => (Some(value.trim().to_string()), None),
-            Err(error) => (None, Some(error)),
-        },
-        None => (None, None),
-    };
-
-    Dev2MergeObservedState {
-        pr_bot_marker_exists,
-        pr_state,
-        pr_state_error,
-    }
-}
-
-fn evaluate_dev2merge_completion(
-    facts: &Dev2MergeCompletionFacts,
-    observed: &Dev2MergeObservedState,
-) -> Vec<String> {
-    let mut failures = Vec::new();
-    if !facts.push_gate_completed {
-        failures.push(
-            "ERROR: Push Gate (Step 13) did not complete; branch publication is incomplete."
-                .to_string(),
-        );
-    }
-    if !facts.review_verdict_completed {
-        failures.push("ERROR: Pre-PR Review Verdict Check (Step 14) did not complete.".to_string());
-    }
-    if !facts.pr_completed {
-        failures
-            .push("ERROR: Create or Reuse Pull Request (Step 15) did not complete.".to_string());
-    }
-    if !facts.pr_bot_completed {
-        failures.push("ERROR: pr-bot Review & Merge Gate (Step 16) did not complete.".to_string());
-    }
-    if !facts.post_merge_sync_completed {
-        failures.push("ERROR: Post-Merge Local Sync (Step 17) did not complete.".to_string());
-    }
-
-    match facts.pr_number.as_deref() {
-        Some(_) => {}
-        None => failures.push(
-            "ERROR: PR_NUMBER was not captured; PR creation/reuse is incomplete.".to_string(),
-        ),
-    }
-    match (&facts.pr_bot_done_marker, observed.pr_bot_marker_exists) {
-        (Some(path), Some(true)) => {
-            let _ = path;
-        }
-        (Some(path), Some(false)) => failures.push(format!(
-            "ERROR: pr-bot completion marker is missing: {}.",
-            path.display()
-        )),
-        (None, _) => failures.push(
-            "ERROR: PR_BOT_DONE_MARKER was not captured; pr-bot completion is unverified."
-                .to_string(),
-        ),
-        (Some(path), None) => failures.push(format!(
-            "ERROR: pr-bot completion marker could not be inspected: {}.",
-            path.display()
-        )),
-    }
-    if let Some(error) = &observed.pr_state_error {
-        failures.push(format!(
-            "ERROR: failed to inspect PR state via gh: {error}."
-        ));
-    } else if facts.pr_number.is_some() {
-        match observed.pr_state.as_deref() {
-            Some("MERGED") => {}
-            Some("") => {
-                failures.push("ERROR: PR state is empty; expected MERGED after pr-bot.".to_string())
-            }
-            Some(state) => failures.push(format!(
-                "ERROR: PR state is {state}; expected MERGED after pr-bot."
-            )),
-            None => failures.push(
-                "ERROR: PR state was not observed; expected MERGED after pr-bot.".to_string(),
-            ),
-        }
-    }
-
-    failures
-}
-
-fn dev2merge_lifecycle_not_started_failure_report(
-    workflow_name: &str,
-    workflow_path: &Path,
-    facts: &Dev2MergeCompletionFacts,
-) -> PlanFailureError {
-    let summary = "dev2merge lifecycle side-effect verification failed: publish gate never started"
-        .to_string();
-    let mut error = vec![
-        "ERROR: dev2merge lifecycle side-effect verification failed after workflow steps reported success."
-            .to_string(),
-        "ERROR: Publish Gate (Step 13) did not run; branch publication, PR creation, pr-bot merge, and post-merge sync were not attempted."
-            .to_string(),
-    ];
-    if facts.dev2merge_skip {
-        error.push(
-            "ERROR: DEV2MERGE_SKIP was true, but the Already-Resolved Check (Step 0) did not declare the skip in this run.".to_string(),
-        );
-    } else {
-        error.push(
-            "ERROR: DEV2MERGE_SKIP was not set by the Already-Resolved Check; terminal success would be transport-only.".to_string(),
-        );
-    }
-    error.push(
-        "Retry dev2merge from the current branch, or resume the journal if a manual handoff was expected; callers should treat this structured result as a missing lifecycle gate."
-            .to_string(),
-    );
-    let error = error.join("\n");
-    let synthetic_result = StepResult {
-        step_id: DEV2MERGE_VERIFY_STEP_ID,
-        title: "Dev2merge Lifecycle Side-Effect Verification".to_string(),
-        exit_code: 1,
-        duration_secs: 0.0,
-        skipped: false,
-        error: Some(error.clone()),
-        output: None,
-        session_id: None,
-        command: Some(
-            "post-run verifier: require Step 13-17 side effects or Step 0 already-resolved DEV2MERGE_SKIP=true"
-                .to_string(),
-        ),
-        stderr: Some(error),
-    };
-    let report = PlanFailureReport::from_results(
-        workflow_name,
-        workflow_path,
-        summary.clone(),
-        &[synthetic_result],
-        None,
-    );
-    PlanFailureError::new(summary, report)
-}
-
-fn dev2merge_completion_failure_report(
-    workflow_name: &str,
-    workflow_path: &Path,
-    failures: Vec<String>,
-) -> PlanFailureError {
-    let summary = "dev2merge publish side-effect verification failed".to_string();
-    let mut error = vec![
-        "ERROR: dev2merge publish side-effect verification failed after workflow steps reported success."
-            .to_string(),
-    ];
-    error.extend(failures);
-    error.push(
-        "Retry after resolving the named incomplete side effect; callers should use this structured result instead of hidden session transcripts."
-            .to_string(),
-    );
-    let error = error.join("\n");
-    let synthetic_result = StepResult {
-        step_id: DEV2MERGE_VERIFY_STEP_ID,
-        title: "Dev2merge Publish Side-Effect Verification".to_string(),
-        exit_code: 1,
-        duration_secs: 0.0,
-        skipped: false,
-        error: Some(error.clone()),
-        output: None,
-        session_id: None,
-        command: Some(
-            "post-run verifier: check Step 13-17 completion, PR_NUMBER, PR_BOT_DONE_MARKER, and gh PR state"
-                .to_string(),
-        ),
-        stderr: Some(error),
-    };
-    let report = PlanFailureReport::from_results(
-        workflow_name,
-        workflow_path,
-        summary.clone(),
-        &[synthetic_result],
-        None,
-    );
-    PlanFailureError::new(summary, report)
-}
-
-fn step_completed_successfully(
-    results: &[StepResult],
-    completed_steps: &[usize],
-    dev2merge_skip: bool,
-    step_id: usize,
-) -> bool {
-    if let Some(result) = results.iter().find(|result| result.step_id == step_id) {
-        return !result.skipped && result.exit_code == 0;
-    }
-    !dev2merge_skip && completed_steps.contains(&step_id)
-}
-
-fn already_resolved_step_declared_skip(results: &[StepResult]) -> bool {
-    results.iter().any(|result| {
-        result.step_id == DEV2MERGE_ALREADY_RESOLVED_STEP_ID
-            && !result.skipped
-            && result.exit_code == 0
-            && result.output.as_deref().is_some_and(|output| {
-                output
-                    .lines()
-                    .any(|line| line.trim() == "CSA_VAR:DEV2MERGE_SKIP=true")
-            })
-    })
-}
-
-fn truthy(value: Option<&String>) -> bool {
-    value
-        .map(|value| {
-            let lower = value.trim().to_ascii_lowercase();
-            !lower.is_empty() && lower != "false" && lower != "0"
-        })
-        .unwrap_or(false)
-}
-
-fn non_empty_var(vars: &HashMap<String, String>, key: &str) -> Option<String> {
-    vars.get(key)
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-}
-
-fn resolve_observed_path(project_root: &Path, path: &Path) -> PathBuf {
-    if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        project_root.join(path)
-    }
-}
-
-fn git_stdout(project_root: &Path, args: &[&str]) -> Result<String> {
-    command_stdout(project_root, "git", args).map_err(anyhow::Error::msg)
-}
-
-fn command_stdout(project_root: &Path, program: &str, args: &[&str]) -> Result<String, String> {
-    let output = Command::new(program)
-        .args(args)
-        .current_dir(project_root)
-        .output()
-        .map_err(|error| format!("{program} {} failed to start: {error}", args.join(" ")))?;
-    if output.status.success() {
-        return Ok(String::from_utf8_lossy(&output.stdout).to_string());
-    }
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let detail = if stderr.is_empty() { stdout } else { stderr };
-    Err(format!(
-        "{program} {} exited {}{}",
-        args.join(" "),
-        output.status.code().unwrap_or(1),
-        if detail.is_empty() {
-            String::new()
-        } else {
-            format!(": {detail}")
-        }
-    ))
+    Ok(None)
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/plan_cmd_completion_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_completion_tests.rs
@@ -11,8 +11,15 @@ fn completed_facts() -> Dev2MergeCompletionFacts {
         pr_bot_completed: true,
         post_merge_sync_completed: true,
         branch: Some("fix/issue".to_string()),
+        default_branch: Some("main".to_string()),
+        issue_number: None,
         pr_number: Some("42".to_string()),
         pr_bot_done_marker: Some(PathBuf::from("/tmp/pr-bot.done")),
+        review_completed: true,
+        review_verdict_checked: true,
+        pushed: true,
+        already_resolved_message: None,
+        initial_head: Some("0000000000000000000000000000000000000000".to_string()),
     }
 }
 
@@ -26,6 +33,7 @@ fn verify_dev2merge_completion_without_publish_steps_returns_structured_failure_
     let completed_steps = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     let snapshot = PlanCompletionSnapshot {
         initial_branch: Some("fix/issue".to_string()),
+        initial_head: None,
     };
 
     let err = verify_plan_completion(PlanCompletionInput {
@@ -80,6 +88,7 @@ fn verify_dev2merge_completion_allows_already_resolved_skip_from_step_zero() {
     }];
     let snapshot = PlanCompletionSnapshot {
         initial_branch: Some("fix/issue".to_string()),
+        initial_head: None,
     };
 
     let summary = verify_plan_completion(PlanCompletionInput {
@@ -95,7 +104,8 @@ fn verify_dev2merge_completion_allows_already_resolved_skip_from_step_zero() {
     .expect("already-resolved skip should produce completion context");
 
     assert!(
-        summary.contains("already-resolved check declared an explicit no-op"),
+        summary.contains("already-resolved no-op")
+            && summary.contains("state=dev2merge: issue is already CLOSED"),
         "summary should distinguish explicit no-op from transport success: {summary}"
     );
 }
@@ -107,6 +117,14 @@ fn dev2merge_completion_passes_when_publish_side_effects_are_complete() {
         pr_bot_marker_exists: Some(true),
         pr_state: Some("MERGED".to_string()),
         pr_state_error: None,
+        current_branch: Some("main".to_string()),
+        current_head: Some("1111111111111111111111111111111111111111".to_string()),
+        branch_head: Some("2222222222222222222222222222222222222222".to_string()),
+        branch_moved: Some(true),
+        implementation_commits_ahead: Some(2),
+        implementation_commits_created: Some(1),
+        implementation_diff_paths: Some(3),
+        implementation_diff_empty: Some(false),
     };
 
     let failures = evaluate_dev2merge_completion(&facts, &observed);
@@ -125,6 +143,14 @@ fn dev2merge_completion_fails_when_pr_was_not_captured() {
         pr_bot_marker_exists: Some(true),
         pr_state: None,
         pr_state_error: None,
+        current_branch: None,
+        current_head: None,
+        branch_head: None,
+        branch_moved: None,
+        implementation_commits_ahead: None,
+        implementation_commits_created: None,
+        implementation_diff_paths: None,
+        implementation_diff_empty: None,
     };
 
     let failures = evaluate_dev2merge_completion(&facts, &observed);
@@ -144,6 +170,14 @@ fn dev2merge_completion_fails_when_pr_is_not_merged() {
         pr_bot_marker_exists: Some(true),
         pr_state: Some("OPEN".to_string()),
         pr_state_error: None,
+        current_branch: None,
+        current_head: None,
+        branch_head: None,
+        branch_moved: None,
+        implementation_commits_ahead: None,
+        implementation_commits_created: None,
+        implementation_diff_paths: None,
+        implementation_diff_empty: None,
     };
 
     let failures = evaluate_dev2merge_completion(&facts, &observed);
@@ -163,6 +197,14 @@ fn dev2merge_completion_fails_when_pr_bot_marker_is_missing() {
         pr_bot_marker_exists: Some(false),
         pr_state: Some("MERGED".to_string()),
         pr_state_error: None,
+        current_branch: None,
+        current_head: None,
+        branch_head: None,
+        branch_moved: None,
+        implementation_commits_ahead: None,
+        implementation_commits_created: None,
+        implementation_diff_paths: None,
+        implementation_diff_empty: None,
     };
 
     let failures = evaluate_dev2merge_completion(&facts, &observed);
@@ -183,6 +225,14 @@ fn dev2merge_completion_fails_when_publish_step_was_skipped() {
         pr_bot_marker_exists: Some(true),
         pr_state: Some("MERGED".to_string()),
         pr_state_error: None,
+        current_branch: None,
+        current_head: None,
+        branch_head: None,
+        branch_moved: None,
+        implementation_commits_ahead: None,
+        implementation_commits_created: None,
+        implementation_diff_paths: None,
+        implementation_diff_empty: None,
     };
 
     let failures = evaluate_dev2merge_completion(&facts, &observed);
@@ -192,6 +242,83 @@ fn dev2merge_completion_fails_when_publish_step_was_skipped() {
             .iter()
             .any(|failure| failure.contains("Push Gate (Step 13) did not complete")),
         "skipped publish step must be named: {failures:?}"
+    );
+}
+
+#[test]
+fn dev2merge_success_summary_names_side_effects_and_next_action() {
+    let facts = completed_facts();
+    let observed = Dev2MergeObservedState {
+        pr_bot_marker_exists: Some(true),
+        pr_state: Some("MERGED".to_string()),
+        pr_state_error: None,
+        current_branch: Some("main".to_string()),
+        current_head: Some("1111111111111111111111111111111111111111".to_string()),
+        branch_head: Some("2222222222222222222222222222222222222222".to_string()),
+        branch_moved: Some(true),
+        implementation_commits_ahead: Some(0),
+        implementation_commits_created: Some(1),
+        implementation_diff_paths: Some(0),
+        implementation_diff_empty: Some(true),
+    };
+
+    let summary = dev2merge_success_summary(&facts, &observed);
+
+    for required in [
+        "dev2merge side effects verified",
+        "branch=fix/issue",
+        "checkout=main",
+        "branch_moved=true",
+        "implementation_commits_created=1",
+        "review_completed=true",
+        "review_verdict_checked=true",
+        "pushed=true",
+        "pr=#42 state=MERGED",
+        "pr_bot_marker=present",
+        "next=none",
+    ] {
+        assert!(
+            summary.contains(required),
+            "success summary must include {required}: {summary}"
+        );
+    }
+}
+
+#[test]
+fn dev2merge_completion_fails_empty_diff_without_side_effect() {
+    let mut facts = completed_facts();
+    facts.pr_number = None;
+    facts.pr_bot_done_marker = None;
+    facts.review_completed = true;
+    facts.review_verdict_checked = true;
+    facts.pushed = false;
+    let observed = Dev2MergeObservedState {
+        pr_bot_marker_exists: None,
+        pr_state: None,
+        pr_state_error: None,
+        current_branch: Some("fix/issue".to_string()),
+        current_head: Some("1111111111111111111111111111111111111111".to_string()),
+        branch_head: Some("1111111111111111111111111111111111111111".to_string()),
+        branch_moved: Some(false),
+        implementation_commits_ahead: Some(0),
+        implementation_commits_created: Some(0),
+        implementation_diff_paths: Some(0),
+        implementation_diff_empty: Some(true),
+    };
+
+    let failures = evaluate_dev2merge_completion(&facts, &observed);
+
+    assert!(
+        failures
+            .iter()
+            .any(|failure| failure.contains("no dev2merge side effect was observed")),
+        "empty no-op must fail with missing side-effect detail: {failures:?}"
+    );
+    assert!(
+        failures
+            .iter()
+            .any(|failure| failure.contains("cumulative diff main...fix/issue is empty")),
+        "empty diff must be named explicitly: {failures:?}"
     );
 }
 
@@ -271,6 +398,7 @@ fn verify_dev2merge_completion_missing_pr_returns_structured_failure_report() {
     let completed_steps = vec![13, 14, 15, 16, 17];
     let snapshot = PlanCompletionSnapshot {
         initial_branch: Some("fix/issue".to_string()),
+        initial_head: None,
     };
 
     let err = verify_plan_completion(PlanCompletionInput {

--- a/crates/cli-sub-agent/src/plan_cmd_dev2merge_completion.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_dev2merge_completion.rs
@@ -1,0 +1,599 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::Result;
+
+use super::{PlanCompletionInput, PlanCompletionSnapshot};
+use crate::plan_cmd::StepResult;
+use crate::plan_cmd::plan_cmd_failure::{PlanFailureError, PlanFailureReport};
+
+pub(super) const DEV2MERGE_WORKFLOW_NAME: &str = "dev2merge";
+const DEV2MERGE_VERIFY_STEP_ID: usize = 18;
+const DEV2MERGE_ALREADY_RESOLVED_STEP_ID: usize = 0;
+const DEV2MERGE_PUBLISH_STEPS: [usize; 5] = [13, 14, 15, 16, 17];
+
+pub(super) fn capture_snapshot(workflow_name: &str, project_root: &Path) -> PlanCompletionSnapshot {
+    if workflow_name != DEV2MERGE_WORKFLOW_NAME {
+        return PlanCompletionSnapshot::default();
+    }
+    PlanCompletionSnapshot {
+        initial_branch: git_trimmed(project_root, &["branch", "--show-current"])
+            .filter(|value| value != "HEAD"),
+        initial_head: git_trimmed(project_root, &["rev-parse", "--verify", "HEAD"]),
+    }
+}
+
+pub(super) fn verify_plan_completion(
+    input: PlanCompletionInput<'_>,
+) -> std::result::Result<Option<String>, Box<PlanFailureError>> {
+    let facts = Dev2MergeCompletionFacts::from_input(&input);
+    if !facts.publish_started {
+        if facts.already_resolved_skip {
+            return Ok(Some(dev2merge_already_resolved_summary(&facts)));
+        }
+        return Err(Box::new(dev2merge_lifecycle_not_started_failure_report(
+            input.workflow_name,
+            input.workflow_path,
+            &facts,
+        )));
+    }
+
+    let observed = observe_dev2merge_state(input.project_root, &facts);
+    let failures = evaluate_dev2merge_completion(&facts, &observed);
+    if failures.is_empty() {
+        return Ok(Some(dev2merge_success_summary(&facts, &observed)));
+    }
+
+    Err(Box::new(dev2merge_completion_failure_report(
+        input.workflow_name,
+        input.workflow_path,
+        failures,
+    )))
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct Dev2MergeCompletionFacts {
+    pub(super) dev2merge_skip: bool,
+    pub(super) already_resolved_skip: bool,
+    pub(super) publish_started: bool,
+    pub(super) push_gate_completed: bool,
+    pub(super) review_verdict_completed: bool,
+    pub(super) pr_completed: bool,
+    pub(super) pr_bot_completed: bool,
+    pub(super) post_merge_sync_completed: bool,
+    pub(super) branch: Option<String>,
+    pub(super) default_branch: Option<String>,
+    pub(super) issue_number: Option<String>,
+    pub(super) pr_number: Option<String>,
+    pub(super) pr_bot_done_marker: Option<PathBuf>,
+    pub(super) review_completed: bool,
+    pub(super) review_verdict_checked: bool,
+    pub(super) pushed: bool,
+    pub(super) already_resolved_message: Option<String>,
+    pub(super) initial_head: Option<String>,
+}
+
+impl Dev2MergeCompletionFacts {
+    fn from_input(input: &PlanCompletionInput<'_>) -> Self {
+        let dev2merge_skip = truthy(input.vars.get("DEV2MERGE_SKIP"));
+        let already_resolved_skip =
+            dev2merge_skip && already_resolved_step_declared_skip(input.results);
+        let step_completed = |step_id| {
+            step_completed_successfully(
+                input.results,
+                input.completed_steps,
+                dev2merge_skip,
+                step_id,
+            )
+        };
+        let branch = input
+            .snapshot
+            .initial_branch
+            .clone()
+            .or_else(|| non_empty_var(input.vars, "WORKFLOW_BRANCH"))
+            .or_else(|| non_empty_var(input.vars, "BRANCH"));
+        Self {
+            dev2merge_skip,
+            already_resolved_skip,
+            publish_started: DEV2MERGE_PUBLISH_STEPS.into_iter().any(&step_completed),
+            push_gate_completed: step_completed(13),
+            review_verdict_completed: step_completed(14),
+            pr_completed: step_completed(15),
+            pr_bot_completed: step_completed(16),
+            post_merge_sync_completed: step_completed(17),
+            branch,
+            default_branch: non_empty_var(input.vars, "DEFAULT_BRANCH"),
+            issue_number: numeric_var(input.vars, "ISSUE_NUMBER"),
+            pr_number: numeric_var(input.vars, "PR_NUMBER"),
+            pr_bot_done_marker: non_empty_var(input.vars, "PR_BOT_DONE_MARKER").map(PathBuf::from),
+            review_completed: truthy(input.vars.get("REVIEW_COMPLETED")),
+            review_verdict_checked: truthy(input.vars.get("REVIEW_VERDICT_CHECKED")),
+            pushed: truthy(input.vars.get("PUSHED")),
+            already_resolved_message: already_resolved_skip_message(input.results),
+            initial_head: input.snapshot.initial_head.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct Dev2MergeObservedState {
+    pub(super) pr_bot_marker_exists: Option<bool>,
+    pub(super) pr_state: Option<String>,
+    pub(super) pr_state_error: Option<String>,
+    pub(super) current_branch: Option<String>,
+    pub(super) current_head: Option<String>,
+    pub(super) branch_head: Option<String>,
+    pub(super) branch_moved: Option<bool>,
+    pub(super) implementation_commits_ahead: Option<usize>,
+    pub(super) implementation_commits_created: Option<usize>,
+    pub(super) implementation_diff_paths: Option<usize>,
+    pub(super) implementation_diff_empty: Option<bool>,
+}
+
+fn observe_dev2merge_state(
+    project_root: &Path,
+    facts: &Dev2MergeCompletionFacts,
+) -> Dev2MergeObservedState {
+    let pr_bot_marker_exists = facts
+        .pr_bot_done_marker
+        .as_ref()
+        .map(|path| resolve_observed_path(project_root, path).is_file());
+    let (pr_state, pr_state_error) = match facts.pr_number.as_deref() {
+        Some(pr_number) => match command_stdout(
+            project_root,
+            "gh",
+            &["pr", "view", pr_number, "--json", "state", "-q", ".state"],
+        ) {
+            Ok(value) => (Some(value.trim().to_string()), None),
+            Err(error) => (None, Some(error)),
+        },
+        None => (None, None),
+    };
+    let current_branch =
+        git_trimmed(project_root, &["branch", "--show-current"]).filter(|value| value != "HEAD");
+    let current_head = git_trimmed(project_root, &["rev-parse", "--verify", "HEAD"]);
+    let branch_head = facts
+        .branch
+        .as_deref()
+        .and_then(|branch| git_trimmed(project_root, &["rev-parse", "--verify", branch]));
+    let branch_moved = facts
+        .initial_head
+        .as_deref()
+        .zip(branch_head.as_deref())
+        .map(|(initial, branch)| initial != branch);
+    let implementation_commits_created = facts
+        .initial_head
+        .as_deref()
+        .zip(facts.branch.as_deref())
+        .and_then(|(initial_head, branch)| {
+            git_count(project_root, &format!("{initial_head}..{branch}"))
+        });
+    let implementation_commits_ahead = facts
+        .default_branch
+        .as_deref()
+        .zip(facts.branch.as_deref())
+        .and_then(|(default_branch, branch)| {
+            git_count(project_root, &format!("{default_branch}..{branch}"))
+        });
+    let implementation_diff_paths = facts
+        .default_branch
+        .as_deref()
+        .zip(facts.branch.as_deref())
+        .and_then(|(default_branch, branch)| {
+            git_stdout(
+                project_root,
+                &[
+                    "diff",
+                    "--name-only",
+                    &format!("{default_branch}...{branch}"),
+                ],
+            )
+            .ok()
+            .map(|value| value.lines().filter(|line| !line.trim().is_empty()).count())
+        });
+    Dev2MergeObservedState {
+        pr_bot_marker_exists,
+        pr_state,
+        pr_state_error,
+        current_branch,
+        current_head,
+        branch_head,
+        branch_moved,
+        implementation_commits_ahead,
+        implementation_commits_created,
+        implementation_diff_empty: implementation_diff_paths.map(|count| count == 0),
+        implementation_diff_paths,
+    }
+}
+
+pub(super) fn evaluate_dev2merge_completion(
+    facts: &Dev2MergeCompletionFacts,
+    observed: &Dev2MergeObservedState,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    if !facts.push_gate_completed {
+        failures.push(
+            "ERROR: Push Gate (Step 13) did not complete; branch publication is incomplete."
+                .to_string(),
+        );
+    }
+    if !facts.review_verdict_completed {
+        failures.push("ERROR: Pre-PR Review Verdict Check (Step 14) did not complete.".to_string());
+    }
+    if !facts.pr_completed {
+        failures
+            .push("ERROR: Create or Reuse Pull Request (Step 15) did not complete.".to_string());
+    }
+    if !facts.pr_bot_completed {
+        failures.push("ERROR: pr-bot Review & Merge Gate (Step 16) did not complete.".to_string());
+    }
+    if !facts.post_merge_sync_completed {
+        failures.push("ERROR: Post-Merge Local Sync (Step 17) did not complete.".to_string());
+    }
+    match facts.pr_number.as_deref() {
+        Some(_) => {}
+        None => failures.push(
+            "ERROR: PR_NUMBER was not captured; PR creation/reuse is incomplete.".to_string(),
+        ),
+    }
+    match (&facts.pr_bot_done_marker, observed.pr_bot_marker_exists) {
+        (Some(path), Some(false)) => failures.push(format!(
+            "ERROR: pr-bot completion marker is missing: {}.",
+            path.display()
+        )),
+        (None, _) => failures.push(
+            "ERROR: PR_BOT_DONE_MARKER was not captured; pr-bot completion is unverified."
+                .to_string(),
+        ),
+        (Some(path), None) => failures.push(format!(
+            "ERROR: pr-bot completion marker could not be inspected: {}.",
+            path.display()
+        )),
+        (Some(_), Some(true)) => {}
+    }
+    if let Some(error) = &observed.pr_state_error {
+        failures.push(format!(
+            "ERROR: failed to inspect PR state via gh: {error}."
+        ));
+    } else if facts.pr_number.is_some() {
+        match observed.pr_state.as_deref() {
+            Some("MERGED") => {}
+            Some("") => {
+                failures.push("ERROR: PR state is empty; expected MERGED after pr-bot.".to_string())
+            }
+            Some(state) => failures.push(format!(
+                "ERROR: PR state is {state}; expected MERGED after pr-bot."
+            )),
+            None => failures.push(
+                "ERROR: PR state was not observed; expected MERGED after pr-bot.".to_string(),
+            ),
+        }
+    }
+    if !dev2merge_observed_side_effect(facts, observed) {
+        failures.push(
+            "ERROR: no dev2merge side effect was observed: branch did not move, no implementation commit was detected, no PR/merge side effect was verified, and no closed-issue no-op was recorded."
+                .to_string(),
+        );
+    }
+    if observed.implementation_diff_empty == Some(true)
+        && !dev2merge_publish_side_effect_verified(facts, observed)
+    {
+        failures.push(format!(
+            "ERROR: cumulative diff {}...{} is empty and no PR/issue/merge side effect was verified.",
+            facts.default_branch.as_deref().unwrap_or("main"),
+            facts.branch.as_deref().unwrap_or("HEAD"),
+        ));
+    }
+    failures
+}
+
+fn dev2merge_observed_side_effect(
+    facts: &Dev2MergeCompletionFacts,
+    observed: &Dev2MergeObservedState,
+) -> bool {
+    observed.branch_moved == Some(true)
+        || observed
+            .implementation_commits_created
+            .is_some_and(|count| count > 0)
+        || observed
+            .implementation_commits_ahead
+            .is_some_and(|count| count > 0)
+        || dev2merge_publish_side_effect_verified(facts, observed)
+        || facts.already_resolved_skip
+}
+
+fn dev2merge_publish_side_effect_verified(
+    facts: &Dev2MergeCompletionFacts,
+    observed: &Dev2MergeObservedState,
+) -> bool {
+    facts.pr_number.is_some()
+        && observed.pr_state.as_deref() == Some("MERGED")
+        && observed.pr_bot_marker_exists == Some(true)
+}
+
+fn dev2merge_already_resolved_summary(facts: &Dev2MergeCompletionFacts) -> String {
+    let mut parts = vec!["dev2merge: already-resolved no-op".to_string()];
+    if let Some(branch) = &facts.branch {
+        parts.push(format!("branch={branch}"));
+    }
+    if let Some(issue) = &facts.issue_number {
+        parts.push(format!("issue=#{issue}"));
+    }
+    if let Some(message) = &facts.already_resolved_message {
+        parts.push(format!("state={}", compact_summary_fragment(message)));
+    }
+    parts.push("next=none".to_string());
+    parts.join("; ")
+}
+
+pub(super) fn dev2merge_success_summary(
+    facts: &Dev2MergeCompletionFacts,
+    observed: &Dev2MergeObservedState,
+) -> String {
+    let mut parts = vec!["dev2merge side effects verified".to_string()];
+    if let Some(branch) = &facts.branch {
+        parts.push(format!("branch={branch}"));
+    }
+    if let Some(current_branch) = &observed.current_branch {
+        parts.push(format!("checkout={current_branch}"));
+    }
+    if let Some(head_moved) = observed.branch_moved {
+        parts.push(format!("branch_moved={head_moved}"));
+    }
+    if let Some(count) = observed.implementation_commits_ahead {
+        parts.push(format!("implementation_commits_ahead={count}"));
+    }
+    if let Some(count) = observed.implementation_commits_created {
+        parts.push(format!("implementation_commits_created={count}"));
+    }
+    if let Some(paths) = observed.implementation_diff_paths {
+        parts.push(format!("diff_paths={paths}"));
+    }
+    if let Some(current_head) = observed.current_head.as_deref().map(short_sha) {
+        parts.push(format!("current_head={current_head}"));
+    }
+    if let Some(branch_head) = observed.branch_head.as_deref().map(short_sha) {
+        parts.push(format!("branch_head={branch_head}"));
+    }
+    parts.push(format!("review_completed={}", facts.review_completed));
+    parts.push(format!(
+        "review_verdict_checked={}",
+        facts.review_verdict_checked
+    ));
+    parts.push(format!("pushed={}", facts.pushed));
+    if let Some(pr_number) = &facts.pr_number {
+        parts.push(format!(
+            "pr=#{pr_number} state={}",
+            observed.pr_state.as_deref().unwrap_or("unknown")
+        ));
+    } else {
+        parts.push("pr=none".to_string());
+    }
+    parts.push(match observed.pr_bot_marker_exists {
+        Some(true) => "pr_bot_marker=present".to_string(),
+        Some(false) => "pr_bot_marker=missing".to_string(),
+        None => "pr_bot_marker=unknown".to_string(),
+    });
+    parts.push("next=none".to_string());
+    parts.join("; ")
+}
+
+fn dev2merge_lifecycle_not_started_failure_report(
+    workflow_name: &str,
+    workflow_path: &Path,
+    facts: &Dev2MergeCompletionFacts,
+) -> PlanFailureError {
+    let summary = "dev2merge lifecycle side-effect verification failed: publish gate never started"
+        .to_string();
+    let mut error = vec![
+        "ERROR: dev2merge lifecycle side-effect verification failed after workflow steps reported success."
+            .to_string(),
+        "ERROR: Publish Gate (Step 13) did not run; branch publication, PR creation, pr-bot merge, and post-merge sync were not attempted."
+            .to_string(),
+    ];
+    if facts.dev2merge_skip {
+        error.push(
+            "ERROR: DEV2MERGE_SKIP was true, but the Already-Resolved Check (Step 0) did not declare the skip in this run.".to_string(),
+        );
+    } else {
+        error.push(
+            "ERROR: DEV2MERGE_SKIP was not set by the Already-Resolved Check; terminal success would be transport-only.".to_string(),
+        );
+    }
+    error.push(
+        "Retry dev2merge from the current branch, or resume the journal if a manual handoff was expected; callers should treat this structured result as a missing lifecycle gate."
+            .to_string(),
+    );
+    synthetic_failure(
+        workflow_name,
+        workflow_path,
+        summary,
+        "Dev2merge Lifecycle Side-Effect Verification",
+        "post-run verifier: require Step 13-17 side effects or Step 0 already-resolved DEV2MERGE_SKIP=true",
+        error,
+    )
+}
+
+fn dev2merge_completion_failure_report(
+    workflow_name: &str,
+    workflow_path: &Path,
+    failures: Vec<String>,
+) -> PlanFailureError {
+    let summary = "dev2merge publish side-effect verification failed".to_string();
+    let mut error = vec![
+        "ERROR: dev2merge publish side-effect verification failed after workflow steps reported success."
+            .to_string(),
+    ];
+    error.extend(failures);
+    error.push(
+        "Retry after resolving the named incomplete side effect; callers should use this structured result instead of hidden session transcripts."
+            .to_string(),
+    );
+    synthetic_failure(
+        workflow_name,
+        workflow_path,
+        summary,
+        "Dev2merge Publish Side-Effect Verification",
+        "post-run verifier: check Step 13-17 completion, PR_NUMBER, PR_BOT_DONE_MARKER, and gh PR state",
+        error,
+    )
+}
+
+fn synthetic_failure(
+    workflow_name: &str,
+    workflow_path: &Path,
+    summary: String,
+    title: &str,
+    command: &str,
+    error: Vec<String>,
+) -> PlanFailureError {
+    let error = error.join("\n");
+    let synthetic_result = StepResult {
+        step_id: DEV2MERGE_VERIFY_STEP_ID,
+        title: title.to_string(),
+        exit_code: 1,
+        duration_secs: 0.0,
+        skipped: false,
+        error: Some(error.clone()),
+        output: None,
+        session_id: None,
+        command: Some(command.to_string()),
+        stderr: Some(error),
+    };
+    let report = PlanFailureReport::from_results(
+        workflow_name,
+        workflow_path,
+        summary.clone(),
+        &[synthetic_result],
+        None,
+    );
+    PlanFailureError::new(summary, report)
+}
+
+pub(super) fn step_completed_successfully(
+    results: &[StepResult],
+    completed_steps: &[usize],
+    dev2merge_skip: bool,
+    step_id: usize,
+) -> bool {
+    if let Some(result) = results.iter().find(|result| result.step_id == step_id) {
+        return !result.skipped && result.exit_code == 0;
+    }
+    !dev2merge_skip && completed_steps.contains(&step_id)
+}
+
+fn already_resolved_step_declared_skip(results: &[StepResult]) -> bool {
+    already_resolved_skip_message(results).is_some()
+}
+
+fn already_resolved_skip_message(results: &[StepResult]) -> Option<String> {
+    results.iter().find_map(|result| {
+        if result.step_id != DEV2MERGE_ALREADY_RESOLVED_STEP_ID
+            || result.skipped
+            || result.exit_code != 0
+        {
+            return None;
+        }
+        result.output.as_deref().and_then(|output| {
+            output
+                .lines()
+                .any(|line| line.trim() == "CSA_VAR:DEV2MERGE_SKIP=true")
+                .then(|| {
+                    output
+                        .lines()
+                        .map(str::trim)
+                        .find(|line| {
+                            !line.is_empty()
+                                && !line.starts_with("CSA_VAR:")
+                                && line.starts_with("dev2merge:")
+                        })
+                        .unwrap_or("already-resolved no-op")
+                        .to_string()
+                })
+        })
+    })
+}
+
+fn truthy(value: Option<&String>) -> bool {
+    value
+        .map(|value| {
+            let lower = value.trim().to_ascii_lowercase();
+            !lower.is_empty() && lower != "false" && lower != "0"
+        })
+        .unwrap_or(false)
+}
+
+fn numeric_var(vars: &HashMap<String, String>, key: &str) -> Option<String> {
+    non_empty_var(vars, key).filter(|value| value.chars().all(|ch| ch.is_ascii_digit()))
+}
+
+fn non_empty_var(vars: &HashMap<String, String>, key: &str) -> Option<String> {
+    vars.get(key)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn resolve_observed_path(project_root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        project_root.join(path)
+    }
+}
+
+fn git_trimmed(project_root: &Path, args: &[&str]) -> Option<String> {
+    git_stdout(project_root, args)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn git_stdout(project_root: &Path, args: &[&str]) -> Result<String> {
+    command_stdout(project_root, "git", args).map_err(anyhow::Error::msg)
+}
+
+fn git_count(project_root: &Path, rev_range: &str) -> Option<usize> {
+    git_stdout(project_root, &["rev-list", "--count", rev_range])
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+}
+
+fn command_stdout(project_root: &Path, program: &str, args: &[&str]) -> Result<String, String> {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(project_root)
+        .output()
+        .map_err(|error| format!("{program} {} failed to start: {error}", args.join(" ")))?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).to_string());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if stderr.is_empty() { stdout } else { stderr };
+    Err(format!(
+        "{program} {} exited {}{}",
+        args.join(" "),
+        output.status.code().unwrap_or(1),
+        if detail.is_empty() {
+            String::new()
+        } else {
+            format!(": {detail}")
+        }
+    ))
+}
+
+fn short_sha(value: &str) -> String {
+    value.chars().take(12).collect()
+}
+
+fn compact_summary_fragment(value: &str) -> String {
+    const MAX_CHARS: usize = 160;
+    let mut chars = value.chars();
+    let truncated: String = chars.by_ref().take(MAX_CHARS).collect();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}

--- a/crates/cli-sub-agent/src/plan_cmd_failure_detail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_detail.rs
@@ -83,11 +83,8 @@ fn select_todo_persist_failure_detail(lines: &[&str]) -> Option<String> {
         .copied()
         .find(|line| is_todo_persist_wrapper(line))?;
 
-    let diagnostic = lines
-        .iter()
-        .rev()
-        .copied()
-        .find(|line| is_todo_persist_diagnostic(line));
+    let diagnostic = select_todo_validation_diagnostic_line(lines)
+        .filter(|line| is_todo_persist_diagnostic(line));
 
     let mut parts = Vec::new();
     if let Some(diagnostic) = diagnostic {
@@ -101,23 +98,58 @@ fn select_todo_persist_failure_detail(lines: &[&str]) -> Option<String> {
             parts.push(line);
         }
     }
+    for line in todo_recovery_action_lines(lines) {
+        if !parts.contains(&line) {
+            parts.push(line);
+        }
+    }
 
     Some(truncate_failure_detail(&parts.join(" | ")))
 }
 
 fn select_todo_validation_failure_detail(lines: &[&str]) -> Option<String> {
-    let diagnostic = lines
-        .iter()
-        .rev()
-        .copied()
-        .find(|line| is_todo_validation_diagnostic(line))?;
+    let diagnostic = select_todo_validation_diagnostic_line(lines)?;
     let mut parts = vec![diagnostic];
     for line in prioritized_todo_context_lines(lines) {
         if !parts.contains(&line) {
             parts.push(line);
         }
     }
+    for line in todo_recovery_action_lines(lines) {
+        if !parts.contains(&line) {
+            parts.push(line);
+        }
+    }
     Some(truncate_failure_detail(&parts.join(" | ")))
+}
+
+fn select_todo_validation_diagnostic_line<'a>(lines: &'a [&str]) -> Option<&'a str> {
+    lines
+        .iter()
+        .rev()
+        .copied()
+        .find(|line| is_todo_field_or_section_diagnostic(line))
+        .or_else(|| {
+            lines
+                .iter()
+                .rev()
+                .copied()
+                .find(|line| is_todo_validation_diagnostic(line) && !is_todo_recovery_action(line))
+        })
+        .or_else(|| {
+            lines
+                .iter()
+                .rev()
+                .copied()
+                .find(|line| is_todo_recovery_action(line))
+        })
+}
+
+fn todo_recovery_action_lines<'a>(lines: &'a [&str]) -> impl Iterator<Item = &'a str> {
+    lines
+        .iter()
+        .copied()
+        .filter(|line| is_todo_recovery_action(line))
 }
 
 fn prioritized_todo_context_lines<'a>(lines: &'a [&str]) -> Vec<&'a str> {
@@ -175,6 +207,22 @@ fn is_todo_persist_diagnostic(line: &str) -> bool {
     !is_todo_persist_wrapper(line) && is_todo_validation_diagnostic(line)
 }
 
+fn is_todo_field_or_section_diagnostic(line: &str) -> bool {
+    let normalized = line.to_ascii_lowercase();
+    normalized.contains("invalid field")
+        || normalized.contains("invalid section")
+        || normalized.contains("missing field")
+        || normalized.contains("missing section")
+        || normalized.contains("unknown field")
+        || normalized.contains("unknown section")
+        || normalized.contains("expected field")
+        || normalized.contains("expected section")
+}
+
+fn is_todo_recovery_action(line: &str) -> bool {
+    line.to_ascii_lowercase().contains("recovery action")
+}
+
 fn is_todo_validation_diagnostic(line: &str) -> bool {
     let normalized = line.to_ascii_lowercase();
     normalized.contains("failed to parse spec file")
@@ -191,6 +239,15 @@ fn is_todo_validation_diagnostic(line: &str) -> bool {
         || normalized.contains("spec plan_ulid")
         || normalized.contains("without a mechanically-verifiable")
         || normalized.contains("invalid criterion")
+        || normalized.contains("invalid field")
+        || normalized.contains("invalid section")
+        || normalized.contains("missing field")
+        || normalized.contains("missing section")
+        || normalized.contains("unknown field")
+        || normalized.contains("unknown section")
+        || normalized.contains("expected field")
+        || normalized.contains("expected section")
+        || normalized.contains("recovery action")
         || normalized.contains("no non-empty checkbox tasks")
         || normalized.contains("summary lacks han")
         || normalized.contains("todo han chars")

--- a/crates/cli-sub-agent/src/plan_cmd_failure_recovery.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_recovery.rs
@@ -104,6 +104,11 @@ impl PlanFailureRecoverySnapshot {
             );
         };
         if !initial_status.is_empty() {
+            let pre_existing = initial_status
+                .iter()
+                .map(|line| line.trim_start())
+                .collect::<Vec<_>>()
+                .join("; ");
             return PlanFailureRecoveryReport::manual(
                 initial_ref_label.clone(),
                 current_ref_before,
@@ -112,6 +117,7 @@ impl PlanFailureRecoverySnapshot {
                         "Automatic recovery skipped because the worktree was already dirty before {} started.",
                         self.workflow_name
                     ),
+                    format!("Pre-existing dirty paths: {pre_existing}"),
                     format!(
                         "Resolve the pre-existing changes before retrying {}.",
                         self.workflow_name

--- a/crates/cli-sub-agent/src/plan_cmd_failure_recovery_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_recovery_tests.rs
@@ -121,6 +121,35 @@ fn dev2merge_recovery_snapshot_declares_weave_lock_drift() {
 }
 
 #[test]
+fn dev2merge_recovery_snapshot_names_pre_existing_dirty_paths() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let project_root = temp.path().join("repo");
+    init_recovery_test_repo(&project_root, true);
+    std::fs::write(project_root.join("README.md"), "dirty before workflow\n")
+        .expect("write pre-existing dirt");
+    let snapshot = capture_failure_recovery_snapshot("dev2merge", &project_root)
+        .expect("dev2merge should capture a failure recovery snapshot");
+
+    std::fs::write(project_root.join(WEAVE_LOCK), "lock = 1\nplan drift\n")
+        .expect("write post-snapshot weave.lock change");
+
+    let recovery = snapshot.recover_after_failure(&project_root);
+    let mut rendered = String::new();
+    recovery.render_markdown_into(&mut rendered);
+
+    assert_eq!(recovery.status.as_str(), "manual-required");
+    assert!(
+        rendered.contains("worktree was already dirty before dev2merge started")
+            && rendered.contains("Pre-existing dirty paths: M README.md"),
+        "pre-existing user dirtiness must be distinguished from later workflow side effects: {rendered}"
+    );
+    assert!(
+        !rendered.contains("Preserved dirty weave.lock"),
+        "pre-existing dirt path should not be reported as workflow-introduced lockfile-only recovery: {rendered}"
+    );
+}
+
+#[test]
 fn recovery_ignores_untracked_plan_journal_after_snapshot() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let project_root = temp.path().join("repo");

--- a/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
@@ -244,6 +244,51 @@ fn failure_summary_surfaces_todo_persist_validation_detail() {
 }
 
 #[test]
+fn failure_summary_surfaces_mktd_invalid_field_recovery_action() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let workflow_path = temp.path().join("workflow.toml");
+    let results = vec![StepResult {
+        step_id: 7,
+        title: "Plan with mktd".to_string(),
+        exit_code: 1,
+        duration_secs: 0.0,
+        skipped: false,
+        error: Some("Exit code 1".to_string()),
+        output: None,
+        session_id: None,
+        command: Some("timeout -k 30 1800 csa plan run --sa-mode true --pattern mktd".to_string()),
+        stderr: Some(
+            [
+                "RECON validation failed",
+                "invalid field [spec.criteria.done_when]: expected non-empty string",
+                "recovery action: regenerate spec.toml with a mechanically-verifiable DONE WHEN",
+                "Spec artifact path: /tmp/mktd-save/spec.toml",
+            ]
+            .join("\n"),
+        ),
+    }];
+    let report = PlanFailureReport::from_results(
+        "dev2merge",
+        &workflow_path,
+        "1 step(s) failed".to_string(),
+        &results,
+        None,
+    );
+
+    let summary_line = report.summary_line("patterns/dev2merge/workflow.toml");
+    let summary_section = report.render_summary_section();
+
+    for rendered in [&summary_line, &summary_section] {
+        assert!(
+            rendered.contains("invalid field [spec.criteria.done_when]")
+                && rendered.contains("Spec artifact path: /tmp/mktd-save/spec.toml")
+                && rendered.contains("recovery action: regenerate spec.toml"),
+            "parent-visible mktd failure should name the invalid field, recovery action, and artifact path: {rendered}"
+        );
+    }
+}
+
+#[test]
 fn failure_summary_prefers_underlying_command_failure_over_spec_contract_noise() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let workflow_path = temp.path().join("workflow.toml");

--- a/crates/cli-sub-agent/src/plan_cmd_repo.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_repo.rs
@@ -1,0 +1,38 @@
+use std::path::Path;
+use std::process::Command;
+
+pub(crate) fn detect_effective_repo(project_root: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["config", "--get", "remote.origin.url"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+    let sanitized = if let Some(pos) = raw.find("://") {
+        let (scheme, rest) = raw.split_at(pos + 3);
+        rest.find('@')
+            .map(|at_pos| format!("{}{}", scheme, &rest[at_pos + 1..]))
+            .unwrap_or(raw)
+    } else {
+        raw
+    };
+
+    let trimmed = sanitized.trim_end_matches(".git");
+    for prefix in [
+        "git@github.com:",
+        "https://github.com/",
+        "ssh://git@github.com/",
+    ] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            return Some(rest.to_string());
+        }
+    }
+    Some(trimmed.to_string())
+}

--- a/crates/cli-sub-agent/src/plan_cmd_tests_dev2merge_2305.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_dev2merge_2305.rs
@@ -56,6 +56,11 @@ fn dev2merge_2305_changed_bash_blocks_stay_synced() {
 
     for (title, heading) in [
         (
+            "Cheap Repo Preconditions",
+            "## Step 3: Cheap Repo Preconditions",
+        ),
+        ("FAST_PATH Commit", "## Step 4: FAST_PATH Commit"),
+        (
             "FAST_PATH Version Bump",
             "## Step 5: FAST_PATH Version Bump",
         ),
@@ -64,6 +69,7 @@ fn dev2merge_2305_changed_bash_blocks_stay_synced() {
             "## Step 6: FAST_PATH Pre-PR Review",
         ),
         ("Plan with mktd", "## Step 7: Plan with mktd"),
+        ("Resume Commit", "## Step 9: Resume Commit"),
         ("Ensure Version Bumped", "## Step 10: Ensure Version Bumped"),
         (
             "Pre-PR Cumulative Review Gate",
@@ -80,6 +86,68 @@ fn dev2merge_2305_changed_bash_blocks_stay_synced() {
             "dev2merge PATTERN.md and workflow.toml {heading} bash blocks must stay synced"
         );
     }
+}
+
+#[test]
+fn dev2merge_cheap_preconditions_run_before_expensive_gates() {
+    let workflow =
+        std::fs::read_to_string(workspace_root().join("patterns/dev2merge/workflow.toml")).unwrap();
+    let plan = plan_from_toml(&workflow).unwrap();
+    let step_id = |title: &str| {
+        plan.steps
+            .iter()
+            .find(|step| step.title == title)
+            .unwrap_or_else(|| panic!("missing dev2merge step: {title}"))
+            .id
+    };
+
+    assert!(
+        step_id("FAST_PATH Version Bump") < step_id("FAST_PATH Pre-PR Review"),
+        "FAST_PATH version bump must run before build/review work"
+    );
+    assert!(
+        step_id("Ensure Version Bumped") < step_id("Self-Review Gate"),
+        "full/resume version bump must run before expensive self-review/review gates"
+    );
+
+    let cheap = dev2merge_workflow_step_bash("Cheap Repo Preconditions");
+    assert!(
+        cheap.contains("STAGED_FILES=")
+            && cheap.contains("staged-scope precondition failed")
+            && cheap.contains("check-version-bumped"),
+        "cheap precondition step must cover staged scope and version detection: {cheap}"
+    );
+    for forbidden in ["just clippy", "just test", "csa review", "cargo build"] {
+        assert!(
+            !cheap.contains(forbidden),
+            "cheap precondition step must not run expensive gate {forbidden}: {cheap}"
+        );
+    }
+
+    let fast_commit = dev2merge_workflow_step_bash("FAST_PATH Commit");
+    assert!(
+        fast_commit.contains("git diff --cached --check"),
+        "FAST_PATH commit must run staged-scope checks before downstream gates"
+    );
+    assert!(
+        !fast_commit.contains("just test"),
+        "FAST_PATH commit must stay cheap; tests move to Step 6 after version bump"
+    );
+
+    let fast_review = dev2merge_workflow_step_bash("FAST_PATH Pre-PR Review");
+    let version_gate = step_id("FAST_PATH Version Bump");
+    let review_gate = step_id("FAST_PATH Pre-PR Review");
+    assert!(version_gate < review_gate);
+    let clippy_index = fast_review
+        .find("just clippy")
+        .expect("FAST_PATH review step should run L1 gate before review");
+    let review_index = fast_review
+        .find("cumulative-review-batch.sh")
+        .expect("FAST_PATH review step should run cumulative review");
+    assert!(
+        clippy_index < review_index,
+        "FAST_PATH L1/L2 gates must execute before cumulative review"
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -456,6 +456,9 @@ fn check_session_stale_before_wait(
                 {
                     return Ok(());
                 }
+                if csa_process::ToolLiveness::is_alive(session_dir) {
+                    return Ok(());
+                }
                 match csa_session::load_result(project_root, session_id) {
                     Ok(Some(_)) => return Ok(()),
                     Err(_) => return Ok(()), // result file exists but unparseable

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -124,18 +124,29 @@ pub(crate) fn handle_session_wait_with_emitters(
         .filter(|limit| *limit > 0);
     let mut next_memory_sample_at =
         memory_warn_mb.map(|_| start + wait_options.behavior.timing.memory_sample_interval);
+    let handoff_blocks_initial_stale_precheck = resume_handoff_blocks_target_reconcile(
+        wait_target.follows_resume_target,
+        &session_dir,
+        &wait_target.session_dir,
+    );
 
     // Check if the session is Stale before entering the polling loop.
     // This prevents indefinite polling of sessions that have no live daemon process
     // and no progress for an extended period.
-    if let Err(stale_err) = super::check_session_stale_before_wait(
-        effective_root,
-        &wait_target.session_id,
-        &wait_target.session_dir,
-        wait_options.behavior,
-        worktree_lock_root.as_deref(),
-        &[resolved.session_id.as_str(), &wait_target.session_id],
-    ) {
+    //
+    // A resume wrapper may write resume-target.toml before the target session has
+    // target-local liveness. While the wrapper daemon is still alive, its process
+    // owns that bootstrap window, so target-local silence is not stale yet.
+    if !handoff_blocks_initial_stale_precheck
+        && let Err(stale_err) = super::check_session_stale_before_wait(
+            effective_root,
+            &wait_target.session_id,
+            &wait_target.session_dir,
+            wait_options.behavior,
+            worktree_lock_root.as_deref(),
+            &[resolved.session_id.as_str(), &wait_target.session_id],
+        )
+    {
         if !crate::session_observability::emit_session_registry_state_loss_diagnostic(
             effective_root,
             &wait_target.session_id,

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -201,37 +201,29 @@ else
 fi
 ```
 
-## Step 3: L1/L2 Quality Gates (Always Run)
+## Step 3: Cheap Repo Preconditions
 Tool: bash
 OnFail: abort
-Formatters and linters run regardless of FAST_PATH.
-Language detection: Cargo.toml → Rust, pyproject.toml → Python, package.json → JS/TS, go.mod → Go.
-Falls back to `just pre-commit` when available, skip otherwise.
-
+Cheap repo-local checks run before any cargo build, test, or review gate: staged-scope ownership and optional version-bump detection.
 ```bash
 set -euo pipefail
-if [ -f Cargo.toml ]; then
-  just fmt
-  just clippy
-elif [ -f pyproject.toml ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "lint"; then just lint
-  elif command -v ruff >/dev/null 2>&1; then ruff check .; ruff format --check .;
-  else echo "WARNING: Python project detected but no linter (just lint or ruff) found."; fi
-elif [ -f package.json ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "lint"; then just lint
-  elif command -v biome >/dev/null 2>&1; then biome check .;
-  else echo "WARNING: JS/TS project detected but no linter (just lint or biome) found."; fi
-elif [ -f go.mod ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "lint"; then just lint
-  else
-    go vet ./...
-    if command -v golangci-lint >/dev/null 2>&1; then golangci-lint run; fi
-  fi
-elif just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "pre-commit"; then
-  just pre-commit
-else
-  echo "WARNING: No recognized project type; skipping L1 lint gate."
+STAGED_FILES="$(git diff --cached --name-only)"
+if [ -n "${STAGED_FILES}" ]; then
+  echo "ERROR: staged-scope precondition failed — staged files exist before dev2merge owns staging." >&2
+  printf '%s\n' "${STAGED_FILES}" >&2
+  echo "Commit or unstage pre-existing staged work before retrying." >&2
+  exit 1
 fi
+if [ -f Cargo.toml ] && just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "check-version-bumped"; then
+  if just check-version-bumped; then
+    echo "Version precondition: already bumped."
+  else
+    echo "Version precondition: bump required; version bump step will run before expensive review gates."
+  fi
+else
+  echo "Version precondition: optional check-version-bumped recipe absent."
+fi
+echo "Cheap preconditions passed before build/review gates."
 ```
 
 ## IF ${FAST_PATH}
@@ -244,16 +236,6 @@ stage, generate message, commit. No mktd/mktsk/security-audit overhead.
 
 ```bash
 set -euo pipefail
-if [ -f Cargo.toml ]; then just test
-elif [ -f pyproject.toml ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then just test
-  elif command -v pytest >/dev/null 2>&1; then pytest; fi
-elif [ -f package.json ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then just test
-  elif command -v vitest >/dev/null 2>&1; then vitest run; fi
-elif [ -f go.mod ]; then go test ./...
-elif just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then just test
-else echo "WARNING: No recognized test runner; skipping L2 test gate."; fi
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
 if [ -z "$(git status --porcelain)" ]; then
   COMMITS_AHEAD="$(git rev-list --count "${DEFAULT_BRANCH}..HEAD" 2>/dev/null || echo 0)"
@@ -271,6 +253,7 @@ if ! git diff --cached --name-only | grep -q .; then
   echo "ERROR: No staged files after staging dirty working tree."
   exit 1
 fi
+git diff --cached --check
 COMMIT_MSG="$(scripts/gen_commit_msg.sh "${SCOPE:-}" 2>/dev/null || echo "docs: update documentation")"
 git commit -m "${COMMIT_MSG}"
 echo "CSA_VAR:FAST_PATH_COMMITTED=true"
@@ -299,10 +282,47 @@ git commit -m "chore(release): bump workspace version to ${VERSION}"
 ## Step 6: FAST_PATH Pre-PR Review
 Tool: bash
 OnFail: abort
-Even FAST_PATH runs cumulative review before push.
-
+FAST_PATH runs L1/L2 gates and cumulative review before push.
 ```bash
 set -euo pipefail
+if [ -f Cargo.toml ]; then
+  just fmt
+  just clippy
+  just test
+elif [ -f pyproject.toml ]; then
+  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "lint"; then
+    just lint
+  elif command -v ruff >/dev/null 2>&1; then
+    ruff check .
+    ruff format --check .
+  fi
+  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then
+    just test
+  elif command -v pytest >/dev/null 2>&1; then
+    pytest
+  fi
+elif [ -f package.json ]; then
+  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "lint"; then
+    just lint
+  elif command -v biome >/dev/null 2>&1; then
+    biome check .
+  fi
+  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then
+    just test
+  elif command -v vitest >/dev/null 2>&1; then
+    vitest run
+  fi
+elif [ -f go.mod ]; then
+  go vet ./...
+  if command -v golangci-lint >/dev/null 2>&1; then
+    golangci-lint run
+  fi
+  go test ./...
+elif just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "pre-commit"; then
+  just pre-commit
+else
+  echo "WARNING: No recognized project type; skipping FAST_PATH L1/L2 gate."
+fi
 bash "${CSA_WORKFLOW_DIR:-patterns/dev2merge}/scripts/csa/cumulative-review-batch.sh" --default-branch "${DEFAULT_BRANCH}" -- \
   csa review --sa-mode true --range "${DEFAULT_BRANCH}...HEAD"
 echo "CSA_VAR:REVIEW_COMPLETED=true"
@@ -430,22 +450,9 @@ wins, else tier-*→`--tier`, other→`--tool`.
 Tool: bash
 OnFail: abort
 Condition: ${RESUME_MODE}
-Resume mode skips mktd/mktsk because the work is already on the branch. Run the
-L2 test gate, then commit any uncommitted remainder so review/push see the full
-diff. Mirrors the FAST_PATH commit (Step 4); fails closed when there is no work.
-
+Resume mode skips mktd/mktsk because the work is already on the branch. Commit any uncommitted remainder so the version, review, and push gates see the full diff. Mirrors the FAST_PATH commit (Step 4); fails closed when there is no work.
 ```bash
 set -euo pipefail
-if [ -f Cargo.toml ]; then just test
-elif [ -f pyproject.toml ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then just test
-  elif command -v pytest >/dev/null 2>&1; then pytest; fi
-elif [ -f package.json ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then just test
-  elif command -v vitest >/dev/null 2>&1; then vitest run; fi
-elif [ -f go.mod ]; then go test ./...
-elif just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then just test
-else echo "WARNING: No recognized test runner; skipping L2 test gate."; fi
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
 if [ -z "$(git status --porcelain)" ]; then
   COMMITS_AHEAD="$(git rev-list --count "${DEFAULT_BRANCH}..HEAD" 2>/dev/null || echo 0)"
@@ -461,6 +468,7 @@ if ! git diff --cached --name-only | grep -q .; then
   echo "ERROR: No staged files after staging dirty working tree."
   exit 1
 fi
+git diff --cached --check
 COMMIT_MSG="$(scripts/gen_commit_msg.sh "${SCOPE:-}" 2>/dev/null || echo "chore: commit resumed work")"
 git commit -m "${COMMIT_MSG}"
 ```

--- a/patterns/dev2merge/skills/dev2merge/SKILL.md
+++ b/patterns/dev2merge/skills/dev2merge/SKILL.md
@@ -34,8 +34,8 @@ Treat the run as executor ONLY when initial prompt contains:
 Execute the complete development lifecycle as a **deterministic weave workflow**.
 Every stage has hard gates (`on_fail = "abort"`) — no step can be skipped by the LLM.
 
-Pipeline: Branch Validation → FAST_PATH Detection → L1/L2 Quality Gates →
-(FAST_PATH: commit → bump → review) or (Full: mktd → mktsk [direct, TaskCreate] → bump → cumulative review) →
+Pipeline: Branch Validation → FAST_PATH Detection → Cheap Repo Preconditions →
+(FAST_PATH: commit → bump → L1/L2 gates → review) or (Full: mktd → mktsk [direct, TaskCreate] → bump → cumulative review) →
 Push Gate → Pre-PR Verdict Check → PR Creation → pr-bot Hard Gate → Post-Merge Sync.
 
 ## Execution Protocol (ORCHESTRATOR ONLY)
@@ -121,8 +121,8 @@ csa plan run --sa-mode true patterns/dev2merge/workflow.toml --var DEV2MERGE_MOD
 
 `DEV2MERGE_MODE` defaults to `full` (the complete pipeline). `resume` skips
 only planning (Step 7 mktd, Step 8 mktsk); Step 9 (Resume Commit) commits any
-uncommitted remainder after the L2 test gate, then **every hard gate still
-runs**: version bump, self-review, cumulative review, push, verdict check, PR
+uncommitted remainder, then **every hard gate still runs**: version bump,
+self-review, cumulative review, push, verdict check, PR
 creation, pr-bot, and post-merge sync. Resume fails closed when the branch has
 no work (clean tree with 0 commits ahead of the default branch). A docs-only
 resume run still follows the FAST_PATH branch.
@@ -187,15 +187,15 @@ All steps use `on_fail = "abort"`. Variables propagate via `CSA_VAR:KEY=value`.
 |------|------|------|------|
 | 1 | Validate Branch | Not default branch/dev | bash |
 | 2 | FAST_PATH Detection | Diff-stat heuristic | bash |
-| 3 | L1/L2 Quality Gates | language-aware lint/test gate | bash |
+| 3 | Cheap Repo Preconditions | staged-scope ownership + optional version check, no build/review | bash |
 | **IF FAST_PATH** | | | |
-| 4 | Simplified Commit | `just test && git commit` | bash |
+| 4 | Simplified Commit | stage, staged-diff check, commit | bash |
 | 5 | Version Bump | optional local Just version recipes; missing recipes skip | bash |
-| 6 | Pre-PR Review | cumulative review helper runs `csa review --range` and owns exact-head verdict check when review runs | bash |
+| 6 | Pre-PR Review | L1/L2 gates, then cumulative review helper runs `csa review --range` | bash |
 | **ELSE (Full Pipeline)** | | | |
 | 7 | Plan with mktd | `csa plan run --pattern mktd` by default, `MKTD_WORKFLOW_PATH` override allowed (skipped in resume mode) | bash |
 | 8 | Execute with mktsk | Follow mktsk PATTERN.md directly, TaskCreate/TaskUpdate (skipped in resume mode) | main agent |
-| 9 | Resume Commit | resume mode only: L2 tests + commit uncommitted remainder | bash |
+| 9 | Resume Commit | resume mode only: stage, staged-diff check, commit uncommitted remainder | bash |
 | 10 | Version Bump | optional local Just version recipes; missing recipes skip | bash |
 | 11 | Self-Review Gate | Main agent checks and fixes the full branch diff before CSA review | main agent |
 | 12 | Pre-PR Cumulative Review Gate | cumulative review helper runs `csa review --range ${DEFAULT_BRANCH}...HEAD` and owns exact-head verdict check when review runs | bash |

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -220,41 +220,31 @@ condition = "!(${DEV2MERGE_SKIP})"
 
 [[workflow.steps]]
 id = 3
-title = "L1/L2 Quality Gates (Always Run)"
+title = "Cheap Repo Preconditions"
 tool = "bash"
 prompt = '''
-Formatters and linters run regardless of FAST_PATH.
-Language detection: Cargo.toml → Rust, pyproject.toml → Python, package.json → JS/TS, go.mod → Go.
-Falls back to `just pre-commit` when available, skip otherwise.
+Cheap repo-local checks run before any cargo build, test, or review gate:
+staged-scope ownership and optional version-bump detection.
 
 ```bash
 set -euo pipefail
-if [ -f Cargo.toml ]; then
-  just fmt
-  just clippy
-elif [ -f pyproject.toml ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "lint"; then
-    just lint
-  elif command -v ruff >/dev/null 2>&1; then
-    ruff check .
-    ruff format --check .
-  fi
-elif [ -f package.json ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "lint"; then
-    just lint
-  elif command -v biome >/dev/null 2>&1; then
-    biome check .
-  fi
-elif [ -f go.mod ]; then
-  go vet ./...
-  if command -v golangci-lint >/dev/null 2>&1; then
-    golangci-lint run
-  fi
-elif just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "pre-commit"; then
-  just pre-commit
-else
-  echo "WARNING: No recognized project type; skipping L1 lint gate."
+STAGED_FILES="$(git diff --cached --name-only)"
+if [ -n "${STAGED_FILES}" ]; then
+  echo "ERROR: staged-scope precondition failed — staged files exist before dev2merge owns staging." >&2
+  printf '%s\n' "${STAGED_FILES}" >&2
+  echo "Commit or unstage pre-existing staged work before retrying." >&2
+  exit 1
 fi
+if [ -f Cargo.toml ] && just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "check-version-bumped"; then
+  if just check-version-bumped; then
+    echo "Version precondition: already bumped."
+  else
+    echo "Version precondition: bump required; version bump step will run before expensive review gates."
+  fi
+else
+  echo "Version precondition: optional check-version-bumped recipe absent."
+fi
+echo "Cheap preconditions passed before build/review gates."
 ```'''
 on_fail = "abort"
 condition = "!(${DEV2MERGE_SKIP})"
@@ -269,27 +259,6 @@ stage, generate message, commit. No mktd/mktsk/security-audit overhead.
 
 ```bash
 set -euo pipefail
-if [ -f Cargo.toml ]; then
-  just test
-elif [ -f pyproject.toml ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then
-    just test
-  elif command -v pytest >/dev/null 2>&1; then
-    pytest
-  fi
-elif [ -f package.json ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then
-    just test
-  elif command -v vitest >/dev/null 2>&1; then
-    vitest run
-  fi
-elif [ -f go.mod ]; then
-  go test ./...
-elif just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then
-  just test
-else
-  echo "WARNING: No recognized test runner; skipping L2 test gate."
-fi
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
 if [ -z "$(git status --porcelain)" ]; then
   COMMITS_AHEAD="$(git rev-list --count "${DEFAULT_BRANCH}..HEAD" 2>/dev/null || echo 0)"
@@ -307,6 +276,7 @@ if ! git diff --cached --name-only | grep -q .; then
   echo "ERROR: No staged files after staging dirty working tree."
   exit 1
 fi
+git diff --cached --check
 COMMIT_MSG="$(scripts/gen_commit_msg.sh "${SCOPE:-}" 2>/dev/null || echo "docs: update documentation")"
 git commit -m "${COMMIT_MSG}"
 echo "CSA_VAR:FAST_PATH_COMMITTED=true"
@@ -343,10 +313,48 @@ id = 6
 title = "FAST_PATH Pre-PR Review"
 tool = "bash"
 prompt = '''
-Even FAST_PATH runs cumulative review before push.
+Even FAST_PATH runs L1/L2 gates and cumulative review before push.
 
 ```bash
 set -euo pipefail
+if [ -f Cargo.toml ]; then
+  just fmt
+  just clippy
+  just test
+elif [ -f pyproject.toml ]; then
+  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "lint"; then
+    just lint
+  elif command -v ruff >/dev/null 2>&1; then
+    ruff check .
+    ruff format --check .
+  fi
+  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then
+    just test
+  elif command -v pytest >/dev/null 2>&1; then
+    pytest
+  fi
+elif [ -f package.json ]; then
+  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "lint"; then
+    just lint
+  elif command -v biome >/dev/null 2>&1; then
+    biome check .
+  fi
+  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then
+    just test
+  elif command -v vitest >/dev/null 2>&1; then
+    vitest run
+  fi
+elif [ -f go.mod ]; then
+  go vet ./...
+  if command -v golangci-lint >/dev/null 2>&1; then
+    golangci-lint run
+  fi
+  go test ./...
+elif just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "pre-commit"; then
+  just pre-commit
+else
+  echo "WARNING: No recognized project type; skipping FAST_PATH L1/L2 gate."
+fi
 bash "${CSA_WORKFLOW_DIR:-patterns/dev2merge}/scripts/csa/cumulative-review-batch.sh" --default-branch "${DEFAULT_BRANCH}" -- \
   csa review --sa-mode true --range "${DEFAULT_BRANCH}...HEAD"
 echo "CSA_VAR:REVIEW_COMPLETED=true"
@@ -479,33 +487,12 @@ title = "Resume Commit"
 tool = "bash"
 prompt = '''
 Resume mode (DEV2MERGE_MODE=resume) skips mktd/mktsk because the work is
-already implemented on the branch. Run the L2 test gate, then commit any
-uncommitted remainder so the review/push gates see the full diff. Mirrors
-the FAST_PATH commit (Step 4); fails closed when there is no work to merge.
+already implemented on the branch. Commit any uncommitted remainder so the
+version, review, and push gates see the full diff. Mirrors the FAST_PATH commit
+(Step 4); fails closed when there is no work to merge.
 
 ```bash
 set -euo pipefail
-if [ -f Cargo.toml ]; then
-  just test
-elif [ -f pyproject.toml ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then
-    just test
-  elif command -v pytest >/dev/null 2>&1; then
-    pytest
-  fi
-elif [ -f package.json ]; then
-  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then
-    just test
-  elif command -v vitest >/dev/null 2>&1; then
-    vitest run
-  fi
-elif [ -f go.mod ]; then
-  go test ./...
-elif just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then
-  just test
-else
-  echo "WARNING: No recognized test runner; skipping L2 test gate."
-fi
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
 if [ -z "$(git status --porcelain)" ]; then
   COMMITS_AHEAD="$(git rev-list --count "${DEFAULT_BRANCH}..HEAD" 2>/dev/null || echo 0)"
@@ -521,6 +508,7 @@ if ! git diff --cached --name-only | grep -q .; then
   echo "ERROR: No staged files after staging dirty working tree."
   exit 1
 fi
+git diff --cached --check
 COMMIT_MSG="$(scripts/gen_commit_msg.sh "${SCOPE:-}" 2>/dev/null || echo "chore: commit resumed work")"
 git commit -m "${COMMIT_MSG}"
 ```'''


### PR DESCRIPTION
Closes #2515 (consolidates #2509, #2500, #2469).

## Changes
- Side-effect summary in dev2merge completion: branch/head movement, commits, review/PR/issue state
- Empty-diff fail-fast: dev2merge must not report success when `main..HEAD` is empty with no side effects
- Actionable mktd failure detail: validation errors bubble up with field/section/recovery info
- Cheap-first preconditions: version bump and staged-scope checks before expensive gates
- Dirty-worktree classification: pre-existing vs workflow-introduced
- Regression tests for all scenarios

Reviewed by tier-4-critical CSA-Codex: PASS (1 round, 6m 51s).