### PR TITLE
fix(commit): auto-rescue commit when require-commit policy fails (#2561)

### DIFF
--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -12,6 +12,9 @@ use super::session_exec_runtime::SessionCompletionPlan;
 use super::session_exec_write_guard::apply_write_restriction_violations;
 use crate::pipeline::SessionExecutionResult;
 
+#[path = "pipeline_session_exec_completion_require_commit.rs"]
+mod require_commit;
+
 const REVIEW_FIX_FINDING_TASK_TYPE: &str = "review_fix_finding";
 
 pub(super) struct CompletionInput<'a> {
@@ -105,24 +108,12 @@ pub(super) async fn complete_session_execution(
             &session.meta_session_id,
         );
     }
-    let post_run_workspace = session_exec_audit::capture_git_workspace_snapshot_if_needed(
+    let mut post_run_workspace = session_exec_audit::capture_git_workspace_snapshot_if_needed(
         is_git,
         input.project_root,
         require_commit_on_mutation,
     );
-    let pre_fingerprints = pre_run_workspace
-        .as_ref()
-        .map(session_exec_audit::snapshot_to_fingerprints);
-    let post_fingerprints = post_run_workspace
-        .as_ref()
-        .map(session_exec_audit::snapshot_to_fingerprints);
-    let changed_paths = crate::pipeline::changed_paths::compute_changed_paths(
-        pre_run_workspace.as_ref().map(|s| s.status.as_str()),
-        post_run_workspace.as_ref().map(|s| s.status.as_str()),
-        pre_fingerprints.as_ref(),
-        post_fingerprints.as_ref(),
-    );
-    let snapshots_available = pre_run_workspace.is_some() && post_run_workspace.is_some();
+    let mut rescued_changed_paths = None;
     let mut commit_created = None;
     if commit_guard_enabled {
         let effective_require_commit_on_mutation =
@@ -131,14 +122,45 @@ pub(super) async fn complete_session_execution(
             .as_ref()
             .zip(post_run_workspace.as_ref())
             .map(|(before, after)| before.head != after.head);
-        let commit_guard = crate::run_cmd::evaluate_post_run_commit_guard(
+        let mut commit_guard = crate::run_cmd::evaluate_post_run_commit_guard(
             pre_run_workspace.as_ref(),
             post_run_workspace.as_ref(),
         );
-        let policy_evaluation_failed = effective_require_commit_on_mutation
+        let mut policy_evaluation_failed = effective_require_commit_on_mutation
             && (!inside_git_worktree
                 || pre_run_workspace.is_none()
                 || post_run_workspace.is_none());
+        if require_commit::should_attempt_require_commit_rescue(
+            effective_require_commit_on_mutation,
+            commit_guard.as_ref(),
+        ) && let Some(new_head) =
+            crate::run_cmd::attempt_rescue_commit(input.project_root, input.executor.tool_name())
+        {
+            commit_created = Some(true);
+            rescued_changed_paths = Some(require_commit::compute_changed_paths_from_snapshots(
+                pre_run_workspace.as_ref(),
+                post_run_workspace.as_ref(),
+            ));
+            require_commit::record_require_commit_rescue(
+                input.output_format,
+                &mut result,
+                input.executor.tool_name(),
+                &new_head,
+            );
+            post_run_workspace = session_exec_audit::capture_git_workspace_snapshot_if_needed(
+                is_git,
+                input.project_root,
+                require_commit_on_mutation,
+            );
+            commit_guard = crate::run_cmd::evaluate_post_run_commit_guard(
+                pre_run_workspace.as_ref(),
+                post_run_workspace.as_ref(),
+            );
+            policy_evaluation_failed = effective_require_commit_on_mutation
+                && (!inside_git_worktree
+                    || pre_run_workspace.is_none()
+                    || post_run_workspace.is_none());
+        }
         crate::run_cmd::apply_post_session_commit_policies(
             &mut result,
             crate::run_cmd::PostSessionCommitPolicyArgs {
@@ -162,6 +184,16 @@ pub(super) async fn complete_session_execution(
         );
         apply_fix_finding_terminal_guard_summary(input.project_root, session, &mut result);
     }
+    let mut changed_paths = require_commit::compute_changed_paths_from_snapshots(
+        pre_run_workspace.as_ref(),
+        post_run_workspace.as_ref(),
+    );
+    if changed_paths.is_empty()
+        && let Some(paths) = rescued_changed_paths
+    {
+        changed_paths = paths;
+    }
+    let snapshots_available = pre_run_workspace.is_some() && post_run_workspace.is_some();
     let post_ctx = crate::pipeline_post_exec::PostExecContext {
         executor: input.executor,
         prompt: input.prompt,
@@ -293,6 +325,10 @@ fn is_fix_finding_session(session: &MetaSessionState) -> bool {
 mod fix_finding_tests;
 
 #[cfg(test)]
+#[path = "pipeline_session_exec_completion_require_commit_tests.rs"]
+mod require_commit_tests;
+
+#[cfg(test)]
 mod tests {
     use std::process::Command;
 
@@ -328,8 +364,9 @@ mod tests {
         );
         run_git(project_root, &["config", "user.name", "CSA Test"]);
         run_git(project_root, &["config", "commit.gpgsign", "false"]);
+        std::fs::write(project_root.join(".gitignore"), "state/\n").expect("write gitignore");
         std::fs::write(project_root.join("tracked.txt"), "initial\n").expect("write tracked");
-        run_git(project_root, &["add", "tracked.txt"]);
+        run_git(project_root, &["add", ".gitignore", "tracked.txt"]);
         run_git(project_root, &["commit", "-q", "-m", "initial"]);
     }
 
@@ -484,7 +521,7 @@ mod tests {
             result_file_cleared: false,
             execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
             commit_guard_enabled: true,
-            require_commit_on_mutation: false,
+            require_commit_on_mutation: true,
             hook_bypass_scan_enabled: true,
             is_git: true,
             inside_git_worktree: true,
@@ -518,6 +555,14 @@ mod tests {
 
         assert_eq!(completed.commit_created, Some(true));
         assert_eq!(completed.execution.exit_code, 0);
+        assert!(
+            !completed
+                .execution
+                .stderr_output
+                .contains("CSA require-commit rescue"),
+            "{}",
+            completed.execution.stderr_output
+        );
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion_require_commit.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion_require_commit.rs
@@ -1,0 +1,54 @@
+use csa_core::types::OutputFormat;
+
+use super::session_exec_audit;
+
+pub(super) fn compute_changed_paths_from_snapshots(
+    pre_run_workspace: Option<&crate::run_cmd::GitWorkspaceSnapshot>,
+    post_run_workspace: Option<&crate::run_cmd::GitWorkspaceSnapshot>,
+) -> Vec<String> {
+    let pre_fingerprints = pre_run_workspace.map(session_exec_audit::snapshot_to_fingerprints);
+    let post_fingerprints = post_run_workspace.map(session_exec_audit::snapshot_to_fingerprints);
+    crate::pipeline::changed_paths::compute_changed_paths(
+        pre_run_workspace.map(|s| s.status.as_str()),
+        post_run_workspace.map(|s| s.status.as_str()),
+        pre_fingerprints.as_ref(),
+        post_fingerprints.as_ref(),
+    )
+}
+
+pub(super) fn should_attempt_require_commit_rescue(
+    require_commit_on_mutation: bool,
+    commit_guard: Option<&crate::run_cmd::PostRunCommitGuard>,
+) -> bool {
+    require_commit_on_mutation
+        && commit_guard.is_some_and(|guard| guard.workspace_mutated && !guard.head_changed)
+}
+
+pub(super) fn record_require_commit_rescue(
+    output_format: &OutputFormat,
+    result: &mut csa_process::ExecutionResult,
+    tool_name: &str,
+    new_head: &str,
+) {
+    let message = format!(
+        "CSA require-commit rescue: created commit {new_head} for {tool_name} writer using \
+         CSA-owned rescue path (`git add -A && git commit --no-verify`)."
+    );
+    append_result_stderr_block(result, &message);
+    if matches!(output_format, OutputFormat::Text) {
+        eprintln!("{message}");
+    }
+}
+
+fn append_result_stderr_block(result: &mut csa_process::ExecutionResult, block: &str) {
+    if block.trim().is_empty() {
+        return;
+    }
+    if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
+        result.stderr_output.push('\n');
+    }
+    result.stderr_output.push_str(block);
+    if !result.stderr_output.ends_with('\n') {
+        result.stderr_output.push('\n');
+    }
+}

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion_require_commit_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion_require_commit_tests.rs
@@ -1,0 +1,206 @@
+use std::process::Command;
+
+use csa_core::transport_events::StreamingMetadata;
+use csa_core::types::OutputFormat;
+use csa_executor::{CodexRuntimeMetadata, Executor, TransportResult};
+use csa_session::{create_session, get_session_dir, load_result};
+
+use super::*;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+
+fn run_git(project_root: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {} failed\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_capture(project_root: &std::path::Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {} failed\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn init_git_repo(project_root: &std::path::Path) {
+    run_git(project_root, &["init", "-q"]);
+    run_git(
+        project_root,
+        &["config", "user.email", "csa-test@example.com"],
+    );
+    run_git(project_root, &["config", "user.name", "CSA Test"]);
+    run_git(project_root, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(project_root.join(".gitignore"), "state/\n").expect("write gitignore");
+    std::fs::write(project_root.join("tracked.txt"), "initial\n").expect("write tracked");
+    run_git(project_root, &["add", ".gitignore", "tracked.txt"]);
+    run_git(project_root, &["commit", "-q", "-m", "initial"]);
+}
+
+#[tokio::test]
+async fn completion_rescues_require_commit_when_writer_left_uncommitted_changes() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    init_git_repo(project_root);
+    let initial_head = git_capture(project_root, &["rev-parse", "HEAD"]);
+    let before =
+        crate::run_cmd::capture_git_workspace_snapshot(project_root, false).expect("snapshot");
+
+    std::fs::write(project_root.join("tracked.txt"), "changed\n").expect("write change");
+    run_git(project_root, &["add", "tracked.txt"]);
+
+    let mut session = create_session(
+        project_root,
+        Some("require commit rescue"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_dir = get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: CodexRuntimeMetadata::current(),
+    };
+    let transport_result = TransportResult {
+        execution: csa_process::ExecutionResult {
+            output: "writer completed but commit failed".to_string(),
+            stderr_output: String::new(),
+            summary: "writer completed but commit failed".to_string(),
+            exit_code: 0,
+            model_completed: Some(true),
+            ..Default::default()
+        },
+        provider_session_id: None,
+        events: Vec::new(),
+        metadata: StreamingMetadata {
+            extracted_commands: vec!["git commit -m fix".to_string()],
+            has_tool_calls: true,
+            has_execute_tool_calls: true,
+            turn_count: 1,
+            ..Default::default()
+        },
+    };
+    let plan = SessionCompletionPlan {
+        merged_env: Default::default(),
+        hooks_config: Default::default(),
+        sessions_root: session_dir
+            .parent()
+            .expect("sessions root")
+            .display()
+            .to_string(),
+        edit_guard: None,
+        new_file_guard: None,
+        result_file_cleared: false,
+        execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
+        commit_guard_enabled: true,
+        require_commit_on_mutation: true,
+        hook_bypass_scan_enabled: true,
+        is_git: true,
+        inside_git_worktree: true,
+        pre_run_workspace: Some(before),
+        pre_exec_snapshot: None,
+        timeout_diagnostics: None,
+        sa_mode: false,
+    };
+
+    let completed = complete_session_execution(
+        CompletionInput {
+            executor: &executor,
+            tool: &csa_core::types::ToolName::Codex,
+            prompt: "Fix, verify, and commit the work",
+            output_format: &OutputFormat::Json,
+            task_type: Some("run"),
+            readonly_project_root: false,
+            project_root,
+            config: None,
+            global_config: None,
+            session_dir: &session_dir,
+            memory_project_key: None,
+            effective_prompt: "Fix, verify, and commit the work".to_string(),
+            plan,
+            transport_result,
+        },
+        &mut session,
+    )
+    .await
+    .expect("complete session");
+
+    assert_eq!(
+        completed.execution.exit_code,
+        0,
+        "summary={}\ngate={:?}\nstderr={}",
+        completed.execution.summary,
+        completed.execution.csa_gate_failure,
+        completed.execution.stderr_output
+    );
+    assert!(completed.execution.csa_gate_failure.is_none());
+    assert_eq!(completed.commit_created, Some(true));
+    assert!(
+        completed
+            .changed_paths
+            .as_ref()
+            .is_some_and(|paths| paths.len() == 1 && paths[0] == "tracked.txt")
+    );
+    assert!(
+        completed
+            .execution
+            .stderr_output
+            .contains("CSA require-commit rescue: created commit"),
+        "{}",
+        completed.execution.stderr_output
+    );
+    assert!(
+        !completed
+            .execution
+            .stderr_output
+            .contains("post-run policy blocked"),
+        "{}",
+        completed.execution.stderr_output
+    );
+    assert_ne!(
+        git_capture(project_root, &["rev-parse", "HEAD"]),
+        initial_head
+    );
+    assert_eq!(git_capture(project_root, &["status", "--porcelain=v1"]), "");
+    assert_eq!(
+        git_capture(project_root, &["log", "-1", "--format=%s"]),
+        "feat: auto-rescue commit from CSA codex writer session"
+    );
+    let persisted = load_result(project_root, &session.meta_session_id)
+        .expect("load result")
+        .expect("result should be saved");
+    assert_eq!(persisted.status, "success");
+    assert_eq!(persisted.exit_code, 0);
+}
+
+#[test]
+fn require_commit_rescue_is_not_attempted_when_head_already_changed() {
+    let guard = crate::run_cmd::PostRunCommitGuard {
+        workspace_mutated: true,
+        head_changed: true,
+        head_externally_raced: false,
+        changed_paths: vec!["tracked.txt".to_string()],
+    };
+
+    assert!(!super::require_commit::should_attempt_require_commit_rescue(true, Some(&guard)));
+}

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -28,8 +28,8 @@ mod uncommitted;
 
 pub(crate) use execute::handle_run;
 pub(crate) use git::{
-    GitWorkspaceSnapshot, PostRunCommitGuard, capture_git_workspace_snapshot,
-    evaluate_post_run_commit_guard, is_git_worktree,
+    GitWorkspaceSnapshot, PostRunCommitGuard, attempt_rescue_commit,
+    capture_git_workspace_snapshot, evaluate_post_run_commit_guard, is_git_worktree,
 };
 pub(crate) use policy::{
     PostSessionCommitPolicyArgs, apply_post_session_commit_policies, execute_tool_calls_observed,

--- a/crates/cli-sub-agent/src/run_cmd_git.rs
+++ b/crates/cli-sub-agent/src/run_cmd_git.rs
@@ -72,6 +72,34 @@ pub(crate) fn is_git_worktree(project_root: &Path) -> bool {
         .is_some_and(|value| value.trim() == "true")
 }
 
+/// Attempt a CSA-owned rescue commit after a `--require-commit` writer left
+/// verified workspace mutations uncommitted.
+pub(crate) fn attempt_rescue_commit(project_root: &Path, tool_name: &str) -> Option<String> {
+    let add = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["add", "-A"])
+        .output()
+        .ok()?;
+    if !add.status.success() {
+        return None;
+    }
+
+    let message = format!("feat: auto-rescue commit from CSA {tool_name} writer session");
+    let commit = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["commit", "--no-verify", "-m"])
+        .arg(message)
+        .output()
+        .ok()?;
+    if !commit.status.success() {
+        return None;
+    }
+
+    run_git_capture(project_root, &["rev-parse", "HEAD"]).map(|head| head.trim().to_string())
+}
+
 fn run_git_capture(project_root: &Path, args: &[&str]) -> Option<String> {
     let output = std::process::Command::new("git")
         .arg("-C")
@@ -334,4 +362,83 @@ pub(crate) fn changed_paths_from_status(status: &str, limit: usize) -> Vec<Strin
         .filter_map(|entry| parse_status_entry(entry).map(|(_, _, path)| path.to_string()))
         .take(limit)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::process::Command;
+
+    use super::*;
+
+    fn run_git(project_root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_git_repo(project_root: &Path) {
+        init_empty_git_repo(project_root);
+        std::fs::write(project_root.join("tracked.txt"), "initial\n").expect("write tracked");
+        run_git(project_root, &["add", "tracked.txt"]);
+        run_git(project_root, &["commit", "-q", "-m", "initial"]);
+    }
+
+    fn init_empty_git_repo(project_root: &Path) {
+        run_git(project_root, &["init", "-q"]);
+        run_git(
+            project_root,
+            &["config", "user.email", "csa-test@example.com"],
+        );
+        run_git(project_root, &["config", "user.name", "CSA Test"]);
+        run_git(project_root, &["config", "commit.gpgsign", "false"]);
+    }
+
+    #[test]
+    fn rescue_commit_succeeds_when_writer_left_uncommitted_changes() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project_root = tmp.path();
+        init_git_repo(project_root);
+        let before = run_git_capture(project_root, &["rev-parse", "HEAD"]).expect("head");
+
+        std::fs::write(project_root.join("tracked.txt"), "changed\n").expect("write tracked");
+        std::fs::write(project_root.join("new.txt"), "new\n").expect("write untracked");
+
+        let rescued_head =
+            attempt_rescue_commit(project_root, "codex").expect("rescue commit should succeed");
+
+        assert_ne!(rescued_head, before.trim());
+        assert_eq!(
+            run_git_capture(project_root, &["status", "--porcelain=v1"])
+                .expect("status")
+                .trim(),
+            ""
+        );
+        assert_eq!(
+            run_git_capture(project_root, &["log", "-1", "--format=%s"])
+                .expect("log")
+                .trim(),
+            "feat: auto-rescue commit from CSA codex writer session"
+        );
+    }
+
+    #[test]
+    fn rescue_commit_fails_gracefully_on_empty_repo() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project_root = tmp.path();
+        init_empty_git_repo(project_root);
+
+        assert!(attempt_rescue_commit(project_root, "codex").is_none());
+        assert!(run_git_capture(project_root, &["rev-parse", "HEAD"]).is_none());
+    }
 }

--- a/crates/csa-config/src/config_tool.rs
+++ b/crates/csa-config/src/config_tool.rs
@@ -333,10 +333,7 @@ transport = "cli"
             config.resolve_transport("gemini-cli"),
             Some(TransportKind::Cli)
         );
-        assert_eq!(
-            config.resolve_transport("hermes"),
-            Some(TransportKind::Acp)
-        );
+        assert_eq!(config.resolve_transport("hermes"), Some(TransportKind::Acp));
     }
 
     #[test]
@@ -349,10 +346,7 @@ transport = "cli"
             config.resolve_transport("opencode"),
             Some(TransportKind::Cli)
         );
-        assert_eq!(
-            config.resolve_transport("hermes"),
-            Some(TransportKind::Acp)
-        );
+        assert_eq!(config.resolve_transport("hermes"), Some(TransportKind::Acp));
     }
 
     /// Mirrors `test_resolve_transport_claude_code_cli_round_trips` for codex.

--- a/crates/csa-executor/src/executor.rs
+++ b/crates/csa-executor/src/executor.rs
@@ -13,12 +13,12 @@ use crate::claude_runtime::{
     ClaudeCodeRuntimeMetadata, ClaudeCodeTransport, claude_runtime_metadata,
 };
 use crate::codex_runtime::{CodexRuntimeMetadata, CodexTransport, codex_runtime_metadata};
-use crate::install_hints::{
-    ANTIGRAVITY_CLI_INSTALL_HINT, GEMINI_CLI_INSTALL_HINT, OPENAI_COMPAT_INSTALL_HINT,
-    OPENCODE_INSTALL_HINT, HERMES_INSTALL_HINT,
-};
 #[cfg(feature = "acp")]
 use crate::hermes_config::HermesRunConfig;
+use crate::install_hints::{
+    ANTIGRAVITY_CLI_INSTALL_HINT, GEMINI_CLI_INSTALL_HINT, HERMES_INSTALL_HINT,
+    OPENAI_COMPAT_INSTALL_HINT, OPENCODE_INSTALL_HINT,
+};
 use crate::lefthook_guard::{sanitize_args_for_codex, sanitize_env_for_codex};
 use crate::model_spec::{ModelSpec, ThinkingBudget};
 use crate::session_config::SessionConfig;

--- a/crates/csa-executor/src/hermes_config.rs
+++ b/crates/csa-executor/src/hermes_config.rs
@@ -33,11 +33,7 @@ impl HermesRunConfig {
         }
     }
 
-    pub fn from_model_spec(
-        provider: String,
-        model: String,
-        thinking: ThinkingBudget,
-    ) -> Self {
+    pub fn from_model_spec(provider: String, model: String, thinking: ThinkingBudget) -> Self {
         Self::new(Some(provider), Some(model), Some(thinking))
     }
 

--- a/crates/csa-executor/src/transport.rs
+++ b/crates/csa-executor/src/transport.rs
@@ -4,12 +4,12 @@ use std::time::Duration;
 
 use crate::executor::Executor;
 #[cfg(feature = "acp")]
-use crate::lefthook_guard::sanitize_args_for_codex;
-#[cfg(feature = "acp")]
 use crate::hermes_config::{
     HermesRunConfig, filter_resume_session_id_for_hermes, persist_hermes_fingerprint,
     run_hermes_acp_check,
 };
+#[cfg(feature = "acp")]
+use crate::lefthook_guard::sanitize_args_for_codex;
 #[cfg(feature = "acp")]
 use crate::session_config::SessionConfig;
 use crate::transport_gemini_retry::{

--- a/crates/csa-executor/src/transport_lean_mode_tests.rs
+++ b/crates/csa-executor/src/transport_lean_mode_tests.rs
@@ -1,8 +1,8 @@
 use serde_json::json;
 
 use super::AcpTransport;
-use crate::{AcpMcpServerConfig as McpServerConfig, HermesRunConfig, SessionConfig};
 use crate::model_spec::ThinkingBudget;
+use crate::{AcpMcpServerConfig as McpServerConfig, HermesRunConfig, SessionConfig};
 use std::collections::HashMap;
 
 #[test]


### PR DESCRIPTION
When `--require-commit` detects the writer completed work but failed to commit, CSA now attempts a rescue commit (`git add -A && git commit --no-verify`) before marking the run as failed.

New: `pipeline_session_exec_completion_require_commit.rs` (54 lines) + `attempt_rescue_commit` in `run_cmd_git.rs` (107 lines) + 206 lines of tests.

Closes #2561