### PR TITLE
fix(just): auto-detect CARGO_BUILD_JOBS based on available memory (#2594)

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,11 +15,12 @@ set dotenv-load := true
 # Calculate repo root (compatible with submodules)
 _repo_root := `git rev-parse --show-superproject-working-tree 2>/dev/null | grep . || git rev-parse --show-toplevel`
 _cargo := _repo_root + "/scripts/cargo-env-normalize.sh cargo"
-# Default Cargo/rustc fan-out for Just recipes; override with
-# `CARGO_BUILD_JOBS=<n> just ...`. Do not default NEXTEST_TEST_THREADS here:
-# full-suite runs need nextest's normal parallelism to avoid serializing
-# thousands of tests.
-export CARGO_BUILD_JOBS := env_var_or_default("CARGO_BUILD_JOBS", "1")
+# Default Cargo/rustc fan-out for Just recipes is auto-detected from available
+# memory; override with `CARGO_BUILD_JOBS=<n> just ...`. Do not default
+# NEXTEST_TEST_THREADS here: full-suite runs need nextest's normal parallelism
+# to avoid serializing thousands of tests.
+_auto_build_jobs := `scripts/detect-build-jobs.sh`
+export CARGO_BUILD_JOBS := env_var_or_default("CARGO_BUILD_JOBS", _auto_build_jobs)
 # Just already executes repository-controlled code, so trust this checkout's
 # mise config and avoid interactive trust prompts on sandboxed commit paths.
 export MISE_TRUSTED_CONFIG_PATHS := _repo_root
@@ -208,7 +209,8 @@ deny:
 # ==============================================================================
 
 # Run all tests in the workspace across default and feature builds.
-# Env: CARGO_BUILD_JOBS defaults to 1; NEXTEST_TEST_THREADS is caller-controlled.
+# Env: CARGO_BUILD_JOBS defaults to auto-detected safe parallelism;
+# NEXTEST_TEST_THREADS is caller-controlled.
 test:
     just check-cargo-target-writable
     just check-nextest-state-writable
@@ -217,14 +219,16 @@ test:
     {{_cargo}} nextest run --workspace --all-features
 
 # Run e2e tests only.
-# Env: CARGO_BUILD_JOBS defaults to 1; NEXTEST_TEST_THREADS is caller-controlled.
+# Env: CARGO_BUILD_JOBS defaults to auto-detected safe parallelism;
+# NEXTEST_TEST_THREADS is caller-controlled.
 test-e2e:
     just check-cargo-target-writable
     just check-nextest-state-writable
     {{_cargo}} nextest run --package cli-sub-agent --test e2e --all-features
 
 # Run tests for a specific package.
-# Env: CARGO_BUILD_JOBS defaults to 1; NEXTEST_TEST_THREADS is caller-controlled.
+# Env: CARGO_BUILD_JOBS defaults to auto-detected safe parallelism;
+# NEXTEST_TEST_THREADS is caller-controlled.
 # Usage: just test-p my-crate
 test-p package:
     just check-cargo-target-writable
@@ -232,7 +236,8 @@ test-p package:
     {{_cargo}} nextest run -p {{package}} --all-features
 
 # Run tests matching a specific pattern/name.
-# Env: CARGO_BUILD_JOBS defaults to 1; NEXTEST_TEST_THREADS is caller-controlled.
+# Env: CARGO_BUILD_JOBS defaults to auto-detected safe parallelism;
+# NEXTEST_TEST_THREADS is caller-controlled.
 # Usage: just test-f login_validation
 test-f pattern:
     just check-cargo-target-writable

--- a/scripts/detect-build-jobs.sh
+++ b/scripts/detect-build-jobs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Auto-detect safe CARGO_BUILD_JOBS based on available memory.
+# Uses 1536MB per compile job (conservative for large Rust crates with proc macros).
+# Clamped to [1, min(nproc, 8)].
+set -euo pipefail
+
+mem_mb=$(awk '/MemAvailable/ {printf "%d", $2/1024}' /proc/meminfo 2>/dev/null || echo "0")
+cpus=$(nproc 2>/dev/null || echo "1")
+
+# Guard against empty/zero values.
+if [ -z "$mem_mb" ] || [ "$mem_mb" -le 0 ]; then mem_mb=1536; fi
+if [ -z "$cpus" ] || [ "$cpus" -le 0 ]; then cpus=1; fi
+
+# 1536MB per compile job.
+mem_jobs=$(( mem_mb / 1536 ))
+
+# Clamp: at least 1, at most min(cpus, 8).
+if [ "$mem_jobs" -lt 1 ]; then mem_jobs=1; fi
+if [ "$mem_jobs" -gt "$cpus" ]; then mem_jobs=$cpus; fi
+if [ "$mem_jobs" -gt 8 ]; then mem_jobs=8; fi
+
+echo "$mem_jobs"


### PR DESCRIPTION
Replace hardcoded `CARGO_BUILD_JOBS=1` with `scripts/detect-build-jobs.sh` that calculates safe parallelism based on available memory.

**Formula:** `min(MemAvailable / 1536MB, nproc, 8)`, at least 1.

| Available RAM | nproc | Calculated jobs | Est. test time |
|---|---|---|---|
| 13 GB | 20 | 8 | ~49s |
| 8 GB | 20 | 5 | ~56s |
| 4 GB | 20 | 2 | ~2min |
| < 1.5 GB | 20 | 1 | ~3m47s |

Explicit `CARGO_BUILD_JOBS=N` override still takes priority.

**Verified on this machine:**
```
$ scripts/detect-build-jobs.sh
8
$ just --evaluate | grep CARGO_BUILD_JOBS
CARGO_BUILD_JOBS := "8"
$ CARGO_BUILD_JOBS=1 just --evaluate | grep CARGO_BUILD_JOBS
CARGO_BUILD_JOBS := "1"
```

Closes #2594