### PR TITLE
fix(csa-lock): FD_CLOEXEC on lock/slot FDs + stale-PID slot recovery

### DIFF
--- a/crates/csa-lock/src/lib.rs
+++ b/crates/csa-lock/src/lib.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::{Path, PathBuf};
 
 /// Diagnostic information written to lock files
@@ -132,7 +132,7 @@ pub(crate) fn acquire_lock_at_path_with_metadata(
     let diagnostic = read_lock_diagnostic(lock_path)?;
     let error_msg = diagnostic
         .as_ref()
-        .map(format_lock_diagnostic)
+        .map(|diagnostic| format_lock_diagnostic(lock_path, diagnostic))
         .unwrap_or_else(|| "Session is locked (unable to read diagnostic info)".to_string());
 
     // Resource-scoped locks such as the worktree write lock layer their own
@@ -188,6 +188,8 @@ fn try_acquire_lock_at_path(
     let ret = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
 
     if ret == 0 {
+        set_fd_cloexec(fd, lock_path)?;
+
         // Lock acquired successfully. Write diagnostic information.
         let mut lock = SessionLock {
             file,
@@ -221,6 +223,24 @@ fn try_acquire_lock_at_path(
     }
 }
 
+pub(crate) fn set_fd_cloexec(fd: RawFd, path: &Path) -> Result<()> {
+    // SAFETY: `fd` is owned by a live `File`; F_GETFD reads descriptor flags.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags == -1 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("Failed to read fd flags for {}", path.display()));
+    }
+
+    // SAFETY: `fd` is valid, and F_SETFD updates only close-on-exec flags.
+    let ret = unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) };
+    if ret == -1 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("Failed to set FD_CLOEXEC on {}", path.display()));
+    }
+
+    Ok(())
+}
+
 #[cfg(target_os = "linux")]
 pub(crate) fn process_start_time_ticks(pid: u32) -> Option<u64> {
     let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
@@ -234,7 +254,7 @@ pub(crate) fn process_start_time_ticks(_pid: u32) -> Option<u64> {
 }
 
 /// Check whether a PID is dead or has been recycled since it acquired the lock.
-fn is_pid_dead(pid: u32, pid_start_time_ticks: Option<u64>) -> bool {
+pub(crate) fn is_pid_dead(pid: u32, pid_start_time_ticks: Option<u64>) -> bool {
     let Ok(pid_i32) = i32::try_from(pid) else {
         return false;
     };
@@ -284,7 +304,7 @@ fn clear_stale_lock_file(lock_path: &Path) -> bool {
     }
 }
 
-fn format_lock_diagnostic(diagnostic: &LockDiagnostic) -> String {
+fn format_lock_diagnostic(lock_path: &Path, diagnostic: &LockDiagnostic) -> String {
     let holder = diagnostic
         .holder_session_id
         .as_deref()
@@ -295,9 +315,18 @@ fn format_lock_diagnostic(diagnostic: &LockDiagnostic) -> String {
         .as_deref()
         .map(|path| format!(", resource_path: {path}"))
         .unwrap_or_default();
+    let pid_status = if is_pid_dead(diagnostic.pid, diagnostic.pid_start_time_ticks) {
+        "dead_or_recycled"
+    } else {
+        "alive"
+    };
     format!(
-        "Session locked by PID {} (tool: {}, reason: {}, acquired: {}{}{})",
+        "Session locked by PID {} (lock_path: {}, pid_status: {}, \
+         pid_start_time_ticks: {:?}, tool: {}, reason: {}, acquired: {}{}{})",
         diagnostic.pid,
+        lock_path.display(),
+        pid_status,
+        diagnostic.pid_start_time_ticks,
         diagnostic.tool_name,
         diagnostic.reason,
         diagnostic.acquired_at,

--- a/crates/csa-lock/src/lib_tests.rs
+++ b/crates/csa-lock/src/lib_tests.rs
@@ -120,6 +120,17 @@ fn test_second_lock_fails() {
 }
 
 #[test]
+fn session_lock_sets_fd_cloexec() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let session_dir = temp_dir.path();
+
+    let lock =
+        acquire_lock(session_dir, "codex", "running task").expect("lock acquisition should work");
+
+    assert_fd_cloexec(lock.file.as_raw_fd());
+}
+
+#[test]
 fn session_lock_recovers_dead_pid_with_held_stale_flock() {
     let temp_dir = tempdir().expect("Failed to create temp dir");
     let lock_path = temp_dir.path().join("locks/codex.lock");
@@ -348,6 +359,30 @@ fn test_second_lock_error_contains_diagnostic() {
 }
 
 #[test]
+fn lock_error_includes_path_pid_liveness_and_start_ticks() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let session_dir = temp_dir.path();
+
+    let _lock =
+        acquire_lock(session_dir, "codex", "first task").expect("First lock should succeed");
+
+    let err = acquire_lock(session_dir, "codex", "second task")
+        .unwrap_err()
+        .to_string();
+
+    let expected_path = session_dir.join("locks/codex.lock");
+    assert!(
+        err.contains(&format!("lock_path: {}", expected_path.display())),
+        "missing lock path: {err}"
+    );
+    assert!(err.contains("pid_status: alive"), "missing liveness: {err}");
+    assert!(
+        err.contains("pid_start_time_ticks:"),
+        "missing start time ticks: {err}"
+    );
+}
+
+#[test]
 fn test_parent_fork_lock_serializes_same_parent() {
     let temp_dir = tempdir().expect("Failed to create temp dir");
     let state_root = temp_dir.path();
@@ -498,4 +533,15 @@ impl Drop for ManualFlock {
             libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
         }
     }
+}
+
+fn assert_fd_cloexec(fd: std::os::unix::io::RawFd) {
+    // SAFETY: `fd` is owned by a live lock guard in the calling test.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    assert_ne!(flags, -1, "F_GETFD should succeed");
+    assert_ne!(
+        flags & libc::FD_CLOEXEC,
+        0,
+        "lock fd should be marked close-on-exec"
+    );
 }

--- a/crates/csa-lock/src/slot.rs
+++ b/crates/csa-lock/src/slot.rs
@@ -21,6 +21,8 @@ use std::time::{Duration, Instant};
 #[derive(Debug, Serialize, Deserialize)]
 struct SlotDiagnostic {
     pid: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pid_start_time_ticks: Option<u64>,
     tool_name: String,
     slot_index: u32,
     acquired_at: DateTime<Utc>,
@@ -172,36 +174,25 @@ pub fn try_acquire_slot(
 
         let fd = file.as_raw_fd();
 
-        // SAFETY: `fd` is a valid file descriptor from the `File` we just opened.
-        // `LOCK_EX | LOCK_NB` requests an exclusive non-blocking lock.
-        let ret = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
-
-        if ret == 0 {
-            // Slot acquired. Write diagnostic info.
-            let mut slot = ToolSlot {
-                file,
-                slot_path,
-                tool_name: tool_name.to_string(),
-                slot_index: index,
-                released: false,
-            };
-
-            let diagnostic = SlotDiagnostic {
-                pid: std::process::id(),
-                tool_name: tool_name.to_string(),
-                slot_index: index,
-                acquired_at: Utc::now(),
-                session_id: session_id.map(|s| s.to_string()),
-            };
-
-            if let Ok(json) = serde_json::to_string(&diagnostic) {
-                let _ = slot.file.set_len(0);
-                let _ = slot.file.write_all(json.as_bytes());
-                let _ = slot.file.flush();
-            }
-
-            return Ok(SlotAcquireResult::Acquired(slot));
+        // First attempt: non-blocking flock.
+        // SAFETY: fd is valid, LOCK_EX | LOCK_NB is a non-blocking advisory lock.
+        if unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+            return Ok(SlotAcquireResult::Acquired(try_acquire_slot_file_owned(
+                file, slot_path, tool_name, index, session_id, fd,
+            )?));
         }
+
+        // flock failed. If the on-disk diagnostic shows a dead PID, the kernel
+        // has already released the flock — retry flock on the SAME fd without
+        // removing the file (avoids TOCTOU: remove_file could unlink a live slot).
+        if is_slot_diagnostic_pid_dead(&slot_path)
+            && unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) } == 0
+        {
+            return Ok(SlotAcquireResult::Acquired(try_acquire_slot_file_owned(
+                file, slot_path, tool_name, index, session_id, fd,
+            )?));
+        }
+
         // This slot is held; try the next one.
         occupied += 1;
     }
@@ -247,6 +238,64 @@ pub fn try_acquire_slot(
         max_slots: max_concurrent,
         occupied: max_concurrent,
     }))
+}
+
+fn try_acquire_slot_file_owned(
+    file: File,
+    slot_path: PathBuf,
+    tool_name: &str,
+    slot_index: u32,
+    session_id: Option<&str>,
+    fd: std::os::unix::io::RawFd,
+) -> Result<ToolSlot> {
+    crate::set_fd_cloexec(fd, &slot_path)?;
+
+    let mut slot = ToolSlot {
+        file,
+        slot_path,
+        tool_name: tool_name.to_string(),
+        slot_index,
+        released: false,
+    };
+
+    let diagnostic = SlotDiagnostic {
+        pid: std::process::id(),
+        pid_start_time_ticks: crate::process_start_time_ticks(std::process::id()),
+        tool_name: tool_name.to_string(),
+        slot_index,
+        acquired_at: Utc::now(),
+        session_id: session_id.map(ToString::to_string),
+    };
+
+    if let Ok(json) = serde_json::to_string(&diagnostic) {
+        let _ = slot.file.set_len(0);
+        let _ = slot.file.write_all(json.as_bytes());
+        let _ = slot.file.flush();
+    }
+
+    Ok(slot)
+}
+
+fn is_slot_diagnostic_pid_dead(slot_path: &Path) -> bool {
+    let Some(diagnostic) = read_slot_diagnostic(slot_path) else {
+        return false;
+    };
+    if !crate::is_pid_dead(diagnostic.pid, diagnostic.pid_start_time_ticks) {
+        return false;
+    }
+
+    tracing::warn!(
+        slot_path = %slot_path.display(),
+        holder_pid = diagnostic.pid,
+        holder_session = ?diagnostic.session_id,
+        "retrying slot flock after detecting dead holder PID (no file removal — avoids TOCTOU)"
+    );
+    true
+}
+
+fn read_slot_diagnostic(slot_path: &Path) -> Option<SlotDiagnostic> {
+    let contents = fs::read_to_string(slot_path).ok()?;
+    serde_json::from_str(&contents).ok()
 }
 
 /// Block-wait for a slot with timeout.
@@ -434,9 +483,94 @@ mod tests {
         let diag: SlotDiagnostic = serde_json::from_str(&content).unwrap();
 
         assert_eq!(diag.pid, std::process::id());
+        assert_eq!(
+            diag.pid_start_time_ticks,
+            crate::process_start_time_ticks(std::process::id())
+        );
         assert_eq!(diag.tool_name, "test-tool");
         assert_eq!(diag.slot_index, 0);
         assert_eq!(diag.session_id.as_deref(), Some("session-123"));
+    }
+
+    #[test]
+    fn test_slot_fd_sets_cloexec() {
+        let dir = tempdir().unwrap();
+        let slots_dir = dir.path();
+
+        let result = try_acquire_slot(slots_dir, "codex", 1, Some("session-123")).unwrap();
+        let SlotAcquireResult::Acquired(slot) = result else {
+            panic!("expected acquired slot");
+        };
+
+        assert_fd_cloexec(slot.file.as_raw_fd());
+    }
+
+    #[test]
+    fn test_slot_recovers_dead_pid_when_flock_released() {
+        // When the holder PID is dead, the kernel has already released the flock.
+        // The on-disk diagnostic still shows the dead PID. try_acquire_slot should
+        // detect the dead PID, retry flock on the same fd, and succeed.
+        let dir = tempdir().unwrap();
+        let slots_dir = dir.path();
+        let tool_dir = slots_dir.join("codex");
+        fs::create_dir_all(&tool_dir).unwrap();
+        let slot_path = tool_dir.join("slot-00.lock");
+
+        // Write a stale diagnostic with a definitely-dead PID.
+        // No ManualSlotFlock — the flock is free because the dead process released it.
+        write_slot_diagnostic(
+            &slot_path,
+            i32::MAX as u32,
+            None,
+            "codex",
+            0,
+            Some("01STALE"),
+        );
+
+        let result = try_acquire_slot(slots_dir, "codex", 1, Some("01FRESH")).unwrap();
+        let SlotAcquireResult::Acquired(slot) = result else {
+            panic!("dead PID diagnostic with free flock should be reclaimed");
+        };
+        assert_eq!(slot.slot_index(), 0);
+
+        let content = fs::read_to_string(&slot_path).unwrap();
+        let diag: SlotDiagnostic = serde_json::from_str(&content).unwrap();
+        assert_eq!(diag.pid, std::process::id());
+        assert_eq!(diag.tool_name, "codex");
+        assert_eq!(diag.slot_index, 0);
+        assert_eq!(diag.session_id.as_deref(), Some("01FRESH"));
+    }
+
+    #[test]
+    fn test_slot_dead_pid_with_held_flock_does_not_steal() {
+        // If the diagnostic PID is dead BUT another live process now holds the flock
+        // (e.g., it acquired between our first flock attempt and our dead-PID check),
+        // we must NOT steal the slot. The retry flock should fail.
+        let dir = tempdir().unwrap();
+        let slots_dir = dir.path();
+        let tool_dir = slots_dir.join("codex");
+        fs::create_dir_all(&tool_dir).unwrap();
+        let slot_path = tool_dir.join("slot-00.lock");
+        write_slot_diagnostic(
+            &slot_path,
+            i32::MAX as u32,
+            None,
+            "codex",
+            0,
+            Some("01STALE"),
+        );
+        // A live process holds the flock now.
+        let _live_flock = ManualSlotFlock::acquire(&slot_path);
+
+        let result = try_acquire_slot(slots_dir, "codex", 1, Some("01FRESH")).unwrap();
+        match result {
+            SlotAcquireResult::Exhausted(status) => {
+                assert_eq!(status.occupied, 1);
+            }
+            SlotAcquireResult::Acquired(_) => {
+                panic!("must not steal slot held by live flock even if diagnostic PID is dead");
+            }
+        }
     }
 
     #[test]
@@ -725,5 +859,64 @@ mod tests {
             "error should include file path: {msg}"
         );
         assert!(msg.contains("Hint:"), "error should include hint: {msg}");
+    }
+
+    fn write_slot_diagnostic(
+        slot_path: &Path,
+        pid: u32,
+        pid_start_time_ticks: Option<u64>,
+        tool_name: &str,
+        slot_index: u32,
+        session_id: Option<&str>,
+    ) {
+        let diagnostic = SlotDiagnostic {
+            pid,
+            pid_start_time_ticks,
+            tool_name: tool_name.to_string(),
+            slot_index,
+            acquired_at: Utc::now(),
+            session_id: session_id.map(ToString::to_string),
+        };
+        fs::write(slot_path, serde_json::to_string(&diagnostic).unwrap())
+            .expect("write slot diagnostic");
+    }
+
+    struct ManualSlotFlock {
+        file: File,
+    }
+
+    impl ManualSlotFlock {
+        fn acquire(slot_path: &Path) -> Self {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(slot_path)
+                .expect("open slot file for manual flock");
+            // SAFETY: `file` owns a valid fd, and LOCK_EX | LOCK_NB requests a
+            // non-blocking advisory lock for the stale-slot setup.
+            let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+            assert_eq!(ret, 0, "manual stale slot flock should acquire lock");
+            Self { file }
+        }
+    }
+
+    impl Drop for ManualSlotFlock {
+        fn drop(&mut self) {
+            // SAFETY: `file` owns a valid fd; unlock before close for deterministic cleanup.
+            unsafe {
+                libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+            }
+        }
+    }
+
+    fn assert_fd_cloexec(fd: std::os::unix::io::RawFd) {
+        // SAFETY: `fd` is owned by a live slot guard in the calling test.
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        assert_ne!(flags, -1, "F_GETFD should succeed");
+        assert_ne!(
+            flags & libc::FD_CLOEXEC,
+            0,
+            "slot fd should be marked close-on-exec"
+        );
     }
 }

--- a/scripts/monolith/baseline.toml
+++ b/scripts/monolith/baseline.toml
@@ -620,8 +620,8 @@ rationale = "pre-existing monolith debt grandfathered by #1880 calibration; no-g
 [[files]]
 path = "crates/csa-lock/src/slot.rs"
 kind = "source"
-baseline_tokens = 8246
-baseline_lines = 729
+baseline_tokens = 10501
+baseline_lines = 922
 issue = "1880"
 rationale = "pre-existing monolith debt grandfathered by #1880 calibration; no-growth ratchet"
 


### PR DESCRIPTION
## Summary

Fixes pre-exec codex lock self-deadlock (#2624) via three changes:

1. **FD_CLOEXEC** on both per-session lock and tool slot file descriptors after flock acquisition. Without this, the codex subprocess inherits lock FDs via exec(), orphaning the flock if the orchestrator dies.

2. **Stale-PID slot recovery**: when flock fails on a slot, read the SlotDiagnostic JSON, check is_pid_dead, and if dead retry flock on the SAME fd (no file removal — avoids TOCTOU race where remove_file could unlink a newly acquired live slot).

3. **Improved error diagnostics**: lock failure messages now include blocking lock path, PID liveness status, and pid_start_time_ticks.

Closes #2624

## Test coverage
- `test_slot_fd_sets_cloexec` — FD_CLOEXEC set on slot FD
- `test_slot_recovers_dead_pid_when_flock_released` — stale PID with free flock → recovery succeeds
- `test_slot_dead_pid_with_held_flock_does_not_steal` — stale PID with live flock → does NOT steal
- `session_lock_sets_fd_cloexec` — FD_CLOEXEC on session lock
- `lock_error_includes_path_pid_liveness_and_start_ticks` — diagnostic message completeness