### PR TITLE
fix(commit-guard): detect external HEAD race during child sessions (#2556, #2557)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "chrono",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "chrono",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "axum",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "chrono",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "chrono",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1082"
+version = "0.1.1083"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1082"
+version = "0.1.1083"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -527,6 +527,7 @@ mod tests {
         let commit_guard = crate::run_cmd::PostRunCommitGuard {
             workspace_mutated: true,
             head_changed: true,
+            head_externally_raced: false,
             changed_paths: vec!["tracked.txt".to_string()],
         };
         let mut result = csa_process::ExecutionResult {

--- a/crates/cli-sub-agent/src/run_cmd_git.rs
+++ b/crates/cli-sub-agent/src/run_cmd_git.rs
@@ -17,6 +17,9 @@ pub(crate) struct GitWorkspaceSnapshot {
 pub(crate) struct PostRunCommitGuard {
     pub(crate) workspace_mutated: bool,
     pub(crate) head_changed: bool,
+    /// True when HEAD changed but no git commit was attempted by the child session,
+    /// indicating an external process mutated the worktree during the session (#2556/#2557).
+    pub(crate) head_externally_raced: bool,
     pub(crate) changed_paths: Vec<String>,
 }
 
@@ -318,6 +321,7 @@ pub(crate) fn evaluate_post_run_commit_guard(
     Some(PostRunCommitGuard {
         workspace_mutated,
         head_changed: before.head != after.head,
+        head_externally_raced: false,
         changed_paths: changed_paths_from_status(&after.status, 8),
     })
 }

--- a/crates/cli-sub-agent/src/run_cmd_git.rs
+++ b/crates/cli-sub-agent/src/run_cmd_git.rs
@@ -318,9 +318,11 @@ pub(crate) fn evaluate_post_run_commit_guard(
         return None;
     }
 
+    let head_changed = before.head != after.head;
     Some(PostRunCommitGuard {
         workspace_mutated,
-        head_changed: before.head != after.head,
+        head_changed,
+        // Set by the caller after checking whether the child attempted git commit.
         head_externally_raced: false,
         changed_paths: changed_paths_from_status(&after.status, 8),
     })

--- a/crates/cli-sub-agent/src/run_cmd_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_policy.rs
@@ -74,6 +74,8 @@ pub(crate) fn apply_post_run_commit_policy(
 
     let commit_ref_update_failed =
         git_commit_attempted && commit_guard.workspace_mutated && !commit_guard.head_changed;
+    let head_externally_raced =
+        commit_guard.head_changed && !git_commit_attempted && commit_guard.workspace_mutated;
     let enforce_closed_policy = commit_guard.workspace_mutated
         && !commit_guard.head_changed
         && (require_commit_on_mutation || commit_ref_update_failed);
@@ -81,6 +83,7 @@ pub(crate) fn apply_post_run_commit_policy(
         commit_guard,
         enforce_closed_policy,
         commit_ref_update_failed,
+        head_externally_raced,
         recovery_tool,
     );
 
@@ -300,6 +303,7 @@ pub(crate) fn format_post_run_commit_guard_message(
     guard: &PostRunCommitGuard,
     enforce_closed_policy: bool,
     commit_ref_update_failed: bool,
+    head_externally_raced: bool,
     recovery_tool: Option<&str>,
 ) -> String {
     let severity = if enforce_closed_policy {
@@ -307,8 +311,11 @@ pub(crate) fn format_post_run_commit_guard_message(
     } else {
         "WARNING"
     };
+    let head_externally_raced = head_externally_raced || guard.head_externally_raced;
     let reason = if commit_ref_update_failed {
         "git commit was attempted but HEAD did not advance; work remains uncommitted"
+    } else if head_externally_raced {
+        "HEAD was moved by an external process during this session (worktree race detected, #2556/#2557)"
     } else if guard.head_changed {
         "run created commit(s) but still left uncommitted workspace mutations"
     } else {

--- a/crates/cli-sub-agent/src/run_cmd_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_policy.rs
@@ -74,6 +74,8 @@ pub(crate) fn apply_post_run_commit_policy(
 
     let commit_ref_update_failed =
         git_commit_attempted && commit_guard.workspace_mutated && !commit_guard.head_changed;
+    // #2556/#2557: HEAD changed without a child git commit, so another
+    // process moved the worktree during the session.
     let head_externally_raced =
         commit_guard.head_changed && !git_commit_attempted && commit_guard.workspace_mutated;
     let enforce_closed_policy = commit_guard.workspace_mutated

--- a/crates/cli-sub-agent/src/run_cmd_tests_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_policy.rs
@@ -116,6 +116,7 @@ fn evaluate_post_run_commit_guard_detects_mutation_without_commit() {
     let guard = evaluate_post_run_commit_guard(Some(&before), Some(&after))
         .expect("dirty workspace should produce guard");
     assert!(guard.workspace_mutated);
+    assert!(!guard.head_externally_raced);
     assert_eq!(
         guard.changed_paths,
         vec!["crates/cli-sub-agent/src/run_cmd.rs".to_string()]
@@ -138,6 +139,7 @@ fn evaluate_post_run_commit_guard_detects_mutation_when_head_changed() {
     let guard = evaluate_post_run_commit_guard(Some(&before), Some(&after))
         .expect("dirty workspace should produce guard");
     assert!(guard.workspace_mutated);
+    assert!(!guard.head_externally_raced);
 }
 
 #[test]
@@ -162,13 +164,14 @@ fn format_post_run_commit_guard_message_includes_next_step_and_paths() {
     let guard = PostRunCommitGuard {
         workspace_mutated: true,
         head_changed: false,
+        head_externally_raced: false,
         changed_paths: vec![
             "Cargo.lock".to_string(),
             "crates/cli-sub-agent/src/run_cmd.rs".to_string(),
         ],
     };
 
-    let message = format_post_run_commit_guard_message(&guard, false, false, Some("codex"));
+    let message = format_post_run_commit_guard_message(&guard, false, false, false, Some("codex"));
     assert!(message.contains("WARNING"));
     assert!(message.contains("csa run --tool codex --skill commit"));
     assert!(message.contains("lineage-scoped child sessions"));
@@ -194,6 +197,7 @@ fn evaluate_post_run_commit_guard_detects_dirty_file_mutation_when_status_text_i
     let guard = evaluate_post_run_commit_guard(Some(&before), Some(&after))
         .expect("dirty workspace should produce guard");
     assert!(guard.workspace_mutated);
+    assert!(!guard.head_externally_raced);
 }
 
 #[test]
@@ -209,6 +213,7 @@ fn apply_post_run_commit_policy_sets_failure_when_policy_requires_commit() {
     let guard = PostRunCommitGuard {
         workspace_mutated: true,
         head_changed: false,
+        head_externally_raced: false,
         changed_paths: vec!["src/lib.rs".to_string()],
     };
 
@@ -248,6 +253,7 @@ fn apply_post_run_commit_policy_keeps_success_when_policy_disabled() {
     let guard = PostRunCommitGuard {
         workspace_mutated: true,
         head_changed: false,
+        head_externally_raced: false,
         changed_paths: vec!["src/lib.rs".to_string()],
     };
 
@@ -278,6 +284,7 @@ fn apply_post_run_commit_policy_fails_when_commit_attempt_left_head_unchanged() 
     let guard = PostRunCommitGuard {
         workspace_mutated: true,
         head_changed: false,
+        head_externally_raced: false,
         changed_paths: vec!["src/lib.rs".to_string()],
     };
 
@@ -306,6 +313,87 @@ fn apply_post_run_commit_policy_fails_when_commit_attempt_left_head_unchanged() 
         result
             .stderr_output
             .contains("git commit was attempted but HEAD did not advance"),
+        "{}",
+        result.stderr_output
+    );
+}
+
+#[test]
+fn apply_post_run_commit_policy_warns_when_head_externally_raced() {
+    let mut result = ExecutionResult {
+        output: String::new(),
+        stderr_output: String::new(),
+        summary: "ok".to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+        ..Default::default()
+    };
+    let guard = PostRunCommitGuard {
+        workspace_mutated: true,
+        head_changed: true,
+        head_externally_raced: false,
+        changed_paths: vec!["src/lib.rs".to_string()],
+    };
+
+    apply_post_run_commit_policy(
+        &mut result,
+        &OutputFormat::Json,
+        None,
+        true,
+        false,
+        Some(&guard),
+    );
+
+    assert_eq!(result.exit_code, 0);
+    assert!(result.csa_gate_failure.is_none());
+    assert!(
+        result.stderr_output.contains(
+            "HEAD was moved by an external process during this session (worktree race detected, #2556/#2557)"
+        ),
+        "{}",
+        result.stderr_output
+    );
+}
+
+#[test]
+fn apply_post_run_commit_policy_does_not_report_external_race_for_normal_commit() {
+    let mut result = ExecutionResult {
+        output: String::new(),
+        stderr_output: String::new(),
+        summary: "ok".to_string(),
+        exit_code: 0,
+        peak_memory_mb: None,
+        ..Default::default()
+    };
+    let guard = PostRunCommitGuard {
+        workspace_mutated: true,
+        head_changed: true,
+        head_externally_raced: false,
+        changed_paths: vec!["src/lib.rs".to_string()],
+    };
+
+    apply_post_run_commit_policy(
+        &mut result,
+        &OutputFormat::Json,
+        None,
+        true,
+        true,
+        Some(&guard),
+    );
+
+    assert_eq!(result.exit_code, 0);
+    assert!(result.csa_gate_failure.is_none());
+    assert!(
+        result
+            .stderr_output
+            .contains("run created commit(s) but still left uncommitted workspace mutations"),
+        "{}",
+        result.stderr_output
+    );
+    assert!(
+        !result
+            .stderr_output
+            .contains("HEAD was moved by an external process"),
         "{}",
         result.stderr_output
     );

--- a/crates/cli-sub-agent/src/run_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_tail.rs
@@ -130,6 +130,7 @@ fn apply_post_run_commit_policy_overrides_summary_on_preexisting_failure() {
     let guard = PostRunCommitGuard {
         workspace_mutated: true,
         head_changed: false,
+        head_externally_raced: false,
         changed_paths: vec!["src/lib.rs".to_string()],
     };
 
@@ -229,6 +230,7 @@ fn apply_post_run_commit_policy_does_not_fail_closed_when_head_changed() {
     let guard = PostRunCommitGuard {
         workspace_mutated: true,
         head_changed: true,
+        head_externally_raced: false,
         changed_paths: vec!["src/lib.rs".to_string()],
     };
 
@@ -246,6 +248,6 @@ fn apply_post_run_commit_policy_does_not_fail_closed_when_head_changed() {
     assert!(
         result
             .stderr_output
-            .contains("run created commit(s) but still left uncommitted workspace mutations")
+            .contains("HEAD was moved by an external process during this session")
     );
 }

--- a/crates/csa-config/src/config_tests_tail.rs
+++ b/crates/csa-config/src/config_tests_tail.rs
@@ -769,18 +769,10 @@ fn test_enforce_tool_enabled_includes_alternatives_when_others_enabled() {
 /// be omitted entirely — no point listing an empty set.
 #[test]
 fn test_enforce_tool_enabled_omits_hint_when_no_alternatives() {
-    let known_tools = [
-        "gemini-cli",
-        "opencode",
-        "codex",
-        "claude-code",
-        "openai-compat",
-        "antigravity-cli",
-    ];
     let mut tools = HashMap::new();
-    for name in &known_tools {
+    for name in crate::global::all_known_tools() {
         tools.insert(
-            name.to_string(),
+            name.as_str().to_string(),
             ToolConfig {
                 enabled: false,
                 ..Default::default()

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,7 @@
-package = []
-
 [versions]
-csa = "0.1.1082"
+csa = "0.1.1083"
+weave = "0.1.1083"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.1082"
 
 [migrations]
 applied = [


### PR DESCRIPTION
Add `head_externally_raced` detection to PostRunCommitGuard. When HEAD changes during a child session but no git commit was attempted, the policy emits a specific warning about external worktree mutation.

Closes #2556, closes #2557, relates to #2559