### PR TITLE
fix(review): compound priority spec (P1/P2/P3) not extracted as HIGH finding

### DIFF
--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -333,6 +333,11 @@ fn parse_severity_prefixed_finding(
     allow_description_only: bool,
 ) -> Option<ParsedProseFinding> {
     let (label, rest) = body.split_once(':')?;
+    // Reject compound priority specs like "P1/P2/P3" — these are acceptance-criteria
+    // descriptions, not single severity labels.
+    if label.contains('/') {
+        return None;
+    }
     let severity = severity_from_label(label).or_else(|| leading_severity_from_title(label))?;
     let rest = rest.trim();
     if severity_prefixed_rest_is_zero_count(rest) {
@@ -388,6 +393,11 @@ fn strip_unordered_list_prefix(line: &str) -> &str {
 }
 
 fn leading_severity_from_title(title: &str) -> Option<Severity> {
+    // Reject compound specs like "P1/P2/P3" — the first alphanumeric run
+    // (e.g., "P1") is part of a compound, not a standalone severity label.
+    if title.contains('/') {
+        return None;
+    }
     let first_word = title
         .trim_start()
         .split(|ch: char| !ch.is_ascii_alphanumeric())

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
@@ -233,3 +233,32 @@ fn issue_2516_mixed_resolution_and_active_problem_stays_blocking() {
         "sentence with 'still remains' must not be classified as resolved"
     );
 }
+
+#[test]
+fn issue_2637_compound_priority_spec_not_extracted_as_finding() {
+    // "P1/P2/P3: code paths now classify..." is acceptance-criteria prose,
+    // not a finding. It must not be extracted as a HIGH finding.
+    let text = "## Findings\nP1/P2/P3: code paths now classify status, connect, timeout into bounded cause labels.\n";
+    let findings = extract_review_findings_from_prose(text);
+    assert!(
+        findings.is_empty(),
+        "compound P1/P2/P3 spec should not be extracted as a finding"
+    );
+}
+
+#[test]
+fn issue_2637_single_priority_with_colon_still_parses() {
+    // Single "P1:" should still be parsed as HIGH severity.
+    let text = "## Findings\nP1: critical race in lock acquisition path\n";
+    let findings = extract_review_findings_from_prose(text);
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0].severity, Severity::High);
+}
+
+#[test]
+fn issue_2637_compound_priority_not_blocking_signal() {
+    // Compound spec should not trigger blocking signal extraction either.
+    assert!(!contains_blocking_review_signal(
+        "P1/P2/P3: code paths now classify status into bounded cause labels."
+    ));
+}


### PR DESCRIPTION
## Summary

Fixes false HIGH findings from PASS prose (#2637).

When review prose contains acceptance-criteria descriptions like `"P1/P2/P3: code paths now classify..."`, the parser misidentified the compound priority spec as a single P1 (HIGH) severity label, creating false HIGH findings from clean PASS reports.

## Fix
Reject labels containing `/` as severity in:
- `parse_severity_prefixed_finding` — before attempting severity extraction
- `leading_severity_from_title` — before splitting on non-alphanumeric

This prevents compound specs like `P1/P2/P3` from being parsed as a single `P1` (HIGH) severity.

## Test coverage
- `issue_2637_compound_priority_spec_not_extracted_as_finding` — P1/P2/P3 → no finding
- `issue_2637_single_priority_with_colon_still_parses` — P1: → HIGH (unchanged)
- `issue_2637_compound_priority_not_blocking_signal` — P1/P2/P3 → not blocking signal

Closes #2637