### PR TITLE
fix: cli-hints \n rendering (#2578), review UTF-8 (#2576), dev2merge precedence (#2575), bash csa (#2577)

### DIFF
--- a/crates/cli-sub-agent/src/error_hints.rs
+++ b/crates/cli-sub-agent/src/error_hints.rs
@@ -147,7 +147,7 @@ pub(crate) fn sandbox_fs_denial_hint(
     let path_hint = format!("--extra-writable {suggested}");
 
     Some(format!(
-        "hint: sandbox filesystem write denied for {denied_path}. To continue from this session's partial work rather than re-running from scratch, run:\\n  csa run --fork-from {session_id} {path_hint} --prompt-file CONTINUATION_PROMPT.md"
+        "hint: sandbox filesystem write denied for {denied_path}. To continue from this session's partial work rather than re-running from scratch, run:\n  csa run --fork-from {session_id} {path_hint} --prompt-file CONTINUATION_PROMPT.md"
     ))
 }
 

--- a/crates/cli-sub-agent/src/review_failure_context.rs
+++ b/crates/cli-sub-agent/src/review_failure_context.rs
@@ -311,7 +311,12 @@ fn fix_route_label(session_dir: &Path, session_id: &str) -> String {
             // Truncate to prevent leaking large/sensitive content from suggestion.toml (#2542)
             let truncated = value.trim();
             if truncated.len() > 200 {
-                format!("{}... (truncated)", &truncated[..200])
+                // Use char-boundary-safe truncation to avoid panicking on multi-byte UTF-8 (#2576)
+                let mut end = 200;
+                while end > 0 && !truncated.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}... (truncated)", &truncated[..end])
             } else {
                 truncated.to_string()
             }

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -28,7 +28,7 @@ mod uncommitted;
 
 pub(crate) use execute::handle_run;
 pub(crate) use git::{
-    CommitReflogRace, GitWorkspaceSnapshot, PostRunCommitGuard, attempt_rescue_commit,
+    GitWorkspaceSnapshot, PostRunCommitGuard, attempt_rescue_commit,
     capture_git_workspace_snapshot, detect_external_checkout_after_commit,
     evaluate_post_run_commit_guard, is_git_worktree,
 };

--- a/crates/cli-sub-agent/src/run_cmd_tests_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests_policy.rs
@@ -415,7 +415,7 @@ fn apply_post_run_commit_policy_warns_when_commit_reflog_raced_without_dirty_gua
         peak_memory_mb: None,
         ..Default::default()
     };
-    let race = CommitReflogRace {
+    let race = crate::run_cmd::git::CommitReflogRace {
         created_commit: "aaaaaaaaaaaabbbbbbbbbbbbccccccccccccdddddddd".to_string(),
         current_head: "11111111111122222222222233333333333344444444".to_string(),
     };

--- a/patterns/ai-reviewed-commit/PATTERN.md
+++ b/patterns/ai-reviewed-commit/PATTERN.md
@@ -79,7 +79,7 @@ Tool: bash
 
 ```bash
 SID=$(csa debate --fail-on-revise --fail-on-reject "Review my staged changes for correctness, security, and test gaps. Run 'git diff --staged' yourself to see the full patch.")
-bash csa session wait --session "$SID"
+csa session wait --session "$SID"
 ```
 
 ## ELSE
@@ -90,7 +90,7 @@ Tool: bash
 
 ```bash
 SID=$(csa review --diff --allow-fallback)
-bash csa session wait --session "$SID"
+csa session wait --session "$SID"
 ```
 
 ## ENDIF
@@ -134,7 +134,7 @@ This is still a single-pass workflow step, not a native weave loop.
 
 ```bash
 SID=$(csa review --diff --allow-fallback)
-bash csa session wait --session "$SID"
+csa session wait --session "$SID"
 ```
 
 ## Step 9: Round Cap Check

--- a/patterns/ai-reviewed-commit/workflow.toml
+++ b/patterns/ai-reviewed-commit/workflow.toml
@@ -87,7 +87,7 @@ tool = "bash"
 prompt = '''
 ```bash
 SID=$(csa debate --fail-on-revise --fail-on-reject "Review my staged changes for correctness, security, and test gaps. Run 'git diff --staged' yourself to see the full patch.")
-bash csa session wait --session "$SID"
+csa session wait --session "$SID"
 ```'''
 on_fail = "abort"
 condition = "${SELF_AUTHORED}"
@@ -99,7 +99,7 @@ tool = "bash"
 prompt = '''
 ```bash
 SID=$(csa review --diff --allow-fallback)
-bash csa session wait --session "$SID"
+csa session wait --session "$SID"
 ```'''
 on_fail = "abort"
 condition = "!(${SELF_AUTHORED})"
@@ -142,7 +142,7 @@ This is still a single-pass workflow step, not a native weave loop.
 
 ```bash
 SID=$(csa review --diff --allow-fallback)
-bash csa session wait --session "$SID"
+csa session wait --session "$SID"
 ```'''
 on_fail = "abort"
 condition = "${REVIEW_HAS_ISSUES}"

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -505,7 +505,7 @@ set -euo pipefail
 if [ -f Cargo.toml ]; then
   just fmt && just clippy && just test
 elif [ -f pyproject.toml ]; then
-  (just lint 2>/dev/null || ruff check . && ruff format --check .)
+  { just lint 2>/dev/null || { ruff check . && ruff format --check .; }; }
   (just test 2>/dev/null || pytest)
 elif [ -f package.json ]; then
   (just lint 2>/dev/null || biome check .)


### PR DESCRIPTION
Batch fix for 4 trivial audit findings:
- #2578: `error_hints.rs` — `\\n` renders as literal backslash-n, fix to `\n`
- #2576: `review_failure_context.rs` — byte slice `&truncated[..200]` panics on multi-byte UTF-8, use `is_char_boundary()`
- #2575: `dev2merge/PATTERN.md` — `||`/`&&` precedence error in lint gate, fix with explicit `{ }` grouping
- #2577: `ai-reviewed-commit` pattern — `bash csa` prefix on ELF binary, remove `bash`

Closes #2578, closes #2576, closes #2575, closes #2577