### PR TITLE
fix(review): ignore Chinese positive evidence findings (#2601)

### DIFF
--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_2017_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_2017_tests.rs
@@ -251,3 +251,52 @@ No blocking findings found.
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
+
+#[test]
+fn issue_2601_pass_summary_chinese_positive_evidence_keeps_review_verdict_pass() {
+    let session_id = "01TEST2601CHINESEPASS";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-2601-chinese-positive-evidence", session_id);
+
+    write_extracted_empty_findings(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        concat!(
+            "<!-- CSA:SECTION:summary -->\n",
+            "PASS\n",
+            "<!-- CSA:SECTION:summary:END -->\n\n",
+            "<!-- CSA:SECTION:details -->\n",
+            "\u{7ed3}\u{8bba}\u{ff1a}\u{672a}\u{53d1}\u{73b0}",
+            "\u{9700}\u{8981}\u{963b}\u{65ad}\u{5408}\u{5e76}\u{7684}",
+            "\u{6b63}\u{786e}\u{6027}\u{3001}\u{5b89}\u{5168}\u{6216}",
+            "\u{5951}\u{7ea6}\u{95ee}\u{9898}\u{3002}\n\n",
+            "- P1/P2/C1: \u{9ed8}\u{8ba4} evidence \u{5173}\u{95ed}\u{3001}raw ",
+            "\u{5173}\u{95ed}\u{3001}XDG \u{9ed8}\u{8ba4}\u{8def}\u{5f84}",
+            "\u{4e0e}\u{8def}\u{5f84}\u{8986}\u{76d6}/\u{975e}\u{6cd5}",
+            "\u{8def}\u{5f84}\u{6821}\u{9a8c}\u{5728} settings \u{4e2d}",
+            "\u{5df2}\u{5b9e}\u{73b0}\u{5e76}\u{6d4b}\u{8bd5}\n",
+            "- P2: CLI \u{900f}\u{4f20}\u{5df2}\u{6709}\u{76f4}\u{63a5}",
+            "\u{6d4b}\u{8bd5}\n",
+            "- C1: \u{975e}\u{6cd5}\u{8def}\u{5f84}\u{5df2}\u{901a}\u{8fc7} ",
+            "settings \u{6821}\u{9a8c}\u{7f13}\u{89e3}\n",
+            "- P1: fallback \u{884c}\u{4e3a}\u{5df2}\u{6709}\u{673a}\u{68b0}",
+            "\u{6d4b}\u{8bd5}\n",
+            "- P2: reviewer summary \u{5df2}\u{8986}\u{76d6}\n",
+            "<!-- CSA:SECTION:details:END -->\n",
+        ),
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+
+    let findings = read_findings_toml(&session_dir);
+    assert!(findings.findings.is_empty());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
@@ -115,6 +115,30 @@ Verification:
 }
 
 #[test]
+fn issue_2601_chinese_positive_evidence_bullets_do_not_become_prose_findings() {
+    let findings = extract_review_findings_from_prose(concat!(
+        "PASS\n",
+        "- P1/P2/C1: \u{9ed8}\u{8ba4} evidence \u{5173}\u{95ed}\u{3001}raw ",
+        "\u{5173}\u{95ed}\u{3001}XDG \u{9ed8}\u{8ba4}\u{8def}\u{5f84}",
+        "\u{4e0e}\u{8def}\u{5f84}\u{8986}\u{76d6}/\u{975e}\u{6cd5}",
+        "\u{8def}\u{5f84}\u{6821}\u{9a8c}\u{5728} settings \u{4e2d}",
+        "\u{5df2}\u{5b9e}\u{73b0}\u{5e76}\u{6d4b}\u{8bd5}\n",
+        "- P2: CLI \u{900f}\u{4f20}\u{5df2}\u{6709}\u{76f4}\u{63a5}",
+        "\u{6d4b}\u{8bd5}\n",
+        "- C1: XDG override \u{5df2}\u{901a}\u{8fc7}\u{8def}\u{5f84}",
+        "\u{6821}\u{9a8c}\u{7f13}\u{89e3}\n",
+        "- P1: fallback \u{884c}\u{4e3a}\u{5df2}\u{6709}\u{673a}\u{68b0}",
+        "\u{6d4b}\u{8bd5}\n",
+        "- P2: reviewer summary \u{5df2}\u{8986}\u{76d6}\n",
+    ));
+
+    assert!(
+        findings.is_empty(),
+        "Chinese positive-evidence bullets must not become findings: {findings:?}"
+    );
+}
+
+#[test]
 fn issue_2440_verified_word_does_not_trigger_resolution() {
     use super::finding_text_describes_resolved_issue;
 
@@ -143,6 +167,48 @@ fn issue_2516_no_longer_describes_regression_not_resolution() {
             "The prior high finding is addressed and no longer present"
         ),
         "'no longer present' after a resolution word should be classified as resolved"
+    );
+}
+
+#[test]
+fn issue_2601_chinese_resolution_phrases_describe_resolved_issue() {
+    use super::finding_text_describes_resolved_issue;
+
+    for text in [
+        concat!(
+            "P1/P2/C1\u{ff1a}\u{9ed8}\u{8ba4} evidence \u{5173}\u{95ed}\u{3001}raw ",
+            "\u{5173}\u{95ed}\u{3001}XDG \u{9ed8}\u{8ba4}\u{8def}\u{5f84}",
+            "\u{4e0e}\u{8def}\u{5f84}\u{8986}\u{76d6}/\u{975e}\u{6cd5}",
+            "\u{8def}\u{5f84}\u{6821}\u{9a8c}\u{5df2}\u{5b9e}\u{73b0}",
+            "\u{5e76}\u{6d4b}\u{8bd5}",
+        ),
+        "P2\u{ff1a}CLI \u{8f93}\u{51fa}\u{5df2}\u{6709}\u{76f4}\u{63a5}\u{6d4b}\u{8bd5}",
+        "C1\u{ff1a}\u{975e}\u{6cd5}\u{8def}\u{5f84}\u{5df2}\u{901a}\u{8fc7} settings \u{6821}\u{9a8c}\u{7f13}\u{89e3}",
+        "P1\u{ff1a}\u{8986}\u{76d6}\u{7387}\u{5df2}\u{6709}\u{673a}\u{68b0}\u{6d4b}\u{8bd5}",
+        "P2\u{ff1a}\u{72b6}\u{6001}\u{6458}\u{8981}\u{5df2}\u{8986}\u{76d6}",
+    ] {
+        assert!(
+            finding_text_describes_resolved_issue(text),
+            "Chinese positive evidence should be classified as resolved: {text}"
+        );
+    }
+}
+
+#[test]
+fn issue_2601_chinese_active_problem_phrases_stay_blocking() {
+    use super::finding_text_describes_resolved_issue;
+
+    assert!(
+        !finding_text_describes_resolved_issue(
+            "P1: settings \u{8def}\u{5f84}\u{6821}\u{9a8c}\u{672a}\u{8986}\u{76d6}"
+        ),
+        "Chinese active problem prose must not be classified as resolved"
+    );
+    assert!(
+        !finding_text_describes_resolved_issue(
+            "P1: evidence \u{5df2}\u{8986}\u{76d6}\u{4e0d}\u{8db3}"
+        ),
+        "Chinese insufficiency prose must not be classified as resolved"
     );
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_prose_resolution.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_resolution.rs
@@ -45,6 +45,28 @@ const ACTIVE_PROBLEM_WORDS: &[&str] = &[
     "unsafe",
     "wrong",
 ];
+const CHINESE_RESOLUTION_PHRASES: &[&str] = &[
+    "\u{5df2}\u{5b9e}\u{73b0}\u{5e76}\u{6d4b}\u{8bd5}",
+    "\u{5df2}\u{6709}\u{76f4}\u{63a5}\u{6d4b}\u{8bd5}",
+    "\u{5df2}\u{6709}\u{673a}\u{68b0}\u{6d4b}\u{8bd5}",
+    "\u{5df2}\u{8986}\u{76d6}",
+];
+const CHINESE_ACTIVE_PROBLEM_PHRASES: &[&str] = &[
+    "\u{672a}\u{5b9e}\u{73b0}",
+    "\u{672a}\u{8986}\u{76d6}",
+    "\u{672a}\u{6d4b}\u{8bd5}",
+    "\u{672a}\u{7f13}\u{89e3}",
+    "\u{5c1a}\u{672a}",
+    "\u{4ecd}\u{672a}",
+    "\u{4ecd}\u{5b58}\u{5728}",
+    "\u{7f3a}\u{5c11}",
+    "\u{9057}\u{6f0f}",
+    "\u{5931}\u{8d25}",
+    "\u{9519}\u{8bef}",
+    "\u{98ce}\u{9669}",
+    "\u{95ee}\u{9898}\u{4ecd}",
+    "\u{8986}\u{76d6}\u{4e0d}\u{8db3}",
+];
 
 pub(super) fn review_signal_describes_resolved_issue(
     tokens: &[String],
@@ -82,13 +104,36 @@ pub(super) fn finding_text_describes_resolved_issue(text: &str) -> bool {
     if tokens
         .iter()
         .any(|token| ACTIVE_PROBLEM_WORDS.contains(&token.as_str()))
+        || chinese_active_problem_phrase_applies(text)
     {
         return false;
+    }
+    if chinese_resolution_phrase_applies(text) {
+        return true;
     }
     tokens
         .iter()
         .enumerate()
         .any(|(index, _)| resolution_token_applies(&tokens, index))
+}
+
+fn chinese_resolution_phrase_applies(text: &str) -> bool {
+    CHINESE_RESOLUTION_PHRASES
+        .iter()
+        .any(|phrase| text.contains(phrase))
+        || ordered_substrings_apply(text, "\u{5df2}\u{901a}\u{8fc7}", "\u{7f13}\u{89e3}")
+}
+
+fn chinese_active_problem_phrase_applies(text: &str) -> bool {
+    CHINESE_ACTIVE_PROBLEM_PHRASES
+        .iter()
+        .any(|phrase| text.contains(phrase))
+}
+
+fn ordered_substrings_apply(text: &str, first: &str, second: &str) -> bool {
+    text.find(first)
+        .and_then(|start| text[start + first.len()..].find(second))
+        .is_some()
 }
 
 fn resolution_token_applies(tokens: &[String], index: usize) -> bool {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
@@ -320,8 +320,7 @@ fn daemon_completion_effective_outcome(
         // non-empty collected output (stdout), treat it as success rather
         // than forcing a misleading failure. (#2588)
         let stdout_path = session_dir.join("stdout.log");
-        let has_output = fs::read_to_string(&stdout_path)
-            .is_ok_and(|s| !s.trim().is_empty());
+        let has_output = fs::read_to_string(&stdout_path).is_ok_and(|s| !s.trim().is_empty());
         if has_output {
             return DaemonCompletionEffectiveOutcome {
                 status: "success".to_string(),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_review_label.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_review_label.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use csa_core::types::ReviewDecision;
 use csa_session::{ReviewSessionMeta, ReviewVerdictArtifact};
+use tracing::warn;
 
 pub(super) fn read_review_verdict_label(
     session_dir: &Path,
@@ -25,6 +26,16 @@ pub(super) fn read_review_verdict_label(
         }
         if summary_requires_failed_gate {
             return Some("FAIL".to_string());
+        }
+        if artifact.decision == ReviewDecision::Fail
+            && human_summary_is_exact_pass(session_dir, result)
+            && !review_artifact_or_meta_has_failure_diagnostic(meta.as_ref(), &artifact)
+        {
+            warn!(
+                session_dir = %session_dir.display(),
+                "Review verdict artifact is FAIL but the human summary is exactly PASS; showing PASS label"
+            );
+            return Some("PASS".to_string());
         }
         if artifact.decision == ReviewDecision::Pass {
             if meta
@@ -179,6 +190,29 @@ fn read_review_meta_for_label(session_dir: &Path) -> Option<ReviewSessionMeta> {
     serde_json::from_str::<ReviewSessionMeta>(&raw).ok()
 }
 
+fn human_summary_is_exact_pass(session_dir: &Path, result: &csa_session::SessionResult) -> bool {
+    crate::session_summary_text::human_session_summary(session_dir, &result.summary)
+        .is_some_and(|summary| summary.trim() == "PASS")
+}
+
+fn review_artifact_or_meta_has_failure_diagnostic(
+    meta: Option<&ReviewSessionMeta>,
+    artifact: &ReviewVerdictArtifact,
+) -> bool {
+    artifact.no_provider_launch.is_some()
+        || non_empty_label(artifact.primary_failure.as_deref())
+        || non_empty_label(artifact.failure_reason.as_deref())
+        || meta.is_some_and(|meta| {
+            non_empty_label(meta.status_reason.as_deref())
+                || non_empty_label(meta.primary_failure.as_deref())
+                || non_empty_label(meta.failure_reason.as_deref())
+        })
+}
+
+fn non_empty_label(value: Option<&str>) -> bool {
+    value.is_some_and(|value| !value.trim().is_empty())
+}
+
 fn review_failure_reason_label(
     meta: Option<&ReviewSessionMeta>,
     artifact: &ReviewVerdictArtifact,
@@ -245,5 +279,90 @@ fn normalize_review_verdict_label(value: &str, result: &csa_session::SessionResu
         "PASS" | "CLEAN" => "PASS".to_string(),
         "FAIL" | "FAILED" | "HAS_ISSUES" => "FAIL".to_string(),
         other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn terminal_result(status: &str, exit_code: i32, summary: &str) -> csa_session::SessionResult {
+        let now = Utc::now();
+        csa_session::SessionResult {
+            status: status.to_string(),
+            exit_code,
+            summary: summary.to_string(),
+            tool: "codex".to_string(),
+            started_at: now,
+            completed_at: now,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn issue_2601_review_label_exact_pass_summary_overrides_failed_prose_artifact() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        csa_session::persist_structured_output(
+            temp.path(),
+            "<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n",
+        )
+        .expect("persist pass summary");
+        let mut artifact = ReviewVerdictArtifact::from_parts(
+            "01TEST2601LABELPASS".to_string(),
+            ReviewDecision::Fail,
+            "HAS_ISSUES",
+            &[],
+            Vec::new(),
+        );
+        artifact
+            .severity_counts
+            .insert(csa_session::Severity::High, 1);
+        csa_session::write_review_verdict(temp.path(), &artifact).expect("write verdict");
+        csa_session::write_findings_toml(
+            temp.path(),
+            &csa_session::FindingsFile {
+                findings: vec![csa_session::ReviewFinding {
+                    id: "prose-001".to_string(),
+                    severity: csa_session::Severity::High,
+                    file_ranges: Vec::new(),
+                    is_regression_of_commit: None,
+                    suggested_test_scenario: None,
+                    description: "P1 positive evidence was misclassified".to_string(),
+                }],
+            },
+        )
+        .expect("write findings");
+
+        let label = read_review_verdict_label(temp.path(), &terminal_result("failure", 1, "PASS"));
+
+        assert_eq!(label.as_deref(), Some("PASS"));
+    }
+
+    #[test]
+    fn issue_2601_review_label_exact_pass_summary_does_not_hide_hard_failure() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        csa_session::persist_structured_output(
+            temp.path(),
+            "<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n",
+        )
+        .expect("persist pass summary");
+        let mut artifact = ReviewVerdictArtifact::from_parts(
+            "01TEST2601LABELFAIL".to_string(),
+            ReviewDecision::Fail,
+            "HAS_ISSUES",
+            &[],
+            Vec::new(),
+        );
+        artifact.failure_reason = Some("provider crashed before final review".to_string());
+        csa_session::write_review_verdict(temp.path(), &artifact).expect("write verdict");
+
+        let label = read_review_verdict_label(temp.path(), &terminal_result("failure", 1, "PASS"));
+
+        assert!(
+            label
+                .as_deref()
+                .is_some_and(|label| label.starts_with("FAIL"))
+        );
     }
 }


### PR DESCRIPTION
## Problem

`csa session wait` returned exit code 1 / `Review verdict: FAIL` for a review whose structured summary was `PASS`. Root cause: reviewer positive-evidence comments in Chinese (e.g. `P1/P2/C1：默认 evidence 关闭...已实现并测试`) were misclassified as HIGH findings by the prose extractor, because `P1` maps to `Severity::High` and the Chinese text `已实现并测试` (already implemented and tested) was not recognized as a resolution phrase.

## Fix (two layers)

### Layer 1: Chinese positive-evidence detection (`review_cmd_prose_resolution.rs`)

Added Chinese resolution phrases (`已实现并测试`, `已有直接测试`, `已有机械测试`, `已覆盖`, `已通过...缓解`) to `finding_text_describes_resolved_issue()`. Added Chinese active-problem phrases (`未实现`, `未覆盖`, `仍未`, `仍存在`, `缺少`, `遗漏`, `失败`, etc.) to ensure real problems stay blocking.

### Layer 2: Verdict contradiction guard (`session_cmds_daemon_wait_review_label.rs`)

When `review-verdict.json` says FAIL but the human summary is exactly `PASS` and there are no failure diagnostics (no `primary_failure`, `failure_reason`, `status_reason`), show PASS with a `warn!` log. This is a defense-in-depth against future misclassification.

## Tests (6 new)

- `issue_2601_chinese_positive_evidence_bullets_do_not_become_prose_findings`
- `issue_2601_chinese_active_problem_phrases_stay_blocking`
- `issue_2601_chinese_resolution_phrases_describe_resolved_issue`
- `issue_2601_review_label_exact_pass_summary_overrides_failed_prose_artifact`
- `issue_2601_review_label_exact_pass_summary_does_not_hide_hard_failure`
- `issue_2601_pass_summary_chinese_positive_evidence_keeps_review_verdict_pass`

All 6 pass. Full workspace nextest (6820 tests) passed via require-commit.

Closes #2601