### PR TITLE
fix(diagnostics): classify earlyoom SIGTERM with --prefer list (#2604, #2605)

### DIFF
--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_earlyoom_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_earlyoom_tests.rs
@@ -1,0 +1,69 @@
+use chrono::Utc;
+
+use super::render_wait_result_summary;
+
+#[test]
+fn compact_summary_includes_unknown_signal_evidence() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let now = Utc::now();
+    let diagnostic = "CSA diagnostic: signal kill hint: unknown_signal (termination_reason=sigterm, MemAvailable: 12000 MB / MemTotal: 16000 MB, earlyoom not running, cgroup memory.events oom=0 oom_kill=0). No timeout or cgroup OOM evidence was found, and memory checks did not identify a concrete kill source; reason remains unknown.";
+    let result = csa_session::SessionResult {
+        post_exec_gate: None,
+        status: "signal".to_string(),
+        exit_code: 143,
+        summary: diagnostic.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        kill_hint: Some("unknown_signal".to_string()),
+        last_item: None,
+        fallback_chain: None,
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTWAITUNKNOWN", &result);
+
+    assert!(summary.contains("Kill hint: unknown_signal"));
+    assert!(summary.contains("termination_reason=sigterm"));
+    assert!(summary.contains("cgroup memory.events oom=0 oom_kill=0"));
+    assert!(summary.contains("reason remains unknown"));
+}
+
+#[test]
+fn compact_summary_includes_earlyoom_prefer_list_hint() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let now = Utc::now();
+    let diagnostic = "CSA diagnostic: signal kill hint: earlyoom (termination_reason=daemon_sigterm, MemAvailable: 14242 MB / MemTotal: 31792 MB, earlyoom running, cgroup memory.events: unavailable at expected session scope). Re-dispatch when host memory frees. If earlyoom has a --prefer list that includes csa/cargo, consider removing it or raising the threshold (-m) to avoid premature kills.";
+    let result = csa_session::SessionResult {
+        post_exec_gate: None,
+        status: "signal".to_string(),
+        exit_code: 143,
+        summary: diagnostic.to_string(),
+        tool: "codex".to_string(),
+        original_tool: None,
+        fallback_tool: None,
+        fallback_reason: None,
+        started_at: now,
+        completed_at: now,
+        events_count: 0,
+        artifacts: Vec::new(),
+        peak_memory_mb: None,
+        kill_hint: Some("earlyoom".to_string()),
+        last_item: None,
+        fallback_chain: None,
+        ..Default::default()
+    };
+
+    let summary = render_wait_result_summary(temp.path(), "01TESTEARLYOOM", &result);
+
+    assert!(summary.contains("Kill hint: earlyoom"));
+    assert!(summary.contains("termination_reason=daemon_sigterm"));
+    assert!(summary.contains("earlyoom running"));
+    assert!(summary.contains("--prefer list"));
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -5,6 +5,8 @@ use super::{
     render_wait_result_summary,
 };
 
+#[path = "session_cmds_daemon_wait_summary_earlyoom_tests.rs"]
+mod earlyoom_tests;
 #[path = "session_cmds_daemon_wait_summary_kill_tests.rs"]
 mod kill_diagnostics;
 #[path = "session_cmds_daemon_wait_summary_provider_quota_tests.rs"]
@@ -208,39 +210,6 @@ fn compact_summary_prefers_post_exec_gate_failure_over_success_markdown() {
         !summary.contains("working tree clean"),
         "wait summary must not show child success markdown as authoritative: {summary}"
     );
-}
-
-#[test]
-fn compact_summary_includes_unknown_signal_evidence() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let now = Utc::now();
-    let diagnostic = "CSA diagnostic: signal kill hint: unknown_signal (termination_reason=sigterm, MemAvailable: 12000 MB / MemTotal: 16000 MB, earlyoom not running, cgroup memory.events oom=0 oom_kill=0). No timeout or cgroup OOM evidence was found, and memory checks did not identify a concrete kill source; reason remains unknown.";
-    let result = csa_session::SessionResult {
-        post_exec_gate: None,
-        status: "signal".to_string(),
-        exit_code: 143,
-        summary: diagnostic.to_string(),
-        tool: "codex".to_string(),
-        original_tool: None,
-        fallback_tool: None,
-        fallback_reason: None,
-        started_at: now,
-        completed_at: now,
-        events_count: 0,
-        artifacts: Vec::new(),
-        peak_memory_mb: None,
-        kill_hint: Some("unknown_signal".to_string()),
-        last_item: None,
-        fallback_chain: None,
-        ..Default::default()
-    };
-
-    let summary = render_wait_result_summary(temp.path(), "01TESTWAITUNKNOWN", &result);
-
-    assert!(summary.contains("Kill hint: unknown_signal"));
-    assert!(summary.contains("termination_reason=sigterm"));
-    assert!(summary.contains("cgroup memory.events oom=0 oom_kill=0"));
-    assert!(summary.contains("reason remains unknown"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_kill_diagnostics.rs
+++ b/crates/cli-sub-agent/src/session_kill_diagnostics.rs
@@ -205,7 +205,7 @@ impl KillDiagnostic {
         let details = self.detail_parts().join(", ");
         let suffix = match self.hint {
             KillHint::Earlyoom | KillHint::MemoryPressure | KillHint::PossibleMemoryPressure => {
-                "Re-dispatch when host memory frees."
+                "Re-dispatch when host memory frees. If earlyoom has a --prefer list that includes csa/cargo, consider removing it or raising the threshold (-m) to avoid premature kills."
             }
             KillHint::CsaTimeout => "The recorded timeout is the concrete kill reason.",
             KillHint::MemorySoftLimit => {
@@ -524,6 +524,19 @@ fn classify_signal_kill(
         KillHint::Earlyoom
     } else if strong_memory_pressure {
         KillHint::MemoryPressure
+    } else if observations.earlyoom_running
+        && exit_code == 143
+        && matches!(
+            terminal_reason.as_deref(),
+            Some("sigterm" | "daemon_sigterm")
+        )
+    {
+        // earlyoom is configured with --prefer lists that target CSA/cargo
+        // processes. Even when current MemAvailable looks healthy at
+        // diagnostic time, a transient spike or the prefer list can cause
+        // earlyoom to send SIGTERM. Report this as earlyoom rather than
+        // unknown_signal so the user gets actionable guidance (#2604, #2605).
+        KillHint::Earlyoom
     } else if possible_low_memory {
         KillHint::PossibleMemoryPressure
     } else if exit_code == 143


### PR DESCRIPTION
## Problem

CSA sessions (#2604 mktd recon, #2605 review) were killed by earlyoom SIGTERM but reported as `unknown_signal` with "reason remains unknown."

Root cause: earlyoom is configured with `--prefer ^(cargo|rustc|csa|...)$`, which targets CSA/cargo processes for killing even when overall MemAvailable is healthy (14GB/31GB = 45%). The previous `classify_signal_kill` only reported `KillHint::Earlyoom` when `strong_memory_pressure` (<5% available or cgroup OOM kill) was true.

## Fix

In `classify_signal_kill()` (`session_kill_diagnostics.rs`), added a new branch: when earlyoom is running AND exit code is 143 AND terminal_reason is `sigterm` or `daemon_sigterm`, classify as `KillHint::Earlyoom` regardless of current MemAvailable. This handles the transient-spike / prefer-list scenario.

Updated the guidance suffix to mention the `--prefer` list so users know to check earlyoom config.

## Tests

- `compact_summary_includes_earlyoom_prefer_list_hint` — verifies the new classification renders correctly in wait summary
- Moved `compact_summary_includes_unknown_signal_evidence` to separate file to stay under monolith budget
- All 10 earlyoom/unknown_signal tests pass

Closes #2604, closes #2605