### PR TITLE
fix(lock): SIGTERM-based reclaim for alive stale holders (#2618)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "chrono",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "chrono",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "axum",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "chrono",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "chrono",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1088"
+version = "0.1.1089"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1088"
+version = "0.1.1089"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -123,6 +123,15 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source(
     } else {
         None
     };
+
+    // For resumed sessions, clear any stale result.toml before acquiring the
+    // worktree lock. This prevents the alive-stale-holder reclaim path from
+    // treating a resumed session's old result as evidence of a stuck holder.
+    if session_arg.is_some() {
+        let result_path = session_dir.join("result.toml");
+        let _ = std::fs::remove_file(&result_path);
+    }
+
     let _worktree_write_lock = session_exec_write_lock::acquire_or_persist_failure(
         project_root,
         &mut session,

--- a/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_write_lock.rs
@@ -45,6 +45,7 @@ pub(super) fn acquire_if_needed(
         &ancestor_session_ids,
         |holder_session_id| holder_session_is_active(project_root, holder_session_id),
         |holder_session_id| holder_session_is_terminal(project_root, holder_session_id),
+        |holder_session_id| holder_session_result_is_stale(project_root, holder_session_id),
     )
     .map(Some)
 }
@@ -146,6 +147,23 @@ fn holder_session_is_terminal(project_root: &Path, session_id: &str) -> bool {
     }
 }
 
+fn holder_session_result_is_stale(project_root: &Path, session_id: &str) -> bool {
+    const STALE_THRESHOLD: chrono::Duration = chrono::Duration::minutes(5);
+
+    let session_dir = match csa_session::get_session_dir(project_root, session_id) {
+        Ok(dir) => dir,
+        Err(_) => return false,
+    };
+    let result_path = session_dir.join("result.toml");
+    let result_mtime = match std::fs::metadata(&result_path).and_then(|meta| meta.modified()) {
+        Ok(time) => time,
+        Err(_) => return false,
+    };
+
+    let result_mtime: chrono::DateTime<chrono::Utc> = result_mtime.into();
+    chrono::Utc::now().signed_duration_since(result_mtime) > STALE_THRESHOLD
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,6 +199,7 @@ mod tests {
             &[],
             |_| false,
             |_| false,
+            |_| false,
         )
         .expect("holder lock");
         let lock_path = holder_lock.lock_path().to_path_buf();
@@ -210,6 +229,7 @@ mod tests {
             temp.path(),
             &holder.meta_session_id,
             &[],
+            |_| false,
             |_| false,
             |_| false,
         )
@@ -251,6 +271,55 @@ mod tests {
                 .expect("create holder session");
 
         assert!(!super::holder_session_is_terminal(
+            temp.path(),
+            &holder.meta_session_id
+        ));
+    }
+
+    #[test]
+    fn holder_session_result_is_not_stale_when_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let holder =
+            csa_session::create_session_fresh(temp.path(), Some("running"), None, Some("codex"))
+                .expect("create holder session");
+
+        assert!(!super::holder_session_result_is_stale(
+            temp.path(),
+            &holder.meta_session_id
+        ));
+    }
+
+    #[test]
+    fn holder_session_result_is_not_stale_when_fresh() {
+        let temp = tempfile::tempdir().unwrap();
+        let holder =
+            csa_session::create_session_fresh(temp.path(), Some("done"), None, Some("codex"))
+                .expect("create holder session");
+        save_success_result(temp.path(), &holder.meta_session_id);
+
+        assert!(!super::holder_session_result_is_stale(
+            temp.path(),
+            &holder.meta_session_id
+        ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn holder_session_result_is_stale_after_threshold() {
+        let temp = tempfile::tempdir().unwrap();
+        let holder =
+            csa_session::create_session_fresh(temp.path(), Some("done"), None, Some("codex"))
+                .expect("create holder session");
+        save_success_result(temp.path(), &holder.meta_session_id);
+        let session_dir = csa_session::get_session_dir(temp.path(), &holder.meta_session_id)
+            .expect("session dir");
+        // Backdate result.toml to simulate a holder whose transport completed
+        // >5 minutes ago. Resumed sessions have their result.toml cleared
+        // before acquiring the lock, so this correctly identifies a stuck
+        // holder in the current execution.
+        set_file_mtime_seconds_ago(&session_dir.join("result.toml"), 301);
+
+        assert!(super::holder_session_result_is_stale(
             temp.path(),
             &holder.meta_session_id
         ));
@@ -369,5 +438,27 @@ mod tests {
             },
         )
         .expect("save result");
+    }
+
+    #[cfg(unix)]
+    fn set_file_mtime_seconds_ago(path: &Path, seconds_ago: u64) {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before unix epoch");
+        let target = now.saturating_sub(std::time::Duration::from_secs(seconds_ago));
+        let tv_sec = target.as_secs() as libc::time_t;
+        let tv_nsec = target.subsec_nanos() as libc::c_long;
+        let times = [
+            libc::timespec { tv_sec, tv_nsec },
+            libc::timespec { tv_sec, tv_nsec },
+        ];
+        let c_path = CString::new(path.as_os_str().as_bytes()).expect("path contains NUL");
+        // SAFETY: `utimensat` is called with a valid NUL-terminated path and
+        // a stack-allocated timespec array.
+        let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+        assert_eq!(rc, 0, "utimensat failed for {}", path.display());
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_tests_locking.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_locking.rs
@@ -65,6 +65,7 @@ fn acquire_active_holder_worktree_lock(
         &[],
         |_| false,
         |_| false,
+        |_| false,
     )
     .expect("holder worktree write lock should succeed");
     (holder.meta_session_id, lock)
@@ -263,6 +264,7 @@ async fn run_commit_child_reenters_under_ancestor_worktree_write_lock() {
         &[],
         |_| false,
         |_| false,
+        |_| false,
     )
     .expect("ancestor worktree write lock should succeed");
     let child = csa_session::create_session(
@@ -381,6 +383,7 @@ async fn review_fix_reenters_under_ancestor_worktree_write_lock() {
         project_root,
         &holder.meta_session_id,
         &[],
+        |_| false,
         |_| false,
         |_| false,
     )

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -322,6 +322,7 @@ async fn handle_run_fails_fast_when_worktree_write_lock_is_held() {
         &[],
         |_| false,
         |_| false,
+        |_| false,
     )
     .expect("holder worktree write lock should succeed");
 

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
@@ -212,9 +212,15 @@ fn handle_session_wait_treats_live_worktree_lock_as_progress_during_stale_preche
     session.last_accessed = chrono::Utc::now() - chrono::Duration::hours(24);
     let session_id = session.meta_session_id.clone();
     save_session(&session).expect("save stale active session");
-    let _worktree_lock =
-        csa_lock::acquire_worktree_write_lock(project, &session_id, &[], |_| false, |_| false)
-            .expect("worktree write lock should be held by session");
+    let _worktree_lock = csa_lock::acquire_worktree_write_lock(
+        project,
+        &session_id,
+        &[],
+        |_| false,
+        |_| false,
+        |_| false,
+    )
+    .expect("worktree write lock should be held by session");
 
     let mut emitted_completion: Option<(String, String, i32, bool)> = None;
     let exit_code = handle_session_wait_with_hooks(
@@ -264,9 +270,15 @@ fn handle_session_wait_sees_git_toplevel_worktree_lock_from_subdirectory() {
     session.last_accessed = chrono::Utc::now() - chrono::Duration::hours(24);
     let session_id = session.meta_session_id.clone();
     save_session(&session).expect("save stale active session");
-    let _worktree_lock =
-        csa_lock::acquire_worktree_write_lock(&repo_root, &session_id, &[], |_| false, |_| false)
-            .expect("writer lock should be held at git toplevel");
+    let _worktree_lock = csa_lock::acquire_worktree_write_lock(
+        &repo_root,
+        &session_id,
+        &[],
+        |_| false,
+        |_| false,
+        |_| false,
+    )
+    .expect("writer lock should be held at git toplevel");
     assert!(
         csa_lock::worktree_write_lock_is_held_by_session(&repo_root, &session_id)
             .expect("probe repo-root worktree lock"),
@@ -326,9 +338,15 @@ fn handle_session_wait_defers_terminal_result_while_worktree_lock_is_live() {
         ..make_result("failure", 1)
     };
     save_result(project, &session_id, &terminal_result).expect("save terminal result");
-    let worktree_lock =
-        csa_lock::acquire_worktree_write_lock(project, &session_id, &[], |_| false, |_| false)
-            .expect("worktree write lock should be held by session");
+    let worktree_lock = csa_lock::acquire_worktree_write_lock(
+        project,
+        &session_id,
+        &[],
+        |_| false,
+        |_| false,
+        |_| false,
+    )
+    .expect("worktree write lock should be held by session");
 
     let mut emitted_completion: Option<(String, String, i32, bool)> = None;
     let exit_code = handle_session_wait_with_hooks(

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs
@@ -245,9 +245,15 @@ fn handle_session_wait_on_resume_wrapper_treats_wrapper_worktree_lock_as_live_in
     let wrapper_id = wrapper.meta_session_id;
     save_session(&worker).unwrap();
     csa_session::write_resume_target(project, &wrapper_id, &worker_id).unwrap();
-    let _worktree_lock =
-        csa_lock::acquire_worktree_write_lock(project, &wrapper_id, &[], |_| false, |_| false)
-            .expect("wrapper worktree lock should be held");
+    let _worktree_lock = csa_lock::acquire_worktree_write_lock(
+        project,
+        &wrapper_id,
+        &[],
+        |_| false,
+        |_| false,
+        |_| false,
+    )
+    .expect("wrapper worktree lock should be held");
 
     let mut emitted_completion = false;
     let exit_code = handle_session_wait_with_hooks(

--- a/crates/csa-lock/src/worktree.rs
+++ b/crates/csa-lock/src/worktree.rs
@@ -7,6 +7,7 @@ use std::fs::{self, OpenOptions};
 use std::io::ErrorKind;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 /// Guard for a write-capable CSA session sharing one git worktree.
 ///
@@ -198,12 +199,18 @@ pub fn worktree_write_lock_is_held_by_session(
 /// Recovery is gated by `is_flock_available`: if the OS reports no process
 /// holds the flock, the lock is reclaimed. No SIGTERM is sent — flock
 /// availability is the sole safety guarantee.
+///
+/// `holder_session_result_is_stale` lets callers identify a post-transport
+/// holder that is still alive but has had a completed `result.toml` for longer
+/// than the caller-owned stale threshold. In that narrow case, this layer sends
+/// SIGTERM to the verified holder PID and waits briefly for flock release.
 pub fn acquire_worktree_write_lock(
     worktree_root: &Path,
     session_id: &str,
     ancestor_session_ids: &[String],
     holder_session_is_live: impl Fn(&str) -> bool,
     holder_session_is_terminal: impl Fn(&str) -> bool,
+    holder_session_result_is_stale: impl Fn(&str) -> bool,
 ) -> Result<WorktreeWriteLock> {
     let session_id = session_id.trim();
     if session_id.is_empty() {
@@ -321,6 +328,51 @@ pub fn acquire_worktree_write_lock(
                 }
             }
 
+            // Alive-stale-holder recovery: if transport completed long enough
+            // ago that the caller considers the holder stale, ask the still-live
+            // holder to terminate gracefully. We only signal when the recorded
+            // PID start time still matches the current process identity.
+            if let Some(diag) = diagnostic.as_ref()
+                && !is_pid_dead(diag.pid, diag.pid_start_time_ticks)
+                && let Some(holder_session_id) = diag.holder_session_id.as_deref()
+                && holder_session_result_is_stale(holder_session_id)
+                && pid_identity_matches(diag.pid, diag.pid_start_time_ticks)
+                && send_sigterm(diag.pid)
+            {
+                if wait_for_flock_available(&lock_path, Duration::from_secs(10)) {
+                    tracing::warn!(
+                        lock_path = %lock_path.display(),
+                        holder_pid = diag.pid,
+                        holder_session = holder_session_id,
+                        "reclaimed worktree write lock after SIGTERM (holder was alive but stale)"
+                    );
+                    match retry_acquire_worktree_write_lock(
+                        &lock_path,
+                        &lock_name,
+                        &reason,
+                        session_id,
+                        &canonical_root,
+                    ) {
+                        Ok(lock) => return Ok(lock),
+                        Err(retry_error) => {
+                            anyhow::bail!(
+                                "concurrent write session blocked: SIGTERM sent to stale holder, \
+                                 flock released, but retry failed: {}. {}",
+                                retry_error,
+                                lock_error
+                            );
+                        }
+                    }
+                } else {
+                    tracing::warn!(
+                        lock_path = %lock_path.display(),
+                        holder_pid = diag.pid,
+                        holder_session = holder_session_id,
+                        "SIGTERM sent but flock not released within 10s grace period"
+                    );
+                }
+            }
+
             let holder = diagnostic
                 .as_ref()
                 .and_then(|diag| diag.holder_session_id.as_deref())
@@ -403,6 +455,38 @@ fn is_flock_available(lock_path: &Path) -> bool {
     }
 }
 
+fn pid_identity_matches(pid: u32, pid_start_time_ticks: Option<u64>) -> bool {
+    let Some(expected_ticks) = pid_start_time_ticks else {
+        return false;
+    };
+    crate::process_start_time_ticks(pid) == Some(expected_ticks)
+}
+
+fn send_sigterm(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    // SAFETY: `kill(pid, SIGTERM)` sends a signal to a PID whose identity was
+    // verified by `pid_identity_matches`; the return value is checked.
+    (unsafe { libc::kill(pid, libc::SIGTERM) }) == 0
+}
+
+fn wait_for_flock_available(lock_path: &Path, timeout: Duration) -> bool {
+    let start = Instant::now();
+    let interval = Duration::from_millis(100);
+    while start.elapsed() < timeout {
+        if is_flock_available(lock_path) {
+            return true;
+        }
+        std::thread::sleep(interval);
+    }
+    false
+}
+
 #[cfg(test)]
 #[path = "worktree_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "worktree_reclaim_tests.rs"]
+mod reclaim_tests;

--- a/crates/csa-lock/src/worktree_reclaim_tests.rs
+++ b/crates/csa-lock/src/worktree_reclaim_tests.rs
@@ -1,0 +1,229 @@
+use super::*;
+use std::ffi::OsString;
+use std::fs;
+use std::path::Path;
+use std::process::{Child, Command};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::Duration;
+use tempfile::tempdir;
+
+fn env_test_lock() -> MutexGuard<'static, ()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    fn set_os(key: &'static str, value: &Path) -> Self {
+        let original = std::env::var_os(key);
+        // SAFETY: test-scoped env mutation is serialized by `env_test_lock`.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.original.take() {
+            // SAFETY: test-scoped env restoration is serialized by `env_test_lock`.
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            // SAFETY: test-scoped env restoration is serialized by `env_test_lock`.
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn worktree_write_lock_reclaims_terminal_session_after_holder_crash() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let ready_path = worktree_root.path().join("holder-ready");
+    let mut holder = spawn_terminal_reclaim_holder(
+        state_home.path(),
+        worktree_root.path(),
+        "01TERMINAL",
+        &ready_path,
+        true,
+    );
+    wait_for_ready_marker(&ready_path);
+    holder.wait_for_exit();
+
+    let lock = acquire_worktree_write_lock(
+        worktree_root.path(),
+        "01NEXT",
+        &[],
+        |_| false,
+        |holder_session_id| holder_session_id == "01TERMINAL",
+        |_| false,
+    )
+    .expect("terminal holder session with free flock should be reclaimed");
+
+    assert!(!lock.is_lineage_reentry());
+}
+
+#[test]
+fn worktree_write_lock_keeps_live_nonterminal_holder_blocked() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let ready_path = worktree_root.path().join("holder-ready");
+    let mut holder = spawn_terminal_reclaim_holder(
+        state_home.path(),
+        worktree_root.path(),
+        "01ACTIVE",
+        &ready_path,
+        false,
+    );
+    wait_for_ready_marker(&ready_path);
+
+    let err = acquire_worktree_write_lock(
+        worktree_root.path(),
+        "01NEXT",
+        &[],
+        |_| false,
+        |_| false,
+        |_| false,
+    )
+    .expect_err("live nonterminal holder must still block")
+    .to_string();
+
+    assert!(err.contains("concurrent write session blocked"));
+    assert!(err.contains("01ACTIVE"));
+    assert!(holder.is_running());
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn worktree_write_lock_sigterms_alive_stale_result_holder() {
+    let _env_lock = env_test_lock();
+    let state_home = tempdir().expect("state-home tempdir");
+    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
+
+    let worktree_root = tempdir().expect("worktree tempdir");
+    let ready_path = worktree_root.path().join("holder-ready");
+    let mut holder = spawn_terminal_reclaim_holder(
+        state_home.path(),
+        worktree_root.path(),
+        "01STALE",
+        &ready_path,
+        false,
+    );
+    wait_for_ready_marker(&ready_path);
+
+    let lock = acquire_worktree_write_lock(
+        worktree_root.path(),
+        "01NEXT",
+        &[],
+        |_| false,
+        |_| false,
+        |holder_session_id| holder_session_id == "01STALE",
+    )
+    .expect("alive stale holder should be terminated and reclaimed");
+
+    assert!(!lock.is_lineage_reentry());
+    holder.wait_for_exit();
+}
+
+#[test]
+fn terminal_reclaim_holder_child_entrypoint() {
+    let Some(worktree_root) = std::env::var_os("CSA_LOCK_TERMINAL_RECLAIM_WORKTREE") else {
+        return;
+    };
+    let Some(ready_path) = std::env::var_os("CSA_LOCK_TERMINAL_RECLAIM_READY") else {
+        return;
+    };
+    let holder_session_id =
+        std::env::var("CSA_LOCK_TERMINAL_RECLAIM_HOLDER").expect("holder session id env");
+
+    let _lock = acquire_worktree_write_lock(
+        Path::new(&worktree_root),
+        &holder_session_id,
+        &[],
+        |_| false,
+        |_| false,
+        |_| false,
+    )
+    .expect("child holder should acquire worktree write lock");
+    fs::write(ready_path, b"ready").expect("write ready marker");
+
+    if std::env::var_os("CSA_LOCK_TERMINAL_RECLAIM_EXIT").is_some() {
+        std::process::exit(0);
+    }
+
+    loop {
+        std::thread::sleep(Duration::from_secs(60));
+    }
+}
+
+fn spawn_terminal_reclaim_holder(
+    state_home: &Path,
+    worktree_root: &Path,
+    holder_session_id: &str,
+    ready_path: &Path,
+    exit_after_ready: bool,
+) -> ChildGuard {
+    let mut cmd = Command::new(std::env::current_exe().expect("current test binary"));
+    cmd.arg("terminal_reclaim_holder_child_entrypoint")
+        .arg("--nocapture")
+        .env("XDG_STATE_HOME", state_home)
+        .env("CSA_LOCK_TERMINAL_RECLAIM_WORKTREE", worktree_root)
+        .env("CSA_LOCK_TERMINAL_RECLAIM_HOLDER", holder_session_id)
+        .env("CSA_LOCK_TERMINAL_RECLAIM_READY", ready_path);
+    if exit_after_ready {
+        cmd.env("CSA_LOCK_TERMINAL_RECLAIM_EXIT", "1");
+    }
+    let child = cmd.spawn().expect("spawn holder child process");
+    ChildGuard { child }
+}
+
+fn wait_for_ready_marker(ready_path: &Path) {
+    for _ in 0..100 {
+        if ready_path.exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    panic!("holder child did not report ready");
+}
+
+struct ChildGuard {
+    child: Child,
+}
+
+impl ChildGuard {
+    fn is_running(&mut self) -> bool {
+        self.child.try_wait().expect("check child status").is_none()
+    }
+
+    fn wait_for_exit(&mut self) {
+        for _ in 0..100 {
+            if self.child.try_wait().expect("check child status").is_some() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("holder child did not exit after stale lock reclaim");
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}

--- a/crates/csa-lock/src/worktree_tests.rs
+++ b/crates/csa-lock/src/worktree_tests.rs
@@ -5,9 +5,8 @@ use std::ffi::OsString;
 use std::fs::{self, File, OpenOptions};
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::io::AsRawFd;
-use std::process::{Child, Command};
+use std::process::Command;
 use std::sync::{Mutex, MutexGuard, OnceLock};
-use std::time::Duration;
 use tempfile::tempdir;
 
 fn env_test_lock() -> MutexGuard<'static, ()> {
@@ -54,6 +53,7 @@ fn acquire_test_worktree_write_lock(
         session_id,
         ancestor_session_ids,
         |holder_session_id| live_holder_session_ids.contains(&holder_session_id),
+        |_| false,
         |_| false,
     )
 }
@@ -150,6 +150,7 @@ fn cross_process_lineage_reentry_child_entrypoint() {
         std::slice::from_ref(&holder_session_id),
         |candidate| candidate == holder_session_id.as_str(),
         |_| false,
+        |_| false,
     )
     .expect("child should re-enter under live ancestor lock held by parent process");
 
@@ -244,101 +245,6 @@ fn worktree_write_lock_keeps_live_holder_blocked() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
-fn worktree_write_lock_reclaims_terminal_session_after_holder_crash() {
-    let _env_lock = env_test_lock();
-    let state_home = tempdir().expect("state-home tempdir");
-    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
-
-    let worktree_root = tempdir().expect("worktree tempdir");
-    let ready_path = worktree_root.path().join("holder-ready");
-    let mut holder = spawn_terminal_reclaim_holder(
-        state_home.path(),
-        worktree_root.path(),
-        "01TERMINAL",
-        &ready_path,
-        true, // exit after ready — simulate crashed holder
-    );
-    wait_for_ready_marker(&ready_path);
-    // Wait for holder to exit so flock is released
-    holder.wait_for_exit();
-
-    let lock = acquire_worktree_write_lock(
-        worktree_root.path(),
-        "01NEXT",
-        &[],
-        |_| false,
-        |holder_session_id| holder_session_id == "01TERMINAL",
-    )
-    .expect("terminal holder session with free flock should be reclaimed");
-
-    assert!(!lock.is_lineage_reentry());
-}
-
-#[test]
-fn worktree_write_lock_keeps_live_nonterminal_holder_blocked() {
-    let _env_lock = env_test_lock();
-    let state_home = tempdir().expect("state-home tempdir");
-    let _state_guard = EnvVarGuard::set_os("XDG_STATE_HOME", state_home.path());
-
-    let worktree_root = tempdir().expect("worktree tempdir");
-    let ready_path = worktree_root.path().join("holder-ready");
-    let mut holder = spawn_terminal_reclaim_holder(
-        state_home.path(),
-        worktree_root.path(),
-        "01ACTIVE",
-        &ready_path,
-        false, // stay alive — simulate live holder holding flock
-    );
-    wait_for_ready_marker(&ready_path);
-
-    let err =
-        acquire_worktree_write_lock(worktree_root.path(), "01NEXT", &[], |_| false, |_| false)
-            .expect_err("live nonterminal holder must still block")
-            .to_string();
-
-    assert!(err.contains("concurrent write session blocked"));
-    assert!(err.contains("01ACTIVE"));
-    assert!(
-        holder.is_running(),
-        "nonterminal holder process must not be terminated"
-    );
-}
-
-#[test]
-fn terminal_reclaim_holder_child_entrypoint() {
-    let Some(worktree_root) = std::env::var_os("CSA_LOCK_TERMINAL_RECLAIM_WORKTREE") else {
-        return;
-    };
-    let Some(ready_path) = std::env::var_os("CSA_LOCK_TERMINAL_RECLAIM_READY") else {
-        return;
-    };
-    let holder_session_id =
-        std::env::var("CSA_LOCK_TERMINAL_RECLAIM_HOLDER").expect("holder session id env");
-
-    let _lock = acquire_worktree_write_lock(
-        Path::new(&worktree_root),
-        &holder_session_id,
-        &[],
-        |_| false,
-        |_| false,
-    )
-    .expect("child holder should acquire worktree write lock");
-    fs::write(ready_path, b"ready").expect("write ready marker");
-
-    // Check if this child should exit immediately (simulating a crashed holder
-    // that released flock but left stale metadata) or stay alive (simulating
-    // a live holder still holding flock).
-    if std::env::var_os("CSA_LOCK_TERMINAL_RECLAIM_EXIT").is_some() {
-        std::process::exit(0);
-    }
-
-    loop {
-        std::thread::sleep(Duration::from_secs(60));
-    }
-}
-
-#[test]
 fn worktree_write_lock_probe_detects_live_matching_holder() {
     let _env_lock = env_test_lock();
     let state_home = tempdir().expect("state-home tempdir");
@@ -353,66 +259,6 @@ fn worktree_write_lock_probe_detects_live_matching_holder() {
             .expect("probe live holder"),
         "live flock plus matching diagnostic should report held"
     );
-}
-
-fn spawn_terminal_reclaim_holder(
-    state_home: &Path,
-    worktree_root: &Path,
-    holder_session_id: &str,
-    ready_path: &Path,
-    exit_after_ready: bool,
-) -> ChildGuard {
-    let mut cmd = Command::new(std::env::current_exe().expect("current test binary"));
-    cmd.arg("terminal_reclaim_holder_child_entrypoint")
-        .arg("--nocapture")
-        .env("XDG_STATE_HOME", state_home)
-        .env("CSA_LOCK_TERMINAL_RECLAIM_WORKTREE", worktree_root)
-        .env("CSA_LOCK_TERMINAL_RECLAIM_HOLDER", holder_session_id)
-        .env("CSA_LOCK_TERMINAL_RECLAIM_READY", ready_path);
-    if exit_after_ready {
-        cmd.env("CSA_LOCK_TERMINAL_RECLAIM_EXIT", "1");
-    }
-    let child = cmd.spawn().expect("spawn holder child process");
-    ChildGuard { child }
-}
-
-fn wait_for_ready_marker(ready_path: &Path) {
-    for _ in 0..100 {
-        if ready_path.exists() {
-            return;
-        }
-        std::thread::sleep(Duration::from_millis(10));
-    }
-    panic!("holder child did not report ready");
-}
-
-struct ChildGuard {
-    child: Child,
-}
-
-impl ChildGuard {
-    fn is_running(&mut self) -> bool {
-        self.child.try_wait().expect("check child status").is_none()
-    }
-
-    fn wait_for_exit(&mut self) {
-        for _ in 0..100 {
-            if self.child.try_wait().expect("check child status").is_some() {
-                return;
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        panic!("holder child did not exit after stale lock reclaim");
-    }
-}
-
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        if self.child.try_wait().ok().flatten().is_none() {
-            let _ = self.child.kill();
-            let _ = self.child.wait();
-        }
-    }
 }
 
 #[test]
@@ -653,8 +499,14 @@ fn issue_2528_stale_lock_with_dead_holder_is_recovered() {
     std::fs::write(&lock_path, stale_diag.to_string()).unwrap();
 
     // The lock file exists but the PID is dead — acquisition should succeed
-    let lock =
-        crate::acquire_worktree_write_lock(project, "NEW_SESSION", &[], |_| false, |_| false);
+    let lock = crate::acquire_worktree_write_lock(
+        project,
+        "NEW_SESSION",
+        &[],
+        |_| false,
+        |_| false,
+        |_| false,
+    );
     assert!(
         lock.is_ok(),
         "should recover stale lock with dead holder PID: {:?}",

--- a/scripts/monolith/baseline.toml
+++ b/scripts/monolith/baseline.toml
@@ -792,3 +792,12 @@ baseline_tokens = 9260
 baseline_lines = 653
 issue = "2615"
 rationale = "run-level outer timeout fix adds synthetic ExecutionResult + RunLoopOutcome for both pre-attempt and mid-attempt timeout branches (~60 lines); pre-existing at ~8400 tokens"
+
+
+[[files]]
+path = "crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs"
+kind = "test"
+baseline_tokens = 8003
+baseline_lines = 643
+issue = "2618"
+rationale = "3-line addition for new holder_session_result_is_stale callback parameter"


### PR DESCRIPTION
## Summary

Fixes #2618.

Adds a third recovery branch to `acquire_worktree_write_lock` for the case where the holder PID is alive and holding flock, but the holder session has a stale `result.toml` (transport completed >5 minutes ago).

## Recovery Conditions

1. Holder PID is alive (`is_pid_dead` returns false)
2. PID identity verified (`pid_start_time_ticks` matches current process)
3. Holder session has `result.toml` written >5 minutes ago
4. SIGTERM sent to verified holder PID
5. Poll `is_flock_available` for up to 10 seconds (100ms intervals)
6. If flock releases → reclaim; otherwise → bail with standard blocked error

## Resume Safety

When a session is resumed from Available, `pipeline_session_exec.rs` now clears any stale `result.toml` **before** acquiring the worktree lock. This prevents the reclaim path from treating a resumed session's old result as evidence of a stuck holder.

## Review History

4 rounds of tier-4 critical review. Key findings addressed:
- Round 1: resumed sessions keep old result.toml → fixed by clearing result before lock acquisition
- Round 2: state.toml mtime guard was counterproductive for normal-completion stuck holders → removed
- Round 3: test fixture mtime ordering fixed
- Round 4: confirmed approach is sound

The SIGTERM + 10s flock grace period ensures the holder has a chance to exit gracefully before reclaim.