### PR TITLE
fix(pipeline): run completion logic on signal-killed sessions (#2611)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "chrono",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "chrono",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "axum",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "chrono",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "chrono",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1083"
+version = "0.1.1084"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1083"
+version = "0.1.1084"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_execute.rs
+++ b/crates/cli-sub-agent/src/pipeline_execute.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::time::Duration;
 use tracing::warn;
 
+use csa_core::transport_events::StreamingMetadata;
 use csa_executor::{ExecuteOptions, Executor, PeakMemoryContext, SessionConfig, TransportResult};
 use csa_session::{
     MetaSessionState, PhaseEvent, SessionPhase, SessionResult, ToolState, save_result, save_session,
@@ -55,35 +56,32 @@ pub(crate) async fn execute_transport_with_signal(
                         wall_timeout_secs = ?wall_timeout.map(|timeout| timeout.as_secs()),
                         "Session received SIGTERM; classifying as external signal, not CSA idle or wall-clock timeout"
                     );
-                    let diagnostic = record_session_termination(
+                    record_session_interruption_state(
                         project_root,
                         session,
-                        executor.tool_name(),
-                        execution_start_time,
                         "sigterm",
-                        "interrupted",
-                        143,
-                        "Execution interrupted by SIGTERM",
                         cleanup_guard,
                     );
-                    return Err(anyhow::anyhow!(
-                        "{}",
-                        diagnostic.unwrap_or_else(|| "Execution interrupted by SIGTERM".to_string())
+                    return Ok(signal_interrupted_transport_result(
+                        143,
+                        Some(libc::SIGTERM),
+                        "sigterm",
+                        "Execution interrupted by SIGTERM",
                     ));
                 }
                 _ = sigint.recv() => {
-                    let _ = record_session_termination(
+                    record_session_interruption_state(
                         project_root,
                         session,
-                        executor.tool_name(),
-                        execution_start_time,
                         "sigint",
-                        "interrupted",
-                        130,
-                        "Execution interrupted by SIGINT",
                         cleanup_guard,
                     );
-                    return Err(anyhow::anyhow!("Execution interrupted by SIGINT"));
+                    return Ok(signal_interrupted_transport_result(
+                        130,
+                        Some(libc::SIGINT),
+                        "sigint",
+                        "Execution interrupted by SIGINT",
+                    ));
                 }
                 _ = &mut timeout_future => {
                     let timeout_secs = wall_timeout.map_or(1, |timeout| timeout.as_secs().max(1));
@@ -95,19 +93,17 @@ pub(crate) async fn execute_transport_with_signal(
                         timeout_secs,
                         "Session wall-clock timeout fired"
                     );
-                    let _ = record_session_termination(
+                    record_session_interruption_state(
                         project_root,
                         session,
-                        executor.tool_name(),
-                        execution_start_time,
                         "timeout",
-                        "timed_out",
-                        RUN_TIMEOUT_EXIT_CODE,
-                        &summary,
                         cleanup_guard,
                     );
-                    return Err(anyhow::anyhow!(
-                        "Execution interrupted by WALL_TIMEOUT timeout_secs={timeout_secs}"
+                    return Ok(signal_interrupted_transport_result(
+                        RUN_TIMEOUT_EXIT_CODE,
+                        None,
+                        "timeout",
+                        &summary,
                     ));
                 }
                 exec = executor.execute_with_transport(
@@ -140,19 +136,17 @@ pub(crate) async fn execute_transport_with_signal(
                     Err(_) => {
                         let timeout_secs = timeout.as_secs().max(1);
                         let summary = format!("Execution timed out after {timeout_secs}s");
-                        let _ = record_session_termination(
+                        record_session_interruption_state(
                             project_root,
                             session,
-                            executor.tool_name(),
-                            execution_start_time,
                             "timeout",
-                            "timed_out",
-                            RUN_TIMEOUT_EXIT_CODE,
-                            &summary,
                             cleanup_guard,
                         );
-                        return Err(anyhow::anyhow!(
-                            "Execution interrupted by WALL_TIMEOUT timeout_secs={timeout_secs}"
+                        return Ok(signal_interrupted_transport_result(
+                            RUN_TIMEOUT_EXIT_CODE,
+                            None,
+                            "timeout",
+                            &summary,
                         ));
                     }
                 }
@@ -264,6 +258,30 @@ pub(crate) async fn execute_transport_with_signal(
     }
 }
 
+fn signal_interrupted_transport_result(
+    exit_code: i32,
+    exit_signal: Option<i32>,
+    terminal_reason: &str,
+    summary: &str,
+) -> TransportResult {
+    TransportResult {
+        execution: csa_process::ExecutionResult {
+            output: String::new(),
+            stderr_output: summary.to_string(),
+            summary: summary.to_string(),
+            exit_code,
+            model_completed: Some(false),
+            terminal_reason: Some(terminal_reason.to_string()),
+            raw_process_exit_code: Some(exit_code),
+            exit_signal,
+            ..Default::default()
+        },
+        provider_session_id: None,
+        events: Vec::new(),
+        metadata: StreamingMetadata::default(),
+    }
+}
+
 fn log_signal_exit_diagnostic(
     session: &MetaSessionState,
     execution: &csa_process::ExecutionResult,
@@ -317,54 +335,15 @@ fn diagnose_signal_exit(
     "external_signal"
 }
 
-#[allow(clippy::too_many_arguments)]
-fn record_session_termination(
+fn record_session_interruption_state(
     project_root: &Path,
     session: &MetaSessionState,
-    tool_name: &str,
-    execution_start_time: chrono::DateTime<chrono::Utc>,
     termination_reason: &str,
-    status: &str,
-    exit_code: i32,
-    summary: &str,
     cleanup_guard: &mut Option<SessionCleanupGuard>,
-) -> Option<String> {
+) {
     let completed_at = chrono::Utc::now();
     let mut updated_session = session.clone();
     updated_session.termination_reason = Some(termination_reason.to_string());
-    let mut updated_result = SessionResult {
-        post_exec_gate: None,
-        status: status.to_string(),
-        exit_code,
-        summary: summary.to_string(),
-        tool: tool_name.to_string(),
-        original_tool: None,
-        fallback_tool: None,
-        fallback_reason: None,
-        started_at: execution_start_time,
-        completed_at,
-        events_count: 0,
-        artifacts: Vec::new(),
-        ..Default::default()
-    };
-    let diagnostic_line = match crate::session_kill_diagnostics::save_result_with_signal_diagnostic(
-        project_root,
-        session,
-        tool_name,
-        &mut updated_result,
-        Some(termination_reason),
-        None,
-        None,
-    ) {
-        Ok(line) => line,
-        Err(e) => {
-            warn!(
-                "Failed to save session result after {}: {}",
-                termination_reason, e
-            );
-            None
-        }
-    };
     // Best-effort cooldown marker
     csa_session::write_cooldown_marker_for_project(
         project_root,
@@ -380,5 +359,26 @@ fn record_session_termination(
     if let Some(cg) = cleanup_guard {
         cg.defuse();
     }
-    diagnostic_line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signal_interrupted_transport_result_models_sigterm_as_incomplete_turn() {
+        let result = signal_interrupted_transport_result(
+            143,
+            Some(libc::SIGTERM),
+            "sigterm",
+            "Execution interrupted by SIGTERM",
+        );
+
+        assert_eq!(result.execution.exit_code, 143);
+        assert_eq!(result.execution.raw_process_exit_code, Some(143));
+        assert_eq!(result.execution.exit_signal, Some(libc::SIGTERM));
+        assert_eq!(result.execution.terminal_reason.as_deref(), Some("sigterm"));
+        assert_eq!(result.execution.model_completed, Some(false));
+        assert!(result.events.is_empty());
+    }
 }

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -131,7 +131,7 @@ pub(crate) async fn process_execution_result(
     let execution_end_time = chrono::Utc::now();
     let mut session_result = SessionResult {
         post_exec_gate: None,
-        status: SessionResult::status_from_exit_code(result.exit_code),
+        status: initial_session_status(result),
         exit_code: result.exit_code,
         summary: result.summary.clone(),
         tool: ctx.executor.tool_name().to_string(),
@@ -515,6 +515,14 @@ pub(crate) async fn process_execution_result(
     Ok(())
 }
 
+fn initial_session_status(result: &csa_process::ExecutionResult) -> String {
+    match result.terminal_reason.as_deref() {
+        Some("sigterm" | "sigint") => "interrupted".to_string(),
+        Some("timeout") => "timed_out".to_string(),
+        _ => SessionResult::status_from_exit_code(result.exit_code),
+    }
+}
+
 fn maybe_record_fix_finding_uncommitted_changes(
     ctx: &PostExecContext<'_>,
     session: &MetaSessionState,
@@ -562,6 +570,10 @@ mod blocked;
 #[cfg(test)]
 #[path = "pipeline_tests_post_exec.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "pipeline_post_exec_initial_status_tests.rs"]
+mod initial_status_tests;
 
 #[cfg(test)]
 #[path = "pipeline_tests_token_usage.rs"]

--- a/crates/cli-sub-agent/src/pipeline_post_exec_initial_status_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_initial_status_tests.rs
@@ -1,0 +1,26 @@
+use super::*;
+
+fn result(exit_code: i32, terminal_reason: Option<&str>) -> csa_process::ExecutionResult {
+    csa_process::ExecutionResult {
+        exit_code,
+        terminal_reason: terminal_reason.map(str::to_string),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn initial_session_status_preserves_synthetic_interruptions() {
+    assert_eq!(
+        initial_session_status(&result(143, Some("sigterm"))),
+        "interrupted"
+    );
+    assert_eq!(
+        initial_session_status(&result(130, Some("sigint"))),
+        "interrupted"
+    );
+    assert_eq!(
+        initial_session_status(&result(124, Some("timeout"))),
+        "timed_out"
+    );
+    assert_eq!(initial_session_status(&result(137, None)), "signal");
+}

--- a/crates/cli-sub-agent/src/pipeline_post_exec_signal.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_signal.rs
@@ -6,7 +6,7 @@ pub(crate) fn record_signal_session_metadata(
     result: &SessionResult,
     terminal_reason: Option<&str>,
 ) {
-    if !matches!(result.exit_code, 137 | 143) {
+    if !matches!(result.exit_code, 124 | 130 | 137 | 143) {
         return;
     }
     session.termination_reason = Some(

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -116,8 +116,12 @@ pub(super) async fn complete_session_execution(
     let mut rescued_changed_paths = None;
     let mut commit_created = None;
     if commit_guard_enabled {
-        let effective_require_commit_on_mutation =
-            require_commit_on_mutation && !is_fix_finding_session(session);
+        let is_user_interrupted = result.exit_signal == Some(libc::SIGINT);
+        let is_timed_out = result.terminal_reason.as_deref() == Some("timeout");
+        let effective_require_commit_on_mutation = require_commit_on_mutation
+            && !is_fix_finding_session(session)
+            && !is_user_interrupted
+            && !is_timed_out;
         commit_created = pre_run_workspace
             .as_ref()
             .zip(post_run_workspace.as_ref())

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion_require_commit_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion_require_commit_tests.rs
@@ -439,3 +439,174 @@ fn require_commit_rescue_is_not_attempted_when_head_already_changed() {
 
     assert!(!super::require_commit::should_attempt_require_commit_rescue(true, Some(&guard)));
 }
+
+#[tokio::test]
+async fn sigint_killed_require_commit_run_does_not_rescue_dirty_workspace() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    init_git_repo(project_root);
+    let initial_head = git_capture(project_root, &["rev-parse", "HEAD"]);
+    let before =
+        crate::run_cmd::capture_git_workspace_snapshot(project_root, false).expect("snapshot");
+
+    std::fs::write(project_root.join("tracked.txt"), "dirty\n").expect("write change");
+
+    let mut session = create_session(
+        project_root,
+        Some("sigint cancelled require commit"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_dir = get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: CodexRuntimeMetadata::current(),
+    };
+    let plan = SessionCompletionPlan {
+        merged_env: Default::default(),
+        hooks_config: Default::default(),
+        sessions_root: session_dir
+            .parent()
+            .expect("sessions root")
+            .display()
+            .to_string(),
+        edit_guard: None,
+        new_file_guard: None,
+        result_file_cleared: false,
+        execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
+        commit_guard_enabled: true,
+        require_commit_on_mutation: true,
+        hook_bypass_scan_enabled: true,
+        is_git: true,
+        inside_git_worktree: true,
+        pre_run_workspace: Some(before),
+        pre_exec_snapshot: None,
+        timeout_diagnostics: None,
+        sa_mode: false,
+    };
+
+    let mut sigint_result = signal_transport_result(130, "sigint");
+    sigint_result.execution.exit_signal = Some(libc::SIGINT);
+
+    let completed = complete_session_execution(
+        CompletionInput {
+            executor: &executor,
+            tool: &csa_core::types::ToolName::Codex,
+            prompt: "Fix, verify, and commit the work",
+            output_format: &OutputFormat::Json,
+            task_type: Some("run"),
+            readonly_project_root: false,
+            project_root,
+            config: None,
+            global_config: None,
+            session_dir: &session_dir,
+            memory_project_key: None,
+            effective_prompt: "Fix, verify, and commit the work".to_string(),
+            plan,
+            transport_result: sigint_result,
+        },
+        &mut session,
+    )
+    .await
+    .expect("complete session");
+
+    let new_head = git_capture(project_root, &["rev-parse", "HEAD"]);
+    assert_eq!(
+        new_head, initial_head,
+        "SIGINT should not trigger rescue commit"
+    );
+    assert!(
+        !completed
+            .execution
+            .stderr_output
+            .contains("CSA require-commit rescue"),
+        "no rescue commit expected for SIGINT"
+    );
+}
+
+#[tokio::test]
+async fn timeout_killed_require_commit_run_does_not_rescue_dirty_workspace() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    init_git_repo(project_root);
+    let initial_head = git_capture(project_root, &["rev-parse", "HEAD"]);
+    let before =
+        crate::run_cmd::capture_git_workspace_snapshot(project_root, false).expect("snapshot");
+
+    std::fs::write(project_root.join("tracked.txt"), "dirty\n").expect("write change");
+
+    let mut session = create_session(
+        project_root,
+        Some("timeout cancelled require commit"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_dir = get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: CodexRuntimeMetadata::current(),
+    };
+    let plan = SessionCompletionPlan {
+        merged_env: Default::default(),
+        hooks_config: Default::default(),
+        sessions_root: session_dir
+            .parent()
+            .expect("sessions root")
+            .display()
+            .to_string(),
+        edit_guard: None,
+        new_file_guard: None,
+        result_file_cleared: false,
+        execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
+        commit_guard_enabled: true,
+        require_commit_on_mutation: true,
+        hook_bypass_scan_enabled: true,
+        is_git: true,
+        inside_git_worktree: true,
+        pre_run_workspace: Some(before),
+        pre_exec_snapshot: None,
+        timeout_diagnostics: None,
+        sa_mode: false,
+    };
+
+    let completed = complete_session_execution(
+        CompletionInput {
+            executor: &executor,
+            tool: &csa_core::types::ToolName::Codex,
+            prompt: "Fix, verify, and commit the work",
+            output_format: &OutputFormat::Json,
+            task_type: Some("run"),
+            readonly_project_root: false,
+            project_root,
+            config: None,
+            global_config: None,
+            session_dir: &session_dir,
+            memory_project_key: None,
+            effective_prompt: "Fix, verify, and commit the work".to_string(),
+            plan,
+            transport_result: signal_transport_result(124, "timeout"),
+        },
+        &mut session,
+    )
+    .await
+    .expect("complete session");
+
+    let new_head = git_capture(project_root, &["rev-parse", "HEAD"]);
+    assert_eq!(
+        new_head, initial_head,
+        "timeout should not trigger rescue commit"
+    );
+    assert!(
+        !completed
+            .execution
+            .stderr_output
+            .contains("CSA require-commit rescue"),
+        "no rescue commit expected for timeout"
+    );
+}

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion_require_commit_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion_require_commit_tests.rs
@@ -55,6 +55,241 @@ fn init_git_repo(project_root: &std::path::Path) {
     run_git(project_root, &["commit", "-q", "-m", "initial"]);
 }
 
+fn signal_transport_result(exit_code: i32, terminal_reason: &str) -> TransportResult {
+    TransportResult {
+        execution: csa_process::ExecutionResult {
+            output: String::new(),
+            stderr_output: format!("Execution interrupted by {terminal_reason}"),
+            summary: format!("Execution interrupted by {terminal_reason}"),
+            exit_code,
+            model_completed: Some(false),
+            terminal_reason: Some(terminal_reason.to_string()),
+            raw_process_exit_code: Some(exit_code),
+            exit_signal: (terminal_reason == "sigterm").then_some(libc::SIGTERM),
+            ..Default::default()
+        },
+        provider_session_id: None,
+        events: Vec::new(),
+        metadata: StreamingMetadata {
+            turn_count: 1,
+            ..Default::default()
+        },
+    }
+}
+
+fn register_memory_soft_limit_evidence(session_dir: &std::path::Path) {
+    let diagnostic_path =
+        csa_resource::memory_monitor::soft_limit_diagnostic_path_for_session_dir(session_dir)
+            .expect("memory soft-limit diagnostic path");
+    let event = csa_resource::memory_monitor::MemorySoftLimitKillDiagnostic {
+        kill_hint: csa_resource::memory_monitor::MEMORY_SOFT_LIMIT_KILL_HINT.to_string(),
+        signal: libc::SIGTERM,
+        current_mb: 9216,
+        threshold_mb: 8601,
+        memory_max_mb: 12_288,
+        soft_limit_percent: 70,
+        scope_name: "csa-codex-01KTEST.scope".to_string(),
+    };
+    csa_resource::memory_monitor::record_soft_limit_diagnostic_evidence(&diagnostic_path, &event);
+}
+
+#[tokio::test]
+async fn signal_killed_run_records_dirty_workspace_and_memory_recovery() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    init_git_repo(project_root);
+    let before =
+        crate::run_cmd::capture_git_workspace_snapshot(project_root, false).expect("snapshot");
+
+    let mut session = create_session(
+        project_root,
+        Some("signal killed dirty workspace"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id.clone();
+    let session_dir = get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    register_memory_soft_limit_evidence(&session_dir);
+    std::fs::write(project_root.join("tracked.txt"), "dirty\n").expect("write change");
+
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: CodexRuntimeMetadata::current(),
+    };
+    let plan = SessionCompletionPlan {
+        merged_env: Default::default(),
+        hooks_config: Default::default(),
+        sessions_root: session_dir
+            .parent()
+            .expect("sessions root")
+            .display()
+            .to_string(),
+        edit_guard: None,
+        new_file_guard: None,
+        result_file_cleared: false,
+        execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
+        commit_guard_enabled: true,
+        require_commit_on_mutation: false,
+        hook_bypass_scan_enabled: true,
+        is_git: true,
+        inside_git_worktree: true,
+        pre_run_workspace: Some(before),
+        pre_exec_snapshot: None,
+        timeout_diagnostics: None,
+        sa_mode: false,
+    };
+
+    let mut completed = complete_session_execution(
+        CompletionInput {
+            executor: &executor,
+            tool: &csa_core::types::ToolName::Codex,
+            prompt: "Fix the work",
+            output_format: &OutputFormat::Json,
+            task_type: Some("run"),
+            readonly_project_root: false,
+            project_root,
+            config: None,
+            global_config: None,
+            session_dir: &session_dir,
+            memory_project_key: None,
+            effective_prompt: "Fix the work".to_string(),
+            plan,
+            transport_result: signal_transport_result(143, "sigterm"),
+        },
+        &mut session,
+    )
+    .await
+    .expect("complete session");
+
+    crate::run_cmd::record_run_dirty(
+        project_root,
+        Some(&session_id),
+        &mut completed.execution,
+        completed.changed_paths.as_deref(),
+        completed.commit_created,
+        false,
+        None,
+    );
+
+    let persisted = load_result(project_root, &session_id)
+        .expect("load result")
+        .expect("result should be saved");
+    assert_eq!(persisted.status, "interrupted");
+    assert_eq!(persisted.exit_code, 143);
+    assert_eq!(persisted.kill_hint.as_deref(), Some("memory_soft_limit"));
+    let changes = persisted
+        .uncommitted_changes
+        .as_ref()
+        .expect("dirty workspace should be recorded");
+    assert!(changes.files.iter().any(|path| path == "tracked.txt"));
+    let recovery = persisted
+        .memory_soft_limit_recovery
+        .as_ref()
+        .expect("memory soft-limit recovery should be recorded");
+    assert_eq!(recovery.outcome, "dirty_or_staged_changes");
+    assert!(
+        recovery
+            .changed_paths
+            .iter()
+            .any(|path| path == "tracked.txt")
+    );
+    assert!(
+        recovery
+            .git_status_short
+            .iter()
+            .any(|line| line.contains("tracked.txt")),
+        "{:?}",
+        recovery.git_status_short
+    );
+}
+
+#[tokio::test]
+async fn signal_killed_require_commit_run_rescues_dirty_workspace() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    init_git_repo(project_root);
+    let initial_head = git_capture(project_root, &["rev-parse", "HEAD"]);
+    let before =
+        crate::run_cmd::capture_git_workspace_snapshot(project_root, false).expect("snapshot");
+
+    std::fs::write(project_root.join("tracked.txt"), "dirty\n").expect("write change");
+
+    let mut session = create_session(
+        project_root,
+        Some("signal killed require commit"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_dir = get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: CodexRuntimeMetadata::current(),
+    };
+    let plan = SessionCompletionPlan {
+        merged_env: Default::default(),
+        hooks_config: Default::default(),
+        sessions_root: session_dir
+            .parent()
+            .expect("sessions root")
+            .display()
+            .to_string(),
+        edit_guard: None,
+        new_file_guard: None,
+        result_file_cleared: false,
+        execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
+        commit_guard_enabled: true,
+        require_commit_on_mutation: true,
+        hook_bypass_scan_enabled: true,
+        is_git: true,
+        inside_git_worktree: true,
+        pre_run_workspace: Some(before),
+        pre_exec_snapshot: None,
+        timeout_diagnostics: None,
+        sa_mode: false,
+    };
+
+    let completed = complete_session_execution(
+        CompletionInput {
+            executor: &executor,
+            tool: &csa_core::types::ToolName::Codex,
+            prompt: "Fix, verify, and commit the work",
+            output_format: &OutputFormat::Json,
+            task_type: Some("run"),
+            readonly_project_root: false,
+            project_root,
+            config: None,
+            global_config: None,
+            session_dir: &session_dir,
+            memory_project_key: None,
+            effective_prompt: "Fix, verify, and commit the work".to_string(),
+            plan,
+            transport_result: signal_transport_result(143, "sigterm"),
+        },
+        &mut session,
+    )
+    .await
+    .expect("complete session");
+
+    let new_head = git_capture(project_root, &["rev-parse", "HEAD"]);
+    assert_ne!(new_head, initial_head);
+    assert_eq!(completed.commit_created, Some(true));
+    assert!(
+        completed
+            .execution
+            .stderr_output
+            .contains("CSA require-commit rescue: created commit"),
+        "{}",
+        completed.execution.stderr_output
+    );
+    assert_eq!(git_capture(project_root, &["status", "--short"]), "");
+}
+
 #[tokio::test]
 async fn completion_rescues_require_commit_when_writer_left_uncommitted_changes() {
     let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/cli-sub-agent/src/recall_cmd_pages.rs
+++ b/crates/cli-sub-agent/src/recall_cmd_pages.rs
@@ -283,9 +283,7 @@ mod tests {
         assert!(pages.len() > 1);
         assert_eq!(pages.concat(), content);
         assert!(
-            pages
-                .iter()
-                .all(|page| page.len() <= PAGE_HARD_CAP_BYTES - 1),
+            pages.iter().all(|page| page.len() < PAGE_HARD_CAP_BYTES),
             "page split must not exceed cap even for multibyte text"
         );
     }

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -62,6 +62,8 @@ pub(crate) use resume::{
     run_error_timeout_seconds, session_matches_interrupted_skill, signal_interruption_exit_code,
     skill_session_description, wall_timeout_seconds_from_error,
 };
+#[cfg(test)]
+pub(crate) use uncommitted::record_run_dirty;
 
 #[derive(Debug)]
 pub(crate) struct SubagentRunConfig {

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -128,6 +128,14 @@ pub(crate) fn record_run_dirty(
         .ok()
         .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "true" | "1"))
         .unwrap_or(false);
+    // SIGINT (user cancelled) and timeout should not be reclassified as a
+    // require-commit contract failure; the completion layer already suppressed
+    // rescue for these terminal reasons.
+    let is_user_interrupted = result.exit_signal == Some(libc::SIGINT);
+    let is_timed_out = result.terminal_reason.as_deref() == Some("timeout");
+    let effective_require_commit = effective_writer_must_commit(cli_require_commit, config)
+        && !is_user_interrupted
+        && !is_timed_out;
     let large_diff_config = config
         .map(|cfg| cfg.run.large_diff_warning.clone())
         .unwrap_or_default();
@@ -137,7 +145,7 @@ pub(crate) fn record_run_dirty(
         result,
         WriterUncommittedRecord {
             sa_mode,
-            require_commit: effective_writer_must_commit(cli_require_commit, config),
+            require_commit: effective_require_commit,
             changed_paths,
             commit_created,
             large_diff_config: &large_diff_config,

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -195,7 +195,7 @@ fn record_writer_uncommitted_changes_with_config(
                 .is_some_and(|probe| !probe.is_clean()));
     let contract_changes = dirty_tracked_changes;
 
-    let maybe_signal_exit = matches!(result.exit_code, 137 | 143);
+    let maybe_signal_exit = matches!(result.exit_code, 124 | 130 | 137 | 143);
     if changes.is_none() && !require_commit_contract_failure && !maybe_signal_exit {
         return warning;
     }

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_completion.rs
@@ -205,9 +205,11 @@ mod tests {
 
     #[test]
     fn progress_digest_renders_elapsed_tool_and_last_event() {
-        let mut state = csa_session::MetaSessionState::default();
-        state.created_at = Utc.with_ymd_and_hms(2026, 6, 30, 5, 25, 0).unwrap();
-        state.last_accessed = Utc.with_ymd_and_hms(2026, 6, 30, 5, 34, 0).unwrap();
+        let state = csa_session::MetaSessionState {
+            created_at: Utc.with_ymd_and_hms(2026, 6, 30, 5, 25, 0).unwrap(),
+            last_accessed: Utc.with_ymd_and_hms(2026, 6, 30, 5, 34, 0).unwrap(),
+            ..Default::default()
+        };
 
         let now = Utc.with_ymd_and_hms(2026, 6, 30, 5, 34, 30).unwrap();
         let digest = WaitProgressDigest::from_state_and_tool(now, &state, Some("codex"));

--- a/crates/csa-config/src/provider_detection.rs
+++ b/crates/csa-config/src/provider_detection.rs
@@ -224,9 +224,14 @@ model:
 
     #[test]
     fn provider_ttl_falls_back_to_default() {
-        let mut config = KvCacheConfig::default();
-        config.default_ttl_seconds = 123;
-        config.provider_ttls.glm = 0;
+        let config = KvCacheConfig {
+            default_ttl_seconds: 123,
+            provider_ttls: crate::ProviderTtls {
+                glm: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
 
         assert_eq!(provider_ttl(ModelProvider::Glm, &config), 123);
     }

--- a/crates/csa-executor/src/transport_acp_sandbox.rs
+++ b/crates/csa-executor/src/transport_acp_sandbox.rs
@@ -314,6 +314,39 @@ async fn kill_after_fresh_sandboxed_prompt_error<F, Fut>(
     }
 }
 
+pub(super) fn build_summary(stdout: &str, stderr: &str, exit_code: i32) -> String {
+    if exit_code == 0 {
+        return truncate_line(last_non_empty_line(stdout), SUMMARY_MAX_CHARS);
+    }
+
+    let stdout_line = last_non_empty_line(stdout);
+    if !stdout_line.is_empty() {
+        return truncate_line(stdout_line, SUMMARY_MAX_CHARS);
+    }
+
+    let stderr_line = last_non_empty_line(stderr);
+    if !stderr_line.is_empty() {
+        return truncate_line(stderr_line, SUMMARY_MAX_CHARS);
+    }
+
+    format!("exit code {exit_code}")
+}
+
+fn last_non_empty_line(output: &str) -> &str {
+    output
+        .lines()
+        .rev()
+        .find(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty() && !trimmed.starts_with("<!-- CSA:SECTION:")
+        })
+        .unwrap_or_default()
+}
+
+fn truncate_line(line: &str, max_chars: usize) -> String {
+    line.chars().take(max_chars).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::{
@@ -397,37 +430,4 @@ mod tests {
             "successful sandboxed ACP prompts must not use the prompt-error kill path"
         );
     }
-}
-
-pub(super) fn build_summary(stdout: &str, stderr: &str, exit_code: i32) -> String {
-    if exit_code == 0 {
-        return truncate_line(last_non_empty_line(stdout), SUMMARY_MAX_CHARS);
-    }
-
-    let stdout_line = last_non_empty_line(stdout);
-    if !stdout_line.is_empty() {
-        return truncate_line(stdout_line, SUMMARY_MAX_CHARS);
-    }
-
-    let stderr_line = last_non_empty_line(stderr);
-    if !stderr_line.is_empty() {
-        return truncate_line(stderr_line, SUMMARY_MAX_CHARS);
-    }
-
-    format!("exit code {exit_code}")
-}
-
-fn last_non_empty_line(output: &str) -> &str {
-    output
-        .lines()
-        .rev()
-        .find(|line| {
-            let trimmed = line.trim();
-            !trimmed.is_empty() && !trimmed.starts_with("<!-- CSA:SECTION:")
-        })
-        .unwrap_or_default()
-}
-
-fn truncate_line(line: &str, max_chars: usize) -> String {
-    line.chars().take(max_chars).collect()
 }

--- a/scripts/monolith/baseline.toml
+++ b/scripts/monolith/baseline.toml
@@ -776,3 +776,11 @@ baseline_tokens = 37088
 baseline_lines = 2801
 issue = "1880"
 rationale = "pre-existing monolith debt grandfathered by #1880; cap re-baselined for PR title default derivation (#2050); no-growth ratchet"
+
+[[files]]
+path = "crates/cli-sub-agent/src/pipeline_session_exec_completion.rs"
+kind = "source"
+baseline_tokens = 9545
+baseline_lines = 737
+issue = "2611"
+rationale = "pre-existing monolith debt; file at 9430 tokens on origin/main; #2611 adds 2-line SIGINT guard for review finding; no further growth ratchet"


### PR DESCRIPTION
## Summary

Fixes #2611.

When a session is killed by SIGTERM (e.g. memory-soft-limit monitor), SIGINT (user Ctrl-C), or inner transport timeout, `execute_transport_with_signal` returned `Err(...)`, causing `.await?` to short-circuit and skip `complete_session_execution`. This meant:
- No commit guard / require-commit rescue
- No dirty workspace detection
- No recovery diagnostic
- No memory-soft-limit recovery information

## Changes

1. **`pipeline_execute.rs`**: Signal paths return `Ok(signal_interrupted_transport_result(...))` instead of `Err(...)`, allowing completion to run normally.
2. **`pipeline_session_exec_completion.rs`**: SIGINT and timeout do not trigger require-commit rescue — only SIGTERM qualifies.
3. **`run_cmd_uncommitted.rs`**: `record_run_dirty` suppresses require-commit contract failure for SIGINT/timeout.
4. **Tests**: Direct regression tests for SIGINT/timeout no-rescue behavior.

## Review

4 rounds of tier-4 critical review. All findings addressed. Run-level outer timeout gap filed as #2615.