### PR TITLE
fix(session-wait): bind waits to caller output lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "chrono",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "chrono",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "axum",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "chrono",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "chrono",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1091"
+version = "0.1.1092"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1091"
+version = "0.1.1092"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -174,8 +174,12 @@ mod sa_mode;
 #[cfg(test)]
 pub(crate) use sa_mode::validate_sa_mode;
 
+fn main() {
+    async_main(session_cmds::WaitCallerIdentity::capture());
+}
+
 #[tokio::main]
-async fn main() {
+async fn async_main(wait_caller_identity: session_cmds::WaitCallerIdentity) {
     // Restore SIGPIPE to default (terminate) so that piping output into a closed
     // reader exits cleanly instead of panicking with "failed printing to stdout:
     // Broken pipe" (issue #2408). Rust resets SIGPIPE to SIG_IGN at startup.
@@ -187,7 +191,7 @@ async fn main() {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);
     }
 
-    if let Err(err) = run().await {
+    if let Err(err) = run(wait_caller_identity).await {
         eprintln!("{}", error_report::render_user_facing_error(&err));
         if let Some(hint) = error_hints::suggest_fix(&err) {
             eprintln!();
@@ -197,7 +201,7 @@ async fn main() {
     }
 }
 
-async fn run() -> Result<()> {
+async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<()> {
     link_bug_class_pipeline();
 
     let mut startup_env = startup_env::StartupSubtreeEnv::capture_from_process_env();
@@ -503,7 +507,9 @@ async fn run() -> Result<()> {
                     .await?;
             exit_current_process(exit_code);
         }
-        Commands::Session { cmd } => session_dispatch::dispatch(cmd, output_format, &startup_env)?,
+        Commands::Session { cmd } => {
+            session_dispatch::dispatch(cmd, output_format, &startup_env, wait_caller_identity)?
+        }
         Commands::Push(args) => push_cmd::handle_push(args)?,
         Commands::Merge(args) => merge_cmd::handle_merge(args)?,
         Commands::Audit { command } => {
@@ -633,7 +639,7 @@ async fn run() -> Result<()> {
             );
         }
         Commands::McpServer => {
-            mcp_server::run_mcp_server(&startup_env).await?;
+            mcp_server::run_mcp_server(&startup_env, wait_caller_identity).await?;
         }
         Commands::McpHub { cmd } => match cmd {
             McpHubCommands::Serve {

--- a/crates/cli-sub-agent/src/mcp_server.rs
+++ b/crates/cli-sub-agent/src/mcp_server.rs
@@ -26,11 +26,16 @@ const DEFAULT_MCP_SESSION_WAIT_TIMEOUT_SECONDS: u64 =
 /// MCP server implementation
 ///
 /// Exposes CSA session management as MCP tools over JSON-RPC 2.0 stdio protocol.
-pub(crate) async fn run_mcp_server(startup_env: &StartupSubtreeEnv) -> Result<()> {
+pub(crate) async fn run_mcp_server(
+    startup_env: &StartupSubtreeEnv,
+    wait_caller_identity: crate::session_cmds::WaitCallerIdentity,
+) -> Result<()> {
+    let wait_caller_identity = wait_caller_identity.validate_for_wait()?;
     info!("Starting MCP server on stdio");
 
     let state = McpServerState {
         startup_env: startup_env.clone(),
+        wait_caller_identity,
     };
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
@@ -80,6 +85,7 @@ pub(crate) async fn run_mcp_server(startup_env: &StartupSubtreeEnv) -> Result<()
 #[derive(Debug, Clone)]
 struct McpServerState {
     startup_env: StartupSubtreeEnv,
+    wait_caller_identity: crate::session_cmds::WaitCallerIdentity,
 }
 
 /// JSON-RPC 2.0 Request
@@ -353,7 +359,7 @@ async fn handle_tool_call(params: Option<Value>, state: &McpServerState) -> Resu
     match name {
         "csa_session_list" => handle_session_list_tool(arguments).await,
         "csa_session_delete" => handle_session_delete_tool(arguments).await,
-        "csa_session_wait" => handle_session_wait_tool(arguments).await,
+        "csa_session_wait" => handle_session_wait_tool(arguments, state.wait_caller_identity).await,
         "csa_gc" => handle_gc_tool(arguments, &state.startup_env).await,
         "csa_run" => handle_run_tool(arguments, &state.startup_env).await,
         _ => anyhow::bail!("Unknown tool: {name}"),
@@ -450,7 +456,10 @@ async fn handle_session_delete_tool(args: Value) -> Result<Value> {
     }))
 }
 
-async fn handle_session_wait_tool(args: Value) -> Result<Value> {
+async fn handle_session_wait_tool(
+    args: Value,
+    caller_identity: crate::session_cmds::WaitCallerIdentity,
+) -> Result<Value> {
     let session_id = args
         .get("session_id")
         .and_then(|v| v.as_str())
@@ -478,6 +487,7 @@ async fn handle_session_wait_tool(args: Value) -> Result<Value> {
             timeout_seconds,
             memory_warn_mb,
             output_mode,
+            caller_identity,
         )
     })
     .await

--- a/crates/cli-sub-agent/src/mcp_server_tests.rs
+++ b/crates/cli-sub-agent/src/mcp_server_tests.rs
@@ -283,6 +283,7 @@ async fn mcp_session_wait_returns_nonzero_session_result_without_mcp_error() {
     let _cwd_guard = CurrentDirGuard::set(&project_root);
     let state = McpServerState {
         startup_env: crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV.clone(),
+        wait_caller_identity: crate::session_cmds::WaitCallerIdentity::default(),
     };
 
     let response = handle_tool_call(
@@ -323,6 +324,7 @@ async fn mcp_session_wait_json_returns_parseable_document_with_wait_exit_code() 
     let _cwd_guard = CurrentDirGuard::set(&project_root);
     let state = McpServerState {
         startup_env: crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV.clone(),
+        wait_caller_identity: crate::session_cmds::WaitCallerIdentity::default(),
     };
 
     let response = handle_tool_call(
@@ -388,6 +390,7 @@ async fn mcp_session_wait_alive_at_timeout_returns_rewait_content() {
     let _cwd_guard = CurrentDirGuard::set(&project_root);
     let state = McpServerState {
         startup_env: crate::startup_env::EMPTY_STARTUP_SUBTREE_ENV.clone(),
+        wait_caller_identity: crate::session_cmds::WaitCallerIdentity::default(),
     };
 
     let response = handle_tool_call(
@@ -431,6 +434,7 @@ async fn mcp_gc_reap_runtime_protects_hosting_session_runtime() {
             csa_core::env::CSA_SESSION_ID_ENV_KEY,
             session_id,
         )])),
+        wait_caller_identity: crate::session_cmds::WaitCallerIdentity::default(),
     };
 
     let response = handle_tool_call(

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -575,8 +575,9 @@ pub(crate) fn handle_session_checkpoints(cd: Option<String>) -> Result<()> {
 #[cfg(test)]
 pub(crate) use crate::session_cmds_daemon::handle_session_wait;
 pub(crate) use crate::session_cmds_daemon::{
-    SessionWaitOutputMode, handle_session_attach, handle_session_attach_with_prompt,
-    handle_session_kill, handle_session_wait_for_mcp, handle_session_wait_with_options,
+    SessionWaitOutputMode, WaitCallerIdentity, handle_session_attach,
+    handle_session_attach_with_prompt, handle_session_kill, handle_session_wait_for_mcp,
+    handle_session_wait_with_options,
 };
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -39,7 +39,11 @@ pub(crate) use completion::{
 #[cfg(test)]
 pub(crate) use wait::expected_in_flight_turn_result_artifact_path_for_test;
 #[cfg(test)]
+pub(crate) use wait::parent_pid;
+#[cfg(test)]
 pub(crate) use wait::parse_output_result_artifact_for_test;
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) use wait::process_state;
 #[cfg(test)]
 pub(crate) use wait::render_wait_result_summary;
 #[cfg(test)]
@@ -48,11 +52,13 @@ pub(crate) use wait::resolve_wait_completion_status_and_exit;
 pub(crate) use wait::{
     SESSION_WAIT_MEMORY_WARN_EXIT_CODE, WaitBehavior, WaitLoopTiming, WaitReconciliationOutcome,
     handle_session_wait, handle_session_wait_with_hooks,
-    handle_session_wait_with_hooks_and_sampler, synthesized_wait_next_step,
-    try_acquire_session_wait_lock,
+    handle_session_wait_with_hooks_and_sampler, handle_session_wait_with_identity_for_test,
+    process_start_time_ticks, synthesized_wait_next_step, try_acquire_session_wait_lock,
+    try_acquire_session_wait_lock_with_caller,
 };
 pub(crate) use wait::{
-    SessionWaitOutputMode, handle_session_wait_for_mcp, handle_session_wait_with_options,
+    SessionWaitOutputMode, WaitCallerIdentity, handle_session_wait_for_mcp,
+    handle_session_wait_with_options,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -29,7 +29,16 @@ mod types;
 pub(crate) use completion::SESSION_WAIT_MEMORY_WARN_EXIT_CODE;
 #[cfg(test)]
 pub(crate) use completion::resolve_wait_completion_status_and_exit;
+pub(crate) use lock::WaitCallerIdentity;
+#[cfg(test)]
+pub(crate) use lock::parent_pid;
+#[cfg(test)]
+pub(crate) use lock::process_start_time_ticks;
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) use lock::process_state;
+#[cfg(test)]
 pub(crate) use lock::try_acquire_session_wait_lock;
+pub(crate) use lock::try_acquire_session_wait_lock_with_caller;
 pub(crate) use next_step::synthesized_wait_next_step;
 #[cfg(test)]
 pub(crate) use result_loader::expected_in_flight_turn_result_artifact_path_for_test;
@@ -78,6 +87,7 @@ pub(crate) fn handle_session_wait_with_memory_warn(
         wait_timeout_secs,
         memory_warn_mb,
         SessionWaitOutputMode::from_flags(false, false),
+        WaitCallerIdentity::capture(),
     )
 }
 
@@ -87,12 +97,14 @@ pub(crate) fn handle_session_wait_with_options(
     wait_timeout_secs: u64,
     memory_warn_mb: Option<u64>,
     output_mode: SessionWaitOutputMode,
+    caller_identity: WaitCallerIdentity,
 ) -> Result<i32> {
     handle_session_wait_with_hooks_output_mode(
         session,
         cd,
         WaitBehavior::new(wait_timeout_secs, memory_warn_mb),
         output_mode,
+        caller_identity,
         |project_root, session_id, trigger| {
             let reconciled = crate::session_cmds::ensure_terminal_result_for_dead_active_session(
                 project_root,
@@ -114,6 +126,7 @@ pub(crate) fn handle_session_wait_for_mcp(
     wait_timeout_secs: u64,
     memory_warn_mb: Option<u64>,
     output_mode: SessionWaitOutputMode,
+    caller_identity: WaitCallerIdentity,
 ) -> Result<SessionWaitMcpOutput> {
     let compact_json = output_mode == SessionWaitOutputMode::CompactJson;
     let mut cached_memory_sampler: Option<csa_session::SessionTreeMemorySampler> = None;
@@ -125,6 +138,7 @@ pub(crate) fn handle_session_wait_for_mcp(
         WaitExecutionOptions {
             behavior: WaitBehavior::new(wait_timeout_secs, memory_warn_mb),
             output_mode,
+            caller_identity,
         },
         core::WaitEmitters {
             reconcile_dead_active_session: Box::new(|project_root, session_id, trigger| {
@@ -292,6 +306,7 @@ where
         cd,
         wait_behavior,
         SessionWaitOutputMode::from_flags(false, false),
+        WaitCallerIdentity::capture(),
         reconcile_dead_active_session,
         emit_completion_signal,
     )
@@ -302,6 +317,7 @@ fn handle_session_wait_with_hooks_output_mode<R, E>(
     cd: Option<String>,
     wait_behavior: WaitBehavior,
     output_mode: SessionWaitOutputMode,
+    caller_identity: WaitCallerIdentity,
     mut reconcile_dead_active_session: R,
     mut emit_completion_signal: E,
 ) -> Result<i32>
@@ -316,6 +332,7 @@ where
         WaitExecutionOptions {
             behavior: wait_behavior,
             output_mode,
+            caller_identity,
         },
         &mut reconcile_dead_active_session,
         &mut emit_completion_signal,
@@ -357,6 +374,7 @@ where
         WaitExecutionOptions {
             behavior: wait_behavior,
             output_mode: SessionWaitOutputMode::from_flags(false, false),
+            caller_identity: WaitCallerIdentity::capture(),
         },
         reconcile_dead_active_session,
         emit_completion_signal,
@@ -390,6 +408,24 @@ where
         emit_memory_warn_marker,
     )
 }
+
+#[cfg(test)]
+pub(crate) fn handle_session_wait_with_identity_for_test(
+    session: String,
+    cd: Option<String>,
+    wait_timeout_secs: u64,
+    caller_identity: WaitCallerIdentity,
+) -> Result<i32> {
+    handle_session_wait_with_options(
+        session,
+        cd,
+        wait_timeout_secs,
+        None,
+        SessionWaitOutputMode::from_flags(false, false),
+        caller_identity,
+    )
+}
+
 fn emit_wait_next_step_if_needed(session_dir: &Path) -> Result<()> {
     if let Some(directive) = synthesized_wait_next_step(session_dir)? {
         println!("{directive}");

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -22,7 +22,7 @@ use super::target::resolve_wait_target;
 use super::types::{WaitExecutionOptions, WaitReconciliationOutcome};
 use super::{
     emit_wait_terminal_output, load_completed_daemon_result_with_fallback, refresh_result_for_wait,
-    suppress_pending_tier_failover_result, try_acquire_session_wait_lock,
+    suppress_pending_tier_failover_result, try_acquire_session_wait_lock_with_caller,
 };
 use crate::session_cmds::resolve_session_prefix_with_global_fallback;
 use crate::session_cmds_daemon::{
@@ -107,11 +107,20 @@ pub(crate) fn handle_session_wait_with_emitters(
     let is_cross_project = resolved.foreign_project_root.is_some();
     let mut wait_target = resolve_wait_target(effective_root, &resolved.session_id, &session_dir)?;
     let worktree_lock_root = super::resolve_session_wait_worktree_lock_root(effective_root);
-    let mut wait_lock = match try_acquire_session_wait_lock(&wait_target.session_dir)? {
+    if wait_options.caller_identity.is_dead() {
+        eprintln!(
+            "ERROR: session wait caller output closed before lock acquisition; re-issue from the current caller."
+        );
+        return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
+    }
+    let mut wait_lock = match try_acquire_session_wait_lock_with_caller(
+        &wait_target.session_dir,
+        wait_options.caller_identity,
+    )? {
         Some(lock) => lock,
         None => {
             eprintln!(
-                "ERROR: another csa session wait is already running for session {} (lock held). The existing wait will notify you on completion. Do NOT re-issue.",
+                "ERROR: another csa session wait is already running for session {} and the lock could not be safely reclaimed. If the previous wait's caller is gone (Hermes restart, context compaction), kill that wait process and re-issue.",
                 wait_target.session_id
             );
             return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
@@ -166,16 +175,25 @@ pub(crate) fn handle_session_wait_with_emitters(
     }
 
     loop {
+        if wait_options.caller_identity.is_dead() {
+            tracing::warn!(
+                session_id = %wait_target.session_id,
+                "session wait caller output closed; releasing wait lock"
+            );
+            return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
+        }
         if !wait_target.follows_resume_target {
             let updated_target =
                 resolve_wait_target(effective_root, &resolved.session_id, &session_dir)?;
             if updated_target.follows_resume_target {
-                let updated_lock = match try_acquire_session_wait_lock(&updated_target.session_dir)?
-                {
+                let updated_lock = match try_acquire_session_wait_lock_with_caller(
+                    &updated_target.session_dir,
+                    wait_lock.caller_identity(),
+                )? {
                     Some(lock) => lock,
                     None => {
                         eprintln!(
-                            "ERROR: another csa session wait is already running for session {} (lock held). The existing wait will notify you on completion. Do NOT re-issue.",
+                            "ERROR: another csa session wait is already running for session {} and the lock could not be safely reclaimed. If the previous wait's caller is gone (Hermes restart, context compaction), kill that wait process and re-issue.",
                             updated_target.session_id
                         );
                         return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_lock.rs
@@ -1,19 +1,130 @@
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::os::fd::AsRawFd;
+#[cfg(target_os = "linux")]
+use std::os::fd::{FromRawFd, OwnedFd};
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::MetadataExt;
 use std::os::unix::io::RawFd;
 use std::path::Path;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
+/// Caller-owned result channel used as the wait invocation's lifecycle lease.
+///
+/// The output descriptor is inherited from the launcher before this process
+/// can run, so it remains authoritative even if the waiter has already been
+/// reparented. A closed pipe/socket reports HUP or ERR through `poll(2)`;
+/// regular files and terminals remain valid result sinks without relying on a
+/// sampled parent PID.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct WaitCallerIdentity {
+    output_fd: Option<RawFd>,
+    output_device: Option<u64>,
+    output_inode: Option<u64>,
+}
+
+impl WaitCallerIdentity {
+    pub(crate) fn capture() -> Self {
+        Self::from_output_fd(libc::STDOUT_FILENO)
+    }
+
+    /// Validate that the startup result channel still owns this invocation.
+    pub(crate) fn validate_for_wait(self) -> Result<Self> {
+        self.verified_parts().ok_or_else(|| {
+            anyhow::anyhow!(
+                "cannot establish session wait caller lifecycle: stdout identity unavailable"
+            )
+        })?;
+        if self.is_dead() {
+            anyhow::bail!(
+                "session wait caller output closed before wait initialization; re-issue from the current caller"
+            );
+        }
+
+        Ok(self)
+    }
+
+    fn from_output_fd(output_fd: RawFd) -> Self {
+        let Some((output_device, output_inode)) = descriptor_identity(output_fd) else {
+            return Self::default();
+        };
+        Self {
+            output_fd: Some(output_fd),
+            output_device: Some(output_device),
+            output_inode: Some(output_inode),
+        }
+    }
+
+    fn verified_parts(self) -> Option<(RawFd, u64, u64)> {
+        let (output_fd, output_device, output_inode) = self
+            .output_fd
+            .zip(self.output_device)
+            .zip(self.output_inode)
+            .map(|((fd, device), inode)| (fd, device, inode))?;
+        (descriptor_identity(output_fd) == Some((output_device, output_inode))).then_some((
+            output_fd,
+            output_device,
+            output_inode,
+        ))
+    }
+
+    pub(crate) fn is_dead(self) -> bool {
+        let Some((output_fd, _, _)) = self.verified_parts() else {
+            return self.output_fd.is_some();
+        };
+        let mut poll_fd = libc::pollfd {
+            fd: output_fd,
+            events: 0,
+            revents: 0,
+        };
+        // SAFETY: `poll_fd` points to one initialized descriptor entry and a
+        // zero timeout makes this a non-blocking lifecycle probe.
+        let poll_result = unsafe { libc::poll(&mut poll_fd, 1, 0) };
+        poll_result > 0 && poll_fd.revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_output_fd_for_test(output_fd: RawFd) -> Self {
+        Self::from_output_fd(output_fd)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn diagnostic_parts_for_test(self) -> Option<(u64, u64)> {
+        self.verified_parts()
+            .map(|(_, output_device, output_inode)| (output_device, output_inode))
+    }
+}
+
+fn descriptor_identity(fd: RawFd) -> Option<(u64, u64)> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `stat` points to writable storage for one `libc::stat`; `fstat`
+    // initializes it on success and does not retain the pointer.
+    if unsafe { libc::fstat(fd, stat.as_mut_ptr()) } != 0 {
+        return None;
+    }
+    // SAFETY: the successful `fstat` call initialized the entire structure.
+    let stat = unsafe { stat.assume_init() };
+    #[cfg(target_os = "linux")]
+    let identity = (stat.st_dev, stat.st_ino);
+    #[cfg(not(target_os = "linux"))]
+    let identity = (stat.st_dev as u64, stat.st_ino as u64);
+    Some(identity)
+}
+
 pub(crate) struct SessionWaitLock {
     file: std::fs::File,
+    caller_identity: WaitCallerIdentity,
 }
 
 impl SessionWaitLock {
     #[cfg(test)]
     pub(crate) fn raw_fd(&self) -> std::os::unix::io::RawFd {
         self.file.as_raw_fd()
+    }
+
+    pub(crate) fn caller_identity(&self) -> WaitCallerIdentity {
+        self.caller_identity
     }
 }
 
@@ -22,6 +133,14 @@ struct SessionWaitLockDiagnostic {
     pid: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pid_start_time_ticks: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    caller_output_device: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    caller_output_inode: Option<u64>,
+    /// Legacy compatibility for diagnostics written before the caller-owned
+    /// output lifecycle contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    parent_pid: Option<u32>,
 }
 
 impl Drop for SessionWaitLock {
@@ -33,7 +152,15 @@ impl Drop for SessionWaitLock {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn try_acquire_session_wait_lock(session_dir: &Path) -> Result<Option<SessionWaitLock>> {
+    try_acquire_session_wait_lock_with_caller(session_dir, WaitCallerIdentity::capture())
+}
+
+pub(crate) fn try_acquire_session_wait_lock_with_caller(
+    session_dir: &Path,
+    caller_identity: WaitCallerIdentity,
+) -> Result<Option<SessionWaitLock>> {
     let lock_path = session_dir.join(".wait.lock");
     let file = std::fs::OpenOptions::new()
         .create(true)
@@ -45,7 +172,12 @@ pub(crate) fn try_acquire_session_wait_lock(session_dir: &Path) -> Result<Option
     let fd = file.as_raw_fd();
 
     if try_flock_session_wait_file(fd)? {
-        return Ok(Some(finalize_wait_lock(file, fd, &lock_path)?));
+        return Ok(Some(finalize_wait_lock(
+            file,
+            fd,
+            &lock_path,
+            caller_identity,
+        )?));
     }
 
     // flock failed. If the on-disk diagnostic shows a dead PID, the kernel has
@@ -53,7 +185,40 @@ pub(crate) fn try_acquire_session_wait_lock(session_dir: &Path) -> Result<Option
     // (avoids TOCTOU: remove_file could unlink a lock acquired between our check
     // and the unlink).
     if is_wait_lock_diagnostic_pid_dead(&lock_path) && try_flock_session_wait_file(fd)? {
-        return Ok(Some(finalize_wait_lock(file, fd, &lock_path)?));
+        return Ok(Some(finalize_wait_lock(
+            file,
+            fd,
+            &lock_path,
+            caller_identity,
+        )?));
+    }
+
+    // Older diagnostics used a sampled PPID. Preserve their verified reclaim
+    // path while current waiters release on caller-output closure themselves.
+    if let Some(validated) = is_wait_lock_diagnostic_caller_gone(&lock_path)
+        && descriptor_identity(fd)
+            .is_some_and(|identity| kill_wait_lock_holder(&lock_path, identity, validated))
+    {
+        // The verified orphan wait process was signaled. Its exit releases the
+        // kernel flock, so retry acquisition for a bounded interval.
+        // Bounded retry: poll the flock in a deadline loop instead of a
+        // single fixed sleep. Under high load the process may take longer
+        // to exit and release the flock.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            if try_flock_session_wait_file(fd)? {
+                return Ok(Some(finalize_wait_lock(
+                    file,
+                    fd,
+                    &lock_path,
+                    caller_identity,
+                )?));
+            }
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
     }
 
     // Drop file to close the fd we opened (flock not acquired).
@@ -80,7 +245,14 @@ fn try_flock_session_wait_file(fd: RawFd) -> Result<bool> {
     Err(err.into())
 }
 
-fn finalize_wait_lock(file: std::fs::File, fd: RawFd, lock_path: &Path) -> Result<SessionWaitLock> {
+fn finalize_wait_lock(
+    file: std::fs::File,
+    fd: RawFd,
+    lock_path: &Path,
+    caller_identity: WaitCallerIdentity,
+) -> Result<SessionWaitLock> {
+    let pid = std::process::id();
+
     // Set close-on-exec so spawned subprocesses don't inherit the wait lock.
     // SAFETY: fd is valid and F_GETFD only reads descriptor flags.
     let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
@@ -100,16 +272,26 @@ fn finalize_wait_lock(file: std::fs::File, fd: RawFd, lock_path: &Path) -> Resul
         ));
     }
 
-    let mut lock = SessionWaitLock { file };
-    write_session_wait_lock_diagnostic(&mut lock.file)?;
-    Ok(lock)
+    let mut lock_file = file;
+    write_session_wait_lock_diagnostic(&mut lock_file, pid, caller_identity)?;
+    Ok(SessionWaitLock {
+        file: lock_file,
+        caller_identity,
+    })
 }
 
-fn write_session_wait_lock_diagnostic(file: &mut std::fs::File) -> Result<()> {
-    let pid = std::process::id();
+fn write_session_wait_lock_diagnostic(
+    file: &mut std::fs::File,
+    pid: u32,
+    caller_identity: WaitCallerIdentity,
+) -> Result<()> {
+    let caller_parts = caller_identity.verified_parts();
     let diagnostic = SessionWaitLockDiagnostic {
         pid,
         pid_start_time_ticks: process_start_time_ticks(pid),
+        caller_output_device: caller_parts.map(|(_, device, _)| device),
+        caller_output_inode: caller_parts.map(|(_, _, inode)| inode),
+        parent_pid: None,
     };
     let json = serde_json::to_string(&diagnostic)?;
 
@@ -137,6 +319,48 @@ fn is_wait_lock_diagnostic_pid_dead(lock_path: &Path) -> bool {
     true
 }
 
+/// Return a verified live legacy holder whose recorded parent changed.
+///
+/// Current waiters observe their caller-owned output channel directly and
+/// release the flock themselves. This PPID comparison is retained only so a
+/// new binary can safely reclaim locks written by older versions.
+fn is_wait_lock_diagnostic_caller_gone(lock_path: &Path) -> Option<SessionWaitLockDiagnostic> {
+    let diagnostic = read_wait_lock_diagnostic(lock_path)?;
+    let pid_start_time_ticks = diagnostic.pid_start_time_ticks.filter(|ticks| *ticks != 0);
+
+    // Require a non-zero start-time for holder identity verification. Without
+    // it, a recycled PID could cause us to SIGTERM an unrelated process.
+    let expected_start_time = pid_start_time_ticks?;
+
+    // Verify the PID's start-time matches the recorded value (catches recycle).
+    match process_start_time_ticks(diagnostic.pid) {
+        Some(actual) if actual != expected_start_time => return None, // PID recycled.
+        None => return None, // Can't verify identity — don't kill.
+        _ => {}
+    }
+
+    // If the PID is dead, that path is already handled by is_wait_lock_diagnostic_pid_dead.
+    if is_pid_dead(diagnostic.pid, Some(expected_start_time)) {
+        return None;
+    }
+
+    let recorded_ppid = diagnostic.parent_pid?;
+    let current_ppid = parent_pid(diagnostic.pid)?;
+
+    if current_ppid == recorded_ppid {
+        return None; // Same parent — not orphaned.
+    }
+
+    tracing::warn!(
+        lock_path = %lock_path.display(),
+        holder_pid = diagnostic.pid,
+        recorded_ppid,
+        current_ppid,
+        "retrying legacy session wait lock flock after detecting reparented holder PID"
+    );
+    Some(diagnostic)
+}
+
 fn read_wait_lock_diagnostic(lock_path: &Path) -> Option<SessionWaitLockDiagnostic> {
     let mut contents = String::new();
     std::fs::File::open(lock_path)
@@ -147,21 +371,242 @@ fn read_wait_lock_diagnostic(lock_path: &Path) -> Option<SessionWaitLockDiagnost
 }
 
 #[cfg(target_os = "linux")]
-fn process_start_time_ticks(pid: u32) -> Option<u64> {
+pub(crate) fn process_start_time_ticks(pid: u32) -> Option<u64> {
     let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
     let after_comm = stat.rsplit_once(") ")?.1;
     after_comm.split_whitespace().nth(19)?.parse().ok()
 }
 
+#[cfg(target_os = "linux")]
+pub(crate) fn process_state(pid: u32) -> Option<char> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after_comm = stat.rsplit_once(") ")?.1;
+    after_comm.chars().next()
+}
+
 #[cfg(not(target_os = "linux"))]
-fn process_start_time_ticks(_pid: u32) -> Option<u64> {
+fn process_state(_pid: u32) -> Option<char> {
     None
 }
 
+/// macOS: PID/start-time based legacy reclaim is not supported. Current
+/// waiters still release their lock when the caller-owned output closes.
+#[cfg(target_os = "macos")]
+pub(crate) fn process_start_time_ticks(_pid: u32) -> Option<u64> {
+    None
+}
+
+/// Fallback for other platforms (e.g. BSD, Windows): no process start time.
+/// Orphan reclaim is Linux-only.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub(crate) fn process_start_time_ticks(_pid: u32) -> Option<u64> {
+    None
+}
+
+/// Read the parent PID (ppid) from /proc/<pid>/stat.
+/// Linux /proc stat fields (after comm): state(0), ppid(1), ... start_time(19).
+#[cfg(target_os = "linux")]
+pub(crate) fn parent_pid(pid: u32) -> Option<u32> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after_comm = stat.rsplit_once(") ")?.1;
+    after_comm.split_whitespace().nth(1)?.parse().ok()
+}
+
+/// macOS: parent_pid is not available (orphan reclaim is Linux-only).
+#[cfg(target_os = "macos")]
+pub(crate) fn parent_pid(_pid: u32) -> Option<u32> {
+    None
+}
+
+/// Fallback for other platforms: no parent PID reading.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub(crate) fn parent_pid(_pid: u32) -> Option<u32> {
+    None
+}
+
+/// Send SIGTERM to a verified wait lock holder to release the kernel flock.
+///
+/// The diagnostic file is advisory metadata and may be rewritten while another
+/// process holds the flock. Before signaling, bind the target process to the
+/// contested lock's device/inode through `/proc/<pid>/fdinfo`, then use a pidfd
+/// so PID reuse between verification and signal delivery cannot target a new
+/// process.
+#[cfg(target_os = "linux")]
+fn kill_wait_lock_holder(
+    lock_path: &Path,
+    lock_identity: (u64, u64),
+    validated: SessionWaitLockDiagnostic,
+) -> bool {
+    // Zero is an explicit sentinel for diagnostics written without a usable
+    // start-time identity. Refuse to signal without start-time verification
+    // (rule 018: never act on PID-only identity).
+    let expected_start_time = validated.pid_start_time_ticks.filter(|ticks| *ticks != 0);
+
+    // Fresh liveness check, including start-time identity when available.
+    if is_pid_dead(validated.pid, expected_start_time) {
+        return false; // Already dead — flock will be released by the kernel.
+    }
+
+    let Some(pidfd) = open_pidfd(validated.pid) else {
+        return false;
+    };
+
+    // Re-check start-time after opening the pidfd. The pidfd pins signal
+    // delivery to this process even if the numeric PID is later recycled.
+    let Some(expected_start_time) = expected_start_time else {
+        return false;
+    };
+    match process_start_time_ticks(validated.pid) {
+        Some(actual) if actual != expected_start_time => {
+            tracing::warn!(
+                lock_path = %lock_path.display(),
+                holder_pid = validated.pid,
+                "refusing to SIGTERM wait lock holder: PID start-time mismatch (recycled)"
+            );
+            return false;
+        }
+        None => return false,
+        _ => {}
+    }
+
+    let Some(recorded_ppid) = validated.parent_pid else {
+        return false;
+    };
+    match parent_pid(validated.pid) {
+        None => return false,
+        Some(current_ppid) if current_ppid == recorded_ppid => {
+            return false;
+        }
+        _ => {}
+    }
+
+    if !process_holds_exclusive_flock(validated.pid, lock_identity) {
+        tracing::warn!(
+            lock_path = %lock_path.display(),
+            diagnostic_pid = validated.pid,
+            "refusing to SIGTERM wait lock diagnostic PID: process does not hold the contested flock"
+        );
+        return false;
+    }
+
+    if let Err(error) = pidfd_send_sigterm(&pidfd) {
+        tracing::warn!(
+            lock_path = %lock_path.display(),
+            holder_pid = validated.pid,
+            %error,
+            "failed to SIGTERM orphaned wait lock holder"
+        );
+        false
+    } else {
+        tracing::info!(
+            lock_path = %lock_path.display(),
+            holder_pid = validated.pid,
+            "sent SIGTERM to orphaned wait lock holder"
+        );
+        true
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn kill_wait_lock_holder(
+    _lock_path: &Path,
+    _lock_identity: (u64, u64),
+    _validated: SessionWaitLockDiagnostic,
+) -> bool {
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn process_holds_exclusive_flock(pid: u32, lock_identity: (u64, u64)) -> bool {
+    let Ok(fdinfo_entries) = std::fs::read_dir(format!("/proc/{pid}/fdinfo")) else {
+        return false;
+    };
+
+    for entry in fdinfo_entries.flatten() {
+        let fd_name = entry.file_name();
+        let fd_path = Path::new("/proc")
+            .join(pid.to_string())
+            .join("fd")
+            .join(&fd_name);
+        let Ok(metadata) = std::fs::metadata(fd_path) else {
+            continue;
+        };
+        if (metadata.dev(), metadata.ino()) != lock_identity {
+            continue;
+        }
+
+        let Ok(fdinfo) = std::fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        if fdinfo.lines().any(fdinfo_line_is_exclusive_flock) {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn fdinfo_line_is_exclusive_flock(line: &str) -> bool {
+    let Some(lock) = line.strip_prefix("lock:") else {
+        return false;
+    };
+    let mut fields = lock.split_whitespace();
+    let _lock_id = fields.next();
+    matches!(
+        (fields.next(), fields.next(), fields.next()),
+        (Some("FLOCK"), Some("ADVISORY"), Some("WRITE"))
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn open_pidfd(pid: u32) -> Option<OwnedFd> {
+    let pid = i32::try_from(pid).ok()?;
+    // SAFETY: pidfd_open receives a positive PID and zero flags. On success it
+    // returns a new owned file descriptor; no pointers cross the FFI boundary.
+    let raw_fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+    if raw_fd < 0 {
+        return None;
+    }
+    let raw_fd = i32::try_from(raw_fd).ok()?;
+    // SAFETY: a successful pidfd_open returned a fresh descriptor that is
+    // adopted exactly once by OwnedFd.
+    Some(unsafe { OwnedFd::from_raw_fd(raw_fd) })
+}
+
+#[cfg(target_os = "linux")]
+fn pidfd_send_sigterm(pidfd: &OwnedFd) -> std::io::Result<()> {
+    // SAFETY: pidfd is live and owned for this call; a null siginfo pointer and
+    // zero flags are the documented pidfd_send_signal contract for SIGTERM.
+    let rc = unsafe {
+        libc::syscall(
+            libc::SYS_pidfd_send_signal,
+            pidfd.as_raw_fd(),
+            libc::SIGTERM,
+            std::ptr::null::<libc::siginfo_t>(),
+            0,
+        )
+    };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
 fn is_pid_dead(pid: u32, pid_start_time_ticks: Option<u64>) -> bool {
+    // Advisory diagnostics do not confer child-process ownership, so this
+    // liveness probe must never call waitpid(2) or consume an exit status.
     let Ok(pid_i32) = i32::try_from(pid) else {
         return false;
     };
+    if pid_i32 == 0 {
+        return false;
+    }
+    if process_state(pid) == Some('Z') {
+        return true;
+    }
+
     // SAFETY: kill(pid, 0) sends no signal; only checks process existence.
     let alive = unsafe { libc::kill(pid_i32, 0) } == 0;
     if !alive {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_types.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_types.rs
@@ -53,6 +53,7 @@ impl WaitBehavior {
 pub(super) struct WaitExecutionOptions {
     pub(super) behavior: WaitBehavior,
     pub(super) output_mode: SessionWaitOutputMode,
+    pub(super) caller_identity: super::WaitCallerIdentity,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
@@ -1,11 +1,12 @@
 use super::*;
 use crate::session_cmds_daemon::{
-    WaitBehavior, WaitLoopTiming, WaitReconciliationOutcome, handle_session_wait_with_hooks,
-    try_acquire_session_wait_lock,
+    WaitBehavior, WaitCallerIdentity, WaitLoopTiming, WaitReconciliationOutcome,
+    handle_session_wait_with_hooks, handle_session_wait_with_identity_for_test,
+    try_acquire_session_wait_lock, try_acquire_session_wait_lock_with_caller,
 };
 use crate::test_env_lock::TEST_ENV_LOCK;
 use std::io::Write;
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::process::Command;
@@ -37,6 +38,19 @@ impl Drop for EnvVarGuard {
     }
 }
 
+fn caller_output_pipe() -> (OwnedFd, OwnedFd, WaitCallerIdentity) {
+    let mut pipe_fds = [0i32; 2];
+    // SAFETY: `pipe_fds` has space for both descriptors initialized by pipe().
+    assert_eq!(unsafe { libc::pipe(pipe_fds.as_mut_ptr()) }, 0);
+    // SAFETY: pipe() succeeded and returned two new descriptors, each adopted
+    // exactly once by an OwnedFd.
+    let read_end = unsafe { OwnedFd::from_raw_fd(pipe_fds[0]) };
+    // SAFETY: see the ownership argument above for the pipe write descriptor.
+    let write_end = unsafe { OwnedFd::from_raw_fd(pipe_fds[1]) };
+    let caller_identity = WaitCallerIdentity::from_output_fd_for_test(write_end.as_raw_fd());
+    (read_end, write_end, caller_identity)
+}
+
 #[test]
 fn session_wait_lock_creates_dot_wait_lock_file_and_rejects_duplicates() {
     let td = tempdir().expect("tempdir");
@@ -54,6 +68,118 @@ fn session_wait_lock_creates_dot_wait_lock_file_and_rejects_duplicates() {
         second_lock.is_none(),
         "second concurrent wait lock attempt should be rejected"
     );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn session_wait_lock_persists_caller_output_identity() {
+    let td = tempdir().expect("tempdir");
+    let (_caller_read_end, _wait_output_end, caller_identity) = caller_output_pipe();
+    let (output_device, output_inode) = caller_identity
+        .diagnostic_parts_for_test()
+        .expect("pipe output should have a stable descriptor identity");
+
+    let _lock = try_acquire_session_wait_lock_with_caller(td.path(), caller_identity)
+        .expect("wait lock acquisition")
+        .expect("wait lock should be acquired");
+    let diagnostic: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(td.path().join(".wait.lock")).expect("read wait lock diagnostic"),
+    )
+    .expect("parse wait lock diagnostic");
+
+    assert_eq!(
+        diagnostic["caller_output_device"].as_u64(),
+        Some(output_device)
+    );
+    assert_eq!(
+        diagnostic["caller_output_inode"].as_u64(),
+        Some(output_inode)
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn session_wait_rejects_closed_caller_output_before_lock_acquisition() {
+    let (caller_read_end, _wait_output_end, caller_identity) = caller_output_pipe();
+    drop(caller_read_end);
+
+    let error = caller_identity
+        .validate_for_wait()
+        .expect_err("closed caller output must not pass startup validation");
+    assert!(
+        error.to_string().contains("caller output closed"),
+        "unexpected caller validation error: {error}"
+    );
+}
+
+#[test]
+fn session_wait_releases_lock_when_caller_output_closes() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+    let session = create_session(
+        project,
+        Some("caller-output-lifecycle"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let _worktree_lock = csa_lock::acquire_worktree_write_lock(
+        project,
+        &session_id,
+        &[],
+        |_| false,
+        |_| false,
+        |_| false,
+    )
+    .expect("live session worktree lock");
+    let (caller_read_end, _wait_output_end, caller_identity) = caller_output_pipe();
+    let wait_project = project.to_string_lossy().into_owned();
+    let wait_session_id = session_id.clone();
+    let wait_handle = std::thread::spawn(move || {
+        handle_session_wait_with_identity_for_test(
+            wait_session_id,
+            Some(wait_project),
+            5,
+            caller_identity,
+        )
+        .expect("wait should observe caller output closure")
+    });
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        match try_acquire_session_wait_lock(&session_dir).expect("probe wait lock") {
+            None => break,
+            Some(lock) => drop(lock),
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "wait did not acquire its lock before the caller lifecycle test deadline"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    // The output pipe was inherited before the waiter could sample any PPID.
+    // Closing its caller-owned read end must release the lock without a parent
+    // identity baseline, even if process reparenting has already happened.
+    drop(caller_read_end);
+    assert_eq!(wait_handle.join().expect("wait thread should not panic"), 1);
+    assert!(
+        load_result(project, &session_id)
+            .expect("load result after caller output closure")
+            .is_none(),
+        "caller output closure must exit without synthesizing a session result"
+    );
+    let released_lock = try_acquire_session_wait_lock(&session_dir)
+        .expect("probe released wait lock")
+        .expect("caller output closure must release the wait lock");
+    drop(released_lock);
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs
@@ -1,15 +1,63 @@
 use super::*;
 use crate::session_cmds_daemon::{
-    SESSION_WAIT_MEMORY_WARN_EXIT_CODE, WaitBehavior, WaitLoopTiming, WaitReconciliationOutcome,
-    handle_session_wait_with_hooks, handle_session_wait_with_hooks_and_sampler,
-    render_wait_result_summary, try_acquire_session_wait_lock,
+    SESSION_WAIT_MEMORY_WARN_EXIT_CODE, WaitBehavior, WaitCallerIdentity, WaitLoopTiming,
+    WaitReconciliationOutcome, handle_session_wait_with_hooks,
+    handle_session_wait_with_hooks_and_sampler, handle_session_wait_with_identity_for_test,
+    parent_pid, process_start_time_ticks, process_state, render_wait_result_summary,
+    try_acquire_session_wait_lock, try_acquire_session_wait_lock_with_caller,
 };
 use std::fs;
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, SystemTime};
 
 const FIX_FINDING_TASK_TYPE: &str = "review_fix_finding";
+
+#[cfg(target_os = "linux")]
+struct ForkedChildGuard(libc::pid_t);
+
+#[cfg(target_os = "linux")]
+impl ForkedChildGuard {
+    fn try_wait_nohang(&mut self) -> libc::pid_t {
+        let mut status: libc::c_int = 0;
+        // SAFETY: self.0 is a child PID owned by this guard, status points to
+        // writable storage, and WNOHANG makes the ownership check non-blocking.
+        let rc = unsafe { libc::waitpid(self.0, &mut status, libc::WNOHANG) };
+        let ownership_released = rc == self.0
+            || (rc == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ECHILD));
+        if ownership_released {
+            self.0 = 0;
+        }
+        rc
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for ForkedChildGuard {
+    fn drop(&mut self) {
+        if self.0 == 0 {
+            return;
+        }
+        // SAFETY: self.0 is a child PID returned by fork(); kill targets only
+        // that child, and waitpid receives a valid status pointer with EINTR
+        // retried until the child is reaped or is already gone.
+        unsafe {
+            libc::kill(self.0, libc::SIGKILL);
+            loop {
+                let mut status: libc::c_int = 0;
+                let rc = libc::waitpid(self.0, &mut status, 0);
+                if rc == self.0 {
+                    break;
+                }
+                if rc == -1 && std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
+                    break;
+                }
+            }
+        }
+    }
+}
 
 #[path = "session_cmds_tests_tail_wait_resume_wrapper_alias_assert.rs"]
 mod alias_assert;
@@ -719,4 +767,372 @@ fn wait_lock_fd_sets_cloexec() {
     );
 
     drop(lock);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn wait_lock_orphaned_pid_not_reclaimed_when_parent_alive() {
+    // A live wait process with a matching parent PID should NOT be reclaimed.
+    // We verify that when our own PID (alive, parent unchanged) holds the flock,
+    // a second acquire correctly fails — the orphan check doesn't fire.
+    use std::io::Write;
+    use std::os::fd::AsRawFd;
+
+    let td = tempdir().unwrap();
+    let session_dir = td.path();
+
+    // Write diagnostic with our PID and a valid start-time.
+    let my_pid = std::process::id();
+    let my_start_time =
+        process_start_time_ticks(my_pid).expect("Linux test process should expose a start time");
+    let my_ppid = parent_pid(my_pid).expect("Linux test process should expose a parent PID");
+    let diag_json = serde_json::json!({"pid": my_pid, "pid_start_time_ticks": my_start_time, "parent_pid": my_ppid});
+    let mut f = std::fs::File::create(session_dir.join(".wait.lock")).unwrap();
+    writeln!(f, "{diag_json}").unwrap();
+    drop(f);
+
+    // Hold the flock ourselves (alive, parent PID unchanged).
+    let live_flock = std::fs::OpenOptions::new()
+        .write(true)
+        .open(session_dir.join(".wait.lock"))
+        .unwrap();
+    // SAFETY: live_flock owns a valid fd; LOCK_EX | LOCK_NB is a non-blocking advisory lock.
+    let flock_rc = unsafe { libc::flock(live_flock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    assert_eq!(
+        flock_rc,
+        0,
+        "test holder should acquire flock: {}",
+        std::io::Error::last_os_error()
+    );
+
+    let result = try_acquire_session_wait_lock(session_dir).expect("acquire should not error");
+    assert!(
+        result.is_none(),
+        "must not reclaim lock held by live process with a live parent"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn wait_lock_rewritten_diagnostic_cannot_signal_non_holder() {
+    let td = tempdir().unwrap();
+    let lock_path = td.path().join(".wait.lock");
+
+    // Fork the diagnostic victim before opening the lock so it cannot inherit
+    // the locked open-file description.
+    // SAFETY: the child branch calls only async-signal-safe libc functions
+    // before _exit().
+    let victim_pid = unsafe { libc::fork() };
+    assert!(victim_pid >= 0, "fork failed");
+    if victim_pid == 0 {
+        // SAFETY: pause() and _exit() are async-signal-safe after fork().
+        unsafe {
+            libc::pause();
+            libc::_exit(0);
+        }
+    }
+    let mut victim_guard = ForkedChildGuard(victim_pid);
+
+    let victim_start_time = process_start_time_ticks(victim_pid as u32)
+        .expect("diagnostic victim should expose a start time");
+    let victim_parent_pid =
+        parent_pid(victim_pid as u32).expect("diagnostic victim should expose its parent PID");
+    let different_parent_pid = victim_parent_pid
+        .checked_add(1)
+        .unwrap_or(victim_parent_pid - 1);
+
+    let holder = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .unwrap();
+    // SAFETY: holder owns a valid fd; LOCK_EX | LOCK_NB requests an exclusive
+    // non-blocking advisory flock.
+    assert_eq!(
+        unsafe { libc::flock(holder.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+        0,
+        "test holder should acquire flock"
+    );
+
+    // Advisory flock does not prevent this concurrent diagnostic rewrite. The
+    // diagnostic names a live reparented-looking process that is not the holder.
+    let diagnostic = serde_json::json!({
+        "pid": victim_pid,
+        "pid_start_time_ticks": victim_start_time,
+        "parent_pid": different_parent_pid,
+    });
+    std::fs::write(&lock_path, format!("{diagnostic}\n")).unwrap();
+
+    let acquired = try_acquire_session_wait_lock(td.path()).expect("lock probe should not error");
+    assert!(
+        acquired.is_none(),
+        "rewritten diagnostics must not bypass the holder's flock"
+    );
+
+    let victim_wait = victim_guard.try_wait_nohang();
+    assert_eq!(
+        victim_wait, 0,
+        "takeover must preserve the diagnostic PID when it does not hold the flock"
+    );
+
+    drop(holder);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn wait_lock_diagnostic_probe_does_not_reap_unowned_child() {
+    let td = tempdir().unwrap();
+    let lock_path = td.path().join(".wait.lock");
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .unwrap();
+    // SAFETY: lock_file owns a valid fd and the flags request a non-blocking
+    // exclusive advisory lock before fork().
+    assert_eq!(
+        unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+        0,
+        "parent should acquire flock before forking its holder"
+    );
+
+    // SAFETY: the child branch calls only async-signal-safe libc functions
+    // before _exit(); it inherits the locked open-file description.
+    let holder_pid = unsafe { libc::fork() };
+    assert!(holder_pid >= 0, "holder fork failed");
+    if holder_pid == 0 {
+        // SAFETY: pause() and _exit() are async-signal-safe after fork().
+        unsafe {
+            libc::pause();
+            libc::_exit(0);
+        }
+    }
+    let _holder_guard = ForkedChildGuard(holder_pid);
+    drop(lock_file);
+
+    // SAFETY: the child exits immediately using the async-signal-safe _exit().
+    let exited_pid = unsafe { libc::fork() };
+    assert!(exited_pid >= 0, "exited-child fork failed");
+    if exited_pid == 0 {
+        // SAFETY: _exit() is async-signal-safe after fork().
+        unsafe { libc::_exit(0) };
+    }
+    let mut exited_guard = ForkedChildGuard(exited_pid);
+    let exited_pid_u32 = exited_pid as u32;
+    let exited_start_time = process_start_time_ticks(exited_pid_u32)
+        .expect("exited child should expose a Linux start time until reaped");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while process_state(exited_pid_u32) != Some('Z') {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "child did not become waitable before the test deadline"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    for diagnostic_pid in [exited_pid_u32, 0] {
+        let diagnostic = serde_json::json!({
+            "pid": diagnostic_pid,
+            "pid_start_time_ticks": exited_start_time,
+            "parent_pid": 1,
+        });
+        std::fs::write(&lock_path, format!("{diagnostic}\n")).unwrap();
+        let acquired =
+            try_acquire_session_wait_lock(td.path()).expect("lock probe should not error");
+        assert!(
+            acquired.is_none(),
+            "advisory diagnostic must not bypass another process's flock"
+        );
+    }
+
+    assert_eq!(
+        exited_guard.try_wait_nohang(),
+        exited_pid,
+        "advisory liveness probes must leave child reaping to its owner"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn wait_lock_legacy_orphaned_pid_is_reclaimed() {
+    // Positive compatibility test: create a live holder whose legacy recorded
+    // parent differs from its actual parent, then verify lock acquisition
+    // reclaims the holder via SIGTERM.
+    //
+    // Design:
+    // - Acquire flock BEFORE fork on a parent-opened fd. After fork the child
+    //   inherits the locked open-file description. The parent closes its dup
+    //   so only the child holds the lock. This avoids calling flock() after
+    //   fork (not on the POSIX async-signal-safe list).
+    // - RAII ChildGuard kills+reaps the child in Drop (with EINTR retry),
+    //   preventing zombies or hung pause() children even if assertions fail.
+
+    let td = tempdir().unwrap();
+    let session_dir = td.path();
+    let lock_path = session_dir.join(".wait.lock");
+
+    // Open lock file and acquire flock BEFORE fork.
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .unwrap();
+    let lock_fd = std::os::unix::io::AsRawFd::as_raw_fd(&lock_file);
+    // SAFETY: lock_file owns lock_fd, and the flags request a non-blocking advisory lock.
+    let flock_rc = unsafe { libc::flock(lock_fd, libc::LOCK_EX | libc::LOCK_NB) };
+    assert!(flock_rc == 0, "parent should acquire flock before fork");
+
+    // Protocol byte for success (avoid b"\x00" which triggers clippy::manual-c-str-literals).
+    let ok_byte: [u8; 1] = [0];
+
+    // Create pipe for readiness handshake.
+    let mut pipe_fds = [0i32; 2];
+    // SAFETY: pipe_fds has space for the two file descriptors written by pipe().
+    assert!(
+        unsafe { libc::pipe(pipe_fds.as_mut_ptr()) } == 0,
+        "pipe failed"
+    );
+    let read_fd = pipe_fds[0];
+    let write_fd = pipe_fds[1];
+
+    // Fork holder child. The child inherits the locked fd.
+    // SAFETY: the child branch calls only async-signal-safe libc functions before _exit().
+    let child_pid = unsafe { libc::fork() };
+    assert!(child_pid >= 0, "fork failed");
+
+    if child_pid == 0 {
+        // Holder child — only async-signal-safe calls from here.
+        // The inherited lock_fd already holds the flock.
+        // SAFETY: read_fd is the child's valid inherited read end and is no longer needed.
+        unsafe { libc::close(read_fd) };
+
+        // Signal readiness immediately (flock already held). Retry EINTR a
+        // bounded number of times; the parent independently enforces the
+        // overall five-second handshake deadline.
+        // SAFETY: write_fd is valid, ok_byte supplies one readable byte, errno
+        // is read only after a failed write, and all child syscalls used here
+        // are async-signal-safe after fork().
+        unsafe {
+            let mut interrupted_writes = 0;
+            loop {
+                let rc = libc::write(write_fd, ok_byte.as_ptr().cast(), 1);
+                if rc == 1 {
+                    break;
+                }
+                let was_interrupted = rc == -1 && *libc::__errno_location() == libc::EINTR;
+                if was_interrupted && interrupted_writes < 16 {
+                    interrupted_writes += 1;
+                    continue;
+                }
+                libc::_exit(1);
+            }
+            libc::close(write_fd);
+        }
+
+        // Wait to be SIGTERM'd by the reclaimer.
+        // SAFETY: pause() and _exit() are async-signal-safe after fork().
+        unsafe {
+            libc::pause();
+            libc::_exit(0);
+        }
+    }
+
+    // --- Parent continues here ---
+    // Close parent's copy of lock_fd so only the child holds the lock.
+    drop(lock_file);
+
+    // RAII guard kills and reaps the child on every parent exit path.
+    let _guard = ForkedChildGuard(child_pid);
+
+    // SAFETY: write_fd is the parent's inherited write end and is no longer needed.
+    unsafe { libc::close(write_fd) };
+
+    // Bounded pipe read: use poll() with 5s timeout to avoid infinite hang.
+    // Retry poll() and read() on EINTR.
+    let mut readiness = [0u8; 1];
+    let nbytes: isize;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let remaining = deadline
+            .saturating_duration_since(std::time::Instant::now())
+            .as_millis()
+            .min(u32::MAX as u128) as libc::c_int;
+        if remaining <= 0 {
+            nbytes = -1;
+            break;
+        }
+        let mut pollfd = libc::pollfd {
+            fd: read_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: pollfd points to one initialized descriptor entry for this call.
+        let poll_rc = unsafe { libc::poll(&mut pollfd, 1, remaining) };
+        if poll_rc == -1 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            nbytes = -1;
+            break;
+        }
+        if poll_rc > 0 {
+            // SAFETY: read_fd is open and readiness provides one writable byte.
+            let rc = unsafe { libc::read(read_fd, readiness.as_mut_ptr() as *mut _, 1) };
+            if rc == -1 {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() == Some(libc::EINTR) {
+                    continue;
+                }
+                nbytes = -1;
+                break;
+            }
+            nbytes = rc;
+            break;
+        }
+        // poll_rc == 0: timeout
+        nbytes = -1;
+        break;
+    }
+    // SAFETY: read_fd is the parent's valid read end and is no longer needed.
+    unsafe { libc::close(read_fd) };
+
+    assert!(nbytes == 1, "child should signal readiness within 5s");
+    assert!(
+        readiness[0] == ok_byte[0],
+        "child should have successfully acquired flock"
+    );
+
+    // SAFETY: kill(pid, 0) probes the forked child's liveness without sending a signal.
+    let alive = unsafe { libc::kill(child_pid, 0) } == 0;
+    assert!(alive, "child should be alive and holding flock");
+
+    // Derive a legacy recorded parent guaranteed to differ from the child's
+    // actual parent, including when the test process is PID-namespace init.
+    let child_start_time =
+        process_start_time_ticks(child_pid as u32).expect("should have start-time on Linux");
+    let child_parent_pid =
+        parent_pid(child_pid as u32).expect("child should expose its parent PID on Linux");
+    let different_parent_pid = child_parent_pid
+        .checked_add(1)
+        .unwrap_or(child_parent_pid - 1);
+    assert_ne!(different_parent_pid, child_parent_pid);
+    let diag = serde_json::json!({
+        "pid": child_pid,
+        "pid_start_time_ticks": child_start_time,
+        "parent_pid": different_parent_pid,
+    });
+    std::fs::write(&lock_path, format!("{diag}\n")).unwrap();
+
+    // Now try to acquire — should reclaim the lock via SIGTERM + retry.
+    let lock = try_acquire_session_wait_lock(session_dir).expect("acquire should not error");
+    assert!(lock.is_some(), "should reclaim lock from orphaned holder");
+
+    // ChildGuard::drop will kill+reap the child.
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper_alias_race.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper_alias_race.rs
@@ -82,9 +82,18 @@ fn handle_session_wait_on_fix_finding_wrapper_rebinds_when_alias_appears_after_w
 
     let wait_project_arg = project.to_string_lossy().into_owned();
     let wait_wrapper_id = wrapper_id.clone();
+    let caller_identity = WaitCallerIdentity::capture();
+    let (caller_output_device, caller_output_inode) = caller_identity
+        .diagnostic_parts_for_test()
+        .expect("test output should expose a stable descriptor identity");
     let wait_handle = std::thread::spawn(move || {
-        handle_session_wait(wait_wrapper_id, Some(wait_project_arg), 5)
-            .expect("wait should complete after alias and completion appear")
+        handle_session_wait_with_identity_for_test(
+            wait_wrapper_id,
+            Some(wait_project_arg),
+            5,
+            caller_identity,
+        )
+        .expect("wait should complete after alias and completion appear")
     });
     std::thread::sleep(std::time::Duration::from_millis(50));
 
@@ -114,6 +123,25 @@ fn handle_session_wait_on_fix_finding_wrapper_rebinds_when_alias_appears_after_w
         Some(fix_session_id.clone())
     );
     wait_until_wait_lock_is_held(&fix_dir);
+    let target_diagnostic: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(fix_dir.join(".wait.lock"))
+            .expect("read transferred target wait diagnostic"),
+    )
+    .expect("parse transferred target wait diagnostic");
+    assert_eq!(
+        target_diagnostic["caller_output_device"].as_u64(),
+        Some(caller_output_device),
+        "late target lock must inherit the caller output device"
+    );
+    assert_eq!(
+        target_diagnostic["caller_output_inode"].as_u64(),
+        Some(caller_output_inode),
+        "late target lock must inherit the caller output inode"
+    );
+    let wrapper_probe = try_acquire_session_wait_lock_with_caller(&wrapper_dir, caller_identity)
+        .expect("probe released wrapper wait lock")
+        .expect("late target transition must release the wrapper wait lock");
+    drop(wrapper_probe);
     std::fs::write(
         wrapper_dir.join("daemon-completion.toml"),
         "exit_code = 1\nstatus = \"failure\"\n",

--- a/crates/cli-sub-agent/src/session_dispatch.rs
+++ b/crates/cli-sub-agent/src/session_dispatch.rs
@@ -26,6 +26,7 @@ pub(crate) fn dispatch(
     cmd: SessionCommands,
     output_format: OutputFormat,
     startup_env: &StartupSubtreeEnv,
+    wait_caller_identity: session_cmds::WaitCallerIdentity,
 ) -> Result<()> {
     match cmd {
         SessionCommands::List {
@@ -186,6 +187,7 @@ pub(crate) fn dispatch(
             json,
             cd,
         } => {
+            let wait_caller_identity = wait_caller_identity.validate_for_wait()?;
             let sid = resolve_session_id(session_id, session)?;
             let wait_timeout = resolve_wait_ttl(model_provider, cd.as_deref());
             let resolved_memory_warn_mb =
@@ -197,6 +199,7 @@ pub(crate) fn dispatch(
                 wait_timeout,
                 resolved_memory_warn_mb,
                 output_mode,
+                wait_caller_identity,
             )?;
             let _ = std::io::stdout().flush();
             let _ = std::io::stderr().flush();

--- a/scripts/monolith/baseline.toml
+++ b/scripts/monolith/baseline.toml
@@ -797,7 +797,15 @@ rationale = "run-level outer timeout fix adds synthetic ExecutionResult + RunLoo
 [[files]]
 path = "crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper.rs"
 kind = "test"
-baseline_tokens = 8883
-baseline_lines = 722
-issue = "2618"
-rationale = "stale-PID recovery tests + FD_CLOEXEC test for #2636 wait-lock fix"
+baseline_tokens = 14176
+baseline_lines = 1138
+issue = "2642"
+rationale = "legacy orphan reclaim regressions for #2642 cover ownership-bound signaling, advisory diagnostic rewrites, side-effect-free liveness probes for child and zero PIDs, PID-namespace-safe synthetic PPIDs, bounded EINTR handling, and unsafe-call contracts; stale-PID recovery tests + FD_CLOEXEC test for #2636 wait-lock fix"
+
+[[files]]
+path = "crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs"
+kind = "source"
+baseline_tokens = 8300
+baseline_lines = 568
+issue = "2642"
+rationale = "caller-output lifecycle checks and honest alive-orphan recovery messages (#2642)"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1091"
-weave = "0.1.1091"
+csa = "0.1.1092"
+weave = "0.1.1092"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
Closes #2642

## Summary

When a `csa session wait` caller exits while the session is still running, the orphaned wait process retains the session lock and the "will notify you" promise is broken. This PR implements alive-orphan wait-lock takeover on Linux with robust process identity verification.

## Changes

- **Caller output lifecycle lease**: Wait locks are bound to the caller stdout file descriptor, so lock ownership transfers naturally when the caller exits
- **PID + start-time + PPID identity**: Orphan reclaim verifies process identity via `/proc` before any takeover
- **Flock ownership verification**: Before sending SIGTERM, verifies the target PID actually holds the contested flock via `/proc/locks` inode check
- **Side-effect-free liveness probing**: Replaced `waitpid()` in advisory diagnostic checks with `kill(pid, 0)` + `/proc` start-time, preventing unintended child reaping
- **Linux-only reclaim**: Non-Linux platforms conservatively decline orphan takeover
- **Comprehensive test coverage**: Fork/orphan/EINTR tests, late wrapper→target regression, PID-namespace-init compatibility, owner-mismatch negative tests

## Verification

- Focused tests: 17/17 wait-lock + 3/3 caller-output + 1/1 late wrapper regression
- Tier-4 audit review (Codex xhigh, 3 rounds): PASS/CLEAN
- `csa review --check-verdict`: passed for `main...HEAD` at `4484f849`
- Full `just pre-commit` gate passed