### PR TITLE
fix(sandbox): skip readable bind for paths already writable (#2590)

### DIFF
--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -110,7 +110,12 @@ impl BwrapCommandBuilder {
         }
 
         // Read-only readable paths. For /tmp files, only create parent dirs.
+        // Writable grants already imply readability; adding an overlapping
+        // read-only bind afterward would downgrade the writable mount.
         for path in &self.readable_paths {
+            if self.is_covered_by_writable_path(path) {
+                continue;
+            }
             let s = path.to_string_lossy();
             assert!(
                 path != tmp_prefix,
@@ -162,6 +167,13 @@ impl BwrapCommandBuilder {
         cmd.args(&self.tool_args);
 
         cmd
+    }
+
+    fn is_covered_by_writable_path(&self, readable_path: &Path) -> bool {
+        self.writable_paths.iter().any(|writable_path| {
+            let writable_path = writable_path.as_path();
+            readable_path == writable_path || readable_path.starts_with(writable_path)
+        })
     }
 
     fn sandbox_home(&self, host_home: Option<&Path>) -> Option<PathBuf> {

--- a/crates/csa-resource/src/bwrap_tests.rs
+++ b/crates/csa-resource/src/bwrap_tests.rs
@@ -523,6 +523,31 @@ fn test_bwrap_readable_and_writable_paths_after_tmpfs() {
 }
 
 #[test]
+fn test_bwrap_duplicate_readable_writable_path_keeps_writable_bind() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path();
+    let path_str = path.to_string_lossy().into_owned();
+
+    let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+    builder.with_writable_path(path);
+    builder.with_readable_path(path);
+    let cmd = builder.build();
+    let args = command_args(&cmd);
+
+    assert!(
+        args.windows(3)
+            .any(|window| window[0] == "--bind" && window[1] == path_str && window[2] == path_str),
+        "duplicate readable+writable path must remain writable; args: {args:?}"
+    );
+    assert!(
+        !args.windows(3).any(|window| {
+            window[0] == "--ro-bind" && window[1] == path_str && window[2] == path_str
+        }),
+        "duplicate readable+writable path must not be remounted read-only; args: {args:?}"
+    );
+}
+
+#[test]
 fn test_bwrap_nested_tmp_path_creates_intermediate_dirs() {
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_writable_path(Path::new("/tmp/deep/nested/dir"));


### PR DESCRIPTION
When a path is in both `readable_paths` and `writable_paths`, the `--ro-bind` was shadowing the `--bind` (bwrap: later mount wins). Added `is_covered_by_writable_path()` check to skip read-only bind for paths already writable.

Regression test: `test_bwrap_duplicate_readable_writable_path_keeps_writable_bind` verifies `--bind` present and `--ro-bind` absent for duplicate paths.

All 21 bwrap tests pass.

Closes #2590