### PR TITLE
fix(dev2merge): language-aware L1/L2 gates for non-Rust repos

### DIFF
--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -498,13 +498,25 @@ git commit -m "chore(release): bump workspace version to ${VERSION}"
 Tool: bash
 OnFail: abort
 Full and resume paths run the deterministic L1/L2 quality gate before
-cumulative CSA review.
+cumulative CSA review. Language-appropriate checks are run based on project type (#2539).
 
 ```bash
 set -euo pipefail
-just fmt
-just clippy
-just test
+if [ -f Cargo.toml ]; then
+  just fmt && just clippy && just test
+elif [ -f pyproject.toml ]; then
+  (just lint 2>/dev/null || ruff check . && ruff format --check .)
+  (just test 2>/dev/null || pytest)
+elif [ -f package.json ]; then
+  (just lint 2>/dev/null || biome check .)
+  (just test 2>/dev/null || vitest run)
+elif [ -f go.mod ]; then
+  go vet ./... && go test ./...
+elif just --summary 2>/dev/null | grep -q pre-commit; then
+  just pre-commit
+else
+  echo "WARNING: No recognized project type; skipping L1/L2 gate."
+fi
 ```
 
 ## Step 12: Pre-PR Cumulative Review Gate

--- a/patterns/dev2merge/skills/dev2merge/SKILL.md
+++ b/patterns/dev2merge/skills/dev2merge/SKILL.md
@@ -197,7 +197,7 @@ All steps use `on_fail = "abort"`. Variables propagate via `CSA_VAR:KEY=value`.
 | 8 | Execute with mktsk | Follow mktsk PATTERN.md directly, TaskCreate/TaskUpdate (skipped in resume mode) | main agent |
 | 9 | Resume Commit | resume mode only: stage, staged-diff check, commit uncommitted remainder | bash |
 | 10 | Version Bump | optional local Just version recipes; missing recipes skip | bash |
-| 11 | Self-Review Gate | Bash-enforced L1/L2 gate runs `just fmt`, `just clippy`, and `just test` before CSA review | bash |
+| 11 | Self-Review Gate | Language-aware L1/L2 gate: Rust (just fmt/clippy/test), Python (ruff/pytest), Node (biome/vitest), Go (go vet/test); skips gracefully for unrecognized projects (#2539) | bash |
 | 12 | Pre-PR Cumulative Review Gate | cumulative review helper runs `csa review --range ${DEFAULT_BRANCH}...HEAD` and owns exact-head verdict check when review runs | bash |
 | **ENDIF** | | | |
 | 13 | Push Gate | `REVIEW_COMPLETED=true` required | bash |
@@ -248,7 +248,7 @@ ln -sf ../../scripts/hooks/pre-push .git/hooks/pre-push
 
 1. Feature branch validated (not default branch/dev).
 2. FAST_PATH detection completed (heuristic applied).
-3. L1/L2 gates exit 0 (`just fmt`, `just clippy`, and `just test` on the full/resume path).
+3. L1/L2 gates exit 0 (language-appropriate: Rust→just fmt/clippy/test, Python→ruff/pytest, etc.; #2539).
 4. If full pipeline: mktd plan saved with `DONE WHEN` clauses, mktsk executed all tasks via main agent.
 5. If FAST_PATH: simplified commit created with tests passing.
 6. Rust repos with local version recipes bump if needed; non-Rust repos or repos missing those optional recipes skip without aborting.

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -545,13 +545,48 @@ title = "Self-Review Gate"
 tool = "bash"
 prompt = '''
 Full and resume paths run the deterministic L1/L2 quality gate before
-cumulative CSA review.
+cumulative CSA review. Language-appropriate checks are run based on project type (#2539).
 
 ```bash
 set -euo pipefail
-just fmt
-just clippy
-just test
+if [ -f Cargo.toml ]; then
+  just fmt
+  just clippy
+  just test
+elif [ -f pyproject.toml ]; then
+  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "lint"; then
+    just lint
+  elif command -v ruff >/dev/null 2>&1; then
+    ruff check .
+    ruff format --check .
+  fi
+  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then
+    just test
+  elif command -v pytest >/dev/null 2>&1; then
+    pytest
+  fi
+elif [ -f package.json ]; then
+  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "lint"; then
+    just lint
+  elif command -v biome >/dev/null 2>&1; then
+    biome check .
+  fi
+  if just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "test"; then
+    just test
+  elif command -v vitest >/dev/null 2>&1; then
+    vitest run
+  fi
+elif [ -f go.mod ]; then
+  go vet ./...
+  if command -v golangci-lint >/dev/null 2>&1; then
+    golangci-lint run
+  fi
+  go test ./...
+elif just --summary 2>/dev/null | tr ' ' '\n' | grep -qx "pre-commit"; then
+  just pre-commit
+else
+  echo "WARNING: No recognized project type; skipping L1/L2 gate."
+fi
 ```
 '''
 on_fail = "abort"


### PR DESCRIPTION
Closes #2539. Step 11 now detects project language (Rust/Python/Node/Go) and runs appropriate L1/L2 checks instead of hardcoded Rust recipes.