### PR TITLE
fix: stale AcpTransport call (#2566), doctor deadlock (#2567), commit reflog race (#2570)

### DIFF
--- a/crates/cli-sub-agent/src/doctor_tests.rs
+++ b/crates/cli-sub-agent/src/doctor_tests.rs
@@ -129,6 +129,11 @@ fn with_stubbed_claude_code_on_path<T>(test_fn: impl FnOnce() -> T) -> T {
     with_stubbed_binaries_on_path(&["claude", "claude-code-acp"], test_fn)
 }
 
+#[cfg(unix)]
+fn with_stubbed_hermes_on_path<T>(test_fn: impl FnOnce() -> T) -> T {
+    with_stubbed_binaries_on_path(&["hermes"], test_fn)
+}
+
 #[test]
 fn test_format_bytes() {
     assert_eq!(format_bytes(0), "0.0 GB");
@@ -267,6 +272,32 @@ fn default_build_doctor_json_output_reports_codex_transport_details() {
                 "doctor JSON should omit ACP override hints when ACP is not compiled in: {json}"
             );
         }
+    });
+}
+
+#[cfg(unix)]
+#[test]
+fn doctor_reports_hermes_binary_hint_and_acp_transport() {
+    with_stubbed_hermes_on_path(|| {
+        let status = check_tool_status("hermes", None);
+        let rendered = render_tool_status_lines(&status).join("\n");
+
+        assert!(status.is_ready(), "Hermes stub should satisfy doctor");
+        assert_eq!(status.binary_name, "hermes");
+        assert!(status.binary_available());
+        assert!(status.hint.is_none());
+        assert!(
+            rendered.contains("Active transport: acp"),
+            "Hermes doctor should report ACP transport: {rendered}"
+        );
+        assert!(
+            rendered.contains("Probed binary: hermes"),
+            "Hermes doctor should probe the hermes binary: {rendered}"
+        );
+        assert!(
+            rendered.contains("ACP compiled in:"),
+            "Hermes doctor should report ACP compile status: {rendered}"
+        );
     });
 }
 

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -161,6 +161,20 @@ pub(super) async fn complete_session_execution(
                     || pre_run_workspace.is_none()
                     || post_run_workspace.is_none());
         }
+        let git_commit_attempted =
+            !crate::run_cmd::detect_git_commit_commands(&executed_shell_commands).is_empty();
+        let commit_reflog_race = if git_commit_attempted && commit_created == Some(true) {
+            let current_head = post_run_workspace
+                .as_ref()
+                .and_then(|snap| snap.head.as_deref());
+            crate::run_cmd::detect_external_checkout_after_commit(
+                input.project_root,
+                current_head,
+                execution_start_time,
+            )
+        } else {
+            None
+        };
         crate::run_cmd::apply_post_session_commit_policies(
             &mut result,
             crate::run_cmd::PostSessionCommitPolicyArgs {
@@ -172,6 +186,7 @@ pub(super) async fn complete_session_execution(
                 policy_evaluation_failed,
                 hook_bypass_scan_enabled,
                 executed_shell_commands: &executed_shell_commands,
+                commit_reflog_race: commit_reflog_race.as_ref(),
                 merged_env_ref,
                 execute_events_observed,
             },
@@ -356,6 +371,26 @@ mod tests {
         );
     }
 
+    fn git_capture(project_root: &std::path::Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("git output should be utf8")
+            .trim()
+            .to_string()
+    }
+
     fn init_git_repo(project_root: &std::path::Path) {
         run_git(project_root, &["init", "-q"]);
         run_git(
@@ -368,6 +403,115 @@ mod tests {
         std::fs::write(project_root.join("tracked.txt"), "initial\n").expect("write tracked");
         run_git(project_root, &["add", ".gitignore", "tracked.txt"]);
         run_git(project_root, &["commit", "-q", "-m", "initial"]);
+    }
+
+    #[tokio::test]
+    async fn completion_warns_when_commit_reflog_is_followed_by_external_checkout() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+        let project_root = tmp.path();
+        init_git_repo(project_root);
+        let primary_branch = git_capture(project_root, &["branch", "--show-current"]);
+
+        run_git(project_root, &["checkout", "-q", "-b", "other"]);
+        std::fs::write(project_root.join("tracked.txt"), "other\n").expect("write other");
+        run_git(project_root, &["commit", "-am", "other"]);
+        run_git(project_root, &["checkout", "-q", &primary_branch]);
+
+        let before =
+            crate::run_cmd::capture_git_workspace_snapshot(project_root, false).expect("snapshot");
+        let execution_start_time = chrono::Utc::now() - chrono::Duration::seconds(1);
+        std::fs::write(project_root.join("tracked.txt"), "child\n").expect("write child");
+        run_git(project_root, &["commit", "-am", "child commit"]);
+        run_git(project_root, &["checkout", "-q", "other"]);
+
+        let mut session = create_session(
+            project_root,
+            Some("external checkout after commit"),
+            None,
+            Some("codex"),
+        )
+        .expect("create session");
+        let session_dir =
+            get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+        let executor = Executor::Codex {
+            model_override: None,
+            thinking_budget: None,
+            runtime_metadata: CodexRuntimeMetadata::current(),
+        };
+        let transport_result = TransportResult {
+            execution: csa_process::ExecutionResult {
+                output: String::new(),
+                stderr_output: "nothing to commit, working tree clean".to_string(),
+                summary: "nothing to commit".to_string(),
+                exit_code: 1,
+                model_completed: Some(true),
+                ..Default::default()
+            },
+            provider_session_id: None,
+            events: Vec::new(),
+            metadata: StreamingMetadata {
+                extracted_commands: vec!["git commit -m 'child commit'".to_string()],
+                has_tool_calls: true,
+                has_execute_tool_calls: true,
+                turn_count: 1,
+                ..Default::default()
+            },
+        };
+        let plan = SessionCompletionPlan {
+            merged_env: Default::default(),
+            hooks_config: Default::default(),
+            sessions_root: session_dir
+                .parent()
+                .expect("sessions root")
+                .display()
+                .to_string(),
+            edit_guard: None,
+            new_file_guard: None,
+            result_file_cleared: false,
+            execution_start_time,
+            commit_guard_enabled: true,
+            require_commit_on_mutation: true,
+            hook_bypass_scan_enabled: true,
+            is_git: true,
+            inside_git_worktree: true,
+            pre_run_workspace: Some(before),
+            pre_exec_snapshot: None,
+            timeout_diagnostics: None,
+            sa_mode: false,
+        };
+
+        let completed = complete_session_execution(
+            CompletionInput {
+                executor: &executor,
+                tool: &csa_core::types::ToolName::Codex,
+                prompt: "Commit the work",
+                output_format: &OutputFormat::Json,
+                task_type: Some("run"),
+                readonly_project_root: false,
+                project_root,
+                config: None,
+                global_config: None,
+                session_dir: &session_dir,
+                memory_project_key: None,
+                effective_prompt: "Commit the work".to_string(),
+                plan,
+                transport_result,
+            },
+            &mut session,
+        )
+        .await
+        .expect("complete session");
+
+        assert_eq!(completed.commit_created, Some(true));
+        assert!(completed.execution.csa_gate_failure.is_none());
+        assert!(
+            completed.execution.stderr_output.contains(
+                "external checkout/reset moved the worktree before session completion (#2570)"
+            ),
+            "{}",
+            completed.execution.stderr_output
+        );
     }
 
     #[tokio::test]

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -28,15 +28,16 @@ mod uncommitted;
 
 pub(crate) use execute::handle_run;
 pub(crate) use git::{
-    GitWorkspaceSnapshot, PostRunCommitGuard, attempt_rescue_commit,
-    capture_git_workspace_snapshot, evaluate_post_run_commit_guard, is_git_worktree,
+    CommitReflogRace, GitWorkspaceSnapshot, PostRunCommitGuard, attempt_rescue_commit,
+    capture_git_workspace_snapshot, detect_external_checkout_after_commit,
+    evaluate_post_run_commit_guard, is_git_worktree,
 };
 pub(crate) use policy::{
     PostSessionCommitPolicyArgs, apply_post_session_commit_policies, execute_tool_calls_observed,
     extract_executed_shell_commands, is_post_run_commit_policy_gate_failure,
     resolve_hook_bypass_scan_enabled,
 };
-pub(crate) use shell::detect_no_verify_commit_commands;
+pub(crate) use shell::{detect_git_commit_commands, detect_no_verify_commit_commands};
 pub(crate) use uncommitted::{
     collect_uncommitted_changes_for_changed_paths, format_large_diff_warning_block,
     format_uncommitted_warning, is_writer_session, working_tree_changed_lines,

--- a/crates/cli-sub-agent/src/run_cmd_git.rs
+++ b/crates/cli-sub-agent/src/run_cmd_git.rs
@@ -23,6 +23,12 @@ pub(crate) struct PostRunCommitGuard {
     pub(crate) changed_paths: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommitReflogRace {
+    pub(crate) created_commit: String,
+    pub(crate) current_head: String,
+}
+
 pub(crate) fn capture_git_workspace_snapshot(
     project_root: &Path,
     deep_fingerprint: bool,
@@ -100,6 +106,41 @@ pub(crate) fn attempt_rescue_commit(project_root: &Path, tool_name: &str) -> Opt
     run_git_capture(project_root, &["rev-parse", "HEAD"]).map(|head| head.trim().to_string())
 }
 
+pub(crate) fn detect_external_checkout_after_commit(
+    project_root: &Path,
+    current_head: Option<&str>,
+    since: chrono::DateTime<chrono::Utc>,
+) -> Option<CommitReflogRace> {
+    let current_head = current_head?.trim();
+    if current_head.is_empty() {
+        return None;
+    }
+
+    let reflog = run_git_capture(
+        project_root,
+        &["reflog", "--date=unix", "--format=%H%x00%gd%x00%gs", "HEAD"],
+    )?;
+    let since_secs = since.timestamp();
+    for line in reflog.lines() {
+        let entry = parse_head_reflog_entry(line)?;
+        if entry.timestamp_secs < since_secs {
+            break;
+        }
+        if !entry.subject.starts_with("commit") {
+            continue;
+        }
+        if entry.commit == current_head {
+            return None;
+        }
+        return Some(CommitReflogRace {
+            created_commit: entry.commit.to_string(),
+            current_head: current_head.to_string(),
+        });
+    }
+
+    None
+}
+
 fn run_git_capture(project_root: &Path, args: &[&str]) -> Option<String> {
     let output = std::process::Command::new("git")
         .arg("-C")
@@ -111,6 +152,31 @@ fn run_git_capture(project_root: &Path, args: &[&str]) -> Option<String> {
         return None;
     }
     Some(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+struct HeadReflogEntry<'a> {
+    commit: &'a str,
+    timestamp_secs: i64,
+    subject: &'a str,
+}
+
+fn parse_head_reflog_entry(line: &str) -> Option<HeadReflogEntry<'_>> {
+    let mut parts = line.splitn(3, '\0');
+    let commit = parts.next()?.trim();
+    let selector = parts.next()?.trim();
+    let subject = parts.next()?.trim();
+    let timestamp_secs = parse_unix_reflog_selector_timestamp_secs(selector)?;
+    Some(HeadReflogEntry {
+        commit,
+        timestamp_secs,
+        subject,
+    })
+}
+
+fn parse_unix_reflog_selector_timestamp_secs(selector: &str) -> Option<i64> {
+    let selector = selector.trim().strip_suffix('}')?;
+    let (_, timestamp_secs) = selector.rsplit_once("@{")?;
+    timestamp_secs.parse().ok()
 }
 
 fn run_git_capture_with_paths(
@@ -440,5 +506,35 @@ mod tests {
 
         assert!(attempt_rescue_commit(project_root, "codex").is_none());
         assert!(run_git_capture(project_root, &["rev-parse", "HEAD"]).is_none());
+    }
+
+    #[test]
+    fn external_checkout_after_commit_is_detected_from_head_reflog() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project_root = tmp.path();
+        init_git_repo(project_root);
+        let primary_branch = run_git_capture(project_root, &["branch", "--show-current"])
+            .expect("current branch")
+            .trim()
+            .to_string();
+
+        run_git(project_root, &["checkout", "-q", "-b", "other"]);
+        std::fs::write(project_root.join("tracked.txt"), "other\n").expect("write other");
+        run_git(project_root, &["commit", "-am", "other"]);
+        run_git(project_root, &["checkout", "-q", &primary_branch]);
+
+        let since = chrono::Utc::now() - chrono::Duration::seconds(1);
+        std::fs::write(project_root.join("tracked.txt"), "child\n").expect("write child");
+        run_git(project_root, &["commit", "-am", "child commit"]);
+        let child_commit = run_git_capture(project_root, &["rev-parse", "HEAD"]).expect("head");
+
+        run_git(project_root, &["checkout", "-q", "other"]);
+        let current_head = run_git_capture(project_root, &["rev-parse", "HEAD"]).expect("head");
+
+        let race =
+            detect_external_checkout_after_commit(project_root, Some(current_head.trim()), since)
+                .expect("external checkout after commit should be detected");
+        assert_eq!(race.created_commit, child_commit.trim());
+        assert_eq!(race.current_head, current_head.trim());
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_policy.rs
@@ -6,7 +6,7 @@ use csa_core::transport_events::{SessionEvent, StreamingMetadata};
 use csa_core::types::OutputFormat;
 use std::collections::HashMap;
 
-use super::git::PostRunCommitGuard;
+use super::git::{CommitReflogRace, PostRunCommitGuard};
 use super::shell::{
     detect_git_commit_commands, detect_hook_bypass_env_usage, detect_lefthook_bypass_commands,
     detect_no_verify_commit_commands,
@@ -66,9 +66,17 @@ pub(crate) fn apply_post_run_commit_policy(
     recovery_tool: Option<&str>,
     require_commit_on_mutation: bool,
     git_commit_attempted: bool,
+    commit_reflog_race: Option<&CommitReflogRace>,
     commit_guard: Option<&PostRunCommitGuard>,
 ) {
     let Some(commit_guard) = commit_guard else {
+        if let Some(race) = commit_reflog_race {
+            let message = format_external_checkout_after_commit_message(race, recovery_tool);
+            match output_format {
+                OutputFormat::Text => eprintln!("{message}"),
+                OutputFormat::Json => append_stderr_block(&mut result.stderr_output, &message),
+            }
+        }
         return;
     };
 
@@ -86,6 +94,7 @@ pub(crate) fn apply_post_run_commit_policy(
         enforce_closed_policy,
         commit_ref_update_failed,
         head_externally_raced,
+        commit_reflog_race,
         recovery_tool,
     );
 
@@ -128,6 +137,7 @@ pub(crate) struct PostSessionCommitPolicyArgs<'a> {
     pub(crate) policy_evaluation_failed: bool,
     pub(crate) hook_bypass_scan_enabled: bool,
     pub(crate) executed_shell_commands: &'a [String],
+    pub(crate) commit_reflog_race: Option<&'a CommitReflogRace>,
     pub(crate) merged_env_ref: Option<&'a HashMap<String, String>>,
     pub(crate) execute_events_observed: bool,
 }
@@ -143,6 +153,7 @@ pub(crate) fn apply_post_session_commit_policies(
         Some(args.tool_name),
         args.require_commit_on_mutation,
         git_commit_attempted,
+        args.commit_reflog_race,
         args.commit_guard,
     );
     apply_unverifiable_commit_policy(result, args.output_format, args.policy_evaluation_failed);
@@ -306,6 +317,7 @@ pub(crate) fn format_post_run_commit_guard_message(
     enforce_closed_policy: bool,
     commit_ref_update_failed: bool,
     head_externally_raced: bool,
+    commit_reflog_race: Option<&CommitReflogRace>,
     recovery_tool: Option<&str>,
 ) -> String {
     let severity = if enforce_closed_policy {
@@ -315,13 +327,15 @@ pub(crate) fn format_post_run_commit_guard_message(
     };
     let head_externally_raced = head_externally_raced || guard.head_externally_raced;
     let reason = if commit_ref_update_failed {
-        "git commit was attempted but HEAD did not advance; work remains uncommitted"
+        "git commit was attempted but HEAD did not advance; work remains uncommitted".to_string()
+    } else if let Some(race) = commit_reflog_race {
+        external_checkout_after_commit_reason(race)
     } else if head_externally_raced {
-        "HEAD was moved by an external process during this session (worktree race detected, #2556/#2557)"
+        "HEAD was moved by an external process during this session (worktree race detected, #2556/#2557)".to_string()
     } else if guard.head_changed {
-        "run created commit(s) but still left uncommitted workspace mutations"
+        "run created commit(s) but still left uncommitted workspace mutations".to_string()
     } else {
-        "run left uncommitted workspace mutations compared to start"
+        "run left uncommitted workspace mutations compared to start".to_string()
     };
 
     let mut lines = vec![format!("{severity}: csa run completed but {reason}.")];
@@ -339,6 +353,35 @@ pub(crate) fn format_post_run_commit_guard_message(
         lines.push(format!("Changed paths: {}", guard.changed_paths.join(", ")));
     }
     lines.join("\n")
+}
+
+fn format_external_checkout_after_commit_message(
+    race: &CommitReflogRace,
+    recovery_tool: Option<&str>,
+) -> String {
+    let mut lines = vec![format!(
+        "WARNING: csa run completed but {}.",
+        external_checkout_after_commit_reason(race)
+    )];
+    let recovery_command = recovery_tool
+        .map(|tool| format!("csa run --tool {tool} --skill commit \"<scope>\""))
+        .unwrap_or_else(|| "csa run --skill commit \"<scope>\"".to_string());
+    lines.push(format!(
+        "Next step: inspect HEAD/reflog, then run `{recovery_command}` only if additional commit work remains."
+    ));
+    lines.join("\n")
+}
+
+fn external_checkout_after_commit_reason(race: &CommitReflogRace) -> String {
+    format!(
+        "HEAD reflog shows git commit {} was created, but HEAD now points to {}; an external checkout/reset moved the worktree before session completion (#2570)",
+        short_hash(&race.created_commit),
+        short_hash(&race.current_head)
+    )
+}
+
+fn short_hash(hash: &str) -> &str {
+    hash.get(..12).unwrap_or(hash)
 }
 
 fn prompt_allows_no_verify_commit(prompt: &str) -> bool {

--- a/crates/cli-sub-agent/src/run_cmd_tests_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_policy.rs
@@ -171,7 +171,8 @@ fn format_post_run_commit_guard_message_includes_next_step_and_paths() {
         ],
     };
 
-    let message = format_post_run_commit_guard_message(&guard, false, false, false, Some("codex"));
+    let message =
+        format_post_run_commit_guard_message(&guard, false, false, false, None, Some("codex"));
     assert!(message.contains("WARNING"));
     assert!(message.contains("csa run --tool codex --skill commit"));
     assert!(message.contains("lineage-scoped child sessions"));
@@ -223,6 +224,7 @@ fn apply_post_run_commit_policy_sets_failure_when_policy_requires_commit() {
         None,
         true,
         false,
+        None,
         Some(&guard),
     );
 
@@ -263,6 +265,7 @@ fn apply_post_run_commit_policy_keeps_success_when_policy_disabled() {
         None,
         false,
         false,
+        None,
         Some(&guard),
     );
 
@@ -294,6 +297,7 @@ fn apply_post_run_commit_policy_fails_when_commit_attempt_left_head_unchanged() 
         None,
         false,
         true,
+        None,
         Some(&guard),
     );
 
@@ -341,6 +345,7 @@ fn apply_post_run_commit_policy_warns_when_head_externally_raced() {
         None,
         true,
         false,
+        None,
         Some(&guard),
     );
 
@@ -378,6 +383,7 @@ fn apply_post_run_commit_policy_does_not_report_external_race_for_normal_commit(
         None,
         true,
         true,
+        None,
         Some(&guard),
     );
 
@@ -394,6 +400,49 @@ fn apply_post_run_commit_policy_does_not_report_external_race_for_normal_commit(
         !result
             .stderr_output
             .contains("HEAD was moved by an external process"),
+        "{}",
+        result.stderr_output
+    );
+}
+
+#[test]
+fn apply_post_run_commit_policy_warns_when_commit_reflog_raced_without_dirty_guard() {
+    let mut result = ExecutionResult {
+        output: String::new(),
+        stderr_output: String::new(),
+        summary: "nothing to commit".to_string(),
+        exit_code: 1,
+        peak_memory_mb: None,
+        ..Default::default()
+    };
+    let race = CommitReflogRace {
+        created_commit: "aaaaaaaaaaaabbbbbbbbbbbbccccccccccccdddddddd".to_string(),
+        current_head: "11111111111122222222222233333333333344444444".to_string(),
+    };
+
+    apply_post_run_commit_policy(
+        &mut result,
+        &OutputFormat::Json,
+        None,
+        true,
+        true,
+        Some(&race),
+        None,
+    );
+
+    assert_eq!(result.exit_code, 1);
+    assert!(result.csa_gate_failure.is_none());
+    assert!(
+        result
+            .stderr_output
+            .contains("HEAD reflog shows git commit aaaaaaaaaaaa was created"),
+        "{}",
+        result.stderr_output
+    );
+    assert!(
+        result
+            .stderr_output
+            .contains("external checkout/reset moved the worktree before session completion (#2570)"),
         "{}",
         result.stderr_output
     );

--- a/crates/cli-sub-agent/src/run_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_tail.rs
@@ -140,6 +140,7 @@ fn apply_post_run_commit_policy_overrides_summary_on_preexisting_failure() {
         None,
         true,
         false,
+        None,
         Some(&guard),
     );
 
@@ -240,6 +241,7 @@ fn apply_post_run_commit_policy_does_not_fail_closed_when_head_changed() {
         None,
         true,
         false,
+        None,
         Some(&guard),
     );
 

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -228,7 +228,7 @@ fn test_acp_command_for_tool_mappings() {
 
 #[test]
 fn test_codex_acp_fast_mode_uses_config_arg() {
-    let transport = AcpTransport::new_with_codex_fast_mode("codex", None, true);
+    let transport = AcpTransport::new_with_codex_fast_mode("codex", None, true, None);
 
     assert_eq!(
         transport.acp_args,


### PR DESCRIPTION
Batch fix for 3 issues:
- #2566: Update stale `AcpTransport::new_with_codex_fast_mode` test call (add None arg)
- #2567: Fix `doctor_reports_hermes_binary_hint_and_acp_transport` self-deadlock on nested TEST_ENV_LOCK
- #2570: Add `CommitReflogRace` detection for external checkout after successful commit

Closes #2566, closes #2567, closes #2570