### PR TITLE
fix(bwrap): canonicalize symlink paths before bwrap bind (#2613)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "chrono",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "chrono",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "axum",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "chrono",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "chrono",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1085"
+version = "0.1.1086"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1085"
+version = "0.1.1086"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -90,9 +90,11 @@ impl BwrapCommandBuilder {
         // Bind after tmpfs. /tmp itself is an explicit host tmpdir grant.
         let tmp_prefix = Path::new("/tmp");
         for path in &self.writable_paths {
-            let s = path.to_string_lossy();
+            let resolved = resolve_for_bind(path);
+            let s = resolved.to_string_lossy();
+            let dest = path.to_string_lossy();
             if path == tmp_prefix {
-                cmd.args(["--bind", &s, &s]);
+                cmd.args(["--bind", &s, &dest]);
             } else if path.starts_with(tmp_prefix) {
                 if let Some(parent) = path.parent()
                     && parent != tmp_prefix
@@ -101,11 +103,11 @@ impl BwrapCommandBuilder {
                     cmd.args(["--dir", &p]);
                 }
                 if !(path.is_file() || (!path.exists() && path.extension().is_some())) {
-                    cmd.args(["--dir", &s]);
+                    cmd.args(["--dir", &dest]);
                 }
-                cmd.args(["--bind", &s, &s]);
+                cmd.args(["--bind", &s, &dest]);
             } else {
-                cmd.args(["--bind", &s, &s]);
+                cmd.args(["--bind", &s, &dest]);
             }
         }
 
@@ -116,7 +118,9 @@ impl BwrapCommandBuilder {
             if self.is_covered_by_writable_path(path) {
                 continue;
             }
-            let s = path.to_string_lossy();
+            let resolved = resolve_for_bind(path);
+            let s = resolved.to_string_lossy();
+            let dest = path.to_string_lossy();
             assert!(
                 path != tmp_prefix,
                 "readable sandbox path must not be /tmp itself; expose a specific sub-path instead"
@@ -127,7 +131,7 @@ impl BwrapCommandBuilder {
             {
                 cmd.args(["--dir", &parent.to_string_lossy()]);
             }
-            cmd.args(["--ro-bind", &s, &s]);
+            cmd.args(["--ro-bind", &s, &dest]);
         }
 
         // Extra read-only bind mounts.  When the dest path differs from src
@@ -140,6 +144,7 @@ impl BwrapCommandBuilder {
             .cloned()
             .chain(self.implicit_ro_binds(home))
         {
+            let src = resolve_for_bind(&src);
             if src != dest
                 && let Some(parent) = dest.parent()
             {
@@ -257,6 +262,13 @@ pub fn from_isolation_plan(
     }
 
     Some(builder.build())
+}
+
+/// Resolve a bind source path by following symlinks. bwrap operates in the
+/// root namespace where symlink targets must be real paths — if `~/.claude`
+/// is a symlink to `/ssd/.../.claude`, bwrap needs the resolved target.
+fn resolve_for_bind(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 #[cfg(test)]

--- a/crates/csa-resource/src/bwrap_tests.rs
+++ b/crates/csa-resource/src/bwrap_tests.rs
@@ -635,3 +635,37 @@ fn test_bwrap_auto_ro_binds_gh_aider_config_when_present() {
         "~/.config/gh-aider should be explicitly re-bound read-only so sandboxed gh commands can still read the aider auth config; args: {args:?}"
     );
 }
+
+#[test]
+fn test_bwrap_canonicalizes_symlink_writable_path() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let real = tmp.path().join("real-claude");
+    std::fs::create_dir(&real).expect("create real dir");
+    let link = tmp.path().join("link-claude");
+    symlink(&real, &link).expect("create symlink");
+
+    let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+    builder.with_writable_path(&link);
+
+    let cmd = builder.build();
+    let args = command_args(&cmd);
+
+    // The --bind source should be the resolved (canonical) path, not the symlink
+    let bind_idx = args
+        .iter()
+        .position(|a| a == "--bind")
+        .expect("--bind not found");
+    let src = &args[bind_idx + 1];
+    let dest = &args[bind_idx + 2];
+    assert!(
+        src.contains("real-claude"),
+        "bind source should be canonicalized real path, got: {src}"
+    );
+    assert_eq!(
+        dest,
+        &link.to_string_lossy().to_string(),
+        "bind destination should preserve original logical path"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2613.

When `~/.claude` (or any writable/readable path) is a symlink, bwrap `--bind`/`--ro-bind` receives the symlink path rather than the real target. bwrap operates in the root namespace where symlink targets must exist as real paths.

## Changes

- Add `resolve_for_bind()` helper that calls `std::fs::canonicalize` on bind source paths
- Apply to all writable_paths, readable_paths, and ro_binds
- **Source** (host path) is canonicalized; **destination** (sandbox path) preserves the original logical path
- Falls back to original path if canonicalize fails (e.g. path doesn't exist yet)
- Regression test for symlinked writable path

## Review

2 rounds of tier-4 critical review. Finding 1 (source=dest canonicalization) fixed. Final review: no HIGH/CRITICAL findings, MEDIUM test-gap addressed.