### PR TITLE
fix(lock): reclaim terminal worktree locks via flock-availability check (#2612)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "chrono",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "chrono",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "axum",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "chrono",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "chrono",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1084"
+version = "0.1.1085"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1084"
+version = "0.1.1085"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -44,6 +44,7 @@ pub(super) fn acquire_if_needed(
         &session.meta_session_id,
         &ancestor_session_ids,
         |holder_session_id| holder_session_is_active(project_root, holder_session_id),
+        |holder_session_id| holder_session_is_terminal(project_root, holder_session_id),
     )
     .map(Some)
 }
@@ -124,6 +125,30 @@ fn holder_session_is_active(project_root: &Path, session_id: &str) -> bool {
     }
 }
 
+fn holder_session_is_terminal(project_root: &Path, session_id: &str) -> bool {
+    match csa_session::load_result(project_root, session_id) {
+        Ok(Some(_)) => return true,
+        Ok(None) => {}
+        Err(err) => tracing::debug!(
+            session_id,
+            error = %err,
+            "ignoring unreadable holder result while checking terminal worktree-lock holder"
+        ),
+    }
+
+    match csa_session::load_session(project_root, session_id) {
+        Ok(state) => state.phase != SessionPhase::Active,
+        Err(err) => {
+            tracing::debug!(
+                session_id,
+                error = %err,
+                "treating unreadable holder session as non-terminal"
+            );
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,6 +183,7 @@ mod tests {
             &holder.meta_session_id,
             &[],
             |_| false,
+            |_| false,
         )
         .expect("holder lock");
         let lock_path = holder_lock.lock_path().to_path_buf();
@@ -188,6 +214,7 @@ mod tests {
             &holder.meta_session_id,
             &[],
             |_| false,
+            |_| false,
         )
         .expect("holder lock");
         let candidate =
@@ -200,6 +227,50 @@ mod tests {
 
         assert!(err.contains("concurrent write session blocked"));
         assert!(err.contains(&holder.meta_session_id));
+    }
+
+    #[test]
+    fn holder_session_is_terminal_when_result_exists_even_if_phase_is_active() {
+        let temp = tempfile::tempdir().unwrap();
+        let holder =
+            csa_session::create_session_fresh(temp.path(), Some("done"), None, Some("codex"))
+                .expect("create holder session");
+        save_success_result(temp.path(), &holder.meta_session_id);
+
+        assert!(super::holder_session_is_terminal(
+            temp.path(),
+            &holder.meta_session_id
+        ));
+    }
+
+    #[test]
+    fn holder_session_is_terminal_when_phase_is_not_active() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut holder =
+            csa_session::create_session_fresh(temp.path(), Some("available"), None, Some("codex"))
+                .expect("create holder session");
+        holder
+            .apply_phase_event(PhaseEvent::Compressed)
+            .expect("holder should become Available");
+        save_session(&holder).expect("save Available holder");
+
+        assert!(super::holder_session_is_terminal(
+            temp.path(),
+            &holder.meta_session_id
+        ));
+    }
+
+    #[test]
+    fn holder_session_is_not_terminal_when_active_without_result() {
+        let temp = tempfile::tempdir().unwrap();
+        let holder =
+            csa_session::create_session_fresh(temp.path(), Some("running"), None, Some("codex"))
+                .expect("create holder session");
+
+        assert!(!super::holder_session_is_terminal(
+            temp.path(),
+            &holder.meta_session_id
+        ));
     }
 
     #[tokio::test]

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -220,20 +220,6 @@ mod tests {
     }
 
     #[test]
-    fn holder_session_is_terminal_when_result_exists_even_if_phase_is_active() {
-        let temp = tempfile::tempdir().unwrap();
-        let holder =
-            csa_session::create_session_fresh(temp.path(), Some("done"), None, Some("codex"))
-                .expect("create holder session");
-        save_success_result(temp.path(), &holder.meta_session_id);
-
-        assert!(super::holder_session_is_terminal(
-            temp.path(),
-            &holder.meta_session_id
-        ));
-    }
-
-    #[test]
     fn holder_session_is_terminal_when_phase_is_not_active() {
         let temp = tempfile::tempdir().unwrap();
         let mut holder =

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -126,16 +126,6 @@ fn holder_session_is_active(project_root: &Path, session_id: &str) -> bool {
 }
 
 fn holder_session_is_terminal(project_root: &Path, session_id: &str) -> bool {
-    match csa_session::load_result(project_root, session_id) {
-        Ok(Some(_)) => return true,
-        Ok(None) => {}
-        Err(err) => tracing::debug!(
-            session_id,
-            error = %err,
-            "ignoring unreadable holder result while checking terminal worktree-lock holder"
-        ),
-    }
-
     match csa_session::load_session(project_root, session_id) {
         Ok(state) => state.phase != SessionPhase::Active,
         Err(err) => {

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -127,7 +127,14 @@ fn holder_session_is_active(project_root: &Path, session_id: &str) -> bool {
 
 fn holder_session_is_terminal(project_root: &Path, session_id: &str) -> bool {
     match csa_session::load_session(project_root, session_id) {
-        Ok(state) => state.phase != SessionPhase::Active,
+        // Only Retired and ToolExhausted indicate the session lifecycle has
+        // fully completed and the worktree lock guard has been dropped.
+        // Available means the session was compacted but may still hold the
+        // lock during post-exec finalization.
+        Ok(state) => matches!(
+            state.phase,
+            SessionPhase::Retired | SessionPhase::ToolExhausted
+        ),
         Err(err) => {
             tracing::debug!(
                 session_id,
@@ -220,15 +227,15 @@ mod tests {
     }
 
     #[test]
-    fn holder_session_is_terminal_when_phase_is_not_active() {
+    fn holder_session_is_terminal_when_phase_is_retired() {
         let temp = tempfile::tempdir().unwrap();
         let mut holder =
-            csa_session::create_session_fresh(temp.path(), Some("available"), None, Some("codex"))
+            csa_session::create_session_fresh(temp.path(), Some("retired"), None, Some("codex"))
                 .expect("create holder session");
         holder
-            .apply_phase_event(PhaseEvent::Compressed)
-            .expect("holder should become Available");
-        save_session(&holder).expect("save Available holder");
+            .apply_phase_event(PhaseEvent::Retired)
+            .expect("holder should become Retired");
+        save_session(&holder).expect("save Retired holder");
 
         assert!(super::holder_session_is_terminal(
             temp.path(),

--- a/crates/cli-sub-agent/src/pipeline_tests_locking.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_locking.rs
@@ -59,11 +59,14 @@ fn acquire_active_holder_worktree_lock(
 ) -> (String, csa_lock::WorktreeWriteLock) {
     let holder =
         csa_session::create_session(project_root, Some("holder"), None, Some("codex")).unwrap();
-    let lock =
-        csa_lock::acquire_worktree_write_lock(project_root, &holder.meta_session_id, &[], |_| {
-            false
-        })
-        .expect("holder worktree write lock should succeed");
+    let lock = csa_lock::acquire_worktree_write_lock(
+        project_root,
+        &holder.meta_session_id,
+        &[],
+        |_| false,
+        |_| false,
+    )
+    .expect("holder worktree write lock should succeed");
     (holder.meta_session_id, lock)
 }
 
@@ -254,11 +257,14 @@ async fn run_commit_child_reenters_under_ancestor_worktree_write_lock() {
 
     let holder =
         csa_session::create_session(project_root, Some("holder"), None, Some("codex")).unwrap();
-    let _worktree_lock =
-        csa_lock::acquire_worktree_write_lock(project_root, &holder.meta_session_id, &[], |_| {
-            false
-        })
-        .expect("ancestor worktree write lock should succeed");
+    let _worktree_lock = csa_lock::acquire_worktree_write_lock(
+        project_root,
+        &holder.meta_session_id,
+        &[],
+        |_| false,
+        |_| false,
+    )
+    .expect("ancestor worktree write lock should succeed");
     let child = csa_session::create_session(
         project_root,
         Some("skill:commit"),
@@ -371,11 +377,14 @@ async fn review_fix_reenters_under_ancestor_worktree_write_lock() {
     // Ancestor session holds the per-worktree write lock.
     let holder =
         csa_session::create_session(project_root, Some("holder"), None, Some("codex")).unwrap();
-    let _worktree_lock =
-        csa_lock::acquire_worktree_write_lock(project_root, &holder.meta_session_id, &[], |_| {
-            false
-        })
-        .expect("ancestor worktree write lock should succeed");
+    let _worktree_lock = csa_lock::acquire_worktree_write_lock(
+        project_root,
+        &holder.meta_session_id,
+        &[],
+        |_| false,
+        |_| false,
+    )
+    .expect("ancestor worktree write lock should succeed");
 
     // A `--fix` child WITHIN the holder's lineage must re-enter the lock, not
     // fail fast (#1828 reuses #1672's lineage re-entry path).

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -321,6 +321,7 @@ async fn handle_run_fails_fast_when_worktree_write_lock_is_held() {
         &holder.meta_session_id,
         &[],
         |_| false,
+        |_| false,
     )
     .expect("holder worktree write lock should succeed");
 

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
@@ -213,7 +213,7 @@ fn handle_session_wait_treats_live_worktree_lock_as_progress_during_stale_preche
     let session_id = session.meta_session_id.clone();
     save_session(&session).expect("save stale active session");
     let _worktree_lock =
-        csa_lock::acquire_worktree_write_lock(project, &session_id, &[], |_| false)
+        csa_lock::acquire_worktree_write_lock(project, &session_id, &[], |_| false, |_| false)
             .expect("worktree write lock should be held by session");
 
     let mut emitted_completion: Option<(String, String, i32, bool)> = None;
@@ -265,7 +265,7 @@ fn handle_session_wait_sees_git_toplevel_worktree_lock_from_subdirectory() {
     let session_id = session.meta_session_id.clone();
     save_session(&session).expect("save stale active session");
     let _worktree_lock =
-        csa_lock::acquire_worktree_write_lock(&repo_root, &session_id, &[], |_| false)
+        csa_lock::acquire_worktree_write_lock(&repo_root, &session_id, &[], |_| false, |_| false)
             .expect("writer lock should be held at git toplevel");
     assert!(
         csa_lock::worktree_write_lock_is_held_by_session(&repo_root, &session_id)
@@ -326,8 +326,9 @@ fn handle_session_wait_defers_terminal_result_while_worktree_lock_is_live() {
         ..make_result("failure", 1)
     };
     save_result(project, &session_id, &terminal_result).expect("save terminal result");
-    let worktree_lock = csa_lock::acquire_worktree_write_lock(project, &session_id, &[], |_| false)
-        .expect("worktree write lock should be held by session");
+    let worktree_lock =
+        csa_lock::acquire_worktree_write_lock(project, &session_id, &[], |_| false, |_| false)
+            .expect("worktree write lock should be held by session");
 
     let mut emitted_completion: Option<(String, String, i32, bool)> = None;
     let exit_code = handle_session_wait_with_hooks(

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs
@@ -246,7 +246,7 @@ fn handle_session_wait_on_resume_wrapper_treats_wrapper_worktree_lock_as_live_in
     save_session(&worker).unwrap();
     csa_session::write_resume_target(project, &wrapper_id, &worker_id).unwrap();
     let _worktree_lock =
-        csa_lock::acquire_worktree_write_lock(project, &wrapper_id, &[], |_| false)
+        csa_lock::acquire_worktree_write_lock(project, &wrapper_id, &[], |_| false, |_| false)
             .expect("wrapper worktree lock should be held");
 
     let mut emitted_completion = false;

--- a/crates/csa-lock/src/worktree.rs
+++ b/crates/csa-lock/src/worktree.rs
@@ -7,7 +7,6 @@ use std::fs::{self, OpenOptions};
 use std::io::ErrorKind;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 /// Guard for a write-capable CSA session sharing one git worktree.
 ///
@@ -195,10 +194,10 @@ pub fn worktree_write_lock_is_held_by_session(
 /// PID liveness; `csa-lock` stays independent of the session registry crate.
 ///
 /// `holder_session_is_terminal` lets callers reclaim a stale lock when the
-/// session registry says the holder is already done but the holder process is
-/// still alive. In that path the holder PID is asked to terminate before the
-/// lock is retried, and the retry only proceeds after the fd-level flock is
-/// available.
+/// session registry says the holder is done (phase Retired/ToolExhausted).
+/// Recovery is gated by `is_flock_available`: if the OS reports no process
+/// holds the flock, the lock is reclaimed. No SIGTERM is sent — flock
+/// availability is the sole safety guarantee.
 pub fn acquire_worktree_write_lock(
     worktree_root: &Path,
     session_id: &str,
@@ -284,17 +283,24 @@ pub fn acquire_worktree_write_lock(
                 }
             }
 
+            // Terminal-session flock recovery: if the holder session's phase
+            // indicates it has completed (Retired/ToolExhausted) AND the flock
+            // is actually free (no live process holds it), reclaim the lock.
+            // This handles the case where the holder process exited without
+            // running its Drop guard (e.g. crash, SIGKILL) but the PID hasn't
+            // been recycled — is_pid_dead returns false but flock is free.
+            // We do NOT send SIGTERM — flock availability is the sole safety
+            // guarantee, provided atomically by the OS.
             if let Some(diag) = diagnostic.as_ref()
                 && let Some(holder_session_id) = diag.holder_session_id.as_deref()
                 && holder_session_is_terminal(holder_session_id)
-                && terminate_holder_process(diag.pid, diag.pid_start_time_ticks)
-                && wait_for_flock_available_after_termination(&lock_path)
+                && is_flock_available(&lock_path)
             {
                 tracing::warn!(
                     lock_path = %lock_path.display(),
                     holder_pid = diag.pid,
                     holder_session = holder_session_id,
-                    "removing stale worktree write lock (holder session is terminal, holder PID was terminated)"
+                    "removing stale worktree write lock (holder session is terminal, flock is free)"
                 );
                 match retry_acquire_worktree_write_lock(
                     &lock_path,
@@ -307,7 +313,7 @@ pub fn acquire_worktree_write_lock(
                     Err(retry_error) => {
                         anyhow::bail!(
                             "concurrent write session blocked: terminal holder session detected \
-                             and holder process was terminated, but retry failed: {}. {}",
+                             and flock is free, but retry failed: {}. {}",
                             retry_error,
                             lock_error
                         );
@@ -372,91 +378,6 @@ fn is_pid_dead(pid: u32, pid_start_time_ticks: Option<u64>) -> bool {
         return current_ticks != expected_ticks;
     }
     // Can't verify start time; assume the process is alive (conservative).
-    false
-}
-
-fn terminate_holder_process(pid: u32, pid_start_time_ticks: Option<u64>) -> bool {
-    if pid == std::process::id() {
-        tracing::warn!(
-            holder_pid = pid,
-            "refusing to terminate current process while reclaiming worktree write lock"
-        );
-        return false;
-    }
-
-    // Validate PID identity using start-time ticks to prevent killing a
-    // recycled PID that belongs to an unrelated process.
-    if let Some(expected_ticks) = pid_start_time_ticks {
-        match crate::process_start_time_ticks(pid) {
-            Some(current_ticks) if current_ticks == expected_ticks => { /* identity confirmed */ }
-            Some(current_ticks) => {
-                tracing::warn!(
-                    holder_pid = pid,
-                    expected_ticks,
-                    current_ticks,
-                    "refusing to terminate holder process: PID start time mismatch (recycled PID)"
-                );
-                return false;
-            }
-            None => {
-                tracing::warn!(
-                    holder_pid = pid,
-                    "refusing to terminate holder process: could not read current start time"
-                );
-                return false;
-            }
-        }
-    } else {
-        // No start-time available — fail closed for safety.
-        tracing::warn!(
-            holder_pid = pid,
-            "refusing to terminate holder process: no pid_start_time_ticks recorded, cannot verify identity"
-        );
-        return false;
-    }
-
-    // Safe conversion: reject out-of-range PIDs that would wrap on Unix.
-    let pid_i32 = match i32::try_from(pid) {
-        Ok(v) => v,
-        Err(_) => {
-            tracing::warn!(
-                holder_pid = pid,
-                "refusing to terminate holder process: PID exceeds i32 range"
-            );
-            return false;
-        }
-    };
-
-    // SAFETY: `kill(pid, SIGTERM)` requests termination of a process whose
-    // identity was verified above. It does not dereference pointers or
-    // share memory.
-    let ret = unsafe { libc::kill(pid_i32, libc::SIGTERM) };
-    if ret == 0 {
-        return true;
-    }
-
-    let error = std::io::Error::last_os_error();
-    if error.raw_os_error() == Some(libc::ESRCH) {
-        return true;
-    }
-    tracing::warn!(
-        holder_pid = pid,
-        error = %error,
-        "failed to terminate terminal worktree-lock holder process"
-    );
-    false
-}
-
-fn wait_for_flock_available_after_termination(lock_path: &Path) -> bool {
-    const ATTEMPTS: usize = 50;
-    const WAIT: Duration = Duration::from_millis(20);
-
-    for _ in 0..ATTEMPTS {
-        if is_flock_available(lock_path) {
-            return true;
-        }
-        std::thread::sleep(WAIT);
-    }
     false
 }
 

--- a/crates/csa-lock/src/worktree.rs
+++ b/crates/csa-lock/src/worktree.rs
@@ -287,7 +287,7 @@ pub fn acquire_worktree_write_lock(
             if let Some(diag) = diagnostic.as_ref()
                 && let Some(holder_session_id) = diag.holder_session_id.as_deref()
                 && holder_session_is_terminal(holder_session_id)
-                && terminate_holder_process(diag.pid)
+                && terminate_holder_process(diag.pid, diag.pid_start_time_ticks)
                 && wait_for_flock_available_after_termination(&lock_path)
             {
                 tracing::warn!(
@@ -375,7 +375,7 @@ fn is_pid_dead(pid: u32, pid_start_time_ticks: Option<u64>) -> bool {
     false
 }
 
-fn terminate_holder_process(pid: u32) -> bool {
+fn terminate_holder_process(pid: u32, pid_start_time_ticks: Option<u64>) -> bool {
     if pid == std::process::id() {
         tracing::warn!(
             holder_pid = pid,
@@ -384,9 +384,53 @@ fn terminate_holder_process(pid: u32) -> bool {
         return false;
     }
 
-    // SAFETY: `kill(pid, SIGTERM)` requests termination of a process identified
-    // by the diagnostic. It does not dereference pointers or share memory.
-    let ret = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+    // Validate PID identity using start-time ticks to prevent killing a
+    // recycled PID that belongs to an unrelated process.
+    if let Some(expected_ticks) = pid_start_time_ticks {
+        match crate::process_start_time_ticks(pid) {
+            Some(current_ticks) if current_ticks == expected_ticks => { /* identity confirmed */ }
+            Some(current_ticks) => {
+                tracing::warn!(
+                    holder_pid = pid,
+                    expected_ticks,
+                    current_ticks,
+                    "refusing to terminate holder process: PID start time mismatch (recycled PID)"
+                );
+                return false;
+            }
+            None => {
+                tracing::warn!(
+                    holder_pid = pid,
+                    "refusing to terminate holder process: could not read current start time"
+                );
+                return false;
+            }
+        }
+    } else {
+        // No start-time available — fail closed for safety.
+        tracing::warn!(
+            holder_pid = pid,
+            "refusing to terminate holder process: no pid_start_time_ticks recorded, cannot verify identity"
+        );
+        return false;
+    }
+
+    // Safe conversion: reject out-of-range PIDs that would wrap on Unix.
+    let pid_i32 = match i32::try_from(pid) {
+        Ok(v) => v,
+        Err(_) => {
+            tracing::warn!(
+                holder_pid = pid,
+                "refusing to terminate holder process: PID exceeds i32 range"
+            );
+            return false;
+        }
+    };
+
+    // SAFETY: `kill(pid, SIGTERM)` requests termination of a process whose
+    // identity was verified above. It does not dereference pointers or
+    // share memory.
+    let ret = unsafe { libc::kill(pid_i32, libc::SIGTERM) };
     if ret == 0 {
         return true;
     }

--- a/crates/csa-lock/src/worktree.rs
+++ b/crates/csa-lock/src/worktree.rs
@@ -7,6 +7,7 @@ use std::fs::{self, OpenOptions};
 use std::io::ErrorKind;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// Guard for a write-capable CSA session sharing one git worktree.
 ///
@@ -192,11 +193,18 @@ pub fn worktree_write_lock_is_held_by_session(
 ///
 /// `holder_session_is_live` must read caller-owned session state, not process
 /// PID liveness; `csa-lock` stays independent of the session registry crate.
+///
+/// `holder_session_is_terminal` lets callers reclaim a stale lock when the
+/// session registry says the holder is already done but the holder process is
+/// still alive. In that path the holder PID is asked to terminate before the
+/// lock is retried, and the retry only proceeds after the fd-level flock is
+/// available.
 pub fn acquire_worktree_write_lock(
     worktree_root: &Path,
     session_id: &str,
     ancestor_session_ids: &[String],
     holder_session_is_live: impl Fn(&str) -> bool,
+    holder_session_is_terminal: impl Fn(&str) -> bool,
 ) -> Result<WorktreeWriteLock> {
     let session_id = session_id.trim();
     if session_id.is_empty() {
@@ -257,26 +265,49 @@ pub fn acquire_worktree_write_lock(
                     holder_session = ?diag.holder_session_id,
                     "removing stale worktree write lock (holder PID is dead, flock is free)"
                 );
-                match acquire_lock_at_path_with_metadata(
+                match retry_acquire_worktree_write_lock(
                     &lock_path,
                     &lock_name,
                     &reason,
-                    Some(session_id),
-                    Some(&canonical_root),
+                    session_id,
+                    &canonical_root,
                 ) {
-                    Ok(lock) => {
-                        return Ok(WorktreeWriteLock {
-                            inner: WorktreeWriteLockKind::Acquired {
-                                _lock: lock,
-                                owner_session_id: session_id.to_string(),
-                            },
-                            lock_path,
-                        });
-                    }
+                    Ok(lock) => return Ok(lock),
                     Err(retry_error) => {
                         anyhow::bail!(
                             "concurrent write session blocked: stale lock detected but retry \
                              failed: {}. {}",
+                            retry_error,
+                            lock_error
+                        );
+                    }
+                }
+            }
+
+            if let Some(diag) = diagnostic.as_ref()
+                && let Some(holder_session_id) = diag.holder_session_id.as_deref()
+                && holder_session_is_terminal(holder_session_id)
+                && terminate_holder_process(diag.pid)
+                && wait_for_flock_available_after_termination(&lock_path)
+            {
+                tracing::warn!(
+                    lock_path = %lock_path.display(),
+                    holder_pid = diag.pid,
+                    holder_session = holder_session_id,
+                    "removing stale worktree write lock (holder session is terminal, holder PID was terminated)"
+                );
+                match retry_acquire_worktree_write_lock(
+                    &lock_path,
+                    &lock_name,
+                    &reason,
+                    session_id,
+                    &canonical_root,
+                ) {
+                    Ok(lock) => return Ok(lock),
+                    Err(retry_error) => {
+                        anyhow::bail!(
+                            "concurrent write session blocked: terminal holder session detected \
+                             and holder process was terminated, but retry failed: {}. {}",
                             retry_error,
                             lock_error
                         );
@@ -300,6 +331,29 @@ pub fn acquire_worktree_write_lock(
     }
 }
 
+fn retry_acquire_worktree_write_lock(
+    lock_path: &Path,
+    lock_name: &str,
+    reason: &str,
+    session_id: &str,
+    canonical_root: &Path,
+) -> Result<WorktreeWriteLock> {
+    let lock = acquire_lock_at_path_with_metadata(
+        lock_path,
+        lock_name,
+        reason,
+        Some(session_id),
+        Some(canonical_root),
+    )?;
+    Ok(WorktreeWriteLock {
+        inner: WorktreeWriteLockKind::Acquired {
+            _lock: lock,
+            owner_session_id: session_id.to_string(),
+        },
+        lock_path: lock_path.to_path_buf(),
+    })
+}
+
 /// Check whether a PID is dead by sending signal 0 (no-op probe).
 /// Returns true if the PID does not exist or its start time no longer
 /// matches (recycled PID). On platforms where start-time detection is
@@ -318,6 +372,47 @@ fn is_pid_dead(pid: u32, pid_start_time_ticks: Option<u64>) -> bool {
         return current_ticks != expected_ticks;
     }
     // Can't verify start time; assume the process is alive (conservative).
+    false
+}
+
+fn terminate_holder_process(pid: u32) -> bool {
+    if pid == std::process::id() {
+        tracing::warn!(
+            holder_pid = pid,
+            "refusing to terminate current process while reclaiming worktree write lock"
+        );
+        return false;
+    }
+
+    // SAFETY: `kill(pid, SIGTERM)` requests termination of a process identified
+    // by the diagnostic. It does not dereference pointers or share memory.
+    let ret = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+    if ret == 0 {
+        return true;
+    }
+
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        return true;
+    }
+    tracing::warn!(
+        holder_pid = pid,
+        error = %error,
+        "failed to terminate terminal worktree-lock holder process"
+    );
+    false
+}
+
+fn wait_for_flock_available_after_termination(lock_path: &Path) -> bool {
+    const ATTEMPTS: usize = 50;
+    const WAIT: Duration = Duration::from_millis(20);
+
+    for _ in 0..ATTEMPTS {
+        if is_flock_available(lock_path) {
+            return true;
+        }
+        std::thread::sleep(WAIT);
+    }
     false
 }
 

--- a/crates/csa-lock/src/worktree_tests.rs
+++ b/crates/csa-lock/src/worktree_tests.rs
@@ -5,8 +5,9 @@ use std::ffi::OsString;
 use std::fs::{self, File, OpenOptions};
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::io::AsRawFd;
-use std::process::Command;
+use std::process::{Child, Command};
 use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::Duration;
 use tempfile::tempdir;
 
 fn env_test_lock() -> MutexGuard<'static, ()> {
@@ -53,6 +54,7 @@ fn acquire_test_worktree_write_lock(
         session_id,
         ancestor_session_ids,
         |holder_session_id| live_holder_session_ids.contains(&holder_session_id),
+        |_| false,
     )
 }
 
@@ -147,6 +149,7 @@ fn cross_process_lineage_reentry_child_entrypoint() {
         "01CHILD",
         std::slice::from_ref(&holder_session_id),
         |candidate| candidate == holder_session_id.as_str(),
+        |_| false,
     )
     .expect("child should re-enter under live ancestor lock held by parent process");
 
@@ -241,6 +244,90 @@ fn worktree_write_lock_keeps_live_holder_blocked() {
 }
 
 #[test]
+fn worktree_write_lock_reclaims_terminal_session_with_live_holder_pid() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let ready_path = worktree_root.path().join("holder-ready");
+    let mut holder = spawn_terminal_reclaim_holder(
+        state_home.path(),
+        worktree_root.path(),
+        "01TERMINAL",
+        &ready_path,
+    );
+    wait_for_ready_marker(&ready_path);
+
+    let lock = acquire_worktree_write_lock(
+        worktree_root.path(),
+        "01NEXT",
+        &[],
+        |_| false,
+        |holder_session_id| holder_session_id == "01TERMINAL",
+    )
+    .expect("terminal holder session should be terminated and reclaimed");
+
+    assert!(!lock.is_lineage_reentry());
+    holder.wait_for_exit();
+}
+
+#[test]
+fn worktree_write_lock_keeps_live_nonterminal_holder_blocked() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let ready_path = worktree_root.path().join("holder-ready");
+    let mut holder = spawn_terminal_reclaim_holder(
+        state_home.path(),
+        worktree_root.path(),
+        "01ACTIVE",
+        &ready_path,
+    );
+    wait_for_ready_marker(&ready_path);
+
+    let err =
+        acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[], |_| false, |_| false)
+            .expect_err("live nonterminal holder must still block")
+            .to_string();
+
+    assert!(err.contains("concurrent write session blocked"));
+    assert!(err.contains("01ACTIVE"));
+    assert!(
+        holder.is_running(),
+        "nonterminal holder process must not be terminated"
+    );
+}
+
+#[test]
+fn terminal_reclaim_holder_child_entrypoint() {
+    let Some(worktree_root) = std::env::var_os("CSA_LOCK_TERMINAL_RECLAIM_WORKTREE") else {
+        return;
+    };
+    let Some(ready_path) = std::env::var_os("CSA_LOCK_TERMINAL_RECLAIM_READY") else {
+        return;
+    };
+    let holder_session_id =
+        std::env::var("CSA_LOCK_TERMINAL_RECLAIM_HOLDER").expect("holder session id env");
+
+    let _lock = acquire_worktree_write_lock(
+        Path::new(&worktree_root),
+        &holder_session_id,
+        &[],
+        |_| false,
+        |_| false,
+    )
+    .expect("child holder should acquire worktree write lock");
+    fs::write(ready_path, b"ready").expect("write ready marker");
+
+    loop {
+        std::thread::sleep(Duration::from_secs(60));
+    }
+}
+
+#[test]
 fn worktree_write_lock_probe_detects_live_matching_holder() {
     let _env_lock = env_test_lock();
     let state_home = tempdir().expect("state-home tempdir");
@@ -255,6 +342,63 @@ fn worktree_write_lock_probe_detects_live_matching_holder() {
             .expect("probe live holder"),
         "live flock plus matching diagnostic should report held"
     );
+}
+
+fn spawn_terminal_reclaim_holder(
+    state_home: &Path,
+    worktree_root: &Path,
+    holder_session_id: &str,
+    ready_path: &Path,
+) -> ChildGuard {
+    let child = Command::new(std::env::current_exe().expect("current test binary"))
+        .arg("terminal_reclaim_holder_child_entrypoint")
+        .arg("--nocapture")
+        .env("XDG_STATE_HOME", state_home)
+        .env("CSA_LOCK_TERMINAL_RECLAIM_WORKTREE", worktree_root)
+        .env("CSA_LOCK_TERMINAL_RECLAIM_HOLDER", holder_session_id)
+        .env("CSA_LOCK_TERMINAL_RECLAIM_READY", ready_path)
+        .spawn()
+        .expect("spawn holder child process");
+    ChildGuard { child }
+}
+
+fn wait_for_ready_marker(ready_path: &Path) {
+    for _ in 0..100 {
+        if ready_path.exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    panic!("holder child did not report ready");
+}
+
+struct ChildGuard {
+    child: Child,
+}
+
+impl ChildGuard {
+    fn is_running(&mut self) -> bool {
+        self.child.try_wait().expect("check child status").is_none()
+    }
+
+    fn wait_for_exit(&mut self) {
+        for _ in 0..100 {
+            if self.child.try_wait().expect("check child status").is_some() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("holder child did not exit after stale lock reclaim");
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
 }
 
 #[test]
@@ -495,7 +639,8 @@ fn issue_2528_stale_lock_with_dead_holder_is_recovered() {
     std::fs::write(&lock_path, stale_diag.to_string()).unwrap();
 
     // The lock file exists but the PID is dead — acquisition should succeed
-    let lock = crate::acquire_worktree_write_lock(project, "NEW_SESSION", &[], |_| false);
+    let lock =
+        crate::acquire_worktree_write_lock(project, "NEW_SESSION", &[], |_| false, |_| false);
     assert!(
         lock.is_ok(),
         "should recover stale lock with dead holder PID: {:?}",

--- a/crates/csa-lock/src/worktree_tests.rs
+++ b/crates/csa-lock/src/worktree_tests.rs
@@ -245,7 +245,7 @@ fn worktree_write_lock_keeps_live_holder_blocked() {
 
 #[test]
 #[cfg(target_os = "linux")]
-fn worktree_write_lock_reclaims_terminal_session_with_live_holder_pid() {
+fn worktree_write_lock_reclaims_terminal_session_after_holder_crash() {
     let _env_lock = env_test_lock();
     let state_home = tempdir().expect("state-home tempdir");
     let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
@@ -257,8 +257,11 @@ fn worktree_write_lock_reclaims_terminal_session_with_live_holder_pid() {
         worktree_root.path(),
         "01TERMINAL",
         &ready_path,
+        true, // exit after ready — simulate crashed holder
     );
     wait_for_ready_marker(&ready_path);
+    // Wait for holder to exit so flock is released
+    holder.wait_for_exit();
 
     let lock = acquire_worktree_write_lock(
         worktree_root.path(),
@@ -267,10 +270,9 @@ fn worktree_write_lock_reclaims_terminal_session_with_live_holder_pid() {
         |_| false,
         |holder_session_id| holder_session_id == "01TERMINAL",
     )
-    .expect("terminal holder session should be terminated and reclaimed");
+    .expect("terminal holder session with free flock should be reclaimed");
 
     assert!(!lock.is_lineage_reentry());
-    holder.wait_for_exit();
 }
 
 #[test]
@@ -286,6 +288,7 @@ fn worktree_write_lock_keeps_live_nonterminal_holder_blocked() {
         worktree_root.path(),
         "01ACTIVE",
         &ready_path,
+        false, // stay alive — simulate live holder holding flock
     );
     wait_for_ready_marker(&ready_path);
 
@@ -323,6 +326,13 @@ fn terminal_reclaim_holder_child_entrypoint() {
     .expect("child holder should acquire worktree write lock");
     fs::write(ready_path, b"ready").expect("write ready marker");
 
+    // Check if this child should exit immediately (simulating a crashed holder
+    // that released flock but left stale metadata) or stay alive (simulating
+    // a live holder still holding flock).
+    if std::env::var_os("CSA_LOCK_TERMINAL_RECLAIM_EXIT").is_some() {
+        std::process::exit(0);
+    }
+
     loop {
         std::thread::sleep(Duration::from_secs(60));
     }
@@ -350,16 +360,19 @@ fn spawn_terminal_reclaim_holder(
     worktree_root: &Path,
     holder_session_id: &str,
     ready_path: &Path,
+    exit_after_ready: bool,
 ) -> ChildGuard {
-    let child = Command::new(std::env::current_exe().expect("current test binary"))
-        .arg("terminal_reclaim_holder_child_entrypoint")
+    let mut cmd = Command::new(std::env::current_exe().expect("current test binary"));
+    cmd.arg("terminal_reclaim_holder_child_entrypoint")
         .arg("--nocapture")
         .env("XDG_STATE_HOME", state_home)
         .env("CSA_LOCK_TERMINAL_RECLAIM_WORKTREE", worktree_root)
         .env("CSA_LOCK_TERMINAL_RECLAIM_HOLDER", holder_session_id)
-        .env("CSA_LOCK_TERMINAL_RECLAIM_READY", ready_path)
-        .spawn()
-        .expect("spawn holder child process");
+        .env("CSA_LOCK_TERMINAL_RECLAIM_READY", ready_path);
+    if exit_after_ready {
+        cmd.env("CSA_LOCK_TERMINAL_RECLAIM_EXIT", "1");
+    }
+    let child = cmd.spawn().expect("spawn holder child process");
     ChildGuard { child }
 }
 

--- a/crates/csa-lock/src/worktree_tests.rs
+++ b/crates/csa-lock/src/worktree_tests.rs
@@ -244,6 +244,7 @@ fn worktree_write_lock_keeps_live_holder_blocked() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn worktree_write_lock_reclaims_terminal_session_with_live_holder_pid() {
     let _env_lock = env_test_lock();
     let state_home = tempdir().expect("state-home tempdir");

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1083"
-weave = "0.1.1083"
+csa = "0.1.1085"
+weave = "0.1.1085"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Partial fix for #2612.

Adds a new `holder_session_is_terminal` callback to `acquire_worktree_write_lock`. When the holder session phase is `Retired` or `ToolExhausted` AND the OS-level flock is available (no process holds it), the lock is reclaimed.

## Design Decision

After 7 rounds of tier-4 critical review, the PID-kill approach (sending SIGTERM to holder process) was rejected due to:
- Recycled PID safety concerns
- Phase/flock-drop happens-before gap (phase can be persisted before lock guard drops)

The final design uses **flock-availability as the sole safety guarantee**: if the OS reports no process holds the flock, the lock is safe to reclaim. No SIGTERM is sent.

## What This Fixes

- Holder process crashed/exited without running Drop guard, but PID not yet recycled → `is_pid_dead` returns false, but `is_flock_available` returns true → lock reclaimed

## What This Does NOT Fix (Tracked Separately)

The original #2612 scenario (stale session with **alive** holder PID still holding flock) requires deeper session lifecycle changes:
- Session phase transition timing relative to lock guard drop
- Possible "reclaimable" marker written after hooks/artifacts complete
- Or daemon-level intervention to release stale locks

This will be tracked in a follow-up issue.

## Review History

7 rounds of tier-4 critical review. All PID-kill variants rejected. Final flock-only approach is the safest minimal change.