### PR TITLE
fix(pipeline): run-level outer timeout flows through completion (#2615)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "chrono",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "chrono",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "axum",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "chrono",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "chrono",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1086"
+version = "0.1.1087"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1086"
+version = "0.1.1087"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -280,7 +280,47 @@ async fn ri(request: RunLoopRequest<'_>, g: &mut Cg) -> Result<RunLoopCompletion
                 request.skill,
                 timeout_resume_session.as_deref(),
             )?;
-            return Ok(Exit(exit_code));
+            // Break with synthetic timeout result instead of Exit, so the
+            // completion path (restore_cg + Completed) runs consistently.
+            let timeout_result = csa_process::ExecutionResult {
+                output: String::new(),
+                stderr_output: String::new(),
+                summary: format!(
+                    "wall-clock timeout ({}s)",
+                    request
+                        .run_timeout_seconds
+                        .expect("run timeout should be present")
+                ),
+                exit_code,
+                peak_memory_mb: None,
+                model_completed: Some(false),
+                terminal_reason: Some("timeout".to_owned()),
+                raw_process_exit_code: Some(exit_code),
+                exit_signal: None,
+                kill_hint: None,
+                resource_diagnostics: None,
+                csa_gate_failure: None,
+                warnings: Vec::new(),
+            };
+            let (mut result, changed_paths, commit_created) = (
+                timeout_result,
+                merge_changed(
+                    accumulated_changed_paths.clone(),
+                    all_attempt_change_snapshots_available,
+                    None,
+                ),
+                None,
+            );
+            restore_cg(g, commit_created, Some(&mut result))?;
+            return Ok(RunLoopCompletion::Completed(Box::new(RunLoopOutcome {
+                result,
+                current_tool,
+                executed_session_id,
+                changed_paths,
+                commit_created,
+                fork_resolution,
+                fallback_chain,
+            })));
         }
 
         let attempt_started_at = Instant::now();
@@ -417,7 +457,41 @@ async fn ri(request: RunLoopRequest<'_>, g: &mut Cg) -> Result<RunLoopCompletion
                     request.skill,
                     timeout_resume_session.as_deref(),
                 )?;
-                return Ok(Exit(exit_code));
+                // Construct a synthetic timeout result and break to flow
+                // through restore_cg + Completed (instead of Exit), so that
+                // complete_session_execution runs (session state update,
+                // require-commit suppression for timeouts per #2611, commit-
+                // skill workspace guard restoration, and uncommitted tracking).
+                // Previously this path short-circuited completion (#2615).
+                let timeout_result = csa_process::ExecutionResult {
+                    output: String::new(),
+                    stderr_output: String::new(),
+                    summary: format!(
+                        "wall-clock timeout ({}s)",
+                        request
+                            .run_timeout_seconds
+                            .expect("run timeout should be present")
+                    ),
+                    exit_code,
+                    peak_memory_mb: None,
+                    model_completed: Some(false),
+                    terminal_reason: Some("timeout".to_owned()),
+                    raw_process_exit_code: Some(exit_code),
+                    exit_signal: None,
+                    kill_hint: None,
+                    resource_diagnostics: None,
+                    csa_gate_failure: None,
+                    warnings: Vec::new(),
+                };
+                break (
+                    timeout_result,
+                    merge_changed(
+                        accumulated_changed_paths.clone(),
+                        all_attempt_change_snapshots_available,
+                        None,
+                    ),
+                    None,
+                );
             }
             AttemptExecution::Exit(exit_code) => {
                 return Ok(Exit(exit_code));

--- a/scripts/monolith/baseline.toml
+++ b/scripts/monolith/baseline.toml
@@ -784,3 +784,11 @@ baseline_tokens = 9545
 baseline_lines = 737
 issue = "2611"
 rationale = "pre-existing monolith debt; file at 9430 tokens on origin/main; #2611 adds 2-line SIGINT guard for review finding; no further growth ratchet"
+
+[[files]]
+path = "crates/cli-sub-agent/src/run_cmd_attempt.rs"
+kind = "source"
+baseline_tokens = 9210
+baseline_lines = 648
+issue = "2615"
+rationale = "run-level outer timeout fix adds synthetic ExecutionResult + RunLoopOutcome for both pre-attempt and mid-attempt timeout branches (~60 lines); pre-existing at ~8400 tokens"


### PR DESCRIPTION
## Summary

Partial fix for #2615.

When `AttemptExecution::TimedOut` fires (wall-clock run timeout exceeded), the code previously returned `RunLoopCompletion::Exit` which bypassed all post-run processing. This PR changes both timeout paths (pre-attempt zero-remaining and mid-attempt) to return `RunLoopCompletion::Completed` with a synthetic `ExecutionResult` (`terminal_reason=timeout`).

## What This Fixes

- Run-level dirty tracking now records changed paths after timeout
- Commit-skill workspace guard restoration (`restore_cg`) now runs
- `record_run_dirty` runs (with require-commit suppression for timeouts per #2611)
- `restore_failed_commit_skill_workspace` runs

## What This Does NOT Fix (Tracked Separately)

The deeper issue: `run_persistent_with_timeout` wraps `execute_persistent(...)` in `tokio::time::timeout`. When the outer timeout wins the race against the inner timeout, it cancels the inner future before `complete_session_execution` (session-level finalization: terminal result, session retirement, post-exec artifacts) runs.

Fixing this requires either:
- Removing the duplicate outer timeout (relying on inner timeout only)
- Or making the outer cancellation path explicitly invoke session-level completion

This will be tracked in a follow-up issue.

## Review History

2 rounds of tier-4 critical review. Finding 1 (early return bypassing restore_cg) fixed. Finding 2 (session-level cancellation) filed as deeper architectural issue.