### PR TITLE
fix(acp): handle hermes usage_update session event (#2585)

### DIFF
--- a/crates/csa-acp/Cargo.toml
+++ b/crates/csa-acp/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-agent-client-protocol = "0.10"
+agent-client-protocol = { version = "0.10", features = ["unstable_session_usage"] }
 csa-core.workspace = true
 csa-process.workspace = true
 csa-resource.workspace = true

--- a/crates/csa-acp/src/client.rs
+++ b/crates/csa-acp/src/client.rs
@@ -414,6 +414,10 @@ impl AcpClient {
                 tracing::trace!("suppressed protocol-level SessionUpdate (not content)");
                 None
             }
+            SessionUpdate::UsageUpdate(_) => {
+                tracing::trace!("suppressed usage telemetry SessionUpdate");
+                None
+            }
             // Catch-all for future ACP protocol variants (enum is
             // non-exhaustive).  Emit as Other for visibility.
             other => Some(SessionEvent::Other(


### PR DESCRIPTION
Enable `unstable_session_usage` feature on `agent-client-protocol` and add `UsageUpdate` to suppressed `SessionUpdate` arms.

Before: hermes sends `sessionUpdate: "usage_update"` → JSON-RPC decode fails → session marked failure despite correct model response.
After: `UsageUpdate` variant compiled in, suppressed as protocol telemetry (like `AvailableCommandsUpdate`).

Verified: qwen3.6-27b-decensor-by-aeon answers "1+1=**2**" with zero decode errors.

Note: a separate result.toml timing issue remains (daemon exits successfully but result.toml not written). Will be filed separately.

Closes #2585