### PR TITLE
feat(executor): Hermes ACP backend as first-class CSA tool (#2517)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,7 @@ dependencies = [
  "reqwest 0.13.3",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/cli-sub-agent/src/cli_common.rs
+++ b/crates/cli-sub-agent/src/cli_common.rs
@@ -51,11 +51,12 @@ pub(crate) fn parse_cli_tool_name(
         "codex" => Ok(csa_core::types::ToolName::Codex),
         "claude-code" => Ok(csa_core::types::ToolName::ClaudeCode),
         "openai-compat" => Ok(csa_core::types::ToolName::OpenaiCompat),
+        "hermes" => Ok(csa_core::types::ToolName::Hermes),
         "antigravity-cli" => Ok(csa_core::types::ToolName::AntigravityCli),
         "claude" => Ok(csa_core::types::ToolName::ClaudeCode),
         "antigravity" => Ok(csa_core::types::ToolName::AntigravityCli),
         _ => Err(format!(
-            "unknown tool '{tool}'. Valid values: opencode, codex, claude-code, openai-compat, antigravity-cli"
+            "unknown tool '{tool}'. Valid values: opencode, codex, claude-code, openai-compat, hermes, antigravity-cli"
         )),
     }
 }
@@ -161,5 +162,12 @@ mod tests {
 
         assert!(err.contains("no longer supported"), "{err}");
         assert!(err.contains("provider is discontinued"), "{err}");
+    }
+
+    #[test]
+    fn parse_cli_tool_name_accepts_hermes() {
+        let tool = parse_cli_tool_name("hermes").unwrap();
+
+        assert_eq!(tool, csa_core::types::ToolName::Hermes);
     }
 }

--- a/crates/cli-sub-agent/src/doctor_routing.rs
+++ b/crates/cli-sub-agent/src/doctor_routing.rs
@@ -5,10 +5,8 @@
 
 use anyhow::Result;
 use csa_config::{GlobalConfig, ProjectConfig, TierStrategy};
-use csa_core::types::OutputFormat;
+use csa_core::types::{OutputFormat, PRIMARY_TOOL_NAMES};
 use std::{env, fmt::Write as _, path::Path};
-
-const BUILTIN_TOOLS: &[&str] = &["opencode", "codex", "claude-code"];
 
 /// Map tool name (from model spec) to its executable binary name.
 fn tool_exe_name(tool: &str, config: &ProjectConfig) -> String {
@@ -213,7 +211,7 @@ fn build_routing_report(
         ),
     };
     let context = RoutingContext {
-        built_in_tools: BUILTIN_TOOLS
+        built_in_tools: PRIMARY_TOOL_NAMES
             .iter()
             .map(|tool| (*tool).to_string())
             .collect(),
@@ -549,6 +547,7 @@ mod tests {
         // the CLI binary is `claude`, not `claude-code-acp`.
         assert_eq!(tool_exe_name("claude-code", &config), "claude");
         assert_eq!(tool_exe_name("opencode", &config), "opencode");
+        assert_eq!(tool_exe_name("hermes", &config), "hermes");
         assert_eq!(tool_exe_name("antigravity-cli", &config), "antigravity");
         assert_eq!(tool_exe_name("unknown-tool", &config), "unknown-tool");
     }

--- a/crates/cli-sub-agent/src/doctor_tools.rs
+++ b/crates/cli-sub-agent/src/doctor_tools.rs
@@ -192,6 +192,7 @@ fn tool_transport_doctor_status(
     match tool_name {
         "codex" => codex_doctor_status(config),
         "claude-code" => claude_code_doctor_status(config),
+        "hermes" => hermes_doctor_status(),
         _ => None,
     }
 }
@@ -236,6 +237,15 @@ fn claude_code_transport_label(transport: ClaudeCodeTransport) -> &'static str {
         ClaudeCodeTransport::Acp => "acp",
         ClaudeCodeTransport::Tmux => "tmux",
     }
+}
+
+fn hermes_doctor_status() -> Option<ToolTransportDoctorStatus> {
+    Some(ToolTransportDoctorStatus {
+        transport_active: "acp",
+        acp_compiled_in: Some(cfg!(feature = "acp")),
+        probed_binary: "hermes".to_string(),
+        acp_override_hint: None,
+    })
 }
 
 fn yes_no(value: bool) -> &'static str {

--- a/crates/cli-sub-agent/src/run_helpers_basics.rs
+++ b/crates/cli-sub-agent/src/run_helpers_basics.rs
@@ -17,6 +17,7 @@ pub(crate) fn parse_tool_name(name: &str) -> Result<ToolName> {
         "codex" => Ok(ToolName::Codex),
         "claude-code" => Ok(ToolName::ClaudeCode),
         "openai-compat" => Ok(ToolName::OpenaiCompat),
+        "hermes" => Ok(ToolName::Hermes),
         "antigravity-cli" => Ok(ToolName::AntigravityCli),
         _ => anyhow::bail!("Unknown tool: {name}"),
     }

--- a/crates/cli-sub-agent/src/run_helpers_tool_availability.rs
+++ b/crates/cli-sub-agent/src/run_helpers_tool_availability.rs
@@ -86,6 +86,7 @@ pub(crate) fn resolved_tool_binary_name(
         "opencode" => Some("opencode"),
         "codex" => Some(resolved_codex_transport(config).runtime_binary_name()),
         "claude-code" => Some(resolved_claude_code_transport(config).runtime_binary_name()),
+        "hermes" => Some("hermes"),
         "antigravity-cli" => Some("antigravity"),
         "openai-compat" => None,
         _ => None,

--- a/crates/csa-config/src/config_tool.rs
+++ b/crates/csa-config/src/config_tool.rs
@@ -30,6 +30,7 @@ pub fn default_transport_for_tool(tool_name: &str) -> Option<TransportKind> {
         // server-side cache reuse (#760 / #1128). ACP is still reachable via
         // explicit config + the `codex-acp` cargo feature on `csa-executor`.
         "codex" => Some(TransportKind::Cli),
+        "hermes" => Some(TransportKind::Acp),
         "gemini-cli" | "opencode" | "antigravity-cli" => Some(TransportKind::Cli),
         _ => None,
     }
@@ -332,6 +333,10 @@ transport = "cli"
             config.resolve_transport("gemini-cli"),
             Some(TransportKind::Cli)
         );
+        assert_eq!(
+            config.resolve_transport("hermes"),
+            Some(TransportKind::Acp)
+        );
     }
 
     #[test]
@@ -343,6 +348,10 @@ transport = "cli"
         assert_eq!(
             config.resolve_transport("opencode"),
             Some(TransportKind::Cli)
+        );
+        assert_eq!(
+            config.resolve_transport("hermes"),
+            Some(TransportKind::Acp)
         );
     }
 

--- a/crates/csa-config/src/global.rs
+++ b/crates/csa-config/src/global.rs
@@ -783,6 +783,7 @@ pub fn all_known_tools() -> &'static [ToolName] {
         ToolName::Codex,
         ToolName::ClaudeCode,
         ToolName::OpenaiCompat,
+        ToolName::Hermes,
         ToolName::AntigravityCli,
     ]
 }

--- a/crates/csa-config/src/global_tests_heterogeneous.rs
+++ b/crates/csa-config/src/global_tests_heterogeneous.rs
@@ -114,12 +114,13 @@ task_pool_workers = 4
 #[test]
 fn test_all_known_tools() {
     let tools = all_known_tools();
-    assert_eq!(tools.len(), 5);
+    assert_eq!(tools.len(), 6);
     assert!(!tools.contains(&ToolName::GeminiCli));
     assert!(tools.contains(&ToolName::Opencode));
     assert!(tools.contains(&ToolName::Codex));
     assert!(tools.contains(&ToolName::ClaudeCode));
     assert!(tools.contains(&ToolName::OpenaiCompat));
+    assert!(tools.contains(&ToolName::Hermes));
     assert!(tools.contains(&ToolName::AntigravityCli));
 }
 
@@ -131,6 +132,7 @@ fn test_routing_candidate_tools_exclude_explicit_only_tools() {
     assert!(tools.contains(&ToolName::Codex));
     assert!(tools.contains(&ToolName::ClaudeCode));
     assert!(tools.contains(&ToolName::Opencode));
+    assert!(tools.contains(&ToolName::Hermes));
 }
 
 #[test]

--- a/crates/csa-config/src/validate.rs
+++ b/crates/csa-config/src/validate.rs
@@ -10,6 +10,7 @@ const KNOWN_TOOLS: &[&str] = &[
     "codex",
     "claude-code",
     "openai-compat",
+    "hermes",
     "antigravity-cli",
 ];
 const LEGAL_TRANSPORT_VALUES: &str = "auto, acp, cli, tmux";
@@ -375,6 +376,15 @@ fn validate_tool_transport_override_with_raw(
                 bail!("Invalid {key} = \"{raw_transport}\": codex does not support tmux transport.")
             }
         },
+        "hermes" => match transport {
+            TransportKind::Auto | TransportKind::Acp => Ok(()),
+            TransportKind::Cli => bail!(
+                "Invalid {key} = \"{raw_transport}\": hermes currently supports ACP transport only."
+            ),
+            TransportKind::Tmux => bail!(
+                "Invalid {key} = \"{raw_transport}\": hermes does not support tmux transport."
+            ),
+        },
         "gemini-cli" | "opencode" | "antigravity-cli" => match transport {
             TransportKind::Auto | TransportKind::Cli => Ok(()),
             TransportKind::Acp => bail!(
@@ -553,6 +563,7 @@ fn warn_unknown_tool_priority(config: &ProjectConfig) {
         "codex",
         "claude-code",
         "openai-compat",
+        "hermes",
         "antigravity-cli",
     ];
     if let Some(prefs) = &config.preferences {

--- a/crates/csa-config/src/validate_tests_tail.rs
+++ b/crates/csa-config/src/validate_tests_tail.rs
@@ -333,7 +333,13 @@ fn test_validate_all_known_tools_accepted() {
     let dir = tempdir().unwrap();
 
     let mut tools = HashMap::new();
-    for name in &["opencode", "codex", "claude-code", "antigravity-cli"] {
+    for name in &[
+        "opencode",
+        "codex",
+        "claude-code",
+        "hermes",
+        "antigravity-cli",
+    ] {
         tools.insert(name.to_string(), ToolConfig::default());
     }
 

--- a/crates/csa-core/src/model_catalog.rs
+++ b/crates/csa-core/src/model_catalog.rs
@@ -12,6 +12,7 @@ pub fn valid_providers(tool: &str) -> &'static [&'static str] {
         "gemini-cli" => &["google"],
         "opencode" => &["openai", "google", "anthropic"],
         "openai-compat" => &[],
+        "hermes" => &[],
         _ => &[],
     }
 }
@@ -82,18 +83,19 @@ pub fn valid_models(tool: &str, provider: &str) -> &'static [&'static str] {
         ("opencode", "google") => OPENCODE_GOOGLE_MODELS,
         ("opencode", "anthropic") => OPENCODE_ANTHROPIC_MODELS,
         ("openai-compat", _) => &[],
+        ("hermes", _) => &[],
         _ => &[],
     }
 }
 
 /// Whether provider validation is meaningful for this tool.
 pub fn provider_validation_enabled(tool: &str) -> bool {
-    !matches!(tool, "openai-compat")
+    !matches!(tool, "openai-compat" | "hermes")
 }
 
 /// Whether model validation is meaningful for this tool.
 pub fn model_validation_enabled(tool: &str) -> bool {
-    !matches!(tool, "openai-compat")
+    !matches!(tool, "openai-compat" | "hermes")
 }
 
 #[cfg(test)]

--- a/crates/csa-core/src/types.rs
+++ b/crates/csa-core/src/types.rs
@@ -13,11 +13,12 @@ pub enum ToolName {
     Codex,
     ClaudeCode,
     OpenaiCompat,
+    Hermes,
     AntigravityCli,
 }
 
 /// Primary CLI-backed tools surfaced by doctor and default tool listings.
-pub const PRIMARY_TOOL_NAMES: &[&str] = &["opencode", "codex", "claude-code"];
+pub const PRIMARY_TOOL_NAMES: &[&str] = &["opencode", "codex", "claude-code", "hermes"];
 
 /// Tools eligible for general automatic routing and fallback.
 ///
@@ -29,6 +30,7 @@ pub const ROUTING_CANDIDATE_TOOLS: &[ToolName] = &[
     ToolName::Codex,
     ToolName::ClaudeCode,
     ToolName::OpenaiCompat,
+    ToolName::Hermes,
 ];
 
 pub fn is_removed_tool_name(name: &str) -> bool {
@@ -52,6 +54,7 @@ impl ToolName {
             Self::Codex => "codex",
             Self::ClaudeCode => "claude-code",
             Self::OpenaiCompat => "openai-compat",
+            Self::Hermes => "hermes",
             Self::AntigravityCli => "antigravity-cli",
         }
     }
@@ -64,6 +67,7 @@ impl ToolName {
             Self::Codex => ModelFamily::OpenAI,
             Self::Opencode => ModelFamily::Other,
             Self::OpenaiCompat => ModelFamily::Other,
+            Self::Hermes => ModelFamily::Other,
         }
     }
 
@@ -90,6 +94,7 @@ pub fn prompt_transport_capabilities(tool: &ToolName) -> &'static [PromptTranspo
         ToolName::Codex => PROMPT_TRANSPORT_ARGV_AND_STDIN,
         ToolName::GeminiCli | ToolName::AntigravityCli => PROMPT_TRANSPORT_ARGV_AND_STDIN,
         ToolName::ClaudeCode => PROMPT_TRANSPORT_ARGV_AND_STDIN,
+        ToolName::Hermes => PROMPT_TRANSPORT_ARGV_AND_STDIN,
         ToolName::Opencode => PROMPT_TRANSPORT_ARGV_ONLY,
         // OpenAI-compat is HTTP-only; prompt transport is irrelevant (no CLI process).
         // Return Stdin to satisfy callers that check capabilities.
@@ -136,7 +141,7 @@ pub fn provider_for_tool_name(tool: &str) -> Option<ModelFamily> {
         "gemini-cli" | "antigravity-cli" | "antigravity" | "gemini" => Some(ModelFamily::Gemini),
         "claude-code" | "claude" => Some(ModelFamily::Claude),
         "codex" => Some(ModelFamily::OpenAI),
-        "opencode" | "openai-compat" => Some(ModelFamily::Other),
+        "opencode" | "openai-compat" | "hermes" => Some(ModelFamily::Other),
         _ => None,
     }
 }
@@ -185,6 +190,7 @@ impl std::str::FromStr for ToolArg {
             "codex" => Ok(Self::Specific(ToolName::Codex)),
             "claude-code" => Ok(Self::Specific(ToolName::ClaudeCode)),
             "openai-compat" => Ok(Self::Specific(ToolName::OpenaiCompat)),
+            "hermes" => Ok(Self::Specific(ToolName::Hermes)),
             "antigravity-cli" => Ok(Self::Specific(ToolName::AntigravityCli)),
             // Built-in aliases for common short names
             "claude" => Ok(Self::Specific(ToolName::ClaudeCode)),
@@ -211,14 +217,14 @@ impl ToolArg {
                     match resolved {
                         Self::Alias(ref inner) => Err(format!(
                             "tool alias '{alias}' maps to '{inner}' which is not a valid tool \
-                             name. Valid targets: opencode, codex, claude-code, openai-compat, antigravity-cli"
+                             name. Valid targets: opencode, codex, claude-code, openai-compat, hermes, antigravity-cli"
                         )),
                         other => Ok(other),
                     }
                 } else {
                     Err(format!(
                         "unknown tool '{alias}'. Valid values: auto, any-available, \
-                         opencode, codex, claude-code, openai-compat, antigravity-cli. \
+                         opencode, codex, claude-code, openai-compat, hermes, antigravity-cli. \
                          Or define it in [tool_aliases] in config."
                     ))
                 }
@@ -476,6 +482,7 @@ mod tests {
         assert_eq!(ToolName::GeminiCli.model_family(), ModelFamily::Gemini);
         assert_eq!(ToolName::Codex.model_family(), ModelFamily::OpenAI);
         assert_eq!(ToolName::Opencode.model_family(), ModelFamily::Other);
+        assert_eq!(ToolName::Hermes.model_family(), ModelFamily::Other);
     }
 
     #[test]
@@ -502,6 +509,7 @@ mod tests {
         assert_eq!(ToolName::Opencode.as_str(), "opencode");
         assert_eq!(ToolName::Codex.as_str(), "codex");
         assert_eq!(ToolName::ClaudeCode.as_str(), "claude-code");
+        assert_eq!(ToolName::Hermes.as_str(), "hermes");
     }
 
     #[test]
@@ -510,6 +518,7 @@ mod tests {
         assert_eq!(ToolName::Opencode.to_string(), "opencode");
         assert_eq!(ToolName::Codex.to_string(), "codex");
         assert_eq!(ToolName::ClaudeCode.to_string(), "claude-code");
+        assert_eq!(ToolName::Hermes.to_string(), "hermes");
     }
 
     #[test]
@@ -525,6 +534,12 @@ mod tests {
     }
 
     #[test]
+    fn test_tool_arg_from_str_specific_hermes() {
+        let arg = ToolArg::from_str("hermes").unwrap();
+        assert!(matches!(arg, ToolArg::Specific(ToolName::Hermes)));
+    }
+
+    #[test]
     fn test_tool_arg_display_fromstr_roundtrip() {
         let cases = [
             ToolArg::Auto,
@@ -533,6 +548,7 @@ mod tests {
             ToolArg::Specific(ToolName::Codex),
             ToolArg::Specific(ToolName::ClaudeCode),
             ToolArg::Specific(ToolName::OpenaiCompat),
+            ToolArg::Specific(ToolName::Hermes),
             ToolArg::Specific(ToolName::AntigravityCli),
         ];
         for original in &cases {
@@ -549,6 +565,7 @@ mod tests {
             (ToolName::Opencode, "Opencode"),
             (ToolName::Codex, "Codex"),
             (ToolName::ClaudeCode, "ClaudeCode"),
+            (ToolName::Hermes, "Hermes"),
         ];
         for (tool, label) in tools {
             let strategy = ToolArg::Specific(tool).into_strategy();
@@ -571,6 +588,10 @@ mod tests {
         );
         assert_eq!(
             prompt_transport_capabilities(&ToolName::ClaudeCode),
+            &[PromptTransport::Argv, PromptTransport::Stdin]
+        );
+        assert_eq!(
+            prompt_transport_capabilities(&ToolName::Hermes),
             &[PromptTransport::Argv, PromptTransport::Stdin]
         );
         assert_eq!(

--- a/crates/csa-executor/Cargo.toml
+++ b/crates/csa-executor/Cargo.toml
@@ -25,6 +25,7 @@ tracing-appender.workspace = true
 chrono.workspace = true
 regex.workspace = true
 reqwest.workspace = true
+sha2.workspace = true
 
 [features]
 default = []

--- a/crates/csa-executor/src/agent_backend_adapter.rs
+++ b/crates/csa-executor/src/agent_backend_adapter.rs
@@ -46,7 +46,7 @@ impl ExecutorAgentBackend {
 
     fn backend_type_for_executor(executor: &Executor) -> BackendType {
         match executor {
-            Executor::ClaudeCode { .. } => BackendType::ClaudeCode,
+            Executor::ClaudeCode { .. } | Executor::Hermes { .. } => BackendType::ClaudeCode,
             Executor::GeminiCli { .. } | Executor::AntigravityCli { .. } => BackendType::GeminiCli,
             Executor::Codex { .. } | Executor::Opencode { .. } | Executor::OpenaiCompat { .. } => {
                 BackendType::Codex
@@ -77,6 +77,9 @@ impl ExecutorAgentBackend {
                 Executor::OpenaiCompat {
                     model_override: m, ..
                 } => *m = Some(model_override.clone()),
+                Executor::Hermes {
+                    model_override: m, ..
+                } => *m = Some(model_override.clone()),
                 Executor::AntigravityCli {
                     model_override: m, ..
                 } => *m = Some(model_override),
@@ -104,6 +107,9 @@ impl ExecutorAgentBackend {
                     thinking_budget, ..
                 } => *thinking_budget = Some(budget.clone()),
                 Executor::OpenaiCompat {
+                    thinking_budget, ..
+                } => *thinking_budget = Some(budget.clone()),
+                Executor::Hermes {
                     thinking_budget, ..
                 } => *thinking_budget = Some(budget.clone()),
                 Executor::AntigravityCli {
@@ -351,6 +357,14 @@ mod tests {
                 thinking_budget: None,
             }),
             BackendType::Codex
+        );
+        assert_eq!(
+            ExecutorAgentBackend::backend_type_for_executor(&Executor::Hermes {
+                provider_override: None,
+                model_override: None,
+                thinking_budget: None,
+            }),
+            BackendType::ClaudeCode
         );
     }
 

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -15,8 +15,10 @@ use crate::claude_runtime::{
 use crate::codex_runtime::{CodexRuntimeMetadata, CodexTransport, codex_runtime_metadata};
 use crate::install_hints::{
     ANTIGRAVITY_CLI_INSTALL_HINT, GEMINI_CLI_INSTALL_HINT, OPENAI_COMPAT_INSTALL_HINT,
-    OPENCODE_INSTALL_HINT,
+    OPENCODE_INSTALL_HINT, HERMES_INSTALL_HINT,
 };
+#[cfg(feature = "acp")]
+use crate::hermes_config::HermesRunConfig;
 use crate::lefthook_guard::{sanitize_args_for_codex, sanitize_env_for_codex};
 use crate::model_spec::{ModelSpec, ThinkingBudget};
 use crate::session_config::SessionConfig;
@@ -82,6 +84,11 @@ pub enum Executor {
         model_override: Option<String>,
         thinking_budget: Option<ThinkingBudget>,
     },
+    Hermes {
+        provider_override: Option<String>,
+        model_override: Option<String>,
+        thinking_budget: Option<ThinkingBudget>,
+    },
     AntigravityCli {
         model_override: Option<String>,
         thinking_budget: Option<ThinkingBudget>,
@@ -103,6 +110,7 @@ impl Executor {
             Self::Codex { .. } => "codex",
             Self::ClaudeCode { .. } => "claude-code",
             Self::OpenaiCompat { .. } => "openai-compat",
+            Self::Hermes { .. } => "hermes",
             Self::AntigravityCli { .. } => "antigravity-cli",
         }
     }
@@ -114,6 +122,7 @@ impl Executor {
             Self::Codex { .. } => "codex",
             Self::ClaudeCode { .. } => "claude",
             Self::OpenaiCompat { .. } => "openai-compat",
+            Self::Hermes { .. } => "hermes",
             Self::AntigravityCli { .. } => "antigravity",
         }
     }
@@ -129,6 +138,7 @@ impl Executor {
                 runtime_metadata, ..
             } => runtime_metadata.runtime_binary_name(),
             Self::OpenaiCompat { .. } => "openai-compat",
+            Self::Hermes { .. } => "hermes",
             Self::AntigravityCli { .. } => "antigravity",
         }
     }
@@ -144,6 +154,7 @@ impl Executor {
                 runtime_metadata, ..
             } => runtime_metadata.install_hint(),
             Self::OpenaiCompat { .. } => OPENAI_COMPAT_INSTALL_HINT,
+            Self::Hermes { .. } => HERMES_INSTALL_HINT,
             Self::AntigravityCli { .. } => ANTIGRAVITY_CLI_INSTALL_HINT,
         }
     }
@@ -154,7 +165,7 @@ impl Executor {
             Self::Opencode { .. } => &[] as &[&str],
             Self::Codex { .. } => &["--dangerously-bypass-approvals-and-sandbox"],
             Self::ClaudeCode { .. } => &["--dangerously-skip-permissions"],
-            Self::OpenaiCompat { .. } => &[] as &[&str],
+            Self::OpenaiCompat { .. } | Self::Hermes { .. } => &[] as &[&str],
         }
     }
 
@@ -168,9 +179,17 @@ impl Executor {
             "codex" => ToolName::Codex,
             "claude-code" => ToolName::ClaudeCode,
             "openai-compat" => ToolName::OpenaiCompat,
+            "hermes" => ToolName::Hermes,
             "antigravity-cli" => ToolName::AntigravityCli,
             other => anyhow::bail!("Unknown tool '{other}' in model spec"),
         };
+        if matches!(tool, ToolName::Hermes) {
+            return Ok(Self::Hermes {
+                provider_override: Some(spec.provider.clone()),
+                model_override: model,
+                thinking_budget: budget,
+            });
+        }
         Ok(Self::from_tool_name(&tool, model, budget))
     }
 
@@ -204,6 +223,11 @@ impl Executor {
                 model_override: model,
                 thinking_budget,
             },
+            ToolName::Hermes => Self::Hermes {
+                provider_override: None,
+                model_override: model,
+                thinking_budget,
+            },
             ToolName::AntigravityCli => Self::AntigravityCli {
                 model_override: model,
                 thinking_budget,
@@ -229,6 +253,9 @@ impl Executor {
             | Self::OpenaiCompat {
                 thinking_budget, ..
             }
+            | Self::Hermes {
+                thinking_budget, ..
+            }
             | Self::AntigravityCli {
                 thinking_budget, ..
             } => thinking_budget.as_ref(),
@@ -251,6 +278,9 @@ impl Executor {
                 thinking_budget, ..
             }
             | Self::OpenaiCompat {
+                thinking_budget, ..
+            }
+            | Self::Hermes {
                 thinking_budget, ..
             }
             | Self::AntigravityCli {
@@ -288,6 +318,7 @@ impl Executor {
             | Self::Codex { model_override, .. }
             | Self::ClaudeCode { model_override, .. }
             | Self::OpenaiCompat { model_override, .. }
+            | Self::Hermes { model_override, .. }
             | Self::AntigravityCli { model_override, .. } => {
                 *model_override = Some(model);
             }
@@ -503,6 +534,22 @@ impl Executor {
         session_config: Option<SessionConfig>,
     ) -> Result<Box<dyn Transport>> {
         TransportFactory::create(self, session_config)
+    }
+
+    #[cfg(feature = "acp")]
+    pub(crate) fn hermes_run_config(&self) -> Option<HermesRunConfig> {
+        match self {
+            Self::Hermes {
+                provider_override,
+                model_override,
+                thinking_budget,
+            } => Some(HermesRunConfig::new(
+                provider_override.clone(),
+                model_override.clone(),
+                thinking_budget.clone(),
+            )),
+            _ => None,
+        }
     }
 }
 

--- a/crates/csa-executor/src/executor_prompt_helpers.rs
+++ b/crates/csa-executor/src/executor_prompt_helpers.rs
@@ -56,6 +56,12 @@ impl Executor {
                     cmd.arg("-p").arg(prompt);
                 }
             }
+            Self::Hermes { .. } => {
+                cmd.arg("run");
+                if matches!(prompt_transport, PromptTransport::Argv) {
+                    cmd.arg(prompt);
+                }
+            }
             Self::OpenaiCompat { .. } => {} // HTTP-only
             Self::AntigravityCli { .. } => {
                 if matches!(prompt_transport, PromptTransport::Argv) {
@@ -95,6 +101,7 @@ impl Executor {
             Self::Codex { .. } => ToolName::Codex,
             Self::ClaudeCode { .. } => ToolName::ClaudeCode,
             Self::OpenaiCompat { .. } => ToolName::OpenaiCompat,
+            Self::Hermes { .. } => ToolName::Hermes,
             Self::AntigravityCli { .. } => ToolName::AntigravityCli,
         }
     }

--- a/crates/csa-executor/src/executor_tests.rs
+++ b/crates/csa-executor/src/executor_tests.rs
@@ -365,6 +365,22 @@ fn test_from_spec() {
             ..
         }
     ));
+
+    let spec = ModelSpec::parse("hermes/openai/gpt-5.5/xhigh").unwrap();
+    let exec = Executor::from_spec(&spec).unwrap();
+    assert_eq!(exec.tool_name(), "hermes");
+    match exec {
+        Executor::Hermes {
+            provider_override,
+            model_override,
+            thinking_budget,
+        } => {
+            assert_eq!(provider_override.as_deref(), Some("openai"));
+            assert_eq!(model_override.as_deref(), Some("gpt-5.5"));
+            assert!(matches!(thinking_budget, Some(ThinkingBudget::Xhigh)));
+        }
+        other => panic!("expected Hermes executor, got {other:?}"),
+    }
 }
 
 #[test]
@@ -432,6 +448,25 @@ fn test_thinking_budget_from_spec_codex() {
 
     let debug_str = format!("{cmd:?}");
     assert!(debug_str.contains("model_reasoning_effort=low"));
+}
+
+#[test]
+fn test_hermes_thinking_does_not_emit_codex_reasoning_effort() {
+    let spec = ModelSpec::parse("hermes/openai/gpt-5.5/xhigh").unwrap();
+    let exec = Executor::from_spec(&spec).unwrap();
+
+    let mut cmd = Command::new(exec.executable_name());
+    exec.append_tool_args(&mut cmd, "test prompt", None);
+
+    let debug_str = format!("{cmd:?}");
+    assert!(debug_str.contains("--provider"), "{debug_str}");
+    assert!(debug_str.contains("openai"), "{debug_str}");
+    assert!(debug_str.contains("--model"), "{debug_str}");
+    assert!(debug_str.contains("gpt-5.5"), "{debug_str}");
+    assert!(
+        !debug_str.contains("model_reasoning_effort="),
+        "Hermes must not receive Codex-specific reasoning args: {debug_str}"
+    );
 }
 
 #[test]
@@ -649,6 +684,11 @@ fn test_execute_in_preserves_model_override() {
             model_override: Some("gemini-3-pro".to_string()),
             thinking_budget: Some(ThinkingBudget::High),
         },
+        Executor::Hermes {
+            provider_override: Some("anthropic".to_string()),
+            model_override: Some("claude-opus".to_string()),
+            thinking_budget: Some(ThinkingBudget::Medium),
+        },
     ];
 
     for exec in &tools {
@@ -709,6 +749,24 @@ fn test_execute_in_preserves_model_override() {
             }
             Executor::OpenaiCompat { .. } => {
                 // HTTP-only tool — no CLI args. Nothing to assert on Command.
+            }
+            Executor::Hermes { .. } => {
+                assert!(
+                    debug_str.contains("anthropic"),
+                    "Hermes missing provider: {debug_str}"
+                );
+                assert!(
+                    debug_str.contains("claude-opus"),
+                    "Hermes missing model: {debug_str}"
+                );
+                assert!(
+                    debug_str.contains("--thinking"),
+                    "Hermes missing thinking: {debug_str}"
+                );
+                assert!(
+                    !debug_str.contains("model_reasoning_effort="),
+                    "Hermes must not receive Codex-specific thinking args: {debug_str}"
+                );
             }
             Executor::AntigravityCli { .. } => {
                 // `agy` rejects `-m`; the model override is staged in

--- a/crates/csa-executor/src/executor_tool_args.rs
+++ b/crates/csa-executor/src/executor_tool_args.rs
@@ -44,6 +44,9 @@ impl Executor {
                 cmd.arg("--dangerously-skip-permissions");
                 cmd.arg("--output-format").arg("json");
             }
+            Self::Hermes { .. } => {
+                cmd.arg("run");
+            }
             Self::OpenaiCompat { .. } | Self::AntigravityCli { .. } => {}
         }
 
@@ -75,6 +78,9 @@ impl Executor {
                 {
                     cmd.arg("--resume").arg(session_id);
                 }
+                Self::Hermes { .. } => {
+                    cmd.arg("--resume").arg(session_id);
+                }
                 Self::OpenaiCompat { .. } => {} // HTTP-only
                 Self::ClaudeCode { .. } => {}
             }
@@ -89,6 +95,9 @@ impl Executor {
                 Self::Opencode { .. } | Self::Codex { .. } => {
                     cmd.arg(prompt);
                 }
+                Self::Hermes { .. } => {
+                    cmd.arg(prompt);
+                }
                 Self::OpenaiCompat { .. } => {} // HTTP-only
             },
             PromptTransport::Stdin => {
@@ -101,7 +110,10 @@ impl Executor {
                     Self::Codex { .. } if codex_resume => {
                         cmd.arg("-");
                     }
-                    Self::Opencode { .. } | Self::Codex { .. } | Self::OpenaiCompat { .. } => {
+                    Self::Opencode { .. }
+                    | Self::Codex { .. }
+                    | Self::Hermes { .. }
+                    | Self::OpenaiCompat { .. } => {
                         // These tools read from stdin natively without extra flags.
                     }
                 }
@@ -198,6 +210,21 @@ impl Executor {
                     && let Some(level) = budget.claude_effort()
                 {
                     cmd.arg("--effort").arg(level);
+                }
+            }
+            Self::Hermes {
+                provider_override,
+                model_override,
+                thinking_budget,
+            } => {
+                if let Some(provider) = provider_override {
+                    cmd.arg("--provider").arg(provider);
+                }
+                if let Some(model) = model_override {
+                    cmd.arg("--model").arg(model);
+                }
+                if let Some(budget) = thinking_budget {
+                    cmd.arg("--thinking").arg(budget.token_count().to_string());
                 }
             }
             Self::OpenaiCompat { .. } => {} // HTTP-only: model/thinking via API body

--- a/crates/csa-executor/src/hermes_config.rs
+++ b/crates/csa-executor/src/hermes_config.rs
@@ -1,0 +1,249 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::process::Command;
+
+use crate::model_spec::ThinkingBudget;
+
+const HERMES_FINGERPRINT_FILE: &str = "hermes-run-config.sha256";
+
+/// Per-run Hermes selection passed to the ACP adapter.
+///
+/// Hermes reads provider/model/thinking through its ACP session metadata, not
+/// by mutating the user's global `~/.hermes/config.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HermesRunConfig {
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub thinking: Option<ThinkingBudget>,
+}
+
+impl HermesRunConfig {
+    pub fn new(
+        provider: Option<String>,
+        model: Option<String>,
+        thinking: Option<ThinkingBudget>,
+    ) -> Self {
+        Self {
+            provider,
+            model,
+            thinking,
+        }
+    }
+
+    pub fn from_model_spec(
+        provider: String,
+        model: String,
+        thinking: ThinkingBudget,
+    ) -> Self {
+        Self::new(Some(provider), Some(model), Some(thinking))
+    }
+
+    pub fn meta_options(&self) -> Option<serde_json::Value> {
+        let mut options = serde_json::Map::new();
+        if let Some(provider) = self.provider.as_deref().filter(|value| !value.is_empty()) {
+            options.insert("provider".to_string(), provider.into());
+        }
+        if let Some(model) = self.model.as_deref().filter(|value| !value.is_empty()) {
+            options.insert("model".to_string(), model.into());
+        }
+        if let Some(thinking) = &self.thinking {
+            options.insert("thinking".to_string(), thinking_label(thinking).into());
+        }
+
+        (!options.is_empty()).then_some(serde_json::Value::Object(options))
+    }
+
+    pub fn fingerprint(&self) -> String {
+        let payload =
+            serde_json::to_vec(self).expect("HermesRunConfig serialization should not fail");
+        format!("{:x}", Sha256::digest(payload))
+    }
+}
+
+fn thinking_label(thinking: &ThinkingBudget) -> String {
+    match thinking {
+        ThinkingBudget::DefaultBudget => "default".to_string(),
+        ThinkingBudget::Low => "low".to_string(),
+        ThinkingBudget::Medium => "medium".to_string(),
+        ThinkingBudget::High => "high".to_string(),
+        ThinkingBudget::Xhigh => "xhigh".to_string(),
+        ThinkingBudget::Max => "max".to_string(),
+        ThinkingBudget::Custom(value) => value.to_string(),
+    }
+}
+
+pub(crate) fn filter_resume_session_id_for_hermes(
+    session_dir: Option<&Path>,
+    run_config: Option<&HermesRunConfig>,
+    resume_session_id: Option<String>,
+) -> Option<String> {
+    let resume_session_id = resume_session_id?;
+    let Some(run_config) = run_config else {
+        return Some(resume_session_id);
+    };
+    let session_dir = session_dir?;
+    if stored_fingerprint_matches(session_dir, &run_config.fingerprint()) {
+        Some(resume_session_id)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn persist_hermes_fingerprint(
+    session_dir: Option<&Path>,
+    run_config: Option<&HermesRunConfig>,
+) -> Result<()> {
+    let Some(session_dir) = session_dir else {
+        return Ok(());
+    };
+    let Some(run_config) = run_config else {
+        return Ok(());
+    };
+    std::fs::write(
+        fingerprint_path(session_dir),
+        format!("{}\n", run_config.fingerprint()),
+    )
+    .with_context(|| {
+        format!(
+            "failed to write Hermes run-config fingerprint under {}",
+            session_dir.display()
+        )
+    })
+}
+
+fn stored_fingerprint_matches(session_dir: &Path, expected: &str) -> bool {
+    std::fs::read_to_string(fingerprint_path(session_dir))
+        .map(|value| value.trim() == expected)
+        .unwrap_or(false)
+}
+
+fn fingerprint_path(session_dir: &Path) -> PathBuf {
+    session_dir.join(HERMES_FINGERPRINT_FILE)
+}
+
+pub(crate) async fn run_hermes_acp_check(
+    command: &str,
+    args: &[String],
+    working_dir: &Path,
+    env: &std::collections::HashMap<String, String>,
+) -> Result<()> {
+    let mut cmd = Command::new(command);
+    cmd.args(args)
+        .arg("--check")
+        .current_dir(working_dir)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+
+    let output = cmd
+        .output()
+        .await
+        .with_context(|| format!("failed to run Hermes ACP preflight `{}`", check_label(args)))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let code = output
+        .status
+        .code()
+        .map_or_else(|| "signal".to_string(), |code| code.to_string());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Err(anyhow!(
+        "Hermes ACP preflight failed: `{}` exited with {code}\nstdout:\n{}\nstderr:\n{}",
+        check_label(args),
+        stdout.trim(),
+        stderr.trim()
+    ))
+}
+
+fn check_label(args: &[String]) -> String {
+    if args.is_empty() {
+        "hermes --check".to_string()
+    } else {
+        format!("hermes {} --check", args.join(" "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_changes_when_provider_changes() {
+        let first = HermesRunConfig::from_model_spec(
+            "openai".to_string(),
+            "gpt-5.5".to_string(),
+            ThinkingBudget::Xhigh,
+        );
+        let second = HermesRunConfig::from_model_spec(
+            "anthropic".to_string(),
+            "gpt-5.5".to_string(),
+            ThinkingBudget::Xhigh,
+        );
+
+        assert_ne!(first.fingerprint(), second.fingerprint());
+    }
+
+    #[test]
+    fn resume_is_filtered_when_fingerprint_mismatches() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let first = HermesRunConfig::from_model_spec(
+            "openai".to_string(),
+            "gpt-5.5".to_string(),
+            ThinkingBudget::Xhigh,
+        );
+        let second = HermesRunConfig::from_model_spec(
+            "anthropic".to_string(),
+            "claude-opus".to_string(),
+            ThinkingBudget::High,
+        );
+        persist_hermes_fingerprint(Some(dir.path()), Some(&first)).expect("write fingerprint");
+
+        let resume = filter_resume_session_id_for_hermes(
+            Some(dir.path()),
+            Some(&second),
+            Some("provider-session".to_string()),
+        );
+
+        assert_eq!(resume, None);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn acp_check_failure_surfaces_structured_error() {
+        use std::collections::HashMap;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let hermes = dir.path().join("hermes");
+        std::fs::write(&hermes, "#!/bin/sh\necho check-failed >&2\nexit 42\n")
+            .expect("write fake hermes");
+        let mut perms = std::fs::metadata(&hermes)
+            .expect("fake hermes metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&hermes, perms).expect("chmod fake hermes");
+
+        let args = vec!["acp".to_string()];
+        let error = run_hermes_acp_check(
+            hermes.to_str().expect("utf8 path"),
+            &args,
+            dir.path(),
+            &HashMap::new(),
+        )
+        .await
+        .expect_err("check failure should propagate");
+
+        let message = format!("{error:#}");
+        assert!(message.contains("Hermes ACP preflight failed"), "{message}");
+        assert!(message.contains("hermes acp --check"), "{message}");
+        assert!(message.contains("42"), "{message}");
+        assert!(message.contains("check-failed"), "{message}");
+    }
+}

--- a/crates/csa-executor/src/install_hints.rs
+++ b/crates/csa-executor/src/install_hints.rs
@@ -8,6 +8,7 @@ pub const CLAUDE_CODE_CLI_INSTALL_HINT: &str =
     "Install Claude Code CLI and ensure `claude` is on PATH";
 pub const OPENAI_COMPAT_INSTALL_HINT: &str =
     "Configure [tools.openai-compat] with base_url and api_key in config.toml";
+pub const HERMES_INSTALL_HINT: &str = "Install Hermes and ensure `hermes` is on PATH";
 pub const ANTIGRAVITY_CLI_INSTALL_HINT: &str =
     "Install: go install google.dev/antigravity@latest (requires Go 1.22+)";
 
@@ -17,6 +18,7 @@ pub fn install_hint_for_known_tool(tool_name: &str) -> Option<&'static str> {
         "opencode" => Some(OPENCODE_INSTALL_HINT),
         "claude-code" => Some(CLAUDE_CODE_ACP_INSTALL_HINT),
         "openai-compat" => Some(OPENAI_COMPAT_INSTALL_HINT),
+        "hermes" => Some(HERMES_INSTALL_HINT),
         "antigravity-cli" => Some(ANTIGRAVITY_CLI_INSTALL_HINT),
         _ => None,
     }
@@ -43,6 +45,10 @@ mod tests {
         assert_eq!(
             install_hint_for_known_tool("openai-compat"),
             Some(OPENAI_COMPAT_INSTALL_HINT)
+        );
+        assert_eq!(
+            install_hint_for_known_tool("hermes"),
+            Some(HERMES_INSTALL_HINT)
         );
         assert_eq!(install_hint_for_known_tool("codex"), None);
     }

--- a/crates/csa-executor/src/lib.rs
+++ b/crates/csa-executor/src/lib.rs
@@ -6,6 +6,8 @@ pub mod codex_runtime;
 pub mod context_loader;
 pub mod design_context;
 pub mod executor;
+#[cfg(feature = "acp")]
+pub mod hermes_config;
 pub mod install_hints;
 mod lefthook_guard;
 pub mod logging;
@@ -29,9 +31,12 @@ pub use csa_process::ExecutionResult;
 pub use design_context::{extract_design_sections, format_design_context};
 pub use executor::executor_env::STRIPPED_ENV_VARS as CHILD_PROCESS_STRIPPED_ENV_VARS;
 pub use executor::{ExecuteOptions, Executor, SandboxContext};
+#[cfg(feature = "acp")]
+pub use hermes_config::HermesRunConfig;
 pub use install_hints::{
     CLAUDE_CODE_ACP_INSTALL_HINT, CLAUDE_CODE_CLI_INSTALL_HINT, GEMINI_CLI_INSTALL_HINT,
-    OPENAI_COMPAT_INSTALL_HINT, OPENCODE_INSTALL_HINT, install_hint_for_known_tool,
+    HERMES_INSTALL_HINT, OPENAI_COMPAT_INSTALL_HINT, OPENCODE_INSTALL_HINT,
+    install_hint_for_known_tool,
 };
 pub use logging::create_session_log_writer;
 pub use model_spec::{ModelSpec, ThinkingBudget};

--- a/crates/csa-executor/src/model_spec.rs
+++ b/crates/csa-executor/src/model_spec.rs
@@ -40,7 +40,7 @@ pub enum ModelSpecValidationError {
 }
 
 /// Thinking budget for AI models.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ThinkingBudget {
     /// Use the tool's default thinking budget.
     DefaultBudget,
@@ -353,6 +353,12 @@ mod tests {
     fn validate_with_catalog_skips_openai_compat_provider_and_model() {
         let spec = ModelSpec::parse("openai-compat/local/my-fine-tune/medium").unwrap();
         assert!(spec.validate_with_catalog(&["openai-compat"]).is_ok());
+    }
+
+    #[test]
+    fn validate_with_catalog_skips_hermes_provider_and_model() {
+        let spec = ModelSpec::parse("hermes/local/custom-model/xhigh").unwrap();
+        assert!(spec.validate_with_catalog(&["hermes"]).is_ok());
     }
 
     #[test]

--- a/crates/csa-executor/src/session_id.rs
+++ b/crates/csa-executor/src/session_id.rs
@@ -20,6 +20,8 @@ pub fn extract_session_id(tool: &ToolName, output: &str) -> Option<String> {
         ToolName::ClaudeCode => extract_claude_session_id(output),
         // OpenAI-compat is HTTP-only; session ID comes from API response, not output parsing.
         ToolName::OpenaiCompat => None,
+        // Hermes ACP reports provider session IDs through transport metadata.
+        ToolName::Hermes => None,
         // AntigravityCli: same pattern as gemini-cli (no known session ID output).
         ToolName::AntigravityCli => extract_gemini_session_id(output),
     }
@@ -216,6 +218,10 @@ mod tests {
 
         let gemini_output = "gemini output";
         let result = extract_session_id(&ToolName::GeminiCli, gemini_output);
+        assert_eq!(result, None);
+
+        let hermes_output = r#"{"session_id":"hermes_should_not_parse"}"#;
+        let result = extract_session_id(&ToolName::Hermes, hermes_output);
         assert_eq!(result, None);
     }
 

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -6,6 +6,11 @@ use crate::executor::Executor;
 #[cfg(feature = "acp")]
 use crate::lefthook_guard::sanitize_args_for_codex;
 #[cfg(feature = "acp")]
+use crate::hermes_config::{
+    HermesRunConfig, filter_resume_session_id_for_hermes, persist_hermes_fingerprint,
+    run_hermes_acp_check,
+};
+#[cfg(feature = "acp")]
 use crate::session_config::SessionConfig;
 use crate::transport_gemini_retry::{
     apply_gemini_permanent_quota_exhaustion_summary,
@@ -186,18 +191,20 @@ pub struct AcpTransport {
     acp_command: String,
     acp_args: Vec<String>,
     pub(crate) session_config: Option<SessionConfig>,
+    pub(crate) hermes_run_config: Option<HermesRunConfig>,
 }
 
 #[cfg(feature = "acp")]
 impl AcpTransport {
     pub fn new(tool_name: &str, session_config: Option<SessionConfig>) -> Self {
-        Self::new_with_codex_fast_mode(tool_name, session_config, false)
+        Self::new_with_codex_fast_mode(tool_name, session_config, false, None)
     }
 
     pub(crate) fn new_with_codex_fast_mode(
         tool_name: &str,
         session_config: Option<SessionConfig>,
         codex_fast_mode: bool,
+        hermes_run_config: Option<HermesRunConfig>,
     ) -> Self {
         let (cmd, args) = Self::acp_command_for_tool(tool_name);
         let args = if tool_name == "codex" && codex_fast_mode {
@@ -212,6 +219,7 @@ impl AcpTransport {
             acp_command: cmd,
             acp_args: args,
             session_config,
+            hermes_run_config,
         }
     }
 
@@ -222,6 +230,7 @@ impl AcpTransport {
             "claude-code" => ("claude-code-acp".into(), vec![]),
             "codex" => ("codex-acp".into(), vec![]),
             "gemini-cli" => ("gemini".into(), vec!["--acp".into()]),
+            "hermes" => ("hermes".into(), vec!["acp".into()]),
             _ => (format!("{tool_name}-acp"), vec![]),
         }
     }
@@ -257,9 +266,17 @@ impl AcpTransport {
         let mut acp_command = self.acp_command.clone();
         let mut acp_args = acp_args.to_vec();
         let prompt = prompt.to_string();
-        let resume_session_id = resume_session_id.map(String::from);
         let session_dir =
             csa_session::manager::get_session_dir(&working_dir, &session.meta_session_id).ok();
+        let resume_session_id = if self.tool_name == "hermes" {
+            filter_resume_session_id_for_hermes(
+                session_dir.as_deref(),
+                self.hermes_run_config.as_ref(),
+                resume_session_id.map(String::from),
+            )
+        } else {
+            resume_session_id.map(String::from)
+        };
 
         let mut gemini_runtime_home = None;
         let (shared_gemini_npm_cache_raw_path, shared_gemini_npm_cache_source) =
@@ -290,6 +307,9 @@ impl AcpTransport {
         }
         if self.tool_name == "codex" {
             sanitize_args_for_codex(&mut acp_args);
+        }
+        if self.tool_name == "hermes" {
+            run_hermes_acp_check(&acp_command, &acp_args, &working_dir, &env).await?;
         }
         let gemini_sandbox_env_overrides =
             (self.tool_name == "gemini-cli").then(|| gemini_sandbox_runtime_env_overrides(&env));
@@ -329,7 +349,7 @@ impl AcpTransport {
                 &self.tool_name,
                 options.initial_response_timeout,
             )
-        } else if self.tool_name == "codex" {
+        } else if matches!(self.tool_name.as_str(), "codex" | "hermes") {
             consume_resolved_initial_response_timeout_seconds(options.initial_response_timeout)
         } else {
             None
@@ -339,6 +359,7 @@ impl AcpTransport {
         let session_meta = Self::build_session_meta(
             options.setting_sources.as_deref(),
             self.session_config.as_ref(),
+            self.hermes_run_config.as_ref(),
         );
         let acp_payload_debug_path = maybe_write_acp_payload_debug(AcpPayloadDebugRequest {
             env: &env,
@@ -457,6 +478,9 @@ impl AcpTransport {
             .flatten()
         {
             apply_gemini_acp_initial_stall_summary(&mut execution, &classification);
+        }
+        if self.tool_name == "hermes" && execution.exit_code == 0 {
+            persist_hermes_fingerprint(session_dir.as_deref(), self.hermes_run_config.as_ref())?;
         }
 
         Ok(TransportResult {

--- a/crates/csa-executor/src/transport_acp_impl.rs
+++ b/crates/csa-executor/src/transport_acp_impl.rs
@@ -25,12 +25,24 @@ impl Transport for AcpTransport {
     ) -> Result<TransportResult> {
         let is_gemini = self.tool_name == "gemini-cli";
 
-        // Non-gemini tools: ACP crash retry count is configured at execution time.
-        if !is_gemini {
+        if self.tool_name == "codex" {
             return execute_with_crash_retry(
                 self, prompt, tool_state, session, extra_env, &options,
             )
             .await;
+        }
+        if !is_gemini {
+            let resume_session_id = tool_state.and_then(|s| s.provider_session_id.as_deref());
+            return self
+                .execute_acp_attempt(
+                    prompt,
+                    session,
+                    extra_env,
+                    &options,
+                    &self.acp_args,
+                    resume_session_id,
+                )
+                .await;
         }
 
         // Gemini-cli: 3-phase fallback: OAuth(original) → APIKey(original) → APIKey(flash)

--- a/crates/csa-executor/src/transport_factory.rs
+++ b/crates/csa-executor/src/transport_factory.rs
@@ -84,6 +84,7 @@ impl TransportFactory {
     pub fn mode_for_tool(tool_name: &str) -> TransportMode {
         match tool_name {
             "claude-code" => TransportMode::Acp,
+            "hermes" => TransportMode::Acp,
             "openai-compat" => TransportMode::OpenaiCompat,
             _ => TransportMode::Legacy,
         }
@@ -229,6 +230,17 @@ impl TransportFactory {
                 err("openai-compat does not support tmux transport")
             }
 
+            // Hermes: ACP-backed adapter only.
+            #[cfg(feature = "acp")]
+            (Executor::Hermes { .. }, TransportMode::Acp) => Ok(()),
+            (Executor::Hermes { .. }, TransportMode::Legacy) => {
+                err("hermes currently supports acp transport only")
+            }
+            (Executor::Hermes { .. }, TransportMode::OpenaiCompat)
+            | (Executor::Hermes { .. }, TransportMode::Tmux) => {
+                err("hermes only supports acp transport")
+            }
+
             // AntigravityCli: Legacy and ACP (same as gemini-cli)
             (Executor::AntigravityCli { .. }, TransportMode::Legacy) => Ok(()),
             #[cfg(feature = "acp")]
@@ -323,6 +335,7 @@ impl TransportFactory {
                         executor.tool_name(),
                         session_config,
                         executor.codex_fast_mode_enabled(),
+                        executor.hermes_run_config(),
                     )))
                 }
             }

--- a/crates/csa-executor/src/transport_factory_tests.rs
+++ b/crates/csa-executor/src/transport_factory_tests.rs
@@ -42,6 +42,14 @@ fn make_codex_executor_acp() -> Executor {
     }
 }
 
+fn make_hermes_executor() -> Executor {
+    Executor::Hermes {
+        provider_override: Some("openai".to_string()),
+        model_override: Some("gpt-5.5".to_string()),
+        thinking_budget: None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Change 1: default transport flip — explicit Cli routes to Legacy
 // ---------------------------------------------------------------------------
@@ -153,6 +161,27 @@ fn test_mode_for_executor_codex_default_is_legacy() {
         TransportMode::Legacy,
         "default Cli metadata must route to Legacy, not ACP"
     );
+}
+
+#[test]
+#[cfg(feature = "acp")]
+fn test_mode_for_executor_hermes_defaults_to_acp() {
+    let executor = make_hermes_executor();
+    let mode = TransportFactory::mode_for_executor_pub(&executor)
+        .expect("Hermes should use ACP when ACP feature is enabled");
+
+    assert_eq!(mode, TransportMode::Acp);
+}
+
+#[test]
+#[cfg(not(feature = "acp"))]
+fn test_mode_for_executor_hermes_errors_without_acp_feature() {
+    let executor = make_hermes_executor();
+    let error = TransportFactory::mode_for_executor_pub(&executor)
+        .expect_err("Hermes ACP should require the acp feature");
+
+    let message = format!("{error:#}");
+    assert!(message.contains("ACP transport requires"), "{message}");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/csa-executor/src/transport_lean_mode_tests.rs
+++ b/crates/csa-executor/src/transport_lean_mode_tests.rs
@@ -1,13 +1,15 @@
 use serde_json::json;
 
 use super::AcpTransport;
-use crate::{AcpMcpServerConfig as McpServerConfig, SessionConfig};
+use crate::{AcpMcpServerConfig as McpServerConfig, HermesRunConfig, SessionConfig};
+use crate::model_spec::ThinkingBudget;
 use std::collections::HashMap;
 
 #[test]
 fn test_build_session_meta_with_empty_sources() {
     let sources: Vec<String> = vec![];
-    let meta = AcpTransport::build_session_meta(Some(&sources), None).expect("meta should exist");
+    let meta =
+        AcpTransport::build_session_meta(Some(&sources), None, None).expect("meta should exist");
     assert_eq!(
         serde_json::Value::Object(meta),
         json!({"claudeCode": {"options": {"settingSources": []}}})
@@ -17,7 +19,8 @@ fn test_build_session_meta_with_empty_sources() {
 #[test]
 fn test_build_session_meta_with_project_source() {
     let sources = vec!["project".to_string()];
-    let meta = AcpTransport::build_session_meta(Some(&sources), None).expect("meta should exist");
+    let meta =
+        AcpTransport::build_session_meta(Some(&sources), None, None).expect("meta should exist");
     assert_eq!(
         serde_json::Value::Object(meta),
         json!({"claudeCode": {"options": {"settingSources": ["project"]}}})
@@ -27,7 +30,7 @@ fn test_build_session_meta_with_project_source() {
 #[test]
 fn test_build_session_meta_none_returns_none() {
     assert!(
-        AcpTransport::build_session_meta(None, None).is_none(),
+        AcpTransport::build_session_meta(None, None, None).is_none(),
         "meta should be absent when setting_sources is None"
     );
 }
@@ -44,7 +47,7 @@ fn test_build_session_meta_includes_direct_mcp_servers() {
         ..Default::default()
     };
 
-    let meta = AcpTransport::build_session_meta(None, Some(&session_config))
+    let meta = AcpTransport::build_session_meta(None, Some(&session_config), None)
         .expect("meta should include mcpServers");
     assert_eq!(
         serde_json::Value::Object(meta),
@@ -75,9 +78,29 @@ fn test_build_session_meta_prefers_proxy_when_socket_exists() {
         ..Default::default()
     };
 
-    let meta = AcpTransport::build_session_meta(None, Some(&session_config))
+    let meta = AcpTransport::build_session_meta(None, Some(&session_config), None)
         .expect("meta should include proxy mcpServers");
     let mcp_servers = &serde_json::Value::Object(meta)["claudeCode"]["options"]["mcpServers"];
     assert!(mcp_servers.get("csa-mcp-hub").is_some());
     assert!(mcp_servers.get("memory").is_none());
+}
+
+#[test]
+fn test_build_session_meta_includes_hermes_options() {
+    let hermes = HermesRunConfig::from_model_spec(
+        "openai".to_string(),
+        "gpt-5.5".to_string(),
+        ThinkingBudget::Xhigh,
+    );
+    let meta = AcpTransport::build_session_meta(None, None, Some(&hermes))
+        .expect("meta should include Hermes options");
+
+    assert_eq!(
+        serde_json::Value::Object(meta),
+        json!({"hermes": {"options": {
+            "provider": "openai",
+            "model": "gpt-5.5",
+            "thinking": "xhigh"
+        }}})
+    );
 }

--- a/crates/csa-executor/src/transport_meta.rs
+++ b/crates/csa-executor/src/transport_meta.rs
@@ -19,6 +19,8 @@ use serde_json::{Map, Value, json};
 #[cfg(feature = "acp")]
 use super::AcpTransport;
 #[cfg(feature = "acp")]
+use crate::hermes_config::HermesRunConfig;
+#[cfg(feature = "acp")]
 use crate::lefthook_guard::sanitize_env_map_for_codex;
 #[cfg(feature = "acp")]
 use crate::session_config::SessionConfig;
@@ -106,6 +108,7 @@ impl AcpTransport {
     pub(crate) fn build_session_meta(
         setting_sources: Option<&[String]>,
         session_config: Option<&SessionConfig>,
+        hermes_run_config: Option<&HermesRunConfig>,
     ) -> Option<serde_json::Map<String, serde_json::Value>> {
         let mut options = serde_json::Map::new();
         if let Some(sources) = setting_sources {
@@ -129,18 +132,22 @@ impl AcpTransport {
                 options.insert("mcpServers".to_string(), mcp_servers);
             }
         }
-        if options.is_empty() {
-            return None;
+        let mut meta = serde_json::Map::new();
+        if !options.is_empty() {
+            let mut claude_code = serde_json::Map::new();
+            claude_code.insert("options".to_string(), serde_json::Value::Object(options));
+            meta.insert(
+                "claudeCode".to_string(),
+                serde_json::Value::Object(claude_code),
+            );
+        }
+        if let Some(hermes_options) = hermes_run_config.and_then(HermesRunConfig::meta_options) {
+            let mut hermes = serde_json::Map::new();
+            hermes.insert("options".to_string(), hermes_options);
+            meta.insert("hermes".to_string(), serde_json::Value::Object(hermes));
         }
 
-        let mut claude_code = serde_json::Map::new();
-        claude_code.insert("options".to_string(), serde_json::Value::Object(options));
-        let mut meta = serde_json::Map::new();
-        meta.insert(
-            "claudeCode".to_string(),
-            serde_json::Value::Object(claude_code),
-        );
-        Some(meta)
+        (!meta.is_empty()).then_some(meta)
     }
 
     pub(crate) fn build_env(


### PR DESCRIPTION
Design via csa debate (A ACP-backed). ToolName::Hermes + Executor::Hermes preserving provider/model/thinking + ACP transport routing + per-run config without global mutation.

Closes #2517