### PR TITLE
ci: add default-features build check to feature matrix (#2596)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-deny
         uses: taiki-e/install-action@ba41dd491d91278bf5d2280486932414ba6d4991
-      - name: Check workspace
+      - name: Check workspace (default features)
+        run: cargo check --workspace
+      - name: Check workspace (all features)
         run: cargo check --workspace --all-features
       - name: Check dependencies
         run: cargo deny check


### PR DESCRIPTION
The CI `check` job only ran `cargo check --workspace --all-features`. This missed the #2584 regression where `default = ["acp"]` was missing — the default-features build silently broke.

Now runs both:
- `cargo check --workspace` (default features)
- `cargo check --workspace --all-features`

The test job already ran nextest under both feature sets (lines 113-116), but the check job did not.

Closes #2596