### PR TITLE
feat(build): enable acp feature by default (#2584)

### DIFF
--- a/crates/cli-sub-agent/Cargo.toml
+++ b/crates/cli-sub-agent/Cargo.toml
@@ -57,7 +57,7 @@ proptest = "1"
 serial_test = "3.4"
 
 [features]
-default = []
+default = ["acp"]
 acp = ["dep:csa-acp", "csa-executor/acp"]
 codex-acp = ["csa-config/codex-acp", "csa-executor/codex-acp"]
 codex-pty-fork = ["csa-executor/codex-pty-fork"]


### PR DESCRIPTION
Change `default = []` to `default = ["acp"]` in cli-sub-agent Cargo.toml.

Without this, `cargo build --release` produces a binary where hermes tool is non-functional (ACP transport not compiled in). Verified: default build now reports `ACP compiled in: yes`, hermes session launches and qwen3.6-27b correctly answers "1+1=2".

Closes #2584