### PR TITLE
fix(run): preserve cargo target env while normalizing cargo home

### DIFF
--- a/crates/cli-sub-agent/src/pipeline_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_env.rs
@@ -212,15 +212,10 @@ fn apply_rust_session_env_contract_inner(
 
     if materialize_cargo_install_root {
         if let Some(project_root) = project_root {
-            force_project_env_path(
+            ensure_rust_env_path(
                 env,
                 csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY,
                 &project_root.join("target/cargo-install-root"),
-            );
-            force_project_env_path(
-                env,
-                csa_core::env::CARGO_TARGET_DIR_ENV_KEY,
-                &project_root.join("target"),
             );
         } else if let Some(effective_cargo_home) =
             env_path(env, csa_core::env::CARGO_HOME_ENV_KEY).or(cargo_home)

--- a/crates/cli-sub-agent/src/pipeline_sandbox_extra_writable_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_extra_writable_tests.rs
@@ -176,7 +176,7 @@ fn test_rust_env_writable_preserves_explicit_safe_values() {
 }
 
 #[test]
-fn test_rust_env_writable_pins_ambient_cargo_dirs() {
+fn test_rust_env_writable_preserves_ambient_cargo_dirs() {
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let project_root = tempfile::tempdir().expect("project root tempdir");
     let home = project_root.path().join("home");
@@ -213,25 +213,13 @@ fn test_rust_env_writable_pins_ambient_cargo_dirs() {
         panic!("expected sandbox");
     };
     let sandbox = opts.sandbox.expect("sandbox context");
-    let expected_target = project_root.path().join("target");
-    let expected_install_root = expected_target.join("cargo-install-root");
-    for path in [&expected_target, &expected_install_root] {
+    for path in [&cargo_target_dir, &cargo_install_root] {
         assert!(
             sandbox
                 .isolation_plan
                 .writable_paths
                 .contains(&path.canonicalize().unwrap()),
             "missing {}",
-            path.display()
-        );
-    }
-    for path in [&cargo_target_dir, &cargo_install_root] {
-        assert!(
-            !sandbox
-                .isolation_plan
-                .writable_paths
-                .contains(&path.canonicalize().unwrap()),
-            "unexpected {}",
             path.display()
         );
     }

--- a/crates/cli-sub-agent/src/pipeline_tests_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_env.rs
@@ -96,8 +96,7 @@ fn build_merged_env_normalizes_readonly_usr_local_rust_state() {
     let _rustup_home = ScopedEnvVarRestore::set(csa_core::env::RUSTUP_HOME_ENV_KEY, "/usr/local");
     let _cargo_install_root =
         ScopedEnvVarRestore::set(csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY, "/usr/local");
-    let _cargo_target_dir =
-        ScopedEnvVarRestore::set(csa_core::env::CARGO_TARGET_DIR_ENV_KEY, "/usr/local");
+    let _cargo_target_dir = ScopedEnvVarRestore::unset(csa_core::env::CARGO_TARGET_DIR_ENV_KEY);
     let _mise_config =
         ScopedEnvVarRestore::set(csa_core::env::MISE_CONFIG_DIR_ENV_KEY, "/usr/local");
     let _mise_data = ScopedEnvVarRestore::set(
@@ -142,16 +141,9 @@ fn build_merged_env_normalizes_readonly_usr_local_rust_state() {
                 .expect("cargo install root utf8")
         )
     );
-    assert_eq!(
-        merged
-            .get(csa_core::env::CARGO_TARGET_DIR_ENV_KEY)
-            .map(String::as_str),
-        Some(
-            temp.path()
-                .join("target")
-                .to_str()
-                .expect("cargo target dir utf8")
-        )
+    assert!(
+        !merged.contains_key(csa_core::env::CARGO_TARGET_DIR_ENV_KEY),
+        "normal child env must not invent a CARGO_TARGET_DIR fallback"
     );
     assert_eq!(
         merged
@@ -234,12 +226,9 @@ fn build_merged_env_defaults_missing_rust_state_to_known_good_paths() {
                 .expect("cargo install root utf8")
         )
     );
-    assert_eq!(
-        merged
-            .get(csa_core::env::CARGO_TARGET_DIR_ENV_KEY)
-            .map(String::as_str),
-        Some(temp.path().join("target").to_str().expect("target utf8")),
-        "missing CARGO_TARGET_DIR must be pinned to the project target symlink"
+    assert!(
+        !merged.contains_key(csa_core::env::CARGO_TARGET_DIR_ENV_KEY),
+        "missing CARGO_TARGET_DIR must preserve Cargo's default ./target"
     );
     assert_eq!(
         merged
@@ -256,7 +245,7 @@ fn build_merged_env_defaults_missing_rust_state_to_known_good_paths() {
 }
 
 #[test]
-fn build_merged_env_pins_ambient_cargo_target_to_project_target_for_sandbox() {
+fn build_merged_env_preserves_ambient_cargo_target_for_sandbox() {
     let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.blocking_lock();
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
@@ -309,8 +298,6 @@ fn build_merged_env_pins_ambient_cargo_target_to_project_target_for_sandbox() {
         allow_git_push: false,
     });
 
-    let expected_target = temp.path().join("target");
-    let expected_install_root = expected_target.join("cargo-install-root");
     assert_eq!(
         merged.get(csa_core::env::CARGO_HOME_ENV_KEY).map(String::as_str),
         Some(cargo_home.to_str().expect("cargo home utf8"))
@@ -323,13 +310,13 @@ fn build_merged_env_pins_ambient_cargo_target_to_project_target_for_sandbox() {
         merged
             .get(csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY)
             .map(String::as_str),
-        Some(expected_install_root.to_str().expect("cargo install root utf8"))
+        Some(cargo_install_root.to_str().expect("cargo install root utf8"))
     );
     assert_eq!(
         merged
             .get(csa_core::env::CARGO_TARGET_DIR_ENV_KEY)
             .map(String::as_str),
-        Some(expected_target.to_str().expect("cargo target dir utf8"))
+        Some(cargo_target_dir.to_str().expect("cargo target dir utf8"))
     );
     assert_eq!(
         merged
@@ -341,15 +328,13 @@ fn build_merged_env_pins_ambient_cargo_target_to_project_target_for_sandbox() {
     let writable_paths = crate::pipeline_env::rust_session_writable_paths(&merged);
     assert!(writable_paths.contains(&cargo_home));
     assert!(writable_paths.contains(&rustup_home));
-    assert!(writable_paths.contains(&expected_install_root));
-    assert!(writable_paths.contains(&expected_target));
-    assert!(!writable_paths.contains(&cargo_install_root));
-    assert!(!writable_paths.contains(&cargo_target_dir));
+    assert!(writable_paths.contains(&cargo_install_root));
+    assert!(writable_paths.contains(&cargo_target_dir));
     assert!(writable_paths.contains(&mise_config));
 }
 
 #[test]
-fn build_merged_env_pins_ambient_cargo_dirs_without_home_to_project_target() {
+fn build_merged_env_preserves_ambient_cargo_dirs_without_home() {
     let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.blocking_lock();
     let temp = tempfile::tempdir().expect("tempdir");
     let cargo_install_root = temp.path().join("ambient-install-root");
@@ -381,29 +366,25 @@ fn build_merged_env_pins_ambient_cargo_dirs_without_home_to_project_target() {
         allow_git_push: false,
     });
 
-    let expected_target = temp.path().join("target");
-    let expected_install_root = expected_target.join("cargo-install-root");
     assert_eq!(
         merged
             .get(csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY)
             .map(String::as_str),
-        Some(expected_install_root.to_str().expect("cargo install root utf8"))
+        Some(cargo_install_root.to_str().expect("cargo install root utf8"))
     );
     assert_eq!(
         merged
             .get(csa_core::env::CARGO_TARGET_DIR_ENV_KEY)
             .map(String::as_str),
-        Some(expected_target.to_str().expect("cargo target dir utf8"))
+        Some(cargo_target_dir.to_str().expect("cargo target dir utf8"))
     );
     let writable_paths = crate::pipeline_env::rust_session_writable_paths(&merged);
-    assert!(writable_paths.contains(&expected_install_root));
-    assert!(writable_paths.contains(&expected_target));
-    assert!(!writable_paths.contains(&cargo_install_root));
-    assert!(!writable_paths.contains(&cargo_target_dir));
+    assert!(writable_paths.contains(&cargo_install_root));
+    assert!(writable_paths.contains(&cargo_target_dir));
 }
 
 #[test]
-fn build_merged_env_preserves_explicit_writable_rust_state_except_project_target_dirs() {
+fn build_merged_env_preserves_explicit_writable_rust_state() {
     let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.blocking_lock();
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
@@ -462,8 +443,6 @@ fn build_merged_env_preserves_explicit_writable_rust_state_except_project_target
         allow_git_push: false,
     });
 
-    let expected_target = temp.path().join("target");
-    let expected_install_root = expected_target.join("cargo-install-root");
     assert_eq!(
         merged.get(csa_core::env::CARGO_HOME_ENV_KEY),
         extra_env.get(csa_core::env::CARGO_HOME_ENV_KEY)
@@ -473,16 +452,12 @@ fn build_merged_env_preserves_explicit_writable_rust_state_except_project_target
         extra_env.get(csa_core::env::RUSTUP_HOME_ENV_KEY)
     );
     assert_eq!(
-        merged
-            .get(csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY)
-            .map(String::as_str),
-        Some(expected_install_root.to_str().expect("cargo install root utf8"))
+        merged.get(csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY),
+        extra_env.get(csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY)
     );
     assert_eq!(
-        merged
-            .get(csa_core::env::CARGO_TARGET_DIR_ENV_KEY)
-            .map(String::as_str),
-        Some(expected_target.to_str().expect("cargo target dir utf8"))
+        merged.get(csa_core::env::CARGO_TARGET_DIR_ENV_KEY),
+        extra_env.get(csa_core::env::CARGO_TARGET_DIR_ENV_KEY)
     );
     assert_eq!(
         merged.get(csa_core::env::MISE_CONFIG_DIR_ENV_KEY),

--- a/crates/cli-sub-agent/src/pipeline_tests_run_target.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_run_target.rs
@@ -202,7 +202,7 @@ fn apply_run_target_dir_guard_preserves_relative_workspace_target_override() {
 
 #[cfg(unix)]
 #[test]
-fn runtime_guard_replaces_synthesized_workspace_target_for_unwritable_target() {
+fn runtime_guard_replaces_readonly_ambient_target_for_unwritable_target() {
     let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.blocking_lock();
     let project = tempdir().expect("tempdir");
     let home = project.path().join("home");
@@ -235,11 +235,11 @@ fn runtime_guard_replaces_synthesized_workspace_target_for_unwritable_target() {
         pattern_internal: false,
         allow_git_push: false,
     });
-    let synthesized_target = project.path().join("target").to_string_lossy().into_owned();
     assert_eq!(
         env.get(csa_core::env::CARGO_TARGET_DIR_ENV_KEY)
             .map(String::as_str),
-        Some(synthesized_target.as_str())
+        Some("/usr/local"),
+        "normal env merge must preserve the ambient target before the runtime guard decides"
     );
 
     let report = crate::pipeline_cargo_target::apply_runtime_task_target_dir_guards(
@@ -261,7 +261,7 @@ fn runtime_guard_replaces_synthesized_workspace_target_for_unwritable_target() {
 
 #[cfg(unix)]
 #[test]
-fn runtime_guard_replaces_config_normalized_workspace_target_for_unwritable_target() {
+fn runtime_guard_replaces_readonly_caller_target_for_unwritable_target() {
     let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.blocking_lock();
     let project = tempdir().expect("tempdir");
     let home = project.path().join("home");
@@ -288,11 +288,11 @@ fn runtime_guard_replaces_config_normalized_workspace_target_for_unwritable_targ
         pattern_internal: false,
         allow_git_push: false,
     });
-    let synthesized_target = project.path().join("target").to_string_lossy().into_owned();
     assert_eq!(
         env.get(csa_core::env::CARGO_TARGET_DIR_ENV_KEY)
             .map(String::as_str),
-        Some(synthesized_target.as_str())
+        Some("/usr/local"),
+        "normal env merge must preserve the caller target before the runtime guard decides"
     );
 
     let report = crate::pipeline_cargo_target::apply_runtime_task_target_dir_guards(
@@ -344,12 +344,11 @@ fn runtime_guard_preserves_external_caller_supplied_target_override() {
         pattern_internal: false,
         allow_git_push: false,
     });
-    let synthesized_target = project.path().join("target").to_string_lossy().into_owned();
     assert_eq!(
         env.get(csa_core::env::CARGO_TARGET_DIR_ENV_KEY)
             .map(String::as_str),
-        Some(synthesized_target.as_str()),
-        "env merge pins Cargo target before the runtime guard restores caller intent"
+        Some(explicit_target.as_str()),
+        "normal env merge must preserve caller CARGO_TARGET_DIR"
     );
 
     let report = crate::pipeline_cargo_target::apply_runtime_task_target_dir_guards(

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_residual_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_residual_tests.rs
@@ -184,20 +184,18 @@ async fn fix_finding_2348_harness_covers_env_identity_amend_and_residual_gate() 
         explicit_env.get(csa_core::env::CARGO_HOME_ENV_KEY),
         "CARGO_HOME"
     );
-    let expected_target = project_root.join("target");
-    let expected_install_root = expected_target.join("cargo-install-root");
     assert_eq!(
         merged_env
             .get(csa_core::env::CARGO_TARGET_DIR_ENV_KEY)
             .map(String::as_str),
-        Some(expected_target.to_str().expect("target utf8")),
+        Some(cargo_target_dir.to_str().expect("target utf8")),
         "CARGO_TARGET_DIR"
     );
     assert_eq!(
         merged_env
             .get(csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY)
             .map(String::as_str),
-        Some(expected_install_root.to_str().expect("install root utf8")),
+        Some(cargo_install_root.to_str().expect("install root utf8")),
         "CARGO_INSTALL_ROOT"
     );
 
@@ -224,24 +222,13 @@ async fn fix_finding_2348_harness_covers_env_identity_amend_and_residual_gate() 
             panic!("sandbox should be available for #2348 harness: {message}")
         }
     };
-    for path in [&cargo_home, &expected_target, &expected_install_root] {
+    for path in [&cargo_home, &cargo_target_dir, &cargo_install_root] {
         assert!(
             sandbox
                 .isolation_plan
                 .writable_paths
                 .contains(&path.canonicalize().unwrap()),
             "{} must be in writable sandbox contract: {:?}",
-            path.display(),
-            sandbox.isolation_plan.writable_paths
-        );
-    }
-    for path in [&cargo_target_dir, &cargo_install_root] {
-        assert!(
-            !sandbox
-                .isolation_plan
-                .writable_paths
-                .contains(&path.canonicalize().unwrap()),
-            "explicit ambient target path {} must not be writable: {:?}",
             path.display(),
             sandbox.isolation_plan.writable_paths
         );

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -12,7 +12,7 @@ End-to-end development workflow enforced as a weave workflow. Every stage has
 hard gates (`on_fail = "abort"`). No step can be skipped by the LLM.
 
 Pipeline: Already-Resolved Check → Branch Validation → FAST_PATH Detection → mktd (planning) →
-mktsk N*(implement → commit) → Self-Review Gate → Pre-PR Cumulative Review → Push →
+mktsk N*(implement → commit) → Bash L1/L2 Self-Review Gate → Pre-PR Cumulative Review → Push →
 Pre-PR Verdict Check → PR Creation → **pr-bot Hard Gate** → Post-Merge Sync.
 
 **CRITICAL PIPELINE INVARIANT**: Step 15 PR creation and Step 16 pr-bot are
@@ -495,17 +495,17 @@ git commit -m "chore(release): bump workspace version to ${VERSION}"
 
 ## Step 11: Self-Review Gate
 
-Tool: manual (main agent action)
+Tool: bash
 OnFail: abort
-Before triggering `csa review`, the implementing agent MUST self-check the
-entire branch diff and fix any issues it finds.
+Full and resume paths run the deterministic L1/L2 quality gate before
+cumulative CSA review.
 
-Required actions:
-1. Run the project's lint command (Rust: `just clippy`, Python: `just lint` or `ruff check`, Go: `go vet`, JS/TS: `just lint` or `biome check`) and fix every warning.
-2. Run the project's test command (Rust: `just test`, Python: `pytest`, Go: `go test ./...`, JS/TS: `vitest run`) and fix every failure.
-3. If `.csa/review-checklist.md` exists, inspect `git diff "${DEFAULT_BRANCH}...HEAD"` against that checklist for known anti-patterns.
-4. Fix any issues found during this self-review.
-5. Only after completing all checks and fixes, continue to the cumulative `csa review` step.
+```bash
+set -euo pipefail
+just fmt
+just clippy
+just test
+```
 
 ## Step 12: Pre-PR Cumulative Review Gate
 Tool: bash

--- a/patterns/dev2merge/skills/dev2merge/SKILL.md
+++ b/patterns/dev2merge/skills/dev2merge/SKILL.md
@@ -35,7 +35,7 @@ Execute the complete development lifecycle as a **deterministic weave workflow**
 Every stage has hard gates (`on_fail = "abort"`) — no step can be skipped by the LLM.
 
 Pipeline: Branch Validation → FAST_PATH Detection → Cheap Repo Preconditions →
-(FAST_PATH: commit → bump → L1/L2 gates → review) or (Full: mktd → mktsk [direct, TaskCreate] → bump → cumulative review) →
+(FAST_PATH: commit → bump → L1/L2 gates → review) or (Full: mktd → mktsk [direct, TaskCreate] → bump → L1/L2 gate → cumulative review; Resume: commit remainder → bump → L1/L2 gate → cumulative review) →
 Push Gate → Pre-PR Verdict Check → PR Creation → pr-bot Hard Gate → Post-Merge Sync.
 
 ## Execution Protocol (ORCHESTRATOR ONLY)
@@ -197,7 +197,7 @@ All steps use `on_fail = "abort"`. Variables propagate via `CSA_VAR:KEY=value`.
 | 8 | Execute with mktsk | Follow mktsk PATTERN.md directly, TaskCreate/TaskUpdate (skipped in resume mode) | main agent |
 | 9 | Resume Commit | resume mode only: stage, staged-diff check, commit uncommitted remainder | bash |
 | 10 | Version Bump | optional local Just version recipes; missing recipes skip | bash |
-| 11 | Self-Review Gate | Main agent checks and fixes the full branch diff before CSA review | main agent |
+| 11 | Self-Review Gate | Bash-enforced L1/L2 gate runs `just fmt`, `just clippy`, and `just test` before CSA review | bash |
 | 12 | Pre-PR Cumulative Review Gate | cumulative review helper runs `csa review --range ${DEFAULT_BRANCH}...HEAD` and owns exact-head verdict check when review runs | bash |
 | **ENDIF** | | | |
 | 13 | Push Gate | `REVIEW_COMPLETED=true` required | bash |
@@ -248,7 +248,7 @@ ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
 
 1. Feature branch validated (not default branch/dev).
 2. FAST_PATH detection completed (heuristic applied).
-3. Language-aware L1/L2 gates exit 0.
+3. L1/L2 gates exit 0 (`just fmt`, `just clippy`, and `just test` on the full/resume path).
 4. If full pipeline: mktd plan saved with `DONE WHEN` clauses, mktsk executed all tasks via main agent.
 5. If FAST_PATH: simplified commit created with tests passing.
 6. Rust repos with local version recipes bump if needed; non-Rust repos or repos missing those optional recipes skip without aborting.

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -542,17 +542,18 @@ condition = "(!(${DEV2MERGE_SKIP})) && (!(${FAST_PATH}))"
 [[workflow.steps]]
 id = 11
 title = "Self-Review Gate"
-tool = "manual"
-prompt = """
-Before triggering `csa review`, the implementing agent MUST self-check the
-entire branch diff and fix any issues it finds.
+tool = "bash"
+prompt = '''
+Full and resume paths run the deterministic L1/L2 quality gate before
+cumulative CSA review.
 
-Required actions:
-1. Run the project's lint command (Rust: `just clippy`, Python: `just lint` or `ruff check`, Go: `go vet`, JS/TS: `just lint` or `biome check`) and fix every warning.
-2. Run the project's test command (Rust: `just test`, Python: `pytest`, Go: `go test ./...`, JS/TS: `vitest run`) and fix every failure.
-3. If `.csa/review-checklist.md` exists, inspect `git diff "${DEFAULT_BRANCH}...HEAD"` against that checklist for known anti-patterns.
-4. Fix any issues found during this self-review.
-5. Only after completing all checks and fixes, continue to the cumulative `csa review` step."""
+```bash
+set -euo pipefail
+just fmt
+just clippy
+just test
+```
+'''
 on_fail = "abort"
 condition = "(!(${DEV2MERGE_SKIP})) && (!(${FAST_PATH}))"
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,7 +1,9 @@
+package = []
+
 [versions]
 csa = "0.1.1082"
-weave = "0.1.1082"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
+weave = "0.1.1082"
 
 [migrations]
 applied = [


### PR DESCRIPTION
Closes #2510.

## Changes
- `pipeline_env.rs`: normalize read-only `CARGO_HOME` to writable `$HOME/.cargo` fallback while preserving target env
- Dev2merge Step 11: deterministic bash L1/L2 gate (`just fmt`, `just clippy`, `just test`) replacing non-enforceable manual self-review
- PATTERN.md / SKILL.md / workflow.toml synchronized (AGENTS.md rule 027)
- weave.lock updated

Reviewed by tier-4-critical CSA-Codex: PASS (2 rounds — R1 FP resolved, R2 clean).