### PR TITLE
fix(pipeline): remove duplicate outer timeout wrapper (#2621)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "chrono",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "chrono",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "axum",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "chrono",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "chrono",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1087"
+version = "0.1.1088"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1087"
+version = "0.1.1088"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/run_cmd_attempt_exec.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_exec.rs
@@ -146,50 +146,63 @@ pub(super) async fn run_persistent_with_timeout(
     no_hook_bypass_scan: bool,
     startup_env: &StartupSubtreeEnv,
 ) -> Result<AttemptExecution> {
-    match tokio::time::timeout(
-        timeout_duration,
-        execute_persistent(
-            executor,
-            current_tool,
-            effective_prompt,
-            output_format,
-            effective_session_arg,
-            description,
-            skill_session_tag,
-            parent,
-            project_root,
-            config,
-            extra_env,
-            subtree_pin,
-            allow_git_push,
-            resolved_tier_name,
-            context_load_options,
-            stream_mode,
-            idle_timeout_seconds,
-            initial_response_timeout_seconds,
-            Some(timeout_duration),
-            memory_injection,
-            global_config,
-            pre_session_hook,
-            resource_overrides,
-            fork_resolution,
-            fresh_spawn_preflight_override,
-            executed_session_id,
-            pre_created_fork_session_id,
-            no_fs_sandbox,
-            allow_user_daemon_ipc,
-            extra_writable,
-            extra_readable,
-            error_marker_scan_override,
-            no_hook_bypass_scan,
-            startup_env,
-        ),
+    // The pipeline's internal timeout (execute_transport_with_signal) receives
+    // Some(remaining) and handles graceful timeout: it returns a normal
+    // timed-out TransportResult that flows through complete_session_execution
+    // (session retirement, post-exec artifacts, etc.).
+    //
+    // We do NOT wrap execute_persistent in tokio::time::timeout because that
+    // creates a race: when the outer timeout wins (which it always does once
+    // transport starts after setup, since both use the same duration), it
+    // cancels the inner future before session-level completion can run (#2621).
+    //
+    // Instead, execute_persistent receives Some(timeout_duration) which is
+    // already the remaining budget computed from run_started_at by the caller
+    // (run_cmd_attempt.rs:resolve_remaining_run_timeout). The internal timeout
+    // in execute_transport_with_signal uses this duration directly, preserving
+    // graceful session-level completion on timeout.
+    //
+    // Note: the internal timeout starts after session setup, so setup time is
+    // not counted against the transport budget. This is acceptable because
+    // resolve_remaining_run_timeout at the top of each loop iteration catches
+    // fully exhausted budgets before this function is called.
+    execute_persistent(
+        executor,
+        current_tool,
+        effective_prompt,
+        output_format,
+        effective_session_arg,
+        description,
+        skill_session_tag,
+        parent,
+        project_root,
+        config,
+        extra_env,
+        subtree_pin,
+        allow_git_push,
+        resolved_tier_name,
+        context_load_options,
+        stream_mode,
+        idle_timeout_seconds,
+        initial_response_timeout_seconds,
+        Some(timeout_duration),
+        memory_injection,
+        global_config,
+        pre_session_hook,
+        resource_overrides,
+        fork_resolution,
+        fresh_spawn_preflight_override,
+        executed_session_id,
+        pre_created_fork_session_id,
+        no_fs_sandbox,
+        allow_user_daemon_ipc,
+        extra_writable,
+        extra_readable,
+        error_marker_scan_override,
+        no_hook_bypass_scan,
+        startup_env,
     )
     .await
-    {
-        Ok(result) => result,
-        Err(_) => Ok(AttemptExecution::TimedOut),
-    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/scripts/monolith/baseline.toml
+++ b/scripts/monolith/baseline.toml
@@ -788,7 +788,7 @@ rationale = "pre-existing monolith debt; file at 9430 tokens on origin/main; #26
 [[files]]
 path = "crates/cli-sub-agent/src/run_cmd_attempt.rs"
 kind = "source"
-baseline_tokens = 9210
-baseline_lines = 648
+baseline_tokens = 9260
+baseline_lines = 653
 issue = "2615"
 rationale = "run-level outer timeout fix adds synthetic ExecutionResult + RunLoopOutcome for both pre-attempt and mid-attempt timeout branches (~60 lines); pre-existing at ~8400 tokens"


### PR DESCRIPTION
## Summary

Fixes #2621.

`run_persistent_with_timeout` wrapped `execute_persistent(...)` in `tokio::time::timeout(timeout_duration, ...)`. The internal timeout (`execute_transport_with_signal`) used the same `timeout_duration`, creating a race: the outer timeout always won once transport started after setup, cancelling the inner future before `complete_session_execution` could run.

## Fix

Removed the outer `tokio::time::timeout` wrapper. `execute_persistent` receives `Some(timeout_duration)` (already computed as remaining budget from `run_started_at` by the caller). The internal transport timeout now handles timeout expiration gracefully, preserving session-level finalization (terminal result, session retirement, post-exec artifacts).

## Known Limitation

Setup-phase timeout (when session bootstrap/hooks/sandbox setup takes longer than the remaining budget) is not covered by the internal timeout since it only starts in the transport phase. The caller's `resolve_remaining_run_timeout` check at the top of each loop iteration catches fully exhausted budgets. This is acceptable because setup time is typically negligible compared to the transport phase.

## Review History

3 rounds of tier-4 critical review. The double-subtraction issue was identified and fixed. The remaining finding (setup-phase timeout gap) is an inherent trade-off: covering it requires either `tokio::select!` with grace period or passing an absolute deadline through multiple layers.