### PR TITLE
fix(cli-hints): replace shell-unsafe angle-bracket placeholders with shell-safe filenames

### DIFF
--- a/crates/cli-sub-agent/src/debate_cmd_question_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_question_tests.rs
@@ -41,7 +41,7 @@ fn debate_empty_question_fails_with_clear_error() {
         message.contains("stdin is not available to the detached daemon"),
         "{message}"
     );
-    assert!(message.contains("--question-file <path>"), "{message}");
+    assert!(message.contains("--question-file QUESTION.md"), "{message}");
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/debate_errors.rs
+++ b/crates/cli-sub-agent/src/debate_errors.rs
@@ -5,7 +5,7 @@ use csa_session::MetaSessionState;
 
 pub(crate) const EMPTY_DEBATE_QUESTION_ERROR: &str = concat!(
     "debate question is empty (stdin is not available to the detached daemon - ",
-    "pass a positional QUESTION, use --question-file <path>, or pair --context with a QUESTION)"
+    "pass a positional QUESTION, use --question-file QUESTION.md, or pair --context with a QUESTION)"
 );
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/cli-sub-agent/src/error_hints.rs
+++ b/crates/cli-sub-agent/src/error_hints.rs
@@ -147,7 +147,7 @@ pub(crate) fn sandbox_fs_denial_hint(
     let path_hint = format!("--extra-writable {suggested}");
 
     Some(format!(
-        "hint: sandbox filesystem write denied for {denied_path}. To continue from this session's partial work rather than re-running from scratch, run:\n  csa run --fork-from {session_id} {path_hint} --prompt-file <continuation prompt>"
+        "hint: sandbox filesystem write denied for {denied_path}. To continue from this session's partial work rather than re-running from scratch, run:\\n  csa run --fork-from {session_id} {path_hint} --prompt-file CONTINUATION_PROMPT.md"
     ))
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_fix_finding_prompt.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_finding_prompt.rs
@@ -40,7 +40,7 @@ fn read_fix_finding_stdin<R: Read>(stdin_is_terminal: bool, reader: &mut R) -> R
     if stdin_is_terminal {
         anyhow::bail!(
             "No fix prompt provided and stdin is a terminal.\n\n\
-             Usage:\n  csa review --fix-finding --session <failed-review-session-id> --prompt \"confirmed fix instructions\"\n  csa review --fix-finding --session <failed-review-session-id> --prompt-file <path>\n  echo \"confirmed fix instructions\" | csa review --fix-finding --session <failed-review-session-id>"
+             Usage:\n  csa review --fix-finding --session FAILED_REVIEW_SESSION_ID --prompt \"confirmed fix instructions\"\n  csa review --fix-finding --session FAILED_REVIEW_SESSION_ID --prompt-file FIX_PROMPT.md\n  echo \"confirmed fix instructions\" | csa review --fix-finding --session FAILED_REVIEW_SESSION_ID"
         );
     }
     let mut buffer = String::new();

--- a/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
@@ -389,7 +389,7 @@ fn debate_omitted_question_tty_fails_before_spawn() {
 
     let message = err.to_string();
     assert!(message.contains("debate question is empty"), "{message}");
-    assert!(message.contains("--question-file <path>"), "{message}");
+    assert!(message.contains("--question-file QUESTION.md"), "{message}");
 }
 
 #[test]


### PR DESCRIPTION
Closes #2532, closes #2534.

Replaces angle-bracket placeholders (`<path>`, `<continuation prompt>`, `<failed-review-session-id>`) in generated command guidance with shell-safe placeholder filenames (`FIX_PROMPT.md`, `CONTINUATION_PROMPT.md`, `QUESTION.md`, `FAILED_REVIEW_SESSION_ID`).

5 files changed: error_hints.rs, review_cmd_fix_finding_prompt.rs, debate_errors.rs, debate_cmd_question_tests.rs, run_cmd_daemon_tests.rs.

Reviewed by tier-4-critical CSA-Codex: PASS.