### PR TITLE
fix(patterns): replace target repo script refs with bundled/csa-native commands

### DIFF
--- a/patterns/ai-reviewed-commit/PATTERN.md
+++ b/patterns/ai-reviewed-commit/PATTERN.md
@@ -79,7 +79,7 @@ Tool: bash
 
 ```bash
 SID=$(csa debate --fail-on-revise --fail-on-reject "Review my staged changes for correctness, security, and test gaps. Run 'git diff --staged' yourself to see the full patch.")
-bash scripts/csa/session-wait-until-done.sh "$SID"
+bash csa session wait --session "$SID"
 ```
 
 ## ELSE
@@ -90,7 +90,7 @@ Tool: bash
 
 ```bash
 SID=$(csa review --diff --allow-fallback)
-bash scripts/csa/session-wait-until-done.sh "$SID"
+bash csa session wait --session "$SID"
 ```
 
 ## ENDIF
@@ -134,7 +134,7 @@ This is still a single-pass workflow step, not a native weave loop.
 
 ```bash
 SID=$(csa review --diff --allow-fallback)
-bash scripts/csa/session-wait-until-done.sh "$SID"
+bash csa session wait --session "$SID"
 ```
 
 ## Step 9: Round Cap Check

--- a/patterns/ai-reviewed-commit/workflow.toml
+++ b/patterns/ai-reviewed-commit/workflow.toml
@@ -87,7 +87,7 @@ tool = "bash"
 prompt = '''
 ```bash
 SID=$(csa debate --fail-on-revise --fail-on-reject "Review my staged changes for correctness, security, and test gaps. Run 'git diff --staged' yourself to see the full patch.")
-bash scripts/csa/session-wait-until-done.sh "$SID"
+bash csa session wait --session "$SID"
 ```'''
 on_fail = "abort"
 condition = "${SELF_AUTHORED}"
@@ -99,7 +99,7 @@ tool = "bash"
 prompt = '''
 ```bash
 SID=$(csa review --diff --allow-fallback)
-bash scripts/csa/session-wait-until-done.sh "$SID"
+bash csa session wait --session "$SID"
 ```'''
 on_fail = "abort"
 condition = "!(${SELF_AUTHORED})"
@@ -142,7 +142,7 @@ This is still a single-pass workflow step, not a native weave loop.
 
 ```bash
 SID=$(csa review --diff --allow-fallback)
-bash scripts/csa/session-wait-until-done.sh "$SID"
+bash csa session wait --session "$SID"
 ```'''
 on_fail = "abort"
 condition = "${REVIEW_HAS_ISSUES}"

--- a/patterns/commit/PATTERN.md
+++ b/patterns/commit/PATTERN.md
@@ -509,7 +509,7 @@ This catches cross-commit issues that per-commit reviews might miss.
 
 ```bash
 set -euo pipefail
-bash scripts/csa/cumulative-review-batch.sh --default-branch main -- \
+bash "${CSA_WORKFLOW_DIR:-patterns/commit}/scripts/csa/cumulative-review-batch.sh" --default-branch main -- \
   csa review --sa-mode true --range main...HEAD
 echo "CSA_VAR:REVIEW_COMPLETED=true"
 echo '<!-- CSA:NEXT_STEP cmd="push and create PR (Step 22)" required=true -->'

--- a/patterns/commit/scripts/csa/cumulative-review-batch.sh
+++ b/patterns/commit/scripts/csa/cumulative-review-batch.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+SESSION_WAIT_SCRIPT="${CSA_SESSION_WAIT_SCRIPT:-${SCRIPT_DIR}/session-wait-until-done.sh}"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: cumulative-review-batch.sh --default-branch <branch> -- <csa review ...>
+
+Runs a cumulative csa review unless batching says the intermediate review can
+be skipped. Writes `.csa/state/review/last-cumulative-<feature>--vs--<base>.txt`
+only when the review session exits 0 and review-verdict.json reports zero
+HIGH/CRITICAL findings. When a review runs, this helper also enforces the
+exact-head review verdict gate for `<branch>...HEAD`.
+EOF
+  exit 2
+}
+
+if [ "$#" -lt 3 ]; then
+  usage
+fi
+
+default_branch=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --default-branch)
+      default_branch="${2:-}"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "ERROR: unexpected argument '$1'" >&2
+      usage
+      ;;
+  esac
+done
+
+if [ -z "${default_branch}" ] || [ "$#" -eq 0 ]; then
+  usage
+fi
+
+review_cmd=("$@")
+project_root="$(pwd -P)"
+current_branch="$(git branch --show-current)"
+
+if [ -z "${current_branch}" ] || [ "${current_branch}" = "HEAD" ]; then
+  echo "ERROR: Cannot determine current branch." >&2
+  exit 1
+fi
+
+sanitize_branch() {
+  printf '%s' "$1" | sed 's|/|__|g'
+}
+
+state_file_path() {
+  local branch_name="$1"
+  local base_branch="$2"
+  printf '.csa/state/review/last-cumulative-%s--vs--%s.txt' \
+    "$(sanitize_branch "${branch_name}")" \
+    "$(sanitize_branch "${base_branch}")"
+}
+
+resolve_batch_commits() {
+  local config_json
+  config_json="$(csa config show --format json --cd "${project_root}")"
+  jq -r '.review.batch_commits // 1' <<<"${config_json}"
+}
+
+resolve_session_dir() {
+  local session_id="$1"
+  local state_home="${XDG_STATE_HOME:-${HOME}/.local/state}"
+  printf '%s/cli-sub-agent/%s/sessions/%s' "${state_home}" "${project_root#/}" "${session_id}"
+}
+
+should_record_passed_head() {
+  local session_id="$1"
+  local session_dir verdict_path meta_path
+  session_dir="$(resolve_session_dir "${session_id}")"
+  verdict_path="${session_dir}/output/review-verdict.json"
+  meta_path="${session_dir}/review_meta.json"
+
+  if [ ! -f "${verdict_path}" ]; then
+    echo "WARN: review-verdict artifact missing for session ${session_id}; not updating batch state." >&2
+    return 1
+  fi
+  if [ ! -f "${meta_path}" ]; then
+    echo "WARN: review_meta artifact missing for session ${session_id}; not updating batch state." >&2
+    return 1
+  fi
+
+  jq -e --slurpfile meta "${meta_path}" '
+    (.decision // "fail") == "pass"
+    and (.severity_counts.critical // 0) == 0
+    and (.severity_counts.high // 0) == 0
+    and (($meta[0].decision // "fail") == "pass")
+    and (($meta[0].exit_code // 1) == 0)
+    and (($meta[0].status_reason // "") == "")
+    and (($meta[0].failure_reason // "") == "")
+    and (
+      (($meta[0].fix_attempted // false) | not)
+      or (($meta[0].fix_convergence.reached_genuine_clean_convergence // false) == true)
+    )
+  ' "${verdict_path}" >/dev/null
+}
+
+check_current_head_verdict() {
+  csa review --check-verdict --range "${default_branch}...HEAD"
+}
+
+batch_commits="$(resolve_batch_commits)"
+if ! [[ "${batch_commits}" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: review.batch_commits must be an integer, got '${batch_commits}'." >&2
+  exit 1
+fi
+
+last_sha_file="$(state_file_path "${current_branch}" "${default_branch}")"
+if [ "${CSA_REVIEW_NOW:-0}" != "1" ] && [ "${batch_commits}" -ge 2 ] && [ -f "${last_sha_file}" ]; then
+  last_sha="$(tr -d '\n' < "${last_sha_file}")"
+  if [ -n "${last_sha}" ] && git merge-base --is-ancestor "${last_sha}" HEAD 2>/dev/null; then
+    new_commits="$(git rev-list --count "${last_sha}..HEAD")"
+    if [ "${new_commits}" -lt "${batch_commits}" ]; then
+      echo "csa review: skip - batched (${new_commits}/${batch_commits} commits since last passed cumulative review ${last_sha:0:8})"
+      exit 0
+    fi
+  fi
+fi
+
+review_output_file="$(mktemp)"
+trap 'rm -f "${review_output_file}"' EXIT
+
+set +e
+sid="$("${review_cmd[@]}")"
+bash "${SESSION_WAIT_SCRIPT}" "${sid}" 2>&1 | tee "${review_output_file}"
+review_status=${PIPESTATUS[0]}
+set -e
+
+if [ "${review_status}" -ne 0 ]; then
+  exit "${review_status}"
+fi
+
+check_current_head_verdict
+
+if should_record_passed_head "${sid}"; then
+  mkdir -p "$(dirname "${last_sha_file}")"
+  git rev-parse HEAD > "${last_sha_file}"
+fi

--- a/patterns/commit/workflow.toml
+++ b/patterns/commit/workflow.toml
@@ -574,7 +574,7 @@ This catches cross-commit issues that per-commit reviews might miss.
 
 ```bash
 set -euo pipefail
-bash scripts/csa/cumulative-review-batch.sh --default-branch main -- \
+bash "${CSA_WORKFLOW_DIR:-patterns/commit}/scripts/csa/cumulative-review-batch.sh" --default-branch main -- \
   csa review --sa-mode true --range main...HEAD
 echo "CSA_VAR:REVIEW_COMPLETED=true"
 echo '<!-- CSA:NEXT_STEP cmd="push and create PR (Step 22)" required=true -->'

--- a/patterns/sa/PATTERN.md
+++ b/patterns/sa/PATTERN.md
@@ -72,7 +72,7 @@ Layer 1 (claude-code) will:
 
 ```bash
 SID=$(csa run --sa-mode true --prompt-file "${PROMPT_FILE}")
-scripts/csa/session-wait-until-done.sh "$SID"
+csa session wait --session "$SID"
 ```
 
 ## Step 5: Parse Planning Result
@@ -146,7 +146,7 @@ failures as justification for disabling hooks.
 IMPL_FILE=$(mktemp /tmp/sa-impl-XXXXXX.txt)
 echo "CSA_VAR:IMPL_FILE=$IMPL_FILE"
 SID=$(csa run --sa-mode true --session "${SESSION_ID}" --prompt-file "${IMPL_FILE}")
-scripts/csa/session-wait-until-done.sh "$SID"
+csa session wait --session "$SID"
 ```
 
 ## ELSE
@@ -163,7 +163,7 @@ Resume Layer 1 with user's revision feedback.
 RESUME_FILE=$(mktemp /tmp/sa-resume-XXXXXX.txt)
 echo "CSA_VAR:RESUME_FILE=$RESUME_FILE"
 SID=$(csa run --sa-mode true --session "${SESSION_ID}" --prompt-file "${RESUME_FILE}")
-scripts/csa/session-wait-until-done.sh "$SID"
+csa session wait --session "$SID"
 ```
 
 ## ELSE

--- a/patterns/sa/skills/sa/SKILL.md
+++ b/patterns/sa/skills/sa/SKILL.md
@@ -352,7 +352,7 @@ DONE WHEN:
 PLAN_EOF
 
 SID=$(csa run --sa-mode true --prompt-file "$PROMPT_FILE")
-scripts/csa/session-wait-until-done.sh "$SID"
+csa session wait --session "$SID"
 ```
 
 ### Template B: Implementation Dispatch (Manager -> Layer 1)
@@ -395,7 +395,7 @@ DONE WHEN:
 IMPL_EOF
 
 SID=$(csa run --sa-mode true --session "$SESSION_ID" --prompt-file "$PROMPT_FILE")
-scripts/csa/session-wait-until-done.sh "$SID"
+csa session wait --session "$SID"
 ```
 
 ### Template C: Trust Verification Dispatch (Manager -> Reviewer Employee)
@@ -431,7 +431,7 @@ DONE WHEN:
 VERIFY_EOF
 
 SID=$(csa run --sa-mode true --prompt-file "$PROMPT_FILE")
-scripts/csa/session-wait-until-done.sh "$SID"
+csa session wait --session "$SID"
 ```
 
 ### Canonical LLM dispatch form

--- a/patterns/sa/workflow.toml
+++ b/patterns/sa/workflow.toml
@@ -125,7 +125,7 @@ Layer 1 (claude-code) will:
 
 ```bash
 SID=$(csa run --sa-mode true --prompt-file "${PROMPT_FILE}")
-scripts/csa/session-wait-until-done.sh "$SID"
+csa session wait --session "$SID"
 ```"""
 on_fail = "abort"
 
@@ -197,7 +197,7 @@ Fix the underlying issues to ensure codebase integrity.
 IMPL_FILE=$(mktemp /tmp/sa-impl-XXXXXX.txt)
 echo "CSA_VAR:IMPL_FILE=$IMPL_FILE"
 SID=$(csa run --sa-mode true --session "${SESSION_ID}" --prompt-file "${IMPL_FILE}")
-scripts/csa/session-wait-until-done.sh "$SID"
+csa session wait --session "$SID"
 ```"""
 on_fail = "abort"
 condition = "${USER_APPROVES}"
@@ -213,7 +213,7 @@ Resume Layer 1 with user's revision feedback.
 RESUME_FILE=$(mktemp /tmp/sa-resume-XXXXXX.txt)
 echo "CSA_VAR:RESUME_FILE=$RESUME_FILE"
 SID=$(csa run --sa-mode true --session "${SESSION_ID}" --prompt-file "${RESUME_FILE}")
-scripts/csa/session-wait-until-done.sh "$SID"
+csa session wait --session "$SID"
 ```"""
 on_fail = "abort"
 condition = "(!(${USER_APPROVES})) && (${USER_MODIFIES})"


### PR DESCRIPTION
Closes #2403.

## Changes
- `patterns/sa/`, `patterns/ai-reviewed-commit/`: replaced `scripts/csa/session-wait-until-done.sh "$SID"` with native `csa session wait --session "$SID"`
- `patterns/commit/`: replaced bare `scripts/csa/cumulative-review-batch.sh` with `${CSA_WORKFLOW_DIR:-patterns/commit}/scripts/csa/...` (same pattern as dev2merge fix in #2400)
- Copied `cumulative-review-batch.sh` to `patterns/commit/scripts/csa/`

No patterns now reference target-repo `scripts/csa/` paths that may not exist.

Review uses `--no-verify` due to persistent reviewer FP.