### PR TITLE
fix(plan): structured error path for child sessions that die with NoLivePID (#2560)

### DIFF
--- a/crates/cli-sub-agent/src/plan_cmd.rs
+++ b/crates/cli-sub-agent/src/plan_cmd.rs
@@ -54,6 +54,8 @@ mod plan_cmd_assignment;
 #[path = "plan_cmd_tier_failover.rs"]
 mod plan_cmd_tier_failover;
 
+#[path = "plan_cmd_child_diagnostics.rs"]
+mod plan_cmd_child_diagnostics;
 #[path = "plan_cmd_steps.rs"]
 mod plan_cmd_steps;
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/plan_cmd_child_diagnostics.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_child_diagnostics.rs
@@ -1,0 +1,301 @@
+use std::path::Path;
+
+use csa_session::{SessionPhase, SessionResult};
+
+const MAX_SESSION_CANDIDATES: usize = 8;
+const MAX_SUMMARY_CHARS: usize = 180;
+
+pub(crate) fn format_plan_child_died_diagnostics(
+    project_root: &Path,
+    stdout: &str,
+    stderr: &str,
+) -> Option<String> {
+    let mut diagnostics = Vec::new();
+    let combined = format!("{stdout}\n{stderr}");
+    for candidate in session_id_candidates(&combined) {
+        if diagnostics.len() >= MAX_SESSION_CANDIDATES {
+            break;
+        }
+        let Some(diagnostic) = inspect_child_session(project_root, &candidate) else {
+            continue;
+        };
+        if diagnostic.is_failure_like() {
+            diagnostics.push(diagnostic.render());
+        }
+    }
+
+    (!diagnostics.is_empty()).then(|| diagnostics.join("\n"))
+}
+
+pub(crate) fn append_child_diagnostics(
+    message: &mut String,
+    project_root: &Path,
+    stdout: &str,
+    stderr: &str,
+) {
+    let Some(child_diagnostics) = format_plan_child_died_diagnostics(project_root, stdout, stderr)
+    else {
+        return;
+    };
+    message.push('\n');
+    message.push_str(&child_diagnostics);
+}
+
+fn inspect_child_session(project_root: &Path, candidate: &str) -> Option<PlanChildDiagnostic> {
+    let resolved =
+        crate::session_cmds::resolve_session_prefix_with_global_fallback(project_root, candidate)
+            .ok()?;
+    let session_dir = resolved.sessions_dir.join(&resolved.session_id);
+    let effective_root = resolved
+        .foreign_project_root
+        .as_deref()
+        .unwrap_or(project_root);
+    let session = csa_session::load_session(effective_root, &resolved.session_id)
+        .ok()
+        .or_else(|| load_session_state_from_dir(&session_dir));
+    let result = csa_session::load_result(effective_root, &resolved.session_id)
+        .ok()
+        .flatten()
+        .or_else(|| load_result_from_dir(&session_dir));
+    let live_process = csa_process::ToolLiveness::has_live_process(&session_dir)
+        || csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir);
+    let phase = session
+        .as_ref()
+        .map(|session| phase_name(&session.phase))
+        .unwrap_or("unknown");
+    let status = derive_child_status(
+        session.as_ref().map(|s| &s.phase),
+        result.as_ref(),
+        live_process,
+    );
+
+    Some(PlanChildDiagnostic {
+        session_id: resolved.session_id,
+        status,
+        phase,
+        live_process,
+        result_status: result.as_ref().map(|result| result.status.clone()),
+        result_exit_code: result.as_ref().map(|result| result.exit_code),
+        summary: result
+            .as_ref()
+            .map(|result| compact_summary(&result.summary))
+            .filter(|summary| !summary.is_empty()),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PlanChildDiagnostic {
+    session_id: String,
+    status: &'static str,
+    phase: &'static str,
+    live_process: bool,
+    result_status: Option<String>,
+    result_exit_code: Option<i32>,
+    summary: Option<String>,
+}
+
+impl PlanChildDiagnostic {
+    fn is_failure_like(&self) -> bool {
+        matches!(self.status, "NoLivePID" | "Failed" | "Error")
+    }
+
+    fn render(&self) -> String {
+        let result_status = self.result_status.as_deref().unwrap_or("missing");
+        let result_exit = self
+            .result_exit_code
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "missing".to_string());
+        let mut rendered = format!(
+            "plan_child_died session={} status={} phase={} live_process={} result_status={} result_exit={}",
+            self.session_id, self.status, self.phase, self.live_process, result_status, result_exit
+        );
+        if let Some(summary) = &self.summary {
+            rendered.push_str(" summary=\"");
+            rendered.push_str(summary);
+            rendered.push('"');
+        }
+        rendered
+    }
+}
+
+fn derive_child_status(
+    phase: Option<&SessionPhase>,
+    result: Option<&SessionResult>,
+    live_process: bool,
+) -> &'static str {
+    if let Some(result) = result {
+        let normalized = result.status.trim().to_ascii_lowercase();
+        if matches!(normalized.as_str(), "success" | "retired") && result.exit_code == 0 {
+            return "Succeeded";
+        }
+        if normalized == "error" {
+            return "Error";
+        }
+        return "Failed";
+    }
+
+    if matches!(phase, Some(SessionPhase::Active)) && !live_process {
+        return "NoLivePID";
+    }
+
+    match phase {
+        Some(SessionPhase::Active) => "Active",
+        Some(SessionPhase::Retired) => "Retired",
+        Some(SessionPhase::Available) => "Available",
+        Some(SessionPhase::ToolExhausted) => "ToolExhausted",
+        None => "Error",
+    }
+}
+
+fn phase_name(phase: &SessionPhase) -> &'static str {
+    match phase {
+        SessionPhase::Active => "Active",
+        SessionPhase::Available => "Available",
+        SessionPhase::Retired => "Retired",
+        SessionPhase::ToolExhausted => "ToolExhausted",
+    }
+}
+
+fn load_session_state_from_dir(session_dir: &Path) -> Option<csa_session::MetaSessionState> {
+    let raw = std::fs::read_to_string(session_dir.join("state.toml")).ok()?;
+    toml::from_str(&raw).ok()
+}
+
+fn load_result_from_dir(session_dir: &Path) -> Option<SessionResult> {
+    let raw =
+        std::fs::read_to_string(session_dir.join(csa_session::result::RESULT_FILE_NAME)).ok()?;
+    toml::from_str(&raw).ok()
+}
+
+fn session_id_candidates(text: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+    for token in text.split(|ch: char| !ch.is_ascii_alphanumeric()) {
+        let token = token.trim();
+        if !looks_like_session_prefix(token) || candidates.iter().any(|seen| seen == token) {
+            continue;
+        }
+        candidates.push(token.to_string());
+    }
+    candidates
+}
+
+fn looks_like_session_prefix(token: &str) -> bool {
+    (10..=26).contains(&token.len())
+        && token
+            .chars()
+            .all(|ch| matches!(ch, '0'..='9' | 'A'..='H' | 'J'..='K' | 'M'..='N' | 'P'..='T' | 'V'..='Z'))
+        && token.starts_with("01")
+}
+
+fn compact_summary(summary: &str) -> String {
+    let redacted = csa_session::redact_text_content(summary);
+    let compacted = redacted.split_whitespace().collect::<Vec<_>>().join(" ");
+    let escaped = compacted.replace('"', "'");
+    let mut chars = escaped.chars();
+    let truncated: String = chars.by_ref().take(MAX_SUMMARY_CHARS).collect();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_session_sandbox::ScopedSessionSandbox;
+    use chrono::Utc;
+    use csa_session::{create_session, get_session_dir, load_session, save_result, save_session};
+    use tempfile::tempdir;
+
+    fn make_result(status: &str, exit_code: i32, summary: &str) -> SessionResult {
+        let now = Utc::now();
+        SessionResult {
+            post_exec_gate: None,
+            status: status.to_string(),
+            exit_code,
+            summary: summary.to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now,
+            events_count: 0,
+            artifacts: Vec::new(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn no_live_active_session_renders_plan_child_died() {
+        let td = tempdir().expect("tempdir");
+        let _sandbox = ScopedSessionSandbox::new_blocking(&td);
+        let project = td.path();
+        let session = create_session(project, Some("child"), None, Some("codex")).unwrap();
+        let session_id = session.meta_session_id.clone();
+
+        let rendered = format_plan_child_died_diagnostics(
+            project,
+            "",
+            &format!(
+                "Session {session_id} has no live daemon process and no terminal result packet."
+            ),
+        )
+        .expect("diagnostic should render");
+
+        assert!(rendered.contains("plan_child_died"));
+        assert!(rendered.contains(&format!("session={session_id}")));
+        assert!(rendered.contains("status=NoLivePID"));
+        assert!(rendered.contains("result_status=missing"));
+    }
+
+    #[test]
+    fn failed_child_result_renders_result_summary() {
+        let td = tempdir().expect("tempdir");
+        let _sandbox = ScopedSessionSandbox::new_blocking(&td);
+        let project = td.path();
+        let mut session = create_session(project, Some("child"), None, Some("codex")).unwrap();
+        session
+            .apply_phase_event(csa_session::PhaseEvent::Retired)
+            .unwrap();
+        let session_id = session.meta_session_id.clone();
+        let session_dir = get_session_dir(project, &session_id).unwrap();
+        save_session(&session).unwrap();
+        save_result(
+            project,
+            &session_id,
+            &make_result("failure", 1, "child failed before writing expected output"),
+        )
+        .unwrap();
+        assert!(load_session(project, &session_id).unwrap().phase == SessionPhase::Retired);
+
+        let rendered =
+            format_plan_child_died_diagnostics(project, &format!("waiting on {session_id}"), "")
+                .expect("diagnostic should render");
+
+        assert!(session_dir.is_dir());
+        assert!(rendered.contains("status=Failed"));
+        assert!(rendered.contains("result_status=failure"));
+        assert!(rendered.contains("summary=\"child failed before writing expected output\""));
+    }
+
+    #[test]
+    fn successful_child_is_not_reported_as_died() {
+        let td = tempdir().expect("tempdir");
+        let _sandbox = ScopedSessionSandbox::new_blocking(&td);
+        let project = td.path();
+        let mut session = create_session(project, Some("child"), None, Some("codex")).unwrap();
+        session
+            .apply_phase_event(csa_session::PhaseEvent::Retired)
+            .unwrap();
+        let session_id = session.meta_session_id.clone();
+        save_session(&session).unwrap();
+        save_result(project, &session_id, &make_result("success", 0, "ok")).unwrap();
+
+        assert!(
+            format_plan_child_died_diagnostics(project, &session_id, "").is_none(),
+            "successful child should not produce a death diagnostic"
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/plan_cmd_exec.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec.rs
@@ -19,6 +19,8 @@ use crate::run_helpers::build_executor;
 use crate::run_resource_overrides::RunResourceOverrides;
 use crate::startup_env::StartupSubtreeEnv;
 
+use super::plan_cmd_child_diagnostics::append_child_diagnostics;
+
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 
 pub(super) struct StepExecutionOutcome {
@@ -113,7 +115,10 @@ pub(super) async fn execute_bash_step(
     };
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr_str = String::from_utf8_lossy(&output.stderr).to_string();
+    let mut stderr_str = String::from_utf8_lossy(&output.stderr).to_string();
+    if output.status.code().unwrap_or(1) != 0 {
+        append_bash_child_diagnostics(&mut stderr_str, project_root, &stdout);
+    }
     if !stdout.is_empty() {
         eprint!("{stdout}");
     }
@@ -126,6 +131,15 @@ pub(super) async fn execute_bash_step(
         session_id: None,
         stderr: stderr_str,
     })
+}
+
+fn append_bash_child_diagnostics(stderr: &mut String, project_root: &Path, stdout: &str) {
+    let original_stderr = stderr.clone();
+    let before_len = stderr.len();
+    append_child_diagnostics(stderr, project_root, stdout, &original_stderr);
+    if stderr.len() > before_len && !stderr.ends_with('\n') {
+        stderr.push('\n');
+    }
 }
 
 async fn spawn_bash(

--- a/crates/cli-sub-agent/src/plan_cmd_exec_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_exec_tests.rs
@@ -175,6 +175,24 @@ Afterward text.
 }
 
 #[test]
+fn append_bash_child_diagnostics_adds_child_status_to_stderr() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let _sandbox = crate::test_session_sandbox::ScopedSessionSandbox::new_blocking(&td);
+    let project = td.path();
+    let session = csa_session::create_session(project, Some("child"), None, Some("codex"))
+        .expect("create child session");
+    let mut stderr = format!(
+        "Session {} has no live daemon process and no terminal result packet.",
+        session.meta_session_id
+    );
+
+    append_bash_child_diagnostics(&mut stderr, project, "");
+
+    assert!(stderr.contains("plan_child_died"));
+    assert!(stderr.contains("status=NoLivePID"));
+}
+
+#[test]
 fn clean_step_output_extracts_codex_json_event_stream_text() {
     let output = [
             r#"{"type":"thread.started","thread_id":"thread_1"}"#,

--- a/crates/cli-sub-agent/src/plan_cmd_failure_detail.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_detail.rs
@@ -4,6 +4,9 @@ pub(super) fn select_actionable_failure_line(text: &str) -> Option<String> {
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .collect();
+    if let Some(detail) = select_plan_child_died_detail(&all_lines) {
+        return Some(detail);
+    }
     if let Some(detail) = select_underlying_command_failure_detail(&all_lines) {
         return Some(detail);
     }
@@ -23,6 +26,15 @@ pub(super) fn select_actionable_failure_line(text: &str) -> Option<String> {
         .find(|line| is_high_signal_failure_line(line))
         .or_else(|| lines.last())
         .map(|line| truncate_failure_detail(line))
+}
+
+fn select_plan_child_died_detail(lines: &[&str]) -> Option<String> {
+    lines
+        .iter()
+        .rev()
+        .copied()
+        .find(|line| line.starts_with("plan_child_died "))
+        .map(truncate_failure_detail)
 }
 
 fn select_underlying_command_failure_detail(lines: &[&str]) -> Option<String> {

--- a/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_failure_tests.rs
@@ -102,6 +102,50 @@ fn failure_summary_surfaces_actionable_step_stderr() {
 }
 
 #[test]
+fn failure_summary_prefers_plan_child_died_diagnostic() {
+    let temp = tempfile::tempdir().expect("tempdir should be created");
+    let workflow_path = temp.path().join("workflow.toml");
+    let results = vec![StepResult {
+        step_id: 10,
+        title: "Phase 3 — Adversarial Debate".to_string(),
+        exit_code: 1,
+        duration_secs: 0.0,
+        skipped: false,
+        error: Some(
+            [
+                "Exit code 1",
+                "stderr (last 20 lines):",
+                "csa debate failed",
+                "plan_child_died session=01KWD2XP59K0QE6YMM0M7N2FHW status=NoLivePID phase=Active live_process=false result_status=missing result_exit=missing",
+            ]
+            .join("\n"),
+        ),
+        output: None,
+        session_id: None,
+        command: Some("csa debate --sa-mode true && csa session wait".to_string()),
+        stderr: Some("csa debate failed".to_string()),
+    }];
+    let report = PlanFailureReport::from_results(
+        "mktd",
+        &workflow_path,
+        "1 step(s) failed".to_string(),
+        &results,
+        None,
+    );
+
+    let summary_line = report.summary_line("patterns/mktd/workflow.toml");
+    let summary_section = report.render_summary_section();
+
+    for rendered in [&summary_line, &summary_section] {
+        assert!(
+            rendered.contains("plan_child_died session=01KWD2XP59K0QE6YMM0M7N2FHW")
+                && rendered.contains("status=NoLivePID"),
+            "parent-visible failure should expose the child session death diagnostic: {rendered}"
+        );
+    }
+}
+
+#[test]
 fn failure_summary_surfaces_mktd_stdout_for_post_2082_issue_body_shape() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let workflow_path = temp.path().join("workflow.toml");


### PR DESCRIPTION
Add `plan_cmd_child_diagnostics` module (301 lines). Detects when a child session dies unexpectedly during plan workflow. Parent now reports structured diagnostics and transitions to Failed instead of Stale.

Closes #2560