### PR TITLE
fix(session-wait): stale-PID recovery + FD_CLOEXEC on .wait.lock

### DIFF
--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_lock.rs
@@ -1,5 +1,6 @@
-use std::io::{Seek, SeekFrom, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::os::fd::AsRawFd;
+use std::os::unix::io::RawFd;
 use std::path::Path;
 
 use anyhow::Result;
@@ -9,9 +10,18 @@ pub(crate) struct SessionWaitLock {
     file: std::fs::File,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+impl SessionWaitLock {
+    #[cfg(test)]
+    pub(crate) fn raw_fd(&self) -> std::os::unix::io::RawFd {
+        self.file.as_raw_fd()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 struct SessionWaitLockDiagnostic {
     pid: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pid_start_time_ticks: Option<u64>,
 }
 
 impl Drop for SessionWaitLock {
@@ -25,25 +35,36 @@ impl Drop for SessionWaitLock {
 
 pub(crate) fn try_acquire_session_wait_lock(session_dir: &Path) -> Result<Option<SessionWaitLock>> {
     let lock_path = session_dir.join(".wait.lock");
-    let mut file = std::fs::OpenOptions::new()
+    let file = std::fs::OpenOptions::new()
         .create(true)
         .read(true)
         .write(true)
         .truncate(false)
         .open(&lock_path)?;
 
-    if try_flock_session_wait_file(&file)? {
-        write_session_wait_lock_diagnostic(&mut file)?;
-        return Ok(Some(SessionWaitLock { file }));
+    let fd = file.as_raw_fd();
+
+    if try_flock_session_wait_file(fd)? {
+        return Ok(Some(finalize_wait_lock(file, fd, &lock_path)?));
     }
 
+    // flock failed. If the on-disk diagnostic shows a dead PID, the kernel has
+    // already released the flock — retry on the SAME fd without removing the file
+    // (avoids TOCTOU: remove_file could unlink a lock acquired between our check
+    // and the unlink).
+    if is_wait_lock_diagnostic_pid_dead(&lock_path) && try_flock_session_wait_file(fd)? {
+        return Ok(Some(finalize_wait_lock(file, fd, &lock_path)?));
+    }
+
+    // Drop file to close the fd we opened (flock not acquired).
+    drop(file);
     Ok(None)
 }
 
-fn try_flock_session_wait_file(file: &std::fs::File) -> Result<bool> {
-    // SAFETY: `file` owns a valid fd and `LOCK_EX | LOCK_NB` is a standard
-    // non-blocking advisory exclusive lock request.
-    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+fn try_flock_session_wait_file(fd: RawFd) -> Result<bool> {
+    // SAFETY: fd is valid and LOCK_EX | LOCK_NB is a standard non-blocking
+    // advisory exclusive lock request.
+    let rc = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
     if rc == 0 {
         return Ok(true);
     }
@@ -59,9 +80,36 @@ fn try_flock_session_wait_file(file: &std::fs::File) -> Result<bool> {
     Err(err.into())
 }
 
+fn finalize_wait_lock(file: std::fs::File, fd: RawFd, lock_path: &Path) -> Result<SessionWaitLock> {
+    // Set close-on-exec so spawned subprocesses don't inherit the wait lock.
+    // SAFETY: fd is valid and F_GETFD only reads descriptor flags.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags == -1 {
+        return Err(anyhow::anyhow!(
+            "F_GETFD failed for wait lock at {}: {}",
+            lock_path.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+    // SAFETY: fd is valid, F_SETFD sets close-on-exec.
+    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) } == -1 {
+        return Err(anyhow::anyhow!(
+            "F_SETFD failed for wait lock at {}: {}",
+            lock_path.display(),
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    let mut lock = SessionWaitLock { file };
+    write_session_wait_lock_diagnostic(&mut lock.file)?;
+    Ok(lock)
+}
+
 fn write_session_wait_lock_diagnostic(file: &mut std::fs::File) -> Result<()> {
+    let pid = std::process::id();
     let diagnostic = SessionWaitLockDiagnostic {
-        pid: std::process::id(),
+        pid,
+        pid_start_time_ticks: process_start_time_ticks(pid),
     };
     let json = serde_json::to_string(&diagnostic)?;
 
@@ -71,4 +119,61 @@ fn write_session_wait_lock_diagnostic(file: &mut std::fs::File) -> Result<()> {
     file.write_all(b"\n")?;
     file.flush()?;
     Ok(())
+}
+
+fn is_wait_lock_diagnostic_pid_dead(lock_path: &Path) -> bool {
+    let Some(diagnostic) = read_wait_lock_diagnostic(lock_path) else {
+        return false;
+    };
+    if !is_pid_dead(diagnostic.pid, diagnostic.pid_start_time_ticks) {
+        return false;
+    }
+
+    tracing::warn!(
+        lock_path = %lock_path.display(),
+        holder_pid = diagnostic.pid,
+        "retrying session wait lock flock after detecting dead holder PID"
+    );
+    true
+}
+
+fn read_wait_lock_diagnostic(lock_path: &Path) -> Option<SessionWaitLockDiagnostic> {
+    let mut contents = String::new();
+    std::fs::File::open(lock_path)
+        .ok()?
+        .read_to_string(&mut contents)
+        .ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+#[cfg(target_os = "linux")]
+fn process_start_time_ticks(pid: u32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after_comm = stat.rsplit_once(") ")?.1;
+    after_comm.split_whitespace().nth(19)?.parse().ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_start_time_ticks(_pid: u32) -> Option<u64> {
+    None
+}
+
+fn is_pid_dead(pid: u32, pid_start_time_ticks: Option<u64>) -> bool {
+    let Ok(pid_i32) = i32::try_from(pid) else {
+        return false;
+    };
+    // SAFETY: kill(pid, 0) sends no signal; only checks process existence.
+    let alive = unsafe { libc::kill(pid_i32, 0) } == 0;
+    if !alive {
+        let error = std::io::Error::last_os_error();
+        return error.raw_os_error() == Some(libc::ESRCH);
+    }
+
+    if let Some(expected_ticks) = pid_start_time_ticks
+        && let Some(current_ticks) = process_start_time_ticks(pid)
+    {
+        return current_ticks != expected_ticks;
+    }
+
+    false
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs
@@ -641,3 +641,82 @@ fn handle_session_wait_on_resume_wrapper_uses_target_wait_lock() {
         "wrapper-id wait should not acquire an independent wrapper lock"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn wait_lock_stale_pid_diagnostic_with_free_flock_is_reclaimed() {
+    use std::io::Write;
+
+    let td = tempdir().unwrap();
+    let session_dir = td.path();
+
+    // Write a stale diagnostic with a definitely-dead PID.
+    // No process holds the flock — the kernel released it when the dead process exited.
+    let stale_json = serde_json::json!({"pid": i32::MAX, "pid_start_time_ticks": null});
+    let mut f = std::fs::File::create(session_dir.join(".wait.lock")).unwrap();
+    writeln!(f, "{stale_json}").unwrap();
+    drop(f);
+
+    let lock = try_acquire_session_wait_lock(session_dir)
+        .expect("acquire should not error")
+        .expect("dead PID diagnostic with free flock should be reclaimed");
+
+    // Verify the diagnostic was updated with the current PID.
+    let content = std::fs::read_to_string(session_dir.join(".wait.lock")).unwrap();
+    let diag: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(diag["pid"].as_u64(), Some(u64::from(std::process::id())));
+
+    drop(lock);
+}
+
+#[cfg(unix)]
+#[test]
+fn wait_lock_dead_pid_with_held_flock_does_not_steal() {
+    use std::io::Write;
+    use std::os::fd::AsRawFd;
+
+    let td = tempdir().unwrap();
+    let session_dir = td.path();
+
+    // Write a stale diagnostic with a dead PID.
+    let stale_json = serde_json::json!({"pid": i32::MAX, "pid_start_time_ticks": null});
+    let mut f = std::fs::File::create(session_dir.join(".wait.lock")).unwrap();
+    writeln!(f, "{stale_json}").unwrap();
+    drop(f);
+
+    // A live process holds the flock now.
+    let live_flock = std::fs::OpenOptions::new()
+        .write(true)
+        .open(session_dir.join(".wait.lock"))
+        .unwrap();
+    // SAFETY: live_flock owns a valid fd; LOCK_EX | LOCK_NB is a non-blocking advisory lock.
+    unsafe {
+        libc::flock(live_flock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB);
+    }
+
+    let result = try_acquire_session_wait_lock(session_dir).expect("acquire should not error");
+    assert!(
+        result.is_none(),
+        "must not steal wait lock held by live flock even if diagnostic PID is dead"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wait_lock_fd_sets_cloexec() {
+    let td = tempdir().unwrap();
+    let session_dir = td.path();
+
+    let lock = try_acquire_session_wait_lock(session_dir)
+        .expect("acquire should not error")
+        .expect("should acquire on fresh lock");
+
+    // SAFETY: read-only F_GETFD on a valid fd.
+    let flags = unsafe { libc::fcntl(lock.raw_fd(), libc::F_GETFD) };
+    assert!(
+        flags & libc::FD_CLOEXEC != 0,
+        "wait lock fd must have FD_CLOEXEC set"
+    );
+
+    drop(lock);
+}

--- a/scripts/monolith/baseline.toml
+++ b/scripts/monolith/baseline.toml
@@ -797,7 +797,7 @@ rationale = "run-level outer timeout fix adds synthetic ExecutionResult + RunLoo
 [[files]]
 path = "crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs"
 kind = "test"
-baseline_tokens = 8003
-baseline_lines = 643
+baseline_tokens = 8883
+baseline_lines = 722
 issue = "2618"
-rationale = "3-line addition for new holder_session_result_is_stale callback parameter"
+rationale = "stale-PID recovery tests + FD_CLOEXEC test for #2636 wait-lock fix"


### PR DESCRIPTION
## Summary

Fixes orphan wait lock blocking re-wait after Hermes restart (#2636).

1. **Stale-PID recovery**: when flock fails on .wait.lock, read the SessionWaitLockDiagnostic, check is_pid_dead, and if dead retry flock on the same fd (no file removal — TOCTOU-safe, mirroring #2624 slot lock fix).

2. **FD_CLOEXEC**: set close-on-exec on the wait lock fd so spawned subprocesses don't inherit it. Hard error on fcntl failure (not best-effort).

3. **pid_start_time_ticks** in diagnostic: enables PID recycle detection via /proc stat comparison.

## Test coverage
- `wait_lock_stale_pid_diagnostic_with_free_flock_is_reclaimed` — dead PID with free flock → recovery
- `wait_lock_dead_pid_with_held_flock_does_not_steal` — dead PID with live flock → no steal
- `wait_lock_fd_sets_cloexec` — FD_CLOEXEC set on wait lock fd

Closes #2636