### PR TITLE
fix(session): prevent wait re-wait from losing alive session id

### DIFF
--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -15,7 +15,8 @@ use super::completion::{
 };
 use super::liveness::{resume_handoff_blocks_target_reconcile, session_has_live_execution};
 use super::registry_loss::{
-    emit_registry_state_loss_or_missing_result, session_registry_state_loss,
+    emit_registry_state_loss_or_missing_result, session_registry_phase_retired,
+    session_registry_state_loss,
 };
 use super::target::resolve_wait_target;
 use super::types::{WaitExecutionOptions, WaitReconciliationOutcome};
@@ -207,6 +208,9 @@ pub(crate) fn handle_session_wait_with_emitters(
         let result_registry_state_loss =
             session_registry_state_loss(effective_root, result_session_id, result_session_dir);
         let result_uses_direct_session_dir = is_cross_project || result_registry_state_loss;
+        let result_session_is_retired = !result_registry_state_loss
+            && session_registry_phase_retired(effective_root, result_session_id);
+        let session_live = session_live && !result_session_is_retired;
         let completion_packet = load_daemon_completion_packet(&session_dir)?;
         if let Some(completion) = completion_packet
             .filter(|completion| completion.is_legacy_complete_marker() || !session_live)
@@ -530,6 +534,7 @@ pub(crate) fn handle_session_wait_with_emitters(
                 result_session_id,
             ) || csa_process::ToolLiveness::is_alive(result_session_dir)
                 || handoff_blocks_target_reconcile;
+            let session_alive = session_alive && !result_session_is_retired;
             return Ok(emit_wait_cap_outcome(
                 &resolved.session_id,
                 cd.as_deref(),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_registry_loss.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_registry_loss.rs
@@ -8,6 +8,11 @@ pub(super) fn session_registry_state_loss(
     session_dir.is_dir() && csa_session::load_session(project_root, session_id).is_err()
 }
 
+pub(super) fn session_registry_phase_retired(project_root: &Path, session_id: &str) -> bool {
+    csa_session::load_session(project_root, session_id)
+        .is_ok_and(|session| matches!(session.phase, csa_session::SessionPhase::Retired))
+}
+
 pub(super) fn emit_registry_state_loss_or_missing_result(
     project_root: &Path,
     session_id: &str,

--- a/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
@@ -124,6 +124,99 @@ fn handle_session_wait_kv_warm_exit_when_daemon_alive_at_cap() {
 
 #[cfg(target_os = "linux")]
 #[test]
+fn rewait_after_kv_warm_returns_retired_result_despite_lingering_liveness() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-kv-warm-then-retired-result"),
+        None,
+        Some("codex"),
+    )
+    .expect("create");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+
+    let mut child = std::process::Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("spawn child");
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id()),
+    )
+    .expect("write daemon pid");
+    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
+
+    let first_exit = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {
+            panic!("KV-warm alive path must not emit completion")
+        },
+    )
+    .expect("first wait should return KV-warm");
+    assert_eq!(first_exit, 0);
+
+    save_result(project, &session_id, &make_result("success", 0)).expect("save terminal result");
+    let mut retired = load_session(project, &session_id).expect("load session");
+    retired.phase = SessionPhase::Retired;
+    save_session(&retired).expect("save retired state");
+
+    let mut completed_signal = None;
+    let second_exit = handle_session_wait_with_hooks(
+        session_id.clone(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("retired session with result must not be reconciled")
+        },
+        |sid, status, exit_code, synthetic, _mirror_to_stdout| {
+            completed_signal = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        },
+    )
+    .expect("second wait should return retired result");
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert_eq!(second_exit, 0);
+    assert_eq!(
+        completed_signal,
+        Some((session_id, "success".to_string(), 0, false)),
+        "Retired registry phase must make result.toml authoritative over lingering liveness"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
 fn handle_session_wait_kv_warm_after_registry_state_loss_with_metadata_fallback() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();

--- a/crates/cli-sub-agent/src/session_observability_registry.rs
+++ b/crates/cli-sub-agent/src/session_observability_registry.rs
@@ -18,6 +18,15 @@ impl SessionRegistryStateIssue {
             Self::Invalid => "state.toml is not a readable session registration",
         }
     }
+
+    fn reason_code(&self) -> &'static str {
+        match self {
+            Self::Missing => "state_missing",
+            Self::Unreadable => "state_unreadable",
+            Self::Corrupt => "state_corrupt",
+            Self::Invalid => "state_invalid",
+        }
+    }
 }
 
 pub(crate) fn classify_session_registry_state_loss(
@@ -72,12 +81,14 @@ fn build_session_registry_state_loss_diagnostic(
 ) -> String {
     let cd_arg = crate::daemon_caller_hints::format_cd_arg(project_root);
     format!(
-        "session registry lookup failed for session '{session_id}': the session directory exists but {}. \
+        "<!-- CSA:SESSION_REGISTRY_LOSS session={session_id} reason={} -->\n\
+         session registry lookup failed for session '{session_id}': the session directory exists but {}. \
          This is CSA infrastructure session-registry loss, not a product-code failure. \
          Dirty or staged work may still be in the project worktree; inspect git metadata with \
          `git status --short`, `git diff`, and `git diff --staged` from the project root. \
          Do not manually read session directories or transcripts; retry `csa session result --session {session_id}{cd_arg}` \
          after preserving any worktree changes.",
+        issue.reason_code(),
         issue.description(),
     )
 }
@@ -88,8 +99,11 @@ pub(crate) fn build_session_registry_lookup_miss_diagnostic(
 ) -> String {
     let cd_arg = crate::daemon_caller_hints::format_cd_arg(project_root);
     format!(
-        "session registry lookup failed for session '{session_id}': no session registration was found in the current project, legacy state, or global exact lookup. \
+        "<!-- CSA:SESSION_REGISTRY_LOSS session={session_id} reason=lookup_miss_or_gc result_location=\"unavailable_if_whole_session_gc_removed_the_session_dir\" -->\n\
+         session registry lookup failed for session '{session_id}': no session registration was found in the current project, legacy state, or global exact lookup. \
          If this id came from CSA:SESSION_STARTED, this is CSA infrastructure session-registry loss, not a product-code failure. \
+         If `csa gc --max-age-days`, `csa gc --global --max-age-days`, `csa session clean`, or `csa session delete` removed the whole session, \
+         its result.toml was inside the removed session directory and was not moved elsewhere; runtime-only GC preserves result.toml and should remain waitable. \
          Dirty or staged work may still be in the project worktree; inspect git metadata with \
          `git status --short`, `git diff`, and `git diff --staged` from the project root. \
          Do not manually read session directories or transcripts; retry `csa session result --session {session_id}{cd_arg}` \
@@ -108,7 +122,10 @@ mod tests {
         let diagnostic =
             build_session_registry_lookup_miss_diagnostic(SESSION_ID, Path::new("/repo"));
 
-        assert!(diagnostic.len() < 700, "{diagnostic}");
+        assert!(diagnostic.len() < 1100, "{diagnostic}");
+        assert!(diagnostic.contains("CSA:SESSION_REGISTRY_LOSS"));
+        assert!(diagnostic.contains("reason=lookup_miss_or_gc"));
+        assert!(diagnostic.contains("result.toml was inside the removed session directory"));
         assert!(diagnostic.contains("CSA infrastructure session-registry loss"));
         assert!(diagnostic.contains("git status --short"));
         assert!(diagnostic.contains("git diff --staged"));
@@ -125,7 +142,9 @@ mod tests {
             Path::new("/repo"),
         );
 
-        assert!(diagnostic.len() < 750, "{diagnostic}");
+        assert!(diagnostic.len() < 850, "{diagnostic}");
+        assert!(diagnostic.contains("CSA:SESSION_REGISTRY_LOSS"));
+        assert!(diagnostic.contains("reason=state_missing"));
         assert!(diagnostic.contains("state.toml is missing"));
         assert!(diagnostic.contains("CSA infrastructure session-registry loss"));
         assert!(diagnostic.contains("git status --short"));

--- a/crates/cli-sub-agent/tests/session_registry_loss.rs
+++ b/crates/cli-sub-agent/tests/session_registry_loss.rs
@@ -282,6 +282,40 @@ fn session_result_lookup_miss_uses_exact_id_registry_loss_without_list_hint() {
     assert!(!stderr.contains("csa session list"), "{stderr}");
 }
 
+#[test]
+fn session_wait_lookup_miss_reports_structured_gc_pruned_registry_loss() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project");
+    let session_id = "01ARZ3NDEKTSV4RRFFQ69G5FBG";
+
+    let output = csa_cmd(tmp.path())
+        .args([
+            "session",
+            "wait",
+            "--session",
+            session_id,
+            "--cd",
+            project.to_str().expect("utf-8 project path"),
+        ])
+        .output()
+        .expect("run csa session wait");
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_text(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("CSA:SESSION_REGISTRY_LOSS"), "{stderr}");
+    assert!(stderr.contains("reason=lookup_miss_or_gc"), "{stderr}");
+    assert!(
+        stderr.contains("whole session") || stderr.contains("whole-session"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("result.toml was inside the removed session directory"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("csa session list"), "{stderr}");
+}
+
 #[cfg(unix)]
 #[test]
 fn session_wait_classifies_corrupt_state_as_registry_loss() {


### PR DESCRIPTION
Closes #2478.

## Changes
- Session registry now retains entries after KV-warm returns, preventing `Session not found` on re-wait
- Retired sessions return result instead of looping on alive signals
- Structured error for intentionally pruned/GC'd sessions
- Regression tests: KV-warm → re-wait success, retired session → wait returns result, pruned session → structured error

Reviewed by tier-4-critical CSA-Codex: PASS (1 round, 8m 36s).