### PR TITLE
fix(sandbox): override CARGO_HOME/RUSTUP_HOME env when read-only /usr/local (#2607)

### DIFF
--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -14,6 +14,8 @@ mod claude_paths;
 mod codex_paths;
 #[path = "isolation_plan_runtime_path.rs"]
 mod runtime_path;
+#[path = "isolation_plan_rust_env.rs"]
+mod rust_env;
 #[path = "isolation_plan_validation.rs"]
 mod validation;
 #[cfg(test)]
@@ -284,7 +286,8 @@ impl IsolationPlanBuilder {
         self.project_root = Some(project_root.to_path_buf());
         self.writable_paths.push(project_root.to_path_buf());
         self.writable_paths.push(session_dir.to_path_buf());
-        let sandbox_tmpdir = sandbox_tmpdir_for_capability(self.filesystem, session_dir);
+        let sandbox_tmpdir =
+            runtime_path::sandbox_tmpdir_for_capability(self.filesystem, session_dir);
         self.env_overrides.insert(
             "TMPDIR".to_string(),
             sandbox_tmpdir.to_string_lossy().into_owned(),
@@ -334,10 +337,20 @@ impl IsolationPlanBuilder {
             // can create it (the parent must exist).
             let default_cargo_home = home.join(".cargo");
             if let Ok(cargo_home_env) = std::env::var(csa_core::env::CARGO_HOME_ENV_KEY) {
-                let cargo_home = rust_state_path_or_default(&cargo_home_env, &default_cargo_home);
+                let cargo_home =
+                    rust_env::resolve_rust_state_path(&cargo_home_env, &default_cargo_home);
                 if cargo_home == default_cargo_home {
                     // CARGO_HOME points to the default — treat as if unset.
                     add_dir_or_creatable_parent(&mut self.writable_paths, &default_cargo_home);
+                    // Override the env var when the original pointed at a
+                    // read-only system prefix (e.g. /usr/local) so the child
+                    // process uses the writable default instead (#2607).
+                    rust_env::insert_env_override_if_needed(
+                        &mut self.env_overrides,
+                        csa_core::env::CARGO_HOME_ENV_KEY,
+                        &cargo_home_env,
+                        &default_cargo_home,
+                    );
                 } else {
                     // CARGO_HOME points elsewhere — only expose that directory.
                     // Do NOT add ~/.cargo (may contain credentials/config).
@@ -352,9 +365,16 @@ impl IsolationPlanBuilder {
             // CARGO_HOME: when explicitly set elsewhere, don't expose ~/.rustup.
             let default_rustup = home.join(".rustup");
             if let Ok(rustup_home) = std::env::var(csa_core::env::RUSTUP_HOME_ENV_KEY) {
-                let rustup_path = rust_state_path_or_default(&rustup_home, &default_rustup);
+                let rustup_path = rust_env::resolve_rust_state_path(&rustup_home, &default_rustup);
                 if rustup_path == default_rustup {
                     add_dir_or_creatable_parent(&mut self.writable_paths, &default_rustup);
+                    // Same env override as CARGO_HOME (#2607).
+                    rust_env::insert_env_override_if_needed(
+                        &mut self.env_overrides,
+                        csa_core::env::RUSTUP_HOME_ENV_KEY,
+                        &rustup_home,
+                        &default_rustup,
+                    );
                 } else {
                     // RUSTUP_HOME points elsewhere — only expose that directory.
                     add_dir_or_creatable_parent(&mut self.writable_paths, &rustup_path);
@@ -503,7 +523,7 @@ impl IsolationPlanBuilder {
             return;
         };
 
-        for socket_path in runtime_daemon_socket_paths(&runtime_root) {
+        for socket_path in runtime_path::runtime_daemon_socket_paths(&runtime_root) {
             if !socket_path.exists() || self.path_already_exposed(&socket_path) {
                 continue;
             }
@@ -530,98 +550,8 @@ impl IsolationPlanBuilder {
     }
 }
 
-fn runtime_daemon_socket_paths(runtime_root: &Path) -> [PathBuf; 2] {
-    [
-        runtime_root.join("bus"),
-        runtime_root.join("systemd/private"),
-    ]
-}
-
-fn sandbox_tmpdir_for_capability(filesystem: FilesystemCapability, session_dir: &Path) -> PathBuf {
-    match filesystem {
-        FilesystemCapability::Bwrap => PathBuf::from(DEFAULT_SANDBOX_TMPDIR),
-        FilesystemCapability::Landlock | FilesystemCapability::None => session_dir.join("tmp"),
-    }
-}
-
-fn rust_state_path_or_default(value: &str, default: &Path) -> PathBuf {
-    let path = PathBuf::from(value);
-    if value.trim().is_empty() || csa_core::env::rust_state_path_needs_session_override(&path) {
-        default.to_path_buf()
-    } else {
-        path
-    }
-}
-
-/// Add `dir` to `paths` if it exists, otherwise pre-create it when a
-/// non-root ancestor exists (bwrap `--bind` requires the source path to exist).
-///
-/// Rejects paths under sensitive system directories (`/etc`, `/var/lib`,
-/// `/boot`, `/sbin`, etc.) to prevent env vars like `CARGO_HOME` from
-/// escaping the sandbox boundary.
 fn add_dir_or_creatable_parent(paths: &mut Vec<PathBuf>, dir: &Path) -> bool {
-    if is_sensitive_system_path(dir) {
-        tracing::warn!(
-            path = %dir.display(),
-            "rejecting writable path under sensitive system directory"
-        );
-        return false;
-    }
-
-    if dir.exists() {
-        paths.push(dir.to_path_buf());
-        true
-    } else if dir
-        .ancestors()
-        .skip(1)
-        .find(|ancestor| ancestor.exists())
-        .is_some_and(|ancestor| ancestor != Path::new("/"))
-    {
-        // Pre-create the directory so bwrap --bind can mount it.
-        // On cold starts (fresh CARGO_HOME/RUSTUP_HOME/shared npm cache) the
-        // dir or one of its intermediate parents won't exist yet; bwrap
-        // requires the source path to be present.
-        match std::fs::create_dir_all(dir) {
-            Ok(()) => {
-                paths.push(dir.to_path_buf());
-                true
-            }
-            Err(e) => {
-                tracing::warn!(
-                    path = %dir.display(),
-                    error = %e,
-                    "failed to pre-create directory for sandbox writable mount, skipping"
-                );
-                false
-            }
-        }
-    } else {
-        false
-    }
-}
-
-#[cfg(test)]
-mod issue_2404_tests {
-    use super::*;
-
-    #[test]
-    fn issue_2404_user_daemon_ipc_disabled_by_default() {
-        let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
-            .with_filesystem_capability(FilesystemCapability::Bwrap)
-            .build()
-            .expect("build should succeed in BestEffort mode");
-        assert!(!plan.user_daemon_ipc);
-    }
-
-    #[test]
-    fn issue_2404_user_daemon_ipc_enabled_via_builder() {
-        let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
-            .with_filesystem_capability(FilesystemCapability::Bwrap)
-            .with_user_daemon_ipc()
-            .build()
-            .expect("build should succeed in BestEffort mode");
-        assert!(plan.user_daemon_ipc);
-    }
+    runtime_path::add_dir_or_creatable_parent(paths, dir)
 }
 
 #[cfg(test)]
@@ -646,3 +576,7 @@ mod tmpdir_tests;
 #[cfg(test)]
 #[path = "isolation_plan_claude_tests.rs"]
 mod claude_tests;
+
+#[cfg(test)]
+#[path = "isolation_plan_daemon_ipc_tests.rs"]
+mod daemon_ipc_tests;

--- a/crates/csa-resource/src/isolation_plan_daemon_ipc_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_daemon_ipc_tests.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+#[test]
+fn issue_2404_user_daemon_ipc_disabled_by_default() {
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .build()
+        .expect("build should succeed in BestEffort mode");
+    assert!(!plan.user_daemon_ipc);
+}
+
+#[test]
+fn issue_2404_user_daemon_ipc_enabled_via_builder() {
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_user_daemon_ipc()
+        .build()
+        .expect("build should succeed in BestEffort mode");
+    assert!(plan.user_daemon_ipc);
+}

--- a/crates/csa-resource/src/isolation_plan_runtime_path.rs
+++ b/crates/csa-resource/src/isolation_plan_runtime_path.rs
@@ -1,4 +1,25 @@
+use crate::filesystem_sandbox::FilesystemCapability;
+
 use std::path::{Component, Path, PathBuf};
+
+pub(super) const DEFAULT_SANDBOX_TMPDIR: &str = "/tmp";
+
+pub(super) fn runtime_daemon_socket_paths(runtime_root: &Path) -> [PathBuf; 2] {
+    [
+        runtime_root.join("bus"),
+        runtime_root.join("systemd/private"),
+    ]
+}
+
+pub(super) fn sandbox_tmpdir_for_capability(
+    filesystem: FilesystemCapability,
+    session_dir: &Path,
+) -> PathBuf {
+    match filesystem {
+        FilesystemCapability::Bwrap => PathBuf::from(DEFAULT_SANDBOX_TMPDIR),
+        FilesystemCapability::Landlock | FilesystemCapability::None => session_dir.join("tmp"),
+    }
+}
 
 pub(super) fn canonicalize_or_fallback(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
@@ -94,4 +115,51 @@ pub(super) fn is_sensitive_system_path(path: &Path) -> bool {
         }
     }
     path == Path::new("/")
+}
+
+/// Add `dir` to `paths` if it exists, otherwise pre-create it when a
+/// non-root ancestor exists (bwrap `--bind` requires the source path to exist).
+///
+/// Rejects paths under sensitive system directories (`/etc`, `/var/lib`,
+/// `/boot`, `/sbin`, etc.) to prevent env vars like `CARGO_HOME` from
+/// escaping the sandbox boundary.
+pub(super) fn add_dir_or_creatable_parent(paths: &mut Vec<PathBuf>, dir: &Path) -> bool {
+    if is_sensitive_system_path(dir) {
+        tracing::warn!(
+            path = %dir.display(),
+            "rejecting writable path under sensitive system directory"
+        );
+        return false;
+    }
+
+    if dir.exists() {
+        paths.push(dir.to_path_buf());
+        true
+    } else if dir
+        .ancestors()
+        .skip(1)
+        .find(|ancestor| ancestor.exists())
+        .is_some_and(|ancestor| ancestor != Path::new("/"))
+    {
+        // Pre-create the directory so bwrap --bind can mount it.
+        // On cold starts (fresh CARGO_HOME/RUSTUP_HOME/shared npm cache) the
+        // dir or one of its intermediate parents won't exist yet; bwrap
+        // requires the source path to be present.
+        match std::fs::create_dir_all(dir) {
+            Ok(()) => {
+                paths.push(dir.to_path_buf());
+                true
+            }
+            Err(e) => {
+                tracing::warn!(
+                    path = %dir.display(),
+                    error = %e,
+                    "failed to pre-create directory for sandbox writable mount, skipping"
+                );
+                false
+            }
+        }
+    } else {
+        false
+    }
 }

--- a/crates/csa-resource/src/isolation_plan_rust_env.rs
+++ b/crates/csa-resource/src/isolation_plan_rust_env.rs
@@ -1,0 +1,41 @@
+//! Rust toolchain state-path resolution and env override logic for the isolation plan.
+//!
+//! When `CARGO_HOME` or `RUSTUP_HOME` points at a read-only system prefix
+//! (typically `/usr/local`), the sandbox must both (a) add the writable
+//! default (`~/.cargo` / `~/.rustup`) to `writable_paths`, and (b) override
+//! the env var itself in `env_overrides` so the child process uses the
+//! writable path instead of the original read-only one (#2607).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Resolve a Rust state path, falling back to the default when the original
+/// needs session override.
+pub(crate) fn resolve_rust_state_path(value: &str, default: &Path) -> PathBuf {
+    let path = PathBuf::from(value);
+    if value.trim().is_empty() || csa_core::env::rust_state_path_needs_session_override(&path) {
+        default.to_path_buf()
+    } else {
+        path
+    }
+}
+
+/// If the original env value pointed at a read-only system prefix, insert an
+/// override mapping it to the writable default. Returns `true` when an
+/// override was inserted.
+pub(crate) fn insert_env_override_if_needed(
+    env_overrides: &mut HashMap<String, String>,
+    env_key: &str,
+    original_value: &str,
+    default_path: &Path,
+) -> bool {
+    if csa_core::env::rust_state_path_needs_session_override(&PathBuf::from(original_value)) {
+        env_overrides.insert(
+            env_key.to_string(),
+            default_path.to_string_lossy().into_owned(),
+        );
+        true
+    } else {
+        false
+    }
+}

--- a/crates/csa-resource/src/isolation_plan_rust_env_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_rust_env_tests.rs
@@ -65,3 +65,38 @@ fn tool_defaults_do_not_expose_usr_local_as_rust_state_home() {
     assert!(plan.writable_paths.contains(&home.join(".rustup")));
     assert!(!plan.writable_paths.contains(&PathBuf::from("/usr/local")));
 }
+
+#[test]
+fn tool_defaults_override_cargo_home_env_when_usr_local_is_readonly() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(home.join(".cargo")).unwrap();
+    std::fs::create_dir_all(home.join(".rustup")).unwrap();
+    let _home = ScopedEnvVar::set("HOME", &home);
+    let _xdg = ScopedEnvVar::unset("XDG_STATE_HOME");
+    let _cargo_home = ScopedEnvVar::set(csa_core::env::CARGO_HOME_ENV_KEY, "/usr/local");
+    let _rustup_home = ScopedEnvVar::set(csa_core::env::RUSTUP_HOME_ENV_KEY, "/usr/local");
+
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_tool_defaults(
+            "codex",
+            &PathBuf::from("/tmp/project"),
+            &PathBuf::from("/tmp/session"),
+        )
+        .build()
+        .expect("should succeed");
+
+    // The env var must be overridden to the writable default (#2607).
+    assert_eq!(
+        plan.env_overrides.get(csa_core::env::CARGO_HOME_ENV_KEY),
+        Some(&home.join(".cargo").to_string_lossy().to_string()),
+        "CARGO_HOME must be overridden to writable ~/.cargo when original is /usr/local"
+    );
+    assert_eq!(
+        plan.env_overrides.get(csa_core::env::RUSTUP_HOME_ENV_KEY),
+        Some(&home.join(".rustup").to_string_lossy().to_string()),
+        "RUSTUP_HOME must be overridden to writable ~/.rustup when original is /usr/local"
+    );
+}


### PR DESCRIPTION
## Problem

When CARGO_HOME or RUSTUP_HOME points at a read-only system prefix like `/usr/local`, the sandbox already adds `~/.cargo` and `~/.rustup` as writable paths. But the child process still inherited the original `CARGO_HOME=/usr/local` env var, so plain `cargo build` commands (not wrapped by `cargo-env-normalize.sh`) tried to write to `/usr/local/registry/cache/...` and failed with EROFS.

## Fix

Added env override in `isolation_plan.rs`: when `rust_state_path_needs_session_override` detects the read-only source path, `env_overrides` now sets `CARGO_HOME` and `RUSTUP_HOME` to the writable default (`~/.cargo` / `~/.rustup`).

## Refactoring

Extracted `add_dir_or_creatable_parent`, `runtime_daemon_socket_paths`, and `sandbox_tmpdir_for_capability` into `isolation_plan_runtime_path.rs` and rust-state env logic into `isolation_plan_rust_env.rs` to stay under the 8000-token monolith budget.

## Tests

- New: `tool_defaults_override_cargo_home_env_when_usr_local_is_readonly`
- All 139 csa-resource tests pass

Closes #2607