### PR TITLE
chore(config): remove stale tier review specs

### DIFF
--- a/.csa/config.toml
+++ b/.csa/config.toml
@@ -23,12 +23,3 @@ tier = "tier-4-critical"
 
 [debate]
 tier = "tier-4-critical"
-
-[tiers.tier-review]
-description = "Review and debate tier with priority-based fallback"
-strategy = "priority"
-models = [
-  "gemini-cli/google/gemini-3.1-pro-preview/xhigh",
-  "codex/openai/o3/medium",
-  "claude-code/anthropic/claude-sonnet-4-20250514/none",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "chrono",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "chrono",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "chrono",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "chrono",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "chrono",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "axum",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "chrono",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "chrono",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "chrono",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1094"
+version = "0.1.1095"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1094"
+version = "0.1.1095"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1092"
-weave = "0.1.1092"
+csa = "0.1.1095"
+weave = "0.1.1095"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- remove the stale project-local `tier-review` block referencing the removed `gemini-cli` integration and unknown Codex `o3` model
- keep project review and debate on `tier-4-critical`
- advance workspace/weave version metadata to `0.1.1095`

Closes #2656.

## Verification

- `cargo check --workspace --all-features`
- `csa config validate`
- routine CSA commands no longer emit the stale `gemini-cli` / `o3` tier warnings
- `git diff --check main...HEAD`
- hook-enabled commit quality gates passed

## Tier-4 review

- session: `01KXA5JNTNW0HBXK5SP64531TY`
- scope: `main...HEAD`
- tool/tier: Codex / `tier-4-critical`
- depth: audit
- verdict: PASS/CLEAN at `89a68ec02438bcd00b624126333f35e570069719`
- findings: none

## Follow-up evidence

The successful commit exposed an independent `--require-commit` false failure for tracked ignored paths; tracked separately in #2690.