### PR TITLE
feat(review): adversarial bug-category checklist + --depth flag + regression context (#2581)

### DIFF
--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -29,6 +29,29 @@ impl std::fmt::Display for ReviewMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum ReviewDepth {
+    #[default]
+    Standard,
+    Audit,
+}
+
+impl ReviewDepth {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Standard => "standard",
+            Self::Audit => "audit",
+        }
+    }
+}
+
+impl std::fmt::Display for ReviewDepth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize)]
 #[value(rename_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
@@ -175,6 +198,10 @@ pub struct ReviewArgs {
     /// Review mode: standard (default) or red-team
     #[arg(long, value_enum)]
     pub review_mode: Option<ReviewMode>,
+
+    /// Review depth: standard (default) or audit. Audit enables red-team mode.
+    #[arg(long, value_enum, default_value_t = ReviewDepth::Standard)]
+    pub depth: ReviewDepth,
 
     /// Shorthand for `--review-mode red-team`
     #[arg(long)]
@@ -327,7 +354,11 @@ impl ReviewArgs {
     }
 
     pub fn effective_security_mode(&self) -> &str {
-        if self.effective_review_mode() == ReviewMode::RedTeam && self.security_mode == "auto" {
+        self.effective_security_mode_for(self.effective_review_mode())
+    }
+
+    pub fn effective_security_mode_for(&self, review_mode: ReviewMode) -> &str {
+        if review_mode == ReviewMode::RedTeam && self.security_mode == "auto" {
             "on"
         } else {
             &self.security_mode
@@ -355,6 +386,13 @@ pub fn validate_review_args(args: &ReviewArgs) -> std::result::Result<(), clap::
         return Err(clap::Error::raw(
             clap::error::ErrorKind::ArgumentConflict,
             format!("{mode_flag} conflicts with --security-mode off"),
+        ));
+    }
+
+    if args.depth == ReviewDepth::Audit && args.security_mode == "off" {
+        return Err(clap::Error::raw(
+            clap::error::ErrorKind::ArgumentConflict,
+            "--depth audit conflicts with --security-mode off",
         ));
     }
 

--- a/crates/cli-sub-agent/src/plan_cmd_tests_dev2merge_2305.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_dev2merge_2305.rs
@@ -72,6 +72,10 @@ fn dev2merge_2305_changed_bash_blocks_stay_synced() {
         ("Resume Commit", "## Step 9: Resume Commit"),
         ("Ensure Version Bumped", "## Step 10: Ensure Version Bumped"),
         (
+            "Decomposition Review Depth Warning",
+            "## Step 11.5: Decomposition Review Depth Warning",
+        ),
+        (
             "Pre-PR Cumulative Review Gate",
             "## Step 12: Pre-PR Cumulative Review Gate",
         ),
@@ -86,6 +90,35 @@ fn dev2merge_2305_changed_bash_blocks_stay_synced() {
             "dev2merge PATTERN.md and workflow.toml {heading} bash blocks must stay synced"
         );
     }
+}
+
+#[test]
+fn dev2merge_decomposition_warning_placeholders_stay_synced() {
+    let pattern =
+        std::fs::read_to_string(workspace_root().join("patterns/dev2merge/PATTERN.md")).unwrap();
+    let pattern_bash =
+        dev2merge_pattern_step_bash(&pattern, "## Step 11.5: Decomposition Review Depth Warning");
+    let workflow_bash = dev2merge_workflow_step_bash("Decomposition Review Depth Warning");
+
+    assert_eq!(
+        placeholders_in(&pattern_bash),
+        placeholders_in(&workflow_bash),
+        "dev2merge Step 11.5 must not introduce orphan ${{VAR}} placeholders"
+    );
+}
+
+fn placeholders_in(content: &str) -> std::collections::BTreeSet<String> {
+    let mut placeholders = std::collections::BTreeSet::new();
+    let mut rest = content;
+    while let Some(start) = rest.find("${") {
+        let after_start = &rest[start + 2..];
+        let Some(end) = after_start.find('}') else {
+            break;
+        };
+        placeholders.insert(after_start[..end].to_string());
+        rest = &after_start[end + 1..];
+    }
+    placeholders
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -35,6 +35,8 @@ mod bug_class_pipeline;
 mod check_verdict;
 #[path = "review_cmd_chunking.rs"]
 mod chunking;
+#[path = "review_cmd_depth.rs"]
+mod depth;
 #[path = "review_cmd_diff_size.rs"]
 mod diff_size;
 #[path = "review_cmd_dirty_tree.rs"]
@@ -178,6 +180,9 @@ pub(crate) async fn handle_review(
     .await?;
 
     let scope = derive_scope_for_project(&args, &project_root);
+    let depth_assessment =
+        depth::resolve_review_depth_for_project(&args, &project_root, &scope).await;
+    let regression_context = depth::collect_bounded_regression_context(&project_root, &scope).await;
     let diff = diff_size::compute_review_diff_size(&project_root, &scope);
     let large_warn = diff_size::warn_if_large_diff(diff.as_ref(), config.as_ref(), &global_config);
     let mode = if args.fix {
@@ -185,8 +190,13 @@ pub(crate) async fn handle_review(
     } else {
         "review-only"
     };
-    let review_mode = args.effective_review_mode();
-    let security_mode = args.effective_security_mode();
+    let requested_review_mode = args.effective_review_mode();
+    let review_mode = depth_assessment.effective_review_mode(requested_review_mode);
+    let security_mode = if review_mode == requested_review_mode {
+        args.effective_security_mode()
+    } else {
+        args.effective_security_mode_for(review_mode)
+    };
     let auto_discover_context = review_scope_allows_auto_discovery(&args);
     let prompt_file_path = args.prompt_file.as_ref().map(|p| p.display().to_string());
     let explicit_context = args
@@ -225,6 +235,9 @@ pub(crate) async fn handle_review(
             prior_rounds_section: prior_rounds_section.as_deref(),
             current_session_id: startup_env.session_id(),
             full_consistency: args.full_consistency,
+            review_depth: depth_assessment.depth,
+            review_depth_auto_escalation: depth_assessment.auto_escalation_summary(),
+            regression_context: regression_context.as_deref(),
         },
     );
 

--- a/crates/cli-sub-agent/src/review_cmd_artifact_parse.rs
+++ b/crates/cli-sub-agent/src/review_cmd_artifact_parse.rs
@@ -7,6 +7,8 @@ pub(crate) struct LossyReviewArtifactFields {
     pub(crate) findings: Vec<Finding>,
     pub(crate) severity_summary: SeveritySummary,
     pub(crate) overall_risk: Option<String>,
+    pub(crate) schema_version: Option<String>,
+    pub(crate) bug_category_checklist: Vec<Value>,
 }
 
 pub(crate) fn parse_review_artifact_fields_lossy(
@@ -34,11 +36,22 @@ pub(crate) fn parse_review_artifact_fields_lossy(
         .get("overall_risk")
         .and_then(Value::as_str)
         .map(str::to_string);
+    let schema_version = value
+        .get("schema_version")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let bug_category_checklist = value
+        .get("bug_category_checklist")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
 
     Ok(LossyReviewArtifactFields {
         findings,
         severity_summary,
         overall_risk,
+        schema_version,
+        bug_category_checklist,
     })
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_depth.rs
+++ b/crates/cli-sub-agent/src/review_cmd_depth.rs
@@ -1,0 +1,485 @@
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::process::Command;
+
+use crate::cli::{ReviewArgs, ReviewDepth, ReviewMode};
+
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_RISK_DIFF_BYTES: usize = 200_000;
+pub(super) const REVIEW_HISTORY_MAX_CHARS: usize = 2_000;
+const REVIEW_HISTORY_FILES_MAX: usize = 20;
+const REVIEW_HISTORY_COMMITS_PER_FILE: &str = "-5";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ReviewDepthAssessment {
+    pub(super) depth: ReviewDepth,
+    pub(super) auto_escalated: bool,
+    pub(super) risk_signals: Vec<RiskyDiffSignal>,
+}
+
+impl ReviewDepthAssessment {
+    pub(super) fn effective_review_mode(&self, requested: ReviewMode) -> ReviewMode {
+        if self.depth == ReviewDepth::Audit {
+            ReviewMode::RedTeam
+        } else {
+            requested
+        }
+    }
+
+    pub(super) fn auto_escalation_summary(&self) -> Option<String> {
+        if !self.auto_escalated || self.risk_signals.is_empty() {
+            return None;
+        }
+        Some(
+            self.risk_signals
+                .iter()
+                .map(|signal| signal.as_str())
+                .collect::<Vec<_>>()
+                .join(", "),
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum RiskyDiffSignal {
+    ShellProcessSpawning,
+    CommandOutputWithoutObviousTimeout,
+    TenantWildcardFilter,
+    StringSlicing,
+    ToolRoutingMatchGuard,
+    ResourceLimitCode,
+}
+
+impl RiskyDiffSignal {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::ShellProcessSpawning => "shell/process spawning patterns",
+            Self::CommandOutputWithoutObviousTimeout => "Command::output usage",
+            Self::TenantWildcardFilter => "tenant wildcard filter",
+            Self::StringSlicing => "string slicing",
+            Self::ToolRoutingMatchGuard => "ACP/tool routing match guard",
+            Self::ResourceLimitCode => "resource limit code",
+        }
+    }
+}
+
+pub(super) async fn resolve_review_depth_for_project(
+    args: &ReviewArgs,
+    project_root: &Path,
+    scope: &str,
+) -> ReviewDepthAssessment {
+    if args.depth == ReviewDepth::Audit {
+        return ReviewDepthAssessment {
+            depth: ReviewDepth::Audit,
+            auto_escalated: false,
+            risk_signals: Vec::new(),
+        };
+    }
+
+    // Respect an explicit security-off request for standard-depth reviews. An
+    // explicit `--depth audit --security-mode off` is rejected during CLI validation.
+    if args.security_mode == "off" {
+        return ReviewDepthAssessment {
+            depth: ReviewDepth::Standard,
+            auto_escalated: false,
+            risk_signals: Vec::new(),
+        };
+    }
+
+    let risk_signals = collect_review_diff_text(project_root, scope)
+        .await
+        .map(|diff| risky_signals_from_diff(&diff))
+        .unwrap_or_default();
+
+    assessment_from_risk_signals(risk_signals)
+}
+
+fn assessment_from_risk_signals(risk_signals: Vec<RiskyDiffSignal>) -> ReviewDepthAssessment {
+    ReviewDepthAssessment {
+        depth: if risk_signals.is_empty() {
+            ReviewDepth::Standard
+        } else {
+            ReviewDepth::Audit
+        },
+        auto_escalated: !risk_signals.is_empty(),
+        risk_signals,
+    }
+}
+
+async fn collect_review_diff_text(project_root: &Path, scope: &str) -> Option<String> {
+    if scope == "uncommitted" {
+        return run_git_stdout(
+            project_root,
+            &["diff", "HEAD", "--no-color", "--unified=0"],
+            MAX_RISK_DIFF_BYTES,
+        )
+        .await;
+    }
+
+    if let Some(range) = scope.strip_prefix("range:") {
+        return run_git_stdout(
+            project_root,
+            &["diff", "--no-color", "--unified=0", range],
+            MAX_RISK_DIFF_BYTES,
+        )
+        .await;
+    }
+
+    if let Some(base) = scope.strip_prefix("base:") {
+        let range = format!("{base}...HEAD");
+        return run_git_stdout(
+            project_root,
+            &["diff", "--no-color", "--unified=0", &range],
+            MAX_RISK_DIFF_BYTES,
+        )
+        .await;
+    }
+
+    if let Some(commit) = scope.strip_prefix("commit:") {
+        return run_git_stdout(
+            project_root,
+            &["show", "--no-color", "--unified=0", commit],
+            MAX_RISK_DIFF_BYTES,
+        )
+        .await;
+    }
+
+    if let Some(pathspec) = scope.strip_prefix("files:") {
+        return run_git_stdout(
+            project_root,
+            &["diff", "--no-color", "--unified=0", "--", pathspec],
+            MAX_RISK_DIFF_BYTES,
+        )
+        .await;
+    }
+
+    None
+}
+
+pub(super) fn risky_signals_from_diff(diff: &str) -> Vec<RiskyDiffSignal> {
+    let mut signals = BTreeSet::new();
+    let lower = diff.to_ascii_lowercase();
+
+    if diff.contains("Command::new(")
+        || diff.contains("std::process::Command")
+        || diff.contains("tokio::process::Command")
+        || lower.contains("sh -c")
+        || lower.contains("bash -c")
+    {
+        signals.insert(RiskyDiffSignal::ShellProcessSpawning);
+    }
+    if diff.contains(".output().await")
+        || diff.contains(".output()")
+        || diff.contains("Command::output")
+    {
+        signals.insert(RiskyDiffSignal::CommandOutputWithoutObviousTimeout);
+    }
+    if diff.lines().any(line_has_wildcard_true_arm) {
+        signals.insert(RiskyDiffSignal::TenantWildcardFilter);
+    }
+    if diff.contains("[..") || diff.contains("..]") {
+        signals.insert(RiskyDiffSignal::StringSlicing);
+    }
+    if (lower.contains("match")
+        && (lower.contains("toolname")
+            || lower.contains("tool routing")
+            || lower.contains("transport")
+            || lower.contains("acp")
+            || lower.contains("fallback")
+            || lower.contains("model_spec")))
+        || lower.contains("routing match")
+    {
+        signals.insert(RiskyDiffSignal::ToolRoutingMatchGuard);
+    }
+    if lower.contains("cgroup")
+        || lower.contains("container")
+        || lower.contains("memory_max")
+        || lower.contains("min_free_memory")
+        || lower.contains("pids_max")
+        || lower.contains("resource limit")
+        || lower.contains("ulimit")
+    {
+        signals.insert(RiskyDiffSignal::ResourceLimitCode);
+    }
+
+    signals.into_iter().collect()
+}
+
+fn line_has_wildcard_true_arm(line: &str) -> bool {
+    let compact = line.split_whitespace().collect::<String>();
+    compact.contains("_=>true")
+}
+
+pub(super) async fn collect_bounded_regression_context(
+    project_root: &Path,
+    scope: &str,
+) -> Option<String> {
+    let changed_files = collect_changed_files(project_root, scope).await;
+    if changed_files.is_empty() {
+        return None;
+    }
+
+    let mut entries = Vec::new();
+    for file in changed_files.iter().take(REVIEW_HISTORY_FILES_MAX) {
+        let log = run_git_stdout(
+            project_root,
+            &[
+                "log",
+                "--oneline",
+                REVIEW_HISTORY_COMMITS_PER_FILE,
+                "--",
+                file,
+            ],
+            REVIEW_HISTORY_MAX_CHARS,
+        )
+        .await
+        .unwrap_or_default();
+        let commits = log
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        if !commits.is_empty() {
+            entries.push((file.clone(), commits));
+        }
+    }
+
+    format_bounded_review_history(&entries, REVIEW_HISTORY_MAX_CHARS)
+}
+
+async fn collect_changed_files(project_root: &Path, scope: &str) -> Vec<String> {
+    let mut files = BTreeSet::new();
+    if scope == "uncommitted" {
+        insert_name_only_output(
+            &mut files,
+            run_git_stdout(project_root, &["diff", "--name-only", "HEAD"], 50_000).await,
+        );
+        insert_name_only_output(
+            &mut files,
+            run_git_stdout(
+                project_root,
+                &["ls-files", "--others", "--exclude-standard"],
+                50_000,
+            )
+            .await,
+        );
+    } else if let Some(range) = scope.strip_prefix("range:") {
+        insert_name_only_output(
+            &mut files,
+            run_git_stdout(project_root, &["diff", "--name-only", range], 50_000).await,
+        );
+    } else if let Some(base) = scope.strip_prefix("base:") {
+        let range = format!("{base}...HEAD");
+        insert_name_only_output(
+            &mut files,
+            run_git_stdout(project_root, &["diff", "--name-only", &range], 50_000).await,
+        );
+    } else if let Some(commit) = scope.strip_prefix("commit:") {
+        insert_name_only_output(
+            &mut files,
+            run_git_stdout(
+                project_root,
+                &["diff-tree", "--no-commit-id", "--name-only", "-r", commit],
+                50_000,
+            )
+            .await,
+        );
+    } else if let Some(pathspec) = scope.strip_prefix("files:") {
+        insert_name_only_output(
+            &mut files,
+            run_git_stdout(
+                project_root,
+                &["diff", "--name-only", "--", pathspec],
+                50_000,
+            )
+            .await,
+        );
+    }
+
+    files.into_iter().collect()
+}
+
+fn insert_name_only_output(files: &mut BTreeSet<String>, output: Option<String>) {
+    let Some(output) = output else {
+        return;
+    };
+    files.extend(
+        output
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(str::to_string),
+    );
+}
+
+pub(super) fn format_bounded_review_history(
+    entries: &[(String, Vec<String>)],
+    max_chars: usize,
+) -> Option<String> {
+    if entries.is_empty() || max_chars == 0 {
+        return None;
+    }
+
+    let mut rendered =
+        String::from("Recent commit history for changed files (regression context):\n");
+    for (path, commits) in entries {
+        if commits.is_empty() {
+            continue;
+        }
+        rendered.push_str("- ");
+        rendered.push_str(path);
+        rendered.push_str(":\n");
+        for commit in commits {
+            rendered.push_str("  ");
+            rendered.push_str(commit);
+            rendered.push('\n');
+        }
+        if rendered.len() >= max_chars {
+            break;
+        }
+    }
+
+    let rendered = truncate_to_char_boundary(&rendered, max_chars)
+        .trim_end()
+        .to_string();
+    (!rendered.is_empty()).then_some(rendered)
+}
+
+async fn run_git_stdout(project_root: &Path, args: &[&str], max_bytes: usize) -> Option<String> {
+    let mut command = Command::new("git");
+    command
+        .args(args)
+        .current_dir(project_root)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    let output = tokio::time::timeout(GIT_COMMAND_TIMEOUT, command.output())
+        .await
+        .ok()?
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = if output.stdout.len() > max_bytes {
+        &output.stdout[..max_bytes]
+    } else {
+        &output.stdout
+    };
+    Some(String::from_utf8_lossy(stdout).into_owned())
+}
+
+fn truncate_to_char_boundary(text: &str, max_chars: usize) -> &str {
+    if text.len() <= max_chars {
+        return text;
+    }
+    let mut end = max_chars;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn risky_signals_detect_audit_categories() {
+        let diff = r#"
++ let child = tokio::process::Command::new("git").output().await?;
++ match tenant {
++     "known" => true,
++     _ => true,
++ }
++ let prefix = &name[..12];
++ match tool_name {
++     ToolName::Codex => fallback(),
++ }
++ let memory_max_mb = cgroup_limit();
+"#;
+
+        let signals = risky_signals_from_diff(diff);
+
+        assert!(signals.contains(&RiskyDiffSignal::ShellProcessSpawning));
+        assert!(signals.contains(&RiskyDiffSignal::CommandOutputWithoutObviousTimeout));
+        assert!(signals.contains(&RiskyDiffSignal::TenantWildcardFilter));
+        assert!(signals.contains(&RiskyDiffSignal::StringSlicing));
+        assert!(signals.contains(&RiskyDiffSignal::ToolRoutingMatchGuard));
+        assert!(signals.contains(&RiskyDiffSignal::ResourceLimitCode));
+    }
+
+    #[test]
+    fn bounded_history_formatter_caps_output() {
+        let entries = vec![(
+            "src/lib.rs".to_string(),
+            vec![
+                "abc1234 one subject".to_string(),
+                "def5678 second subject".to_string(),
+                "0123456 third subject".to_string(),
+            ],
+        )];
+
+        let rendered = format_bounded_review_history(&entries, 80).expect("history");
+
+        assert!(rendered.len() <= 80);
+        assert!(rendered.starts_with("Recent commit history for changed files"));
+    }
+
+    #[test]
+    fn risky_signal_detection_escalates_to_audit() {
+        let assessment =
+            assessment_from_risk_signals(vec![RiskyDiffSignal::CommandOutputWithoutObviousTimeout]);
+
+        assert_eq!(assessment.depth, ReviewDepth::Audit);
+        assert!(assessment.auto_escalated);
+        assert_eq!(
+            assessment.effective_review_mode(ReviewMode::Standard),
+            ReviewMode::RedTeam
+        );
+    }
+
+    #[tokio::test]
+    async fn regression_context_collects_recent_git_log_for_changed_files() {
+        let temp = tempfile::tempdir().expect("create temp repo");
+        run_git(temp.path(), &["init"]);
+        run_git(temp.path(), &["config", "user.email", "test@example.com"]);
+        run_git(temp.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(temp.path().join("tracked.rs"), "fn main() {}\n").expect("write file");
+        run_git(temp.path(), &["add", "tracked.rs"]);
+        run_git(temp.path(), &["commit", "-m", "initial tracked file"]);
+        std::fs::write(
+            temp.path().join("tracked.rs"),
+            "fn main() { println!(\"hi\"); }\n",
+        )
+        .expect("modify file");
+
+        let context = collect_bounded_regression_context(temp.path(), "uncommitted")
+            .await
+            .expect("regression context");
+
+        assert!(context.len() <= REVIEW_HISTORY_MAX_CHARS);
+        assert!(context.contains("Recent commit history for changed files"));
+        assert!(context.contains("tracked.rs"));
+        assert!(context.contains("initial tracked file"));
+    }
+
+    fn run_git(repo: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .output()
+            .expect("git command should execute");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_fix_finding_prompt.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_finding_prompt.rs
@@ -120,6 +120,7 @@ mod tests {
             fix_finding: true,
             max_rounds: 3,
             review_mode: None,
+            depth: crate::cli::ReviewDepth::Standard,
             red_team: false,
             security_mode: "auto".to_string(),
             context: None,

--- a/crates/cli-sub-agent/src/review_cmd_output_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_artifacts.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use csa_session::{Finding, FindingsFile, Severity, SeveritySummary};
 use serde::Deserialize;
+use serde_json::Value;
 use tracing::warn;
 
 use crate::bug_class::{CONSOLIDATED_REVIEW_ARTIFACT_FILE, SINGLE_REVIEW_ARTIFACT_FILE};
@@ -17,6 +18,17 @@ pub(super) struct PersistedReviewArtifact {
     pub(super) severity_summary: SeveritySummary,
     #[serde(default)]
     pub(super) overall_risk: Option<String>,
+    #[serde(default)]
+    pub(super) schema_version: Option<String>,
+    #[serde(default)]
+    pub(super) bug_category_checklist: Vec<Value>,
+}
+
+impl PersistedReviewArtifact {
+    pub(super) fn missing_required_bug_category_checklist(&self) -> bool {
+        schema_version_requires_bug_category_checklist(self.schema_version.as_deref())
+            && self.bug_category_checklist.is_empty()
+    }
 }
 
 pub(super) fn load_review_artifact_from_output(
@@ -47,6 +59,8 @@ pub(super) fn load_review_artifact_from_output(
                     findings: fields.findings,
                     severity_summary: fields.severity_summary,
                     overall_risk: fields.overall_risk,
+                    schema_version: fields.schema_version,
+                    bug_category_checklist: fields.bug_category_checklist,
                 }));
             }
             warn!(
@@ -58,9 +72,27 @@ pub(super) fn load_review_artifact_from_output(
                 findings: Vec::new(),
                 severity_summary: SeveritySummary::default(),
                 overall_risk: None,
+                schema_version: None,
+                bug_category_checklist: Vec::new(),
             }))
         }
     }
+}
+
+fn schema_version_requires_bug_category_checklist(schema_version: Option<&str>) -> bool {
+    let Some(schema_version) = schema_version else {
+        return false;
+    };
+    let mut parts = schema_version.split('.');
+    let major = parts
+        .next()
+        .and_then(|part| part.parse::<u32>().ok())
+        .unwrap_or(0);
+    let minor = parts
+        .next()
+        .and_then(|part| part.parse::<u32>().ok())
+        .unwrap_or(0);
+    major > 1 || major == 1 && minor >= 1
 }
 
 fn review_artifact_path(session_dir: &Path) -> Option<PathBuf> {

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -23,6 +23,7 @@ use crate::review_cmd::prose_findings::severity_counts_from_review_findings;
 const PROSE_FINDINGS_UNPARSED_REASON: &str = "prose_findings_present_but_unparsed";
 const SEVERITY_FINDINGS_MISMATCH_REASON: &str = "severity_counts_findings_mismatch";
 const EMPTY_FAIL_FINDINGS_ARTIFACT_REASON: &str = "fail_verdict_empty_findings_artifact";
+const MISSING_BUG_CATEGORY_CHECKLIST_REASON: &str = "missing_bug_category_checklist";
 const ARTIFACT_GENERATION_FINDING_ID: &str = "artifact-generation-001";
 
 pub(super) fn enforce_final_verdict_consistency(
@@ -103,6 +104,9 @@ pub(super) fn enforce_final_verdict_consistency(
 
     let resume_to_fix = has_resume_to_fix_suggestion(session_dir)?;
     let review_artifact = load_review_artifact_from_output(session_dir)?;
+    let review_artifact_missing_bug_category_checklist = review_artifact
+        .as_ref()
+        .is_some_and(|artifact| artifact.missing_required_bug_category_checklist());
     let review_artifact_findings: &[Finding] = review_artifact
         .as_ref()
         .map(|artifact| artifact.findings.as_slice())
@@ -149,7 +153,8 @@ pub(super) fn enforce_final_verdict_consistency(
             has_prose_failure_evidence: has_hard_prose_failure_evidence,
             resume_to_fix: resume_to_fix_blocks_clean_recovery,
             review_artifact_has_fail_signal: review_artifact_has_severity_counts
-                || review_artifact_has_blocking_risk,
+                || review_artifact_has_blocking_risk
+                || review_artifact_missing_bug_category_checklist,
             clean_prose_conclusion,
             fail_prose_conclusion: repair_fail_prose_conclusion,
             uncertain_prose_conclusion: repair_uncertain_prose_conclusion,
@@ -188,6 +193,13 @@ pub(super) fn enforce_final_verdict_consistency(
     if artifact.decision == ReviewDecision::Pass && !skip_prose_override && uncertain_prose {
         artifact.decision = ReviewDecision::Uncertain;
         artifact.verdict_legacy = "UNCERTAIN".to_string();
+    }
+    if artifact.decision == ReviewDecision::Pass && review_artifact_missing_bug_category_checklist {
+        artifact.decision = ReviewDecision::Uncertain;
+        artifact.verdict_legacy = "UNCERTAIN".to_string();
+        artifact
+            .failure_reason
+            .get_or_insert_with(|| MISSING_BUG_CATEGORY_CHECKLIST_REASON.to_string());
     }
 
     // #1852: a Fail verdict must carry a severity count that reflects the

--- a/crates/cli-sub-agent/src/review_cmd_output_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_tests.rs
@@ -573,6 +573,54 @@ fn persist_review_verdict_marks_clean_transcript_as_pass() {
 }
 
 #[test]
+fn persist_review_verdict_missing_new_bug_category_checklist_is_uncertain() {
+    let session_id = "01TESTBUGCHECKLISTMISSING000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-missing-bug-checklist", session_id);
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_string_pretty(&json!({
+            "findings": [],
+            "severity_summary": {
+                "critical": 0,
+                "high": 0,
+                "medium": 0,
+                "low": 0
+            },
+            "review_mode": "standard",
+            "schema_version": "1.1",
+            "session_id": session_id,
+            "timestamp": "2026-07-01T00:00:00Z",
+            "overall_risk": "low"
+        }))
+        .expect("serialize review findings"),
+    )
+    .expect("write review-findings.json");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nCLEAN\n<!-- CSA:SECTION:summary:END -->\n\n\
+<!-- CSA:SECTION:details -->\nNo blocking issues found.\nOverall risk: low\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist clean output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let artifact: ReviewVerdictArtifact =
+        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
+            .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Uncertain);
+    assert_eq!(artifact.verdict_legacy, "UNCERTAIN");
+    assert_eq!(
+        artifact.failure_reason.as_deref(),
+        Some("missing_bug_category_checklist")
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn persist_review_verdict_plain_text_full_output_without_review_message_emits_fail_verdict() {
     let session_id = "01TESTMETAFALLBACK000000000";
     let (_env_lock, project_root, session_dir) =

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::Result;
 use tracing::{debug, info, warn};
 
-use crate::cli::{ReviewArgs, ReviewMode};
+use crate::cli::{ReviewArgs, ReviewDepth, ReviewMode};
 use crate::pattern_resolver::ResolvedPattern;
 use crate::review_context::{
     ResolvedReviewContext, ResolvedReviewContextKind, discover_prior_round_assumptions,
@@ -545,6 +545,16 @@ pub(crate) fn build_review_instruction_for_project(
         "diff-only"
     };
     instruction.push_str(&format!("\nconsistency_scope={consistency_scope}"));
+    append_review_depth_metadata(
+        &mut instruction,
+        options.review_depth,
+        options.review_depth_auto_escalation.as_deref(),
+    );
+    if let Some(regression_context) = options.regression_context {
+        instruction.push_str("\n\n<review-regression-context inert=\"true\">\n");
+        instruction.push_str(regression_context);
+        instruction.push_str("\n</review-regression-context>");
+    }
     crate::review_design_anchor::append_design_anchor(&mut instruction);
     instruction.push_str(&format!(
         "\n[project_profile: {}]",
@@ -591,4 +601,31 @@ pub(crate) struct ReviewProjectPromptOptions<'a> {
     pub(crate) prior_rounds_section: Option<&'a str>,
     pub(crate) current_session_id: Option<&'a str>,
     pub(crate) full_consistency: bool,
+    pub(crate) review_depth: ReviewDepth,
+    pub(crate) review_depth_auto_escalation: Option<String>,
+    pub(crate) regression_context: Option<&'a str>,
+}
+
+fn append_review_depth_metadata(
+    instruction: &mut String,
+    review_depth: ReviewDepth,
+    auto_escalation: Option<&str>,
+) {
+    instruction.push_str(&format!("\nreview_depth={review_depth}"));
+    if let Some(auto_escalation) = auto_escalation {
+        instruction.push_str(&format!(
+            "\nreview_depth_auto_escalated=true ({auto_escalation})"
+        ));
+    }
+    instruction.push_str(
+        "\nMandatory bug-category checklist categories: shell_semantics, byte_char_boundary, \
+escape_sequences, binary_vs_script, subprocess_timeout, cross_tenant_isolation, \
+unwrap_on_untrusted, cgroup_container_awareness, crash_retry_coverage, missing_script_binary_refs.",
+    );
+    if review_depth == ReviewDepth::Audit {
+        instruction.push_str(
+            "\nAudit depth is active: red-team review mode is enabled; treat a missing or incomplete \
+bug_category_checklist in new review artifacts as incomplete evidence and return UNCERTAIN.",
+        );
+    }
 }

--- a/crates/cli-sub-agent/src/review_cmd_tests_checklist.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_checklist.rs
@@ -25,6 +25,9 @@ fn build_review_instruction_for_project_injects_review_checklist() {
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 
@@ -56,6 +59,9 @@ fn build_review_instruction_for_project_omits_checklist_when_missing() {
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_cli_flags.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_cli_flags.rs
@@ -29,6 +29,36 @@ fn review_cli_parses_chunked_review_mode_flag() {
 }
 
 #[test]
+fn review_cli_parses_depth_flag() {
+    let default_args = parse_review_args(&["csa", "review", "--diff"]);
+    assert_eq!(default_args.depth, crate::cli::ReviewDepth::Standard);
+
+    let standard_args = parse_review_args(&["csa", "review", "--diff", "--depth", "standard"]);
+    assert_eq!(standard_args.depth, crate::cli::ReviewDepth::Standard);
+
+    let audit_args = parse_review_args(&["csa", "review", "--diff", "--depth", "audit"]);
+    assert_eq!(audit_args.depth, crate::cli::ReviewDepth::Audit);
+}
+
+#[test]
+fn review_cli_rejects_audit_depth_with_security_off() {
+    let err = parse_or_validate_review_error(&[
+        "csa",
+        "review",
+        "--diff",
+        "--depth",
+        "audit",
+        "--security-mode",
+        "off",
+    ]);
+    assert!(
+        err.to_string()
+            .contains("--depth audit conflicts with --security-mode off"),
+        "{err}"
+    );
+}
+
+#[test]
 fn review_cli_parses_fix_finding_prompt_flag() {
     let args = parse_review_args(&[
         "csa",

--- a/crates/cli-sub-agent/src/review_cmd_tests_full_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_full_consistency.rs
@@ -38,11 +38,17 @@ fn test_build_review_instruction_no_diff_content_default() {
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 
     assert!(result.contains("scope=uncommitted"));
     assert!(result.contains("consistency_scope=diff-only"));
+    assert!(result.contains("review_depth=standard"));
+    assert!(result.contains("shell_semantics"));
+    assert!(result.contains("subprocess_timeout"));
     assert!(
         result
             .find("consistency_scope=diff-only")
@@ -53,6 +59,39 @@ fn test_build_review_instruction_no_diff_content_default() {
     );
     assert!(!result.contains("git diff"));
     assert!(!result.contains("Pass 1:"));
+}
+
+#[test]
+fn test_build_review_instruction_audit_depth_metadata() {
+    let project_dir = tempdir().unwrap();
+    let (result, _routing) = build_review_instruction_for_project(
+        "uncommitted",
+        "review-only",
+        "on",
+        ReviewMode::RedTeam,
+        None,
+        project_dir.path(),
+        resolve::ReviewProjectPromptOptions {
+            project_config: None,
+            resolved_pattern: None,
+            prior_rounds_section: None,
+            current_session_id: None,
+            full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Audit,
+            review_depth_auto_escalation: Some("Command::output usage".to_string()),
+            regression_context: Some(
+                "Recent commit history for changed files (regression context):\n- src/lib.rs:\n  abc1234 fix old bug",
+            ),
+        },
+    );
+
+    assert!(result.contains("review_mode=red-team"));
+    assert!(result.contains("review_depth=audit"));
+    assert!(result.contains("review_depth_auto_escalated=true (Command::output usage)"));
+    assert!(result.contains("Audit depth is active: red-team review mode is enabled"));
+    assert!(result.contains("<review-regression-context inert=\"true\">"));
+    assert!(result.contains("Recent commit history for changed files (regression context):"));
+    assert!(result.contains("</review-regression-context>"));
 }
 
 #[test]
@@ -71,6 +110,9 @@ fn test_build_review_instruction_full_consistency() {
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: true,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_iteration.rs
@@ -123,6 +123,9 @@ fn build_review_instruction_for_project_contains_design_preference_anchor() {
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 
@@ -145,6 +148,9 @@ fn build_review_instruction_for_project_contains_same_class_site_sweep_anchor() 
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 
@@ -209,6 +215,9 @@ fn count_prior_reviews_zero_omits_iteration_block() {
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 
@@ -246,6 +255,9 @@ fn count_prior_reviews_one_injects_iteration_two() {
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_prior_rounds.rs
@@ -56,6 +56,9 @@ invariant = "lock-losing resume cannot mutate metadata of winning session"
             prior_rounds_section: Some(&prior_rounds),
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 
@@ -151,6 +154,9 @@ fn build_review_instruction_for_project_without_prior_rounds_flag_leaves_section
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -404,6 +404,9 @@ fn test_build_review_instruction_for_project_includes_rust_profile() {
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 
@@ -428,6 +431,9 @@ fn test_build_review_instruction_for_project_includes_unknown_profile_for_empty_
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 
@@ -580,6 +586,9 @@ fn build_review_instruction_for_project_injects_bundled_pattern_without_repo_loc
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 
@@ -624,6 +633,9 @@ fn build_review_instruction_for_project_injects_repo_local_pattern() {
             prior_rounds_section: None,
             current_session_id: None,
             full_consistency: false,
+            review_depth: crate::cli::ReviewDepth::Standard,
+            review_depth_auto_escalation: None,
+            regression_context: None,
         },
     );
 

--- a/patterns/csa-review/skills/csa-review/references/output-schema.md
+++ b/patterns/csa-review/skills/csa-review/references/output-schema.md
@@ -42,7 +42,7 @@
     "info": 0
   },
   "review_mode": "standard|red-team",
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "session_id": "string",
   "timestamp": "RFC3339 string",
   "overall_risk": "low|medium|high|critical",
@@ -55,6 +55,14 @@
       "source_agents_md": "string",
       "result": "pass|violation",
       "evidence": "string"
+    }
+  ],
+  "bug_category_checklist": [
+    {
+      "category": "shell_semantics|byte_char_boundary|escape_sequences|binary_vs_script|subprocess_timeout|cross_tenant_isolation|unwrap_on_untrusted|cgroup_container_awareness|crash_retry_coverage|missing_script_binary_refs",
+      "status": "pass|na|violation|open_question",
+      "evidence": "string",
+      "files_examined": ["path/to/file.rs"]
     }
   ],
   "test_gaps": ["string"],
@@ -83,10 +91,13 @@
 `review-findings.json` is consumed by `review_consensus.rs`, so the following fields are
 mandatory and must remain ReviewArtifact-compatible:
 
-- Top level: `findings`, `severity_summary`, `review_mode`, `schema_version`, `session_id`, `timestamp`
+- Top level: `findings`, `severity_summary`, `review_mode`, `schema_version`, `session_id`, `timestamp`, `bug_category_checklist`
 - Per finding: `fid`, `severity`, `file`, `line`, `rule_id`, `summary`, `engine`
 
 Additional rich fields are allowed and will be ignored by the consolidator when not needed.
+For schema_version `1.1` or newer, a missing `bug_category_checklist` means the review
+is incomplete and must resolve to `UNCERTAIN`, not `PASS`. A category marked `na`
+is valid evidence and must not fail the review by itself.
 
 ## $CSA_SESSION_DIR/output/review-verdict.json
 
@@ -180,6 +191,18 @@ Mandatory AGENTS.md compliance evidence:
 ## AGENTS.md Checklist
 - [x] `<file>` | `<rule-id>` | `<source AGENTS.md>` | PASS
 - [x] `<file>` | `<rule-id>` | `<source AGENTS.md>` | VIOLATION (finding: `<id>`)
+
+## Bug-Category Checklist
+- [x] `shell_semantics` | PASS | <evidence>
+- [x] `byte_char_boundary` | N/A | <evidence>
+- [x] `escape_sequences` | PASS | <evidence>
+- [x] `binary_vs_script` | PASS | <evidence>
+- [x] `subprocess_timeout` | OPEN_QUESTION | <evidence>
+- [x] `cross_tenant_isolation` | PASS | <evidence>
+- [x] `unwrap_on_untrusted` | PASS | <evidence>
+- [x] `cgroup_container_awareness` | N/A | <evidence>
+- [x] `crash_retry_coverage` | PASS | <evidence>
+- [x] `missing_script_binary_refs` | PASS | <evidence>
 
 ## Security Findings (attacker perspective)
 1. [P?][security] <summary> (`<file>:<line>`)

--- a/patterns/csa-review/skills/csa-review/references/review-protocol.md
+++ b/patterns/csa-review/skills/csa-review/references/review-protocol.md
@@ -280,6 +280,21 @@ Detect AI-generated code redundancy patterns. Severity: LOW-MEDIUM (advisory).
 Report deslop findings as LOW severity unless they significantly inflate module token count
 (approaching or exceeding 8K tokens), in which case use MEDIUM.
 
+## Mandatory Bug-Category Checklist
+
+For each category, the reviewer MUST state one of: PASS / N/A / VIOLATION / OPEN_QUESTION.
+
+- **Shell semantics**: Are all `&&`/`||` chains correctly grouped? Any precedence ambiguity?
+- **Byte/char boundary**: Are all `&str[..N]` / `&str[N..]` slices char-boundary-safe?
+- **Escape sequences**: Are all `\n`, `\t`, `\\` in string literals correct (not double-escaped)?
+- **Binary vs script**: Are all command invocations using the correct executor?
+- **Subprocess timeout**: Does every `cmd.output().await` / `Command::output()` have a timeout?
+- **Cross-tenant isolation**: Does any filter function use a `_ => true` default?
+- **Unwrap on untrusted**: Are there `.unwrap()` / `[]` / `expect()` on external data?
+- **cgroup/container awareness**: Does resource code account for container limits?
+- **Crash-retry coverage**: Did this change narrow any match guard? Did other tools lose coverage?
+- **Missing script/binary refs**: Does any pattern reference a file not included?
+
 ### Pass 1: Broad Issue Discovery (maximize recall)
 Scan all changed code for:
 - Correctness issues
@@ -386,3 +401,4 @@ If P0 or P1 findings exist, set both fields to `null` — the developer needs to
 11. Review completion is invalid if AGENTS.md checklist has any unchecked item or missing applicable rule.
 12. `review-findings.json` must remain deserializable as a `ReviewArtifact`: include compact fields (`fid`, `severity`, `file`, `line`, `rule_id`, `summary`, `engine`) even when richer metadata is attached.
 13. Always include `review_mode` in `review-findings.json` (`standard` or `red-team`).
+14. Always include `bug_category_checklist` in `review-findings.json`. For schema_version `1.1` or newer, a missing checklist means the review is incomplete; return UNCERTAIN rather than PASS.

--- a/patterns/dev2merge/PATTERN.md
+++ b/patterns/dev2merge/PATTERN.md
@@ -519,6 +519,21 @@ else
 fi
 ```
 
+## Step 11.5: Decomposition Review Depth Warning
+Tool: bash
+OnFail: skip
+Warn when the branch diff is broad enough to dilute review depth. This is
+advisory only and does not block Step 12.
+
+```bash
+# Decomposition check — WARN only, does not block
+CHANGED_FILES=$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | wc -l | tr -d ' ')
+if [ "${CHANGED_FILES:-0}" -gt 5 ]; then
+  echo "WARN: Branch has $CHANGED_FILES changed files (>5). Large diffs dilute review depth. Consider splitting into separate issue-scoped PRs."
+  echo "Consider using --depth audit for this review."
+fi
+```
+
 ## Step 12: Pre-PR Cumulative Review Gate
 Tool: bash
 OnFail: abort

--- a/patterns/dev2merge/workflow.toml
+++ b/patterns/dev2merge/workflow.toml
@@ -593,6 +593,25 @@ on_fail = "abort"
 condition = "(!(${DEV2MERGE_SKIP})) && (!(${FAST_PATH}))"
 
 [[workflow.steps]]
+id = 115
+title = "Decomposition Review Depth Warning"
+tool = "bash"
+prompt = '''
+Warn when the branch diff is broad enough to dilute review depth. This is
+advisory only and does not block Step 12.
+
+```bash
+# Decomposition check — WARN only, does not block
+CHANGED_FILES=$(git diff --name-only "${DEFAULT_BRANCH}...HEAD" 2>/dev/null | wc -l | tr -d ' ')
+if [ "${CHANGED_FILES:-0}" -gt 5 ]; then
+  echo "WARN: Branch has $CHANGED_FILES changed files (>5). Large diffs dilute review depth. Consider splitting into separate issue-scoped PRs."
+  echo "Consider using --depth audit for this review."
+fi
+```'''
+on_fail = "skip"
+condition = "(!(${DEV2MERGE_SKIP})) && (!(${FAST_PATH}))"
+
+[[workflow.steps]]
 id = 12
 title = "Pre-PR Cumulative Review Gate"
 tool = "bash"


### PR DESCRIPTION
## Changes

- **Bug-category checklist**: 10 mandatory categories added to `review-protocol.md` and `output-schema.md` (v1.1). Missing checklist → UNCERTAIN.
- **`--depth standard|audit` flag**: Standard (default) adds checklist to prompt. Audit enables red-team + auto-escalates on risky signals.
- **Bounded regression context**: git-log for changed files (max 5 commits/file, ~2000 chars) injected as inert metadata.
- **Decomposition WARN**: dev2merge warns (non-blocking) when branch has >5 changed files.

## Evidence
7 real bugs passed CSA review (#2573–#2579). This checklist covers all 7 categories.

Closes #2581