### PR TITLE
refactor(config,resource): generalize per-tool state-dir exposure (#1722)

### DIFF
--- a/crates/cli-sub-agent/src/claude_sub_agent_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/claude_sub_agent_cmd_tests.rs
@@ -77,6 +77,7 @@ fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }
@@ -462,6 +463,7 @@ fn get_auto_selectable_tools_filters_by_project_config() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/debate_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tests.rs
@@ -88,6 +88,7 @@ fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/debate_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_tier_tests.rs
@@ -54,6 +54,7 @@ fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/difficulty_routing.rs
+++ b/crates/cli-sub-agent/src/difficulty_routing.rs
@@ -232,6 +232,7 @@ mod tests {
             session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
         }
     }

--- a/crates/cli-sub-agent/src/doctor_tests.rs
+++ b/crates/cli-sub-agent/src/doctor_tests.rs
@@ -38,6 +38,7 @@ fn project_config_with_tool_transport(tool_name: &str, transport: TransportKind)
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -218,6 +218,7 @@ pub(crate) fn resolve_sandbox_options_with_overrides(
 
         // Build IsolationPlan via builder (BestEffort for profile defaults).
         let session_dir = resolve_session_dir_for_sandbox(project_root, session_id);
+        let tool_state_dirs = csa_config::default_tool_state_dirs();
         let mut builder = IsolationPlanBuilder::new(ResourceEnforcementMode::BestEffort)
             .with_resource_capability(resource_cap)
             .with_filesystem_capability(fs_cap)
@@ -226,7 +227,12 @@ pub(crate) fn resolve_sandbox_options_with_overrides(
                 defaults.memory_swap_max_mb,
                 None, // pids_max not available from profile defaults
             )
-            .with_tool_defaults(tool_name, project_root, &session_dir)
+            .with_tool_defaults_and_state_dirs(
+                tool_name,
+                project_root,
+                &session_dir,
+                Some(&tool_state_dirs),
+            )
             .with_readonly_project_root(readonly_project_root);
 
         // CSA runtime writable paths.
@@ -413,7 +419,12 @@ pub(crate) fn resolve_sandbox_options_with_overrides(
         .with_resource_capability(resource_cap)
         .with_filesystem_capability(fs_cap)
         .with_resource_limits(Some(memory_max_mb), memory_swap_max_mb, pids_max)
-        .with_tool_defaults(tool_name, project_root, &session_dir)
+        .with_tool_defaults_and_state_dirs(
+            tool_name,
+            project_root,
+            &session_dir,
+            Some(&cfg.tool_state_dirs),
+        )
         .with_readonly_project_root(effective_readonly)
         .with_soft_limit_percent(cfg.resources.soft_limit_percent)
         .with_memory_monitor_interval(cfg.resources.memory_monitor_interval_seconds);

--- a/crates/cli-sub-agent/src/pipeline_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests.rs
@@ -167,6 +167,7 @@ fn resolve_idle_timeout_prefers_cli_override() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -283,6 +284,7 @@ fn resolve_idle_timeout_uses_config_then_default() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -340,6 +342,7 @@ fn resolve_liveness_dead_seconds_uses_config_then_default() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -488,6 +491,7 @@ fn test_config_with_node_heap_limit(node_heap_limit_mb: Option<u64>) -> ProjectC
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }
@@ -537,6 +541,7 @@ fn config_with_tier_for_tool(_tool_prefix: &str, model_spec: &str) -> ProjectCon
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_git_guard_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_git_guard_env.rs
@@ -31,6 +31,7 @@ fn test_config() -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_initial_response.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_initial_response.rs
@@ -41,6 +41,7 @@ fn test_resolve_initial_response_timeout_cli_override_over_config() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     // CLI=60 overrides config=120.
@@ -86,6 +87,7 @@ fn test_resolve_initial_response_timeout_config_zero_disables() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     // Config=0 → disabled.
@@ -131,6 +133,7 @@ fn test_resolve_initial_response_timeout_uses_config_value() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     // Config=90, no CLI → Some(90).
@@ -180,6 +183,7 @@ fn test_resolve_initial_response_timeout_for_tool_disabled_when_idle_timeout_exp
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     // cli_idle_timeout=Some(1200), cli_initial_response_timeout=None → disabled.
@@ -217,6 +221,7 @@ fn test_resolve_initial_response_timeout_for_tool_kept_when_both_explicit() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     // Both explicit → initial_response_timeout=60 wins.
@@ -254,6 +259,7 @@ fn test_resolve_initial_response_timeout_for_tool_falls_through_without_idle_tim
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     // No cli_idle_timeout → config default applies.
@@ -290,6 +296,7 @@ fn test_resolve_initial_response_timeout_for_codex_defaults_to_300_without_overr
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -326,6 +333,7 @@ fn test_resolve_initial_response_timeout_for_gemini_cli_default() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -359,6 +367,7 @@ fn test_resolve_initial_response_timeout_for_non_codex_cli_zero_disables_watchdo
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -401,6 +410,7 @@ fn test_resolve_initial_response_timeout_gemini_cli_honors_override() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -442,6 +452,7 @@ fn test_resolve_initial_response_timeout_gemini_cli_disable() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -478,6 +489,7 @@ fn test_resolve_initial_response_timeout_for_unknown_tool_uses_global_default() 
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -511,6 +523,7 @@ fn test_resolve_initial_response_timeout_for_non_codex_positive_override_passes_
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -547,6 +560,7 @@ fn test_resolve_initial_response_timeout_for_codex_uses_explicit_resource_timeou
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -588,6 +602,7 @@ fn test_resolve_initial_response_timeout_for_codex_uses_tool_override() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -632,6 +647,7 @@ fn test_resolve_initial_response_timeout_for_codex_tool_override_beats_resource_
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -665,6 +681,7 @@ fn test_resolve_initial_response_timeout_for_codex_cli_zero_disables_watchdog() 
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -707,6 +724,7 @@ fn test_resolve_initial_response_timeout_for_codex_tool_zero_disables() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -744,6 +762,7 @@ fn test_resolve_initial_response_timeout_for_codex_global_zero_disables() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -778,6 +797,7 @@ fn test_resolve_initial_response_timeout_for_codex_respects_explicit_idle_overri
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/pipeline_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_preflight.rs
@@ -40,6 +40,7 @@ async fn execute_with_session_and_meta_fails_preflight_before_creating_session()
             },
         },
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     let executor = Executor::Opencode {
@@ -157,6 +158,7 @@ async fn execute_with_session_and_meta_runs_preflight_for_fresh_spawn_override()
             },
         },
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     let executor = Executor::Opencode {
@@ -240,6 +242,7 @@ async fn execute_with_session_and_meta_skips_preflight_for_resume_session() {
             },
         },
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     let executor = Executor::Opencode {

--- a/crates/cli-sub-agent/src/pipeline_tests_prompt_guard.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_prompt_guard.rs
@@ -166,6 +166,7 @@ fn anti_recursion_guard_honors_custom_max_recursion_depth() {
             session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
         }
     }

--- a/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_session_cleanup.rs
@@ -51,6 +51,7 @@ fn project_config_with_min_free_memory(min_free_memory_mb: u64) -> ProjectConfig
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_tail.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_tail.rs
@@ -33,6 +33,7 @@ async fn build_and_validate_executor_no_tiers_both_flags_equivalent() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/pipeline_tests_thinking.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_thinking.rs
@@ -52,6 +52,7 @@ fn config_with_single_tier_model(
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }
@@ -193,6 +194,7 @@ async fn thinking_lock_project_config_overrides_cli_thinking() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -296,6 +298,7 @@ async fn thinking_lock_project_overrides_global() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -459,6 +462,7 @@ async fn project_default_thinking_applies_when_cli_absent() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -532,6 +536,7 @@ async fn project_default_model_is_checked_against_tiers_when_enabled() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -603,6 +608,7 @@ async fn project_default_model_is_ignored_when_tool_defaults_disabled() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/pipeline_transcript.rs
+++ b/crates/cli-sub-agent/src/pipeline_transcript.rs
@@ -87,6 +87,7 @@ mod tests {
             session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
         }
     }

--- a/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_exact_tests.rs
@@ -94,6 +94,7 @@ fn exact_test_project_config_with_enabled_tools(tools: &[&str]) -> csa_config::P
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/review_cmd_fix_finding_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_finding_tests.rs
@@ -46,6 +46,7 @@ fn project_config_with_codex() -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/review_cmd_reviewers_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_reviewers_tests.rs
@@ -106,6 +106,7 @@ fn project_config_with_tier(models: &[&str]) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/review_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests.rs
@@ -72,6 +72,7 @@ pub(crate) fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
@@ -67,6 +67,7 @@ fn project_config_with_quality_tier() -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/review_cmd_tests_session_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_session_fix.rs
@@ -63,6 +63,7 @@ fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
@@ -69,6 +69,7 @@ fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/review_consensus_tests.rs
+++ b/crates/cli-sub-agent/src/review_consensus_tests.rs
@@ -57,6 +57,7 @@ fn project_config_with_enabled_tools(tools: &[&str]) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_attempt_codex_quota_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_codex_quota_tests.rs
@@ -49,6 +49,7 @@ fn make_config(tier_name: &str, models: &[&str]) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_attempt_http_failover_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_http_failover_tests.rs
@@ -46,6 +46,7 @@ fn make_failover_config(models: &[&str]) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_tests.rs
@@ -66,6 +66,7 @@ fn make_named_failover_config(tier_name: &str, models: &[&str]) -> ProjectConfig
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -85,9 +85,13 @@ impl DaemonSpawnOptions {
             } else {
                 RunStdinPrompt::None
             };
+        let prompt_file_to_capture = prompt_file
+            .filter(|path| !crate::run_helpers::is_prompt_file_stdin_sentinel(path))
+            .map(Path::to_path_buf);
 
         Self {
             run_stdin_prompt,
+            prompt_file_to_capture,
             prompt_file_forward_arg: PromptFileForwardArg::PromptFile,
             no_fs_sandbox,
             extra_writable: extra_writable.to_vec(),

--- a/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
@@ -135,6 +135,33 @@ fn run_daemon_options_detect_prompt_file_stdin_sentinel() {
     let options =
         DaemonSpawnOptions::for_run(None, None, None, Some(Path::new("-")), false, &[], false);
     assert_eq!(options.run_stdin_prompt, RunStdinPrompt::PromptFileSentinel);
+    assert!(options.prompt_file_to_capture.is_none());
+}
+
+#[test]
+fn run_daemon_options_capture_regular_prompt_file_before_spawn() {
+    let path = Path::new("RUN_PROMPT.md");
+    let options = DaemonSpawnOptions::for_run(None, None, None, Some(path), false, &[], false);
+
+    assert_eq!(options.run_stdin_prompt, RunStdinPrompt::None);
+    assert_eq!(options.prompt_file_to_capture.as_deref(), Some(path));
+}
+
+#[test]
+fn run_daemon_missing_prompt_file_fails_before_spawn() {
+    let path = Path::new("MISSING_RUN_PROMPT.md");
+    let options = DaemonSpawnOptions::for_run(None, None, None, Some(path), false, &[], false);
+    let mut stdin = std::io::Cursor::new("");
+
+    let err = read_daemon_prompt_input_if_needed_from_reader(&options, true, &mut stdin)
+        .expect_err("missing run --prompt-file must fail before daemon spawn");
+
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("--prompt-file: failed to read"),
+        "{message}"
+    );
+    assert!(message.contains("MISSING_RUN_PROMPT.md"), "{message}");
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_reserved_path_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_reserved_path_tests.rs
@@ -40,6 +40,7 @@ fn project_config_with_gate(gate: PostExecGateConfig) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_residual_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_residual_tests.rs
@@ -337,6 +337,7 @@ fn config_with_gate(gate: PostExecGateConfig) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_staged_gate_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_staged_gate_tests.rs
@@ -40,6 +40,7 @@ fn project_config_with_gate(gate: PostExecGateConfig) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -62,6 +62,7 @@ fn project_config_with_gate(gate: PostExecGateConfig) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -57,6 +57,7 @@ fn run_config_with_tier(
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     config.tiers.insert(

--- a/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_tests.rs
@@ -75,6 +75,7 @@ fn make_test_config() -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_execute_tier_failover_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_tier_failover_tests.rs
@@ -56,6 +56,7 @@ fn make_config_with_tier_models(tier_name: &str, models: &[&str]) -> ProjectConf
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_model_pin_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_model_pin_tests.rs
@@ -618,6 +618,7 @@ fn config_with_tier_models(models: &[&str]) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
@@ -83,6 +83,7 @@ fn run_config_with_tier(
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     config.tiers.insert(

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection_hint_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection_hint_tests.rs
@@ -68,6 +68,7 @@ fn config_with_enabled_tiers(
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection_model_spec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection_model_spec_tests.rs
@@ -59,6 +59,7 @@ fn resolve_tool_by_strategy_model_spec_disables_default_tier_and_runtime_fallbac
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     let global_config = GlobalConfig {

--- a/crates/cli-sub-agent/src/run_cmd_tool_selection_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tool_selection_tests.rs
@@ -72,6 +72,7 @@ fn config_with_openai_compat_tiers(
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_helpers_compat_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_compat_tests.rs
@@ -229,6 +229,7 @@ fn resolve_tool_and_model_skips_compat_check_when_configured_default() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/run_helpers_compound_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_compound_tier_tests.rs
@@ -49,6 +49,7 @@ fn fixture(tool_aliases: HashMap<String, String>) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_helpers_model_spec_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_model_spec_tests.rs
@@ -63,6 +63,7 @@ fn project_config_with_tier_tools(tools: &[&str]) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/run_helpers_override_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_override_tests.rs
@@ -27,6 +27,7 @@ fn resolve_tool_and_model_model_spec_preserves_explicit_model_override() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/run_helpers_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tests.rs
@@ -195,6 +195,7 @@ fn mutating_skill_contract_routes_default_tier_away_from_restricted_tool() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -379,6 +380,7 @@ fn build_executor_uses_project_tool_defaults_when_cli_missing() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -421,6 +423,7 @@ fn build_executor_ignores_project_tool_defaults_when_disabled() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -469,6 +472,7 @@ fn build_executor_cli_overrides_project_tool_defaults() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -693,6 +697,7 @@ fn build_executor_model_spec_overrides_both() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/run_helpers_tier_force_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_force_tests.rs
@@ -33,6 +33,7 @@ fn tier_bypass_gate_allows_bypass_flags_when_no_tiers_configured() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -516,6 +517,7 @@ fn resolve_tool_and_model_force_ignore_tier_skipped_when_no_tiers_configured() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tier_tests.rs
@@ -45,6 +45,7 @@ fn resolve_tool_and_model_disabled_tool_explicit_errors() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -95,6 +96,7 @@ fn resolve_tool_and_model_disabled_tool_with_override_succeeds() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -146,6 +148,7 @@ fn resolve_tool_and_model_disabled_tool_model_spec_errors() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -216,6 +219,7 @@ pub(super) fn config_with_tier(
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }
@@ -608,6 +612,7 @@ fn resolve_tool_and_model_no_tiers_allows_direct_tool() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     let result = super::resolve_tool_and_model(super::RoutingRequest {

--- a/crates/cli-sub-agent/src/run_helpers_tool_availability.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tool_availability.rs
@@ -297,6 +297,7 @@ mod failover_detection_tests {
             session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
         }
     }

--- a/crates/cli-sub-agent/src/run_helpers_transport_tests.rs
+++ b/crates/cli-sub-agent/src/run_helpers_transport_tests.rs
@@ -30,6 +30,7 @@ fn project_config_with_tool(tool_name: &str, tool_config: ToolConfig) -> Project
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/cli-sub-agent/src/tier_model_fallback_tests.rs
+++ b/crates/cli-sub-agent/src/tier_model_fallback_tests.rs
@@ -51,6 +51,7 @@ fn project_config_with_tier(
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     cfg.tiers.insert(

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -513,6 +513,7 @@ fn write_project_config_with_tier(project_root: &Path) {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     config.tiers.insert(

--- a/crates/cli-sub-agent/tests/tier_policy_ux.rs
+++ b/crates/cli-sub-agent/tests/tier_policy_ux.rs
@@ -47,6 +47,7 @@ fn write_project_config_with_tier(project_root: &Path) {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
     config.tiers.insert(

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -16,6 +16,7 @@ use crate::config_raw::{
 pub use crate::config_resources::ResourcesConfig;
 use crate::global::{
     GithubConfig, PreferencesConfig, PreflightConfig, ReviewConfig, SessionWaitConfig,
+    default_tool_state_dirs, ensure_default_tool_state_dirs,
 };
 use crate::memory::MemoryConfig;
 use crate::paths;
@@ -113,6 +114,19 @@ pub struct ProjectConfig {
     /// Memory system configuration.
     #[serde(default, skip_serializing_if = "MemoryConfig::is_default")]
     pub memory: MemoryConfig,
+    /// Per-tool state directories exposed writable to sandboxed tool processes.
+    ///
+    /// Example:
+    /// ```toml
+    /// [tool_state_dirs]
+    /// codex = "~/.codex"
+    /// claude = "~/.claude"
+    /// ```
+    #[serde(
+        default = "default_tool_state_dirs",
+        skip_serializing_if = "HashMap::is_empty"
+    )]
+    pub tool_state_dirs: HashMap<String, PathBuf>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub tools: HashMap<String, ToolConfig>,
     /// Optional per-project override for `csa review` tool selection.
@@ -377,6 +391,7 @@ impl ProjectConfig {
     }
 
     fn sanitize_filesystem_sandbox(&mut self) {
+        ensure_default_tool_state_dirs(&mut self.tool_state_dirs);
         self.filesystem_sandbox.sanitize_legacy_xdg_runtime_root();
         for (tool, config) in &mut self.tools {
             let Some(sandbox) = &mut config.filesystem_sandbox else {

--- a/crates/csa-config/src/config_merge_tests.rs
+++ b/crates/csa-config/src/config_merge_tests.rs
@@ -492,6 +492,47 @@ models = ["codex/openai/o3/high"]
 }
 
 #[test]
+fn test_tool_state_dirs_inherit_from_global_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    let user_path = tmp.path().join("user.toml");
+    let project_path = tmp.path().join("project.toml");
+
+    std::fs::write(
+        &user_path,
+        r#"
+schema_version = 1
+[tool_state_dirs]
+codex = "/srv/codex-state"
+claude = "/srv/claude-state"
+"#,
+    )
+    .unwrap();
+
+    std::fs::write(
+        &project_path,
+        r#"
+schema_version = 1
+[project]
+name = "state-dir-merge"
+"#,
+    )
+    .unwrap();
+
+    let config = ProjectConfig::load_with_paths(Some(&user_path), &project_path)
+        .unwrap()
+        .expect("Should load merged config");
+
+    assert_eq!(
+        config.tool_state_dirs.get("codex"),
+        Some(&PathBuf::from("/srv/codex-state"))
+    );
+    assert_eq!(
+        config.tool_state_dirs.get("claude"),
+        Some(&PathBuf::from("/srv/claude-state"))
+    );
+}
+
+#[test]
 fn test_liveness_dead_seconds_priority_project_over_user_over_default() {
     let tmp = tempfile::tempdir().unwrap();
     let user_path = tmp.path().join("user.toml");

--- a/crates/csa-config/src/config_runtime_fs_sandbox_tests.rs
+++ b/crates/csa-config/src/config_runtime_fs_sandbox_tests.rs
@@ -35,6 +35,7 @@ fn empty_config() -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/csa-config/src/config_runtime_tests.rs
+++ b/crates/csa-config/src/config_runtime_tests.rs
@@ -35,6 +35,7 @@ fn empty_config() -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/csa-config/src/config_runtime_timeout_tests.rs
+++ b/crates/csa-config/src/config_runtime_timeout_tests.rs
@@ -30,6 +30,7 @@ fn empty_config() -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: VcsConfig::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: FilesystemSandboxConfig::default(),
     }
 }

--- a/crates/csa-config/src/config_tests.rs
+++ b/crates/csa-config/src/config_tests.rs
@@ -42,6 +42,7 @@ fn test_save_and_load_roundtrip() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -61,6 +62,61 @@ fn test_save_and_load_roundtrip() {
     assert!(codex.enabled);
     assert_eq!(codex.default_model.as_deref(), Some("gpt-5.4"));
     assert_eq!(codex.default_thinking.as_deref(), Some("xhigh"));
+}
+
+#[test]
+fn test_tool_state_dirs_roundtrip() {
+    let dir = tempdir().unwrap();
+    let config = ProjectConfig {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta {
+            name: "state-dir-test".to_string(),
+            created_at: Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        tool_state_dirs: HashMap::from([
+            ("codex".to_string(), PathBuf::from("~/.codex")),
+            ("claude".to_string(), PathBuf::from("~/.claude")),
+        ]),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        github: None,
+        session: Default::default(),
+        memory: Default::default(),
+        hooks: Default::default(),
+        run: Default::default(),
+        execution: Default::default(),
+        session_wait: None,
+        preflight: Default::default(),
+        vcs: Default::default(),
+        filesystem_sandbox: Default::default(),
+    };
+
+    config.save(dir.path()).unwrap();
+    let project_path = dir.path().join(".csa").join("config.toml");
+    let saved = std::fs::read_to_string(&project_path).unwrap();
+    assert!(saved.contains("[tool_state_dirs]"));
+    assert!(saved.contains(r#"codex = "~/.codex""#));
+
+    let loaded = ProjectConfig::load_with_paths(None, &project_path)
+        .unwrap()
+        .expect("config should load");
+    assert_eq!(
+        loaded.tool_state_dirs.get("codex"),
+        Some(&PathBuf::from("~/.codex"))
+    );
+    assert_eq!(
+        loaded.tool_state_dirs.get("claude"),
+        Some(&PathBuf::from("~/.claude"))
+    );
 }
 
 #[test]
@@ -94,6 +150,7 @@ fn test_is_tool_enabled_configured_enabled() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -139,6 +196,7 @@ fn test_is_tool_enabled_configured_disabled() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -173,6 +231,7 @@ fn test_is_tool_enabled_unconfigured_defaults_to_true() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -223,6 +282,7 @@ fn test_is_tool_configured_in_tiers_detects_presence() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -287,6 +347,7 @@ fn test_is_tool_auto_selectable_requires_enabled_and_tier_membership() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -337,6 +398,7 @@ fn test_can_tool_edit_existing_with_restrictions_false() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -374,6 +436,7 @@ fn test_can_tool_edit_existing_without_restrictions() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -408,6 +471,7 @@ fn test_can_tool_edit_existing_unconfigured_defaults_to_true() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -496,6 +560,7 @@ fn test_max_recursion_depth_override() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -631,6 +696,7 @@ fn test_schema_version_current_is_ok() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -666,6 +732,7 @@ fn test_schema_version_older_is_ok() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -700,6 +767,7 @@ fn test_schema_version_newer_fails() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -765,6 +833,7 @@ fn test_enforce_tool_enabled_disabled_tool_returns_error() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/csa-config/src/config_tests_github.rs
+++ b/crates/csa-config/src/config_tests_github.rs
@@ -1,5 +1,6 @@
 use crate::config::CURRENT_SCHEMA_VERSION;
 use crate::{ProjectConfig, ProjectMeta};
+use std::collections::HashMap;
 use tempfile::tempdir;
 
 struct EnvVarGuard {
@@ -116,6 +117,7 @@ fn test_resolved_github_config_dir_preserves_trimmed_override() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/csa-config/src/config_tests_tail.rs
+++ b/crates/csa-config/src/config_tests_tail.rs
@@ -115,6 +115,7 @@ fn test_save_and_load_roundtrip_with_review_override() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -251,6 +252,7 @@ fn test_enforce_tool_enabled_enabled_tool_returns_ok() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -281,6 +283,7 @@ fn test_enforce_tool_enabled_unconfigured_tool_returns_ok() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -320,6 +323,7 @@ fn test_enforce_tool_enabled_force_override_bypasses_disabled() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -739,6 +743,7 @@ fn test_enforce_tool_enabled_includes_alternatives_when_others_enabled() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -805,6 +810,7 @@ fn test_enforce_tool_enabled_omits_hint_when_no_alternatives() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/csa-config/src/config_tests_tier.rs
+++ b/crates/csa-config/src/config_tests_tier.rs
@@ -51,6 +51,7 @@ fn test_resolve_tier_default_selection() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -105,6 +106,7 @@ fn test_resolve_tier_fallback_to_tier3() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -175,6 +177,7 @@ fn test_resolve_tier_skips_disabled_tools() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -223,6 +226,7 @@ fn test_resolve_alias() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -285,6 +289,7 @@ fn enabled_tier_models_returns_all_when_no_tools_disabled() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -344,6 +349,7 @@ fn enabled_tier_models_excludes_disabled_tool() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -378,6 +384,7 @@ fn enabled_tier_models_returns_empty_for_unknown_tier() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -440,6 +447,7 @@ fn enabled_tier_models_returns_empty_when_all_tools_disabled() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -504,6 +512,7 @@ fn filtered_skips_restricted_tool_when_needs_edit() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -572,6 +581,7 @@ fn filtered_returns_none_when_all_restricted_and_needs_edit() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/csa-config/src/config_tests_tier_selector.rs
+++ b/crates/csa-config/src/config_tests_tier_selector.rs
@@ -38,6 +38,7 @@ fn test_resolve_tier_selector_direct_tier() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -86,6 +87,7 @@ fn test_resolve_tier_selector_alias() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -146,6 +148,7 @@ fn test_resolve_tier_selector_direct_wins_on_collision() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -180,6 +183,7 @@ fn test_resolve_tier_selector_nonexistent() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -213,6 +217,7 @@ fn test_resolve_tier_selector_alias_to_nonexistent_tier() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -266,6 +271,7 @@ fn test_resolve_tier_selector_prefix_unique() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -340,6 +346,7 @@ fn test_resolve_tier_selector_prefix_ambiguous() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -391,6 +398,7 @@ fn test_resolve_tier_selector_exact_wins_over_prefix() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -443,6 +451,7 @@ fn test_suggest_tier_prefix() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -494,6 +503,7 @@ fn test_suggest_tier_substring() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -535,6 +545,7 @@ fn test_suggest_tier_no_match() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -581,6 +592,7 @@ fn test_resolve_tier_selector_empty_string_rejected() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -631,6 +643,7 @@ fn compound_tier_fixture(tool_aliases: HashMap<String, String>) -> ProjectConfig
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/csa-config/src/config_tests_tier_selector_legacy.rs
+++ b/crates/csa-config/src/config_tests_tier_selector_legacy.rs
@@ -36,6 +36,7 @@ fn config_with_tier_4_critical() -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/csa-config/src/config_tests_tier_whitelist.rs
+++ b/crates/csa-config/src/config_tests_tier_whitelist.rs
@@ -36,6 +36,7 @@ fn config_with_tiers(tier_models: &[&str]) -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }
@@ -397,6 +398,7 @@ fn config_with_multi_tiers() -> ProjectConfig {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 pub use crate::global_env::ExecutionEnvOptions;
 pub use crate::global_kv_cache::{
@@ -14,8 +15,10 @@ pub use crate::tool_selection::ToolSelection;
 use csa_core::types::ToolName;
 
 const DEFAULT_MAX_CONCURRENT: u32 = 3;
+pub const DEFAULT_CODEX_STATE_DIR: &str = "~/.codex";
+pub const DEFAULT_CLAUDE_STATE_DIR: &str = "~/.claude";
 /// Global configuration loaded from `~/.config/cli-sub-agent/config.toml`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GlobalConfig {
     #[serde(default)]
     pub defaults: DefaultsConfig,
@@ -45,6 +48,9 @@ pub struct GlobalConfig {
     /// Memory system configuration.
     #[serde(default)]
     pub memory: MemoryConfig,
+    /// Per-tool state directories exposed writable to sandboxed tool processes.
+    #[serde(default = "default_tool_state_dirs")]
+    pub tool_state_dirs: HashMap<String, PathBuf>,
     /// Global hook behavior settings.
     #[serde(default, skip_serializing_if = "GlobalHooksConfig::is_default")]
     pub hooks: GlobalHooksConfig,
@@ -87,6 +93,56 @@ pub struct GlobalConfig {
     /// Experimental feature flags.
     #[serde(default)]
     pub experimental: ExperimentalConfig,
+}
+
+impl Default for GlobalConfig {
+    fn default() -> Self {
+        Self {
+            defaults: DefaultsConfig::default(),
+            preferences: PreferencesConfig::default(),
+            github: GithubConfig::default(),
+            tools: HashMap::new(),
+            review: ReviewConfig::default(),
+            debate: DebateConfig::default(),
+            fallback: FallbackConfig::default(),
+            retry: RetryConfig::default(),
+            budget: BudgetConfig::default(),
+            tier_policy: TierPolicyConfig::default(),
+            todo: TodoDisplayConfig::default(),
+            memory: MemoryConfig::default(),
+            tool_state_dirs: default_tool_state_dirs(),
+            hooks: GlobalHooksConfig::default(),
+            mcp: GlobalMcpConfig::default(),
+            mcp_proxy_socket: None,
+            tool_aliases: HashMap::new(),
+            run: crate::config::RunConfig::default(),
+            execution: crate::config::ExecutionConfig::default(),
+            kv_cache: KvCacheConfig::default(),
+            session_wait: SessionWaitConfig::default(),
+            preflight: PreflightConfig::default(),
+            state_dir: StateDirConfig::default(),
+            acp: crate::AcpConfig::default(),
+            filesystem_sandbox: crate::config_filesystem_sandbox::FilesystemSandboxConfig::default(
+            ),
+            experimental: ExperimentalConfig::default(),
+        }
+    }
+}
+
+pub fn default_tool_state_dirs() -> HashMap<String, PathBuf> {
+    HashMap::from([
+        ("codex".to_string(), PathBuf::from(DEFAULT_CODEX_STATE_DIR)),
+        (
+            "claude".to_string(),
+            PathBuf::from(DEFAULT_CLAUDE_STATE_DIR),
+        ),
+    ])
+}
+
+pub fn ensure_default_tool_state_dirs(tool_state_dirs: &mut HashMap<String, PathBuf>) {
+    for (tool, path) in default_tool_state_dirs() {
+        tool_state_dirs.entry(tool).or_insert(path);
+    }
 }
 
 /// GitHub CLI authentication settings shared across workflows.

--- a/crates/csa-config/src/global_impl.rs
+++ b/crates/csa-config/src/global_impl.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use crate::global::{
     DEFAULT_KV_CACHE_LONG_POLL_SECS, GlobalConfig, KvCacheValueSource, ResolvedKvCacheValue,
-    heterogeneous_counterpart, sort_tools_by_priority,
+    ensure_default_tool_state_dirs, heterogeneous_counterpart, sort_tools_by_priority,
 };
 use crate::mcp::McpServerConfig;
 use crate::paths;
@@ -164,6 +164,7 @@ impl GlobalConfig {
 
     fn sanitized(mut self, path: Option<&Path>) -> Self {
         self.kv_cache = self.kv_cache.sanitized(path);
+        ensure_default_tool_state_dirs(&mut self.tool_state_dirs);
         self.filesystem_sandbox.sanitize_legacy_xdg_runtime_root();
         self
     }

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -9,6 +9,12 @@ pub(crate) fn default_template() -> String {
 max_concurrent = 3  # Default max parallel instances per tool
 # tool = "codex"  # Default tool when auto-detection fails
 
+# Per-tool host state directories exposed writable to sandboxed tool processes.
+# Environment variables such as CODEX_HOME and CLAUDE_CONFIG_DIR still win.
+[tool_state_dirs]
+codex = "~/.codex"
+claude = "~/.claude"
+
 # Per-tool overrides. Uncomment and configure as needed.
 #
 # [tools.claude-code]

--- a/crates/csa-config/src/global_tests.rs
+++ b/crates/csa-config/src/global_tests.rs
@@ -8,6 +8,7 @@ use csa_core::{
 };
 use serial_test::serial;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 struct EnvVarGuard {
     key: &'static str,
@@ -41,6 +42,14 @@ fn test_default_config() {
     assert_eq!(config.defaults.max_concurrent, 3);
     assert_eq!(config.kv_cache.frequent_poll_seconds, 60);
     assert_eq!(config.kv_cache.long_poll_seconds, 240);
+    assert_eq!(
+        config.tool_state_dirs.get("codex"),
+        Some(&PathBuf::from("~/.codex"))
+    );
+    assert_eq!(
+        config.tool_state_dirs.get("claude"),
+        Some(&PathBuf::from("~/.claude"))
+    );
     assert!(config.tools.is_empty());
 }
 
@@ -49,6 +58,39 @@ fn test_kv_cache_defaults_parse_when_section_omitted() {
     let config: GlobalConfig = toml::from_str("").unwrap();
     assert_eq!(config.kv_cache.frequent_poll_seconds, 60);
     assert_eq!(config.kv_cache.long_poll_seconds, 240);
+}
+
+#[test]
+fn test_tool_state_dirs_defaults_parse_when_section_omitted() {
+    let config: GlobalConfig = toml::from_str("").unwrap();
+    assert_eq!(
+        config.tool_state_dirs.get("codex"),
+        Some(&PathBuf::from("~/.codex"))
+    );
+    assert_eq!(
+        config.tool_state_dirs.get("claude"),
+        Some(&PathBuf::from("~/.claude"))
+    );
+}
+
+#[test]
+fn test_tool_state_dirs_parse_from_global_config() {
+    let config: GlobalConfig = toml::from_str(
+        r#"
+[tool_state_dirs]
+codex = "/srv/codex-state"
+claude = "/srv/claude-state"
+"#,
+    )
+    .unwrap();
+    assert_eq!(
+        config.tool_state_dirs.get("codex"),
+        Some(&PathBuf::from("/srv/codex-state"))
+    );
+    assert_eq!(
+        config.tool_state_dirs.get("claude"),
+        Some(&PathBuf::from("/srv/claude-state"))
+    );
 }
 
 #[test]
@@ -492,6 +534,9 @@ fn test_default_template_is_valid_comment_only() {
     assert!(template.contains("[defaults]"));
     assert!(template.contains("max_concurrent"));
     assert!(template.contains("# tool = \"codex\""));
+    assert!(template.contains("[tool_state_dirs]"));
+    assert!(template.contains("codex = \"~/.codex\""));
+    assert!(template.contains("claude = \"~/.claude\""));
     assert!(template.contains("[tier_policy]"));
     assert!(template.contains("allow_force_bypass = false"));
 }

--- a/crates/csa-config/src/global_tests_priority.rs
+++ b/crates/csa-config/src/global_tests_priority.rs
@@ -163,6 +163,7 @@ fn project_config_with_preferences(prefs: Option<PreferencesConfig>) -> crate::P
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     }
 }

--- a/crates/csa-config/src/init.rs
+++ b/crates/csa-config/src/init.rs
@@ -225,6 +225,7 @@ pub fn init_project(
             session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
         }
     } else {
@@ -258,6 +259,7 @@ pub fn init_project(
             session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
         }
     };

--- a/crates/csa-config/src/lib.rs
+++ b/crates/csa-config/src/lib.rs
@@ -50,12 +50,13 @@ pub use config_runtime::{DefaultSandboxOptions, default_sandbox_for_tool};
 pub use config_tool::{TransportKind, default_transport_for_tool};
 pub use gc::GcConfig;
 pub use global::{
-    AiConfigSymlinkCheckConfig, BudgetConfig, DEFAULT_KV_CACHE_FREQUENT_POLL_SECS,
-    DEFAULT_KV_CACHE_LONG_POLL_SECS, ExecutionEnvOptions, ExperimentalConfig, GateMode, GateStep,
-    GithubConfig, GlobalConfig, GlobalHooksConfig, GlobalMcpConfig, KvCacheConfig,
-    KvCacheValueSource, LEGACY_SESSION_WAIT_FALLBACK_SECS, PreflightConfig, ProviderTtls,
-    ResolvedKvCacheValue, RetryConfig, ReviewConfig, SessionWaitConfig, StateDirConfig,
-    StateDirOnExceed, TierPolicyConfig, ToolSelection,
+    AiConfigSymlinkCheckConfig, BudgetConfig, DEFAULT_CLAUDE_STATE_DIR, DEFAULT_CODEX_STATE_DIR,
+    DEFAULT_KV_CACHE_FREQUENT_POLL_SECS, DEFAULT_KV_CACHE_LONG_POLL_SECS, ExecutionEnvOptions,
+    ExperimentalConfig, GateMode, GateStep, GithubConfig, GlobalConfig, GlobalHooksConfig,
+    GlobalMcpConfig, KvCacheConfig, KvCacheValueSource, LEGACY_SESSION_WAIT_FALLBACK_SECS,
+    PreflightConfig, ProviderTtls, ResolvedKvCacheValue, RetryConfig, ReviewConfig,
+    SessionWaitConfig, StateDirConfig, StateDirOnExceed, TierPolicyConfig, ToolSelection,
+    default_tool_state_dirs, ensure_default_tool_state_dirs,
 };
 pub use global_caller_hints::{
     CallerHintsConfig, DEFAULT_CODEX_SESSION_WAIT_MCP_INTERNAL_TIMEOUT_SEC,

--- a/crates/csa-config/src/validate_tests.rs
+++ b/crates/csa-config/src/validate_tests.rs
@@ -58,6 +58,7 @@ fn test_validate_config_succeeds_on_valid() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -98,6 +99,7 @@ fn test_validate_config_fails_on_empty_name() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -142,6 +144,7 @@ fn test_validate_config_fails_on_unknown_tool() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -187,6 +190,7 @@ fn test_validate_config_fails_on_zero_idle_timeout() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -236,6 +240,7 @@ fn test_validate_config_fails_on_invalid_review_tool() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -295,6 +300,7 @@ fn test_validate_config_fails_on_invalid_model_spec() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -357,6 +363,7 @@ fn test_validate_config_fails_on_invalid_tier_mapping() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -428,6 +435,7 @@ fn test_validate_config_fails_on_empty_models() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -490,6 +498,7 @@ fn test_validate_config_accepts_custom_tier_names() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -533,6 +542,7 @@ fn test_validate_config_fails_on_invalid_debate_tool() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -579,6 +589,7 @@ fn test_validate_max_recursion_depth_boundary_20() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -618,6 +629,7 @@ fn test_validate_max_recursion_depth_boundary_21() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/csa-config/src/validate_tests_model_catalog.rs
+++ b/crates/csa-config/src/validate_tests_model_catalog.rs
@@ -46,6 +46,7 @@ fn tier_validate_rejects_cross_provider_opencode_spec() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/csa-config/src/validate_tests_preferences.rs
+++ b/crates/csa-config/src/validate_tests_preferences.rs
@@ -34,6 +34,7 @@ fn test_validate_config_warns_but_passes_on_unknown_tool_priority() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 

--- a/crates/csa-config/src/validate_tests_sandbox.rs
+++ b/crates/csa-config/src/validate_tests_sandbox.rs
@@ -33,6 +33,7 @@ fn test_validate_liveness_dead_seconds_zero_rejected() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -81,6 +82,7 @@ fn test_validate_fatal_error_markers_rejects_blank_marker() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -129,6 +131,7 @@ fn test_validate_memory_max_mb_too_low() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -177,6 +180,7 @@ fn test_validate_memory_max_mb_at_minimum() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -219,6 +223,7 @@ fn test_validate_pids_max_too_low() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -267,6 +272,7 @@ fn test_validate_pids_max_at_minimum() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -309,6 +315,7 @@ fn test_validate_node_heap_limit_mb_too_low_in_resources() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -363,6 +370,7 @@ fn test_validate_per_tool_required_enforcement_without_memory_fails() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -420,6 +428,7 @@ fn test_validate_per_tool_required_enforcement_with_tool_memory_passes() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -471,6 +480,7 @@ fn test_validate_per_tool_required_enforcement_with_global_memory_passes() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -522,6 +532,7 @@ fn test_validate_node_heap_limit_mb_too_low_in_tool() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -570,6 +581,7 @@ fn test_validate_soft_limit_percent_zero_rejected() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -618,6 +630,7 @@ fn test_validate_soft_limit_percent_over_100_rejected() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -666,6 +679,7 @@ fn test_validate_soft_limit_percent_valid() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -708,6 +722,7 @@ fn test_validate_memory_monitor_interval_zero_rejected() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -756,6 +771,7 @@ fn test_validate_memory_monitor_interval_valid() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 

--- a/crates/csa-config/src/validate_tests_tail.rs
+++ b/crates/csa-config/src/validate_tests_tail.rs
@@ -52,6 +52,7 @@ fn test_validate_model_spec_two_parts() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -110,6 +111,7 @@ fn test_validate_model_spec_five_parts() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -158,6 +160,7 @@ fn test_validate_review_tool_auto_accepted() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -200,6 +203,7 @@ fn test_validate_review_batch_commits_zero_rejected() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -255,6 +259,7 @@ fn test_validate_all_known_review_tools_accepted() {
             session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
         };
 
@@ -309,6 +314,7 @@ fn test_validate_all_known_debate_tools_accepted() {
             session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
         };
 
@@ -357,6 +363,7 @@ fn test_validate_all_known_tools_accepted() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -396,6 +403,7 @@ fn test_validate_no_review_no_debate_is_ok() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -435,6 +443,7 @@ fn test_validate_max_recursion_depth_zero() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -481,6 +490,7 @@ fn test_validate_config_warns_but_passes_on_fork_prefix_budget_below_min() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 
@@ -533,6 +543,7 @@ fn test_validate_codex_tmux_mode_rejects_acp_transport() {
         session_wait: None,
         preflight: Default::default(),
         vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
         filesystem_sandbox: Default::default(),
     };
 

--- a/crates/csa-config/src/validate_tests_tiers.rs
+++ b/crates/csa-config/src/validate_tests_tiers.rs
@@ -68,6 +68,7 @@ fn test_validate_multiple_tiers_all_valid() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -123,6 +124,7 @@ fn test_validate_tier_with_multiple_models_all_valid() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -178,6 +180,7 @@ fn test_validate_tier_with_one_bad_model_in_list() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -236,6 +239,7 @@ fn test_validate_tier_token_budget_zero_rejected() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -289,6 +293,7 @@ fn test_validate_tier_max_turns_zero_rejected() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -342,6 +347,7 @@ fn test_validate_tier_with_valid_budget_and_turns() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -394,6 +400,7 @@ fn test_validate_tier_model_spec_unknown_tool_rejected() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -451,6 +458,7 @@ fn test_validate_tier_model_spec_unknown_provider_rejected() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -510,6 +518,7 @@ fn test_validate_tier_model_spec_unknown_model_rejected() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -569,6 +578,7 @@ fn test_validate_tier_model_spec_known_tool_accepted() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -620,6 +630,7 @@ fn tier_validate_rejects_invalid_thinking_budget() {
             session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
         }
     }
@@ -675,6 +686,7 @@ fn test_validate_review_tier_unknown_rejected() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -722,6 +734,7 @@ fn test_validate_debate_tier_unknown_rejected() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 
@@ -782,6 +795,7 @@ fn test_validate_review_tier_valid_accepted() {
         session_wait: None,
             preflight: Default::default(),
             vcs: Default::default(),
+            tool_state_dirs: HashMap::new(),
             filesystem_sandbox: Default::default(),
     };
 

--- a/crates/csa-executor/src/executor_antigravity_settings.rs
+++ b/crates/csa-executor/src/executor_antigravity_settings.rs
@@ -343,7 +343,6 @@ mod tests {
     }
 }
 
-
     #[test]
     fn issue_2347_normalize_model_alias_resolves_slugs() {
         assert_eq!(normalize_model_alias("gemini-3.1-pro-high"), "Gemini 3.1 Pro (High)");

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -228,6 +228,33 @@ impl IsolationPlanBuilder {
         project_root: &Path,
         session_dir: &Path,
     ) -> Self {
+        self.apply_tool_defaults(tool_name, project_root, session_dir, None);
+        self
+    }
+
+    /// Apply per-tool defaults with optional configured tool state dirs.
+    ///
+    /// `tool_state_dirs` maps canonical state names such as `"codex"` and
+    /// `"claude"` to host paths.  Environment variables recognized by the
+    /// underlying tools still take precedence over this table.
+    pub fn with_tool_defaults_and_state_dirs(
+        mut self,
+        tool_name: &str,
+        project_root: &Path,
+        session_dir: &Path,
+        tool_state_dirs: Option<&HashMap<String, PathBuf>>,
+    ) -> Self {
+        self.apply_tool_defaults(tool_name, project_root, session_dir, tool_state_dirs);
+        self
+    }
+
+    fn apply_tool_defaults(
+        &mut self,
+        tool_name: &str,
+        project_root: &Path,
+        session_dir: &Path,
+        tool_state_dirs: Option<&HashMap<String, PathBuf>>,
+    ) {
         self.project_root = Some(project_root.to_path_buf());
         self.writable_paths.push(project_root.to_path_buf());
         self.writable_paths.push(session_dir.to_path_buf());
@@ -318,6 +345,7 @@ impl IsolationPlanBuilder {
             codex_paths::add_codex_home_for_tool(
                 tool_name,
                 &home,
+                tool_state_dirs,
                 &mut self.writable_paths,
                 &mut self.required_writable_dirs,
             );
@@ -331,6 +359,7 @@ impl IsolationPlanBuilder {
             claude_paths::add_claude_home_for_tool(
                 tool_name,
                 &home,
+                tool_state_dirs,
                 &mut self.writable_paths,
                 &mut self.required_writable_dirs,
             );
@@ -350,7 +379,6 @@ impl IsolationPlanBuilder {
                 _ => {}
             }
         }
-        self
     }
 
     /// Consume the builder and produce an [`IsolationPlan`].
@@ -410,6 +438,8 @@ impl IsolationPlanBuilder {
             );
         }
 
+        self.add_runtime_daemon_socket_readable_paths();
+
         codex_paths::validate_required_writable_dirs(
             self.filesystem,
             &self.required_writable_dirs,
@@ -432,6 +462,49 @@ impl IsolationPlanBuilder {
             memory_monitor_interval_seconds: self.memory_monitor_interval_seconds,
         })
     }
+
+    fn add_runtime_daemon_socket_readable_paths(&mut self) {
+        if self.filesystem != FilesystemCapability::Bwrap {
+            return;
+        }
+        let Some(runtime_root) = runtime_path::xdg_runtime_root() else {
+            return;
+        };
+        if !self.has_writable_runtime_child(&runtime_root) {
+            return;
+        }
+
+        for socket_path in runtime_daemon_socket_paths(&runtime_root) {
+            if !socket_path.exists() || self.path_already_exposed(&socket_path) {
+                continue;
+            }
+            self.readable_paths.push(socket_path);
+        }
+    }
+
+    fn has_writable_runtime_child(&self, runtime_root: &Path) -> bool {
+        self.writable_paths.iter().any(|path| {
+            let comparable = runtime_path::canonicalize_or_fallback(path);
+            comparable.starts_with(runtime_root) && comparable != runtime_root
+        })
+    }
+
+    fn path_already_exposed(&self, path: &Path) -> bool {
+        self.readable_paths
+            .iter()
+            .any(|candidate| path == candidate)
+            || self
+                .writable_paths
+                .iter()
+                .any(|candidate| path.starts_with(candidate))
+    }
+}
+
+fn runtime_daemon_socket_paths(runtime_root: &Path) -> [PathBuf; 2] {
+    [
+        runtime_root.join("bus"),
+        runtime_root.join("systemd/private"),
+    ]
 }
 
 fn sandbox_tmpdir_for_capability(filesystem: FilesystemCapability, session_dir: &Path) -> PathBuf {

--- a/crates/csa-resource/src/isolation_plan_claude.rs
+++ b/crates/csa-resource/src/isolation_plan_claude.rs
@@ -26,6 +26,7 @@
 //! ONLY for the owning tool (`claude-code`); peers get a writable bind but no
 //! probe.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -40,8 +41,7 @@ const CLAUDE_DEFAULT_HOME_REL: &str = ".claude";
 /// its own writable entry. Under `CLAUDE_CONFIG_DIR` the config file lives
 /// inside the (already writable) override dir, so no separate entry is needed.
 const CLAUDE_LEGACY_STATE_REL: &str = ".claude.json";
-const CLAUDE_SANDBOX_CONFIG_HINT: &str =
-    "[tools.claude-code].filesystem_sandbox.writable_paths or [filesystem_sandbox].extra_writable";
+const CLAUDE_SANDBOX_CONFIG_HINT: &str = "[tool_state_dirs].claude, [tools.claude-code].filesystem_sandbox.writable_paths, or [filesystem_sandbox].extra_writable";
 
 /// Expose the claude home (`~/.claude` or `$CLAUDE_CONFIG_DIR`) writable so that
 /// a nested claude-code CSA child can create `~/.claude/session-env/<id>`
@@ -58,10 +58,11 @@ const CLAUDE_SANDBOX_CONFIG_HINT: &str =
 pub(super) fn add_claude_home_for_tool(
     tool_name: &str,
     home: &Path,
+    tool_state_dirs: Option<&HashMap<String, PathBuf>>,
     writable_paths: &mut Vec<PathBuf>,
     required_writable_dirs: &mut Vec<RequiredWritableDir>,
 ) {
-    let (claude_home, claude_home_source) = claude_home_dir(home);
+    let (claude_home, claude_home_source) = claude_home_dir(home, tool_state_dirs);
     if tool_name == "claude-code" {
         if claude_home.is_absolute() {
             super::add_dir_or_creatable_parent(writable_paths, &claude_home);
@@ -71,7 +72,7 @@ pub(super) fn add_claude_home_for_tool(
         // entry. Push it raw: it must stay a file, never a pre-created
         // directory (see isolation_plan_path_tests.rs). Under CLAUDE_CONFIG_DIR
         // the config file lives inside the override dir already covered above.
-        if !claude_config_dir_overridden() {
+        if claude_uses_default_legacy_sibling(home, &claude_home) {
             writable_paths.push(home.join(CLAUDE_LEGACY_STATE_REL));
         }
         required_writable_dirs.push(RequiredWritableDir {
@@ -92,16 +93,29 @@ pub(super) fn add_claude_home_for_tool(
 
 /// Resolve the canonical claude home, honoring `CLAUDE_CONFIG_DIR` when set
 /// (mirrors [`super::codex_paths::codex_home_dir`]'s `CODEX_HOME` nuance).
-pub(super) fn claude_home_dir(home: &Path) -> (PathBuf, &'static str) {
+fn claude_home_dir(
+    home: &Path,
+    tool_state_dirs: Option<&HashMap<String, PathBuf>>,
+) -> (PathBuf, String) {
     match std::env::var_os(CLAUDE_CONFIG_DIR_ENV) {
-        Some(value) if !value.is_empty() => (PathBuf::from(value), CLAUDE_CONFIG_DIR_ENV),
-        _ => (home.join(CLAUDE_DEFAULT_HOME_REL), "HOME/.claude"),
+        Some(value) if !value.is_empty() => {
+            (PathBuf::from(value), CLAUDE_CONFIG_DIR_ENV.to_string())
+        }
+        _ => super::codex_paths::tool_state_dir(tool_state_dirs, "claude", home).unwrap_or_else(
+            || {
+                (
+                    home.join(CLAUDE_DEFAULT_HOME_REL),
+                    "HOME/.claude".to_string(),
+                )
+            },
+        ),
     }
 }
 
 /// Whether `CLAUDE_CONFIG_DIR` relocates the claude home away from the default.
-fn claude_config_dir_overridden() -> bool {
-    std::env::var_os(CLAUDE_CONFIG_DIR_ENV).is_some_and(|value| !value.is_empty())
+fn claude_uses_default_legacy_sibling(home: &Path, claude_home: &Path) -> bool {
+    std::env::var_os(CLAUDE_CONFIG_DIR_ENV).is_none_or(|value| value.is_empty())
+        && claude_home == home.join(CLAUDE_DEFAULT_HOME_REL)
 }
 
 /// Check whether any claude-code binary (`claude` CLI or the `claude-code-acp`

--- a/crates/csa-resource/src/isolation_plan_claude_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_claude_tests.rs
@@ -122,6 +122,51 @@ fn test_tool_defaults_claude_code_rejects_unwritable_claude_home() {
     );
 }
 
+#[test]
+fn test_tool_defaults_claude_code_honors_tool_state_dirs_config() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let _home_env = ScopedEnvVar::set("HOME", &home);
+    let _claude_home_env = ScopedEnvVar::unset("CLAUDE_CONFIG_DIR");
+
+    let tool_state_dirs =
+        std::collections::HashMap::from([("claude".to_string(), PathBuf::from("~/.state/claude"))]);
+    let expected = home.join(".state/claude");
+
+    let project = PathBuf::from("/tmp/project");
+    let session = PathBuf::from("/tmp/session");
+
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_tool_defaults_and_state_dirs(
+            "claude-code",
+            &project,
+            &session,
+            Some(&tool_state_dirs),
+        )
+        .build()
+        .expect("configured claude state dir should build");
+
+    assert!(
+        expected.is_dir(),
+        "configured claude state dir should be pre-created"
+    );
+    assert!(
+        plan.writable_paths.contains(&expected),
+        "claude defaults should include configured tool_state_dirs.claude"
+    );
+    assert!(
+        !plan.writable_paths.contains(&home.join(".claude")),
+        "configured claude state dir should replace the hardcoded default"
+    );
+    assert!(
+        !plan.writable_paths.contains(&home.join(".claude.json")),
+        "custom claude state dir should not expose the legacy default-layout sibling"
+    );
+}
+
 /// (b) A peer (non claude-code) tool exposes the claude home WITHOUT a probe,
 /// gated on claude being on PATH.  Because peers register no probe, an
 /// unwritable claude home must NOT abort the build — the asymmetry mirrored from

--- a/crates/csa-resource/src/isolation_plan_codex.rs
+++ b/crates/csa-resource/src/isolation_plan_codex.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -6,8 +7,7 @@ use crate::filesystem_sandbox::FilesystemCapability;
 
 const CODEX_HOME_ENV: &str = "CODEX_HOME";
 const CODEX_DEFAULT_HOME_REL: &str = ".codex";
-const CODEX_SANDBOX_CONFIG_HINT: &str =
-    "[tools.codex].filesystem_sandbox.writable_paths or [filesystem_sandbox].extra_writable";
+const CODEX_SANDBOX_CONFIG_HINT: &str = "[tool_state_dirs].codex, [tools.codex].filesystem_sandbox.writable_paths, or [filesystem_sandbox].extra_writable";
 
 /// A directory that MUST be writable before spawning a tool, validated
 /// fail-fast in `IsolationPlanBuilder::build`.
@@ -20,7 +20,7 @@ const CODEX_SANDBOX_CONFIG_HINT: &str =
 #[derive(Debug, Clone)]
 pub(super) struct RequiredWritableDir {
     pub(super) path: PathBuf,
-    pub(super) source: &'static str,
+    pub(super) source: String,
     pub(super) purpose: &'static str,
     pub(super) config_hint: &'static str,
     /// Lowercase tool identifier ("codex" / "claude") used in error wording.
@@ -30,10 +30,11 @@ pub(super) struct RequiredWritableDir {
 pub(super) fn add_codex_home_for_tool(
     tool_name: &str,
     home: &Path,
+    tool_state_dirs: Option<&HashMap<String, PathBuf>>,
     writable_paths: &mut Vec<PathBuf>,
     required_writable_dirs: &mut Vec<RequiredWritableDir>,
 ) {
-    let (codex_home, codex_home_source) = codex_home_dir(home);
+    let (codex_home, codex_home_source) = codex_home_dir(home, tool_state_dirs);
     if tool_name == "codex" {
         if codex_home.is_absolute() {
             super::add_dir_or_creatable_parent(writable_paths, &codex_home);
@@ -69,11 +70,38 @@ pub(super) fn validate_required_writable_dirs(
     Ok(())
 }
 
-pub(super) fn codex_home_dir(home: &Path) -> (PathBuf, &'static str) {
+pub(super) fn codex_home_dir(
+    home: &Path,
+    tool_state_dirs: Option<&HashMap<String, PathBuf>>,
+) -> (PathBuf, String) {
     match std::env::var_os(CODEX_HOME_ENV) {
-        Some(value) if !value.is_empty() => (PathBuf::from(value), CODEX_HOME_ENV),
-        _ => (home.join(CODEX_DEFAULT_HOME_REL), "HOME/.codex"),
+        Some(value) if !value.is_empty() => (PathBuf::from(value), CODEX_HOME_ENV.to_string()),
+        _ => tool_state_dir(tool_state_dirs, "codex", home)
+            .unwrap_or_else(|| (home.join(CODEX_DEFAULT_HOME_REL), "HOME/.codex".to_string())),
     }
+}
+
+pub(super) fn tool_state_dir(
+    tool_state_dirs: Option<&HashMap<String, PathBuf>>,
+    key: &str,
+    home: &Path,
+) -> Option<(PathBuf, String)> {
+    let configured = tool_state_dirs?.get(key)?;
+    Some((
+        expand_home_prefix(configured, home),
+        format!("tool_state_dirs.{key}"),
+    ))
+}
+
+fn expand_home_prefix(path: &Path, home: &Path) -> PathBuf {
+    let value = path.to_string_lossy();
+    if value == "~" {
+        return home.to_path_buf();
+    }
+    if let Some(rest) = value.strip_prefix("~/") {
+        return home.join(rest);
+    }
+    path.to_path_buf()
 }
 
 /// Check whether any codex binary (`codex` or `codex-acp`) is on `PATH`.

--- a/crates/csa-resource/src/isolation_plan_path_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_path_tests.rs
@@ -124,6 +124,48 @@ fn test_xdg_runtime_child_helper_keeps_run_user_scope_narrow() {
     assert!(!is_xdg_runtime_child_path(Path::new("/run/user/1002/just")));
 }
 
+#[test]
+fn test_runtime_writable_child_exposes_user_daemon_sockets_readonly() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime_root = tmp.path().join("run/user/1001");
+    let runtime_child = runtime_root.join("cli-sub-agent");
+    let bus_socket = runtime_root.join("bus");
+    let systemd_socket = runtime_root.join("systemd/private");
+    std::fs::create_dir_all(&runtime_child).expect("create runtime child");
+    std::fs::create_dir_all(systemd_socket.parent().unwrap()).expect("create systemd dir");
+    std::fs::write(&bus_socket, "").expect("create bus socket placeholder");
+    std::fs::write(&systemd_socket, "").expect("create systemd socket placeholder");
+    let _runtime_env = ScopedEnvVar::set("XDG_RUNTIME_DIR", &runtime_root);
+
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_writable_path(runtime_child)
+        .build()
+        .expect("runtime child scope should build");
+
+    assert!(plan.readable_paths.contains(&bus_socket));
+    assert!(plan.readable_paths.contains(&systemd_socket));
+}
+
+#[test]
+fn test_user_daemon_sockets_not_exposed_without_runtime_writable_child() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let runtime_root = tmp.path().join("run/user/1001");
+    let bus_socket = runtime_root.join("bus");
+    std::fs::create_dir_all(&runtime_root).expect("create runtime root");
+    std::fs::write(&bus_socket, "").expect("create bus socket placeholder");
+    let _runtime_env = ScopedEnvVar::set("XDG_RUNTIME_DIR", &runtime_root);
+
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .build()
+        .expect("plan should build without runtime scope");
+
+    assert!(!plan.readable_paths.contains(&bus_socket));
+}
+
 #[cfg(unix)]
 #[test]
 fn test_writable_validation_error_includes_original_and_resolved_path() {

--- a/crates/csa-resource/src/isolation_plan_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_tests.rs
@@ -386,6 +386,38 @@ fn test_tool_defaults_codex_honors_codex_home_env() {
 }
 
 #[test]
+fn test_tool_defaults_codex_honors_tool_state_dirs_config() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let (home, _env) = isolated_home(&temp);
+    let configured = PathBuf::from("~/.state/codex");
+    let expected = home.join(".state/codex");
+    let tool_state_dirs = std::collections::HashMap::from([("codex".to_string(), configured)]);
+
+    let project = PathBuf::from("/tmp/project");
+    let session = PathBuf::from("/tmp/session");
+
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_tool_defaults_and_state_dirs("codex", &project, &session, Some(&tool_state_dirs))
+        .build()
+        .expect("configured codex state dir should build");
+
+    assert!(
+        expected.is_dir(),
+        "configured codex state dir should be pre-created"
+    );
+    assert!(
+        plan.writable_paths.contains(&expected),
+        "codex defaults should include configured tool_state_dirs.codex"
+    );
+    assert!(
+        !plan.writable_paths.contains(&home.join(".codex")),
+        "configured codex state dir should replace the hardcoded default"
+    );
+}
+
+#[test]
 fn test_tool_defaults_codex_rejects_unwritable_codex_home() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Closes #1722.

Replaces hardcoded `~/.codex` and `~/.claude` state-dir special-casing with a config-driven `[tool_state_dirs]` table.

## Changes (82 files, +690/-28)
- `csa-config/src/global.rs`: `tool_state_dirs: HashMap<String, PathBuf>` with `default_tool_state_dirs()`
- `csa-resource/src/isolation_plan*.rs`: `with_tool_defaults_and_state_dirs()` accepts optional state-dir map
- All test configs updated

Note: #2404 not addressed — requires deeper sandbox work.