### PR TITLE
test(mktd): isolate save fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1098"
+version = "0.1.1099"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/plan_cmd_tests_mktd_save.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_tests_mktd_save.rs
@@ -46,16 +46,14 @@ fn mktd_save_step_persists_issue_quoted_content_without_shell_parse_break() -> a
     let csa_stub = bin_dir.path().join("csa");
     std::fs::write(&csa_stub, csa_stub_script())?;
     make_executable(&csa_stub)?;
-    install_save_script_path_tools(bin_dir.path())?;
 
     run_git(project_dir.path(), &["init"])?;
     run_git(project_dir.path(), &["checkout", "-b", "fix/2041-test"])?;
 
-    let output = std::process::Command::new("bash")
+    let output = save_script_command(bin_dir.path())?
         .arg("-c")
         .arg(save_script)
         .current_dir(project_dir.path())
-        .env("PATH", bin_dir.path())
         .env("CSA_SESSION_DIR", session_dir.path())
         .env("STEP_12_OUTPUT", tricky_todo())
         .env("STEP_8_OUTPUT", spec_toml())
@@ -124,16 +122,14 @@ fn mktd_save_step_normalizes_wrapped_spec_toml_before_persist() -> anyhow::Resul
         let csa_stub = bin_dir.path().join("csa");
         std::fs::write(&csa_stub, csa_stub_script())?;
         make_executable(&csa_stub)?;
-        install_save_script_path_tools(bin_dir.path())?;
 
         run_git(project_dir.path(), &["init"])?;
         run_git(project_dir.path(), &["checkout", "-b", "fix/2375-test"])?;
 
-        let output = std::process::Command::new("bash")
+        let output = save_script_command(bin_dir.path())?
             .arg("-c")
             .arg(&save_script)
             .current_dir(project_dir.path())
-            .env("PATH", bin_dir.path())
             .env("CSA_SESSION_DIR", session_dir.path())
             .env("STEP_12_OUTPUT", tricky_todo())
             .env("STEP_8_OUTPUT", step_8_output)
@@ -181,7 +177,6 @@ fn mktd_save_step_accepts_parser_valid_noncanonical_spec_toml() -> anyhow::Resul
     let csa_stub = bin_dir.path().join("csa");
     std::fs::write(&csa_stub, csa_stub_script())?;
     make_executable(&csa_stub)?;
-    install_save_script_path_tools(bin_dir.path())?;
 
     run_git(project_dir.path(), &["init"])?;
     run_git(
@@ -189,11 +184,10 @@ fn mktd_save_step_accepts_parser_valid_noncanonical_spec_toml() -> anyhow::Resul
         &["checkout", "-b", "fix/2439-noncanonical"],
     )?;
 
-    let output = std::process::Command::new("bash")
+    let output = save_script_command(bin_dir.path())?
         .arg("-c")
         .arg(save_script)
         .current_dir(project_dir.path())
-        .env("PATH", bin_dir.path())
         .env("CSA_SESSION_DIR", session_dir.path())
         .env("STEP_12_OUTPUT", tricky_todo())
         .env("STEP_8_OUTPUT", noncanonical_spec_toml())
@@ -231,16 +225,14 @@ fn mktd_save_step_rejects_unrecoverable_prose_spec_before_persist() -> anyhow::R
     let csa_stub = bin_dir.path().join("csa");
     std::fs::write(&csa_stub, csa_stub_script())?;
     make_executable(&csa_stub)?;
-    install_save_script_path_tools(bin_dir.path())?;
 
     run_git(project_dir.path(), &["init"])?;
     run_git(project_dir.path(), &["checkout", "-b", "fix/2375-bad-spec"])?;
 
-    let output = std::process::Command::new("bash")
+    let output = save_script_command(bin_dir.path())?
         .arg("-c")
         .arg(save_script)
         .current_dir(project_dir.path())
-        .env("PATH", bin_dir.path())
         .env("CSA_SESSION_DIR", session_dir.path())
         .env("STEP_12_OUTPUT", tricky_todo())
         .env(
@@ -294,7 +286,6 @@ fn mktd_save_step_rejects_truncated_spec_with_parser_root_cause() -> anyhow::Res
     let csa_stub = bin_dir.path().join("csa");
     std::fs::write(&csa_stub, csa_stub_script())?;
     make_executable(&csa_stub)?;
-    install_save_script_path_tools(bin_dir.path())?;
 
     run_git(project_dir.path(), &["init"])?;
     run_git(
@@ -302,11 +293,10 @@ fn mktd_save_step_rejects_truncated_spec_with_parser_root_cause() -> anyhow::Res
         &["checkout", "-b", "fix/2439-truncated"],
     )?;
 
-    let output = std::process::Command::new("bash")
+    let output = save_script_command(bin_dir.path())?
         .arg("-c")
         .arg(save_script)
         .current_dir(project_dir.path())
-        .env("PATH", bin_dir.path())
         .env("CSA_SESSION_DIR", session_dir.path())
         .env("STEP_12_OUTPUT", tricky_todo())
         .env(
@@ -352,7 +342,6 @@ fn mktd_save_step_rejects_command_stderr_contaminated_spec() -> anyhow::Result<(
     let csa_stub = bin_dir.path().join("csa");
     std::fs::write(&csa_stub, csa_stub_script())?;
     make_executable(&csa_stub)?;
-    install_save_script_path_tools(bin_dir.path())?;
 
     run_git(project_dir.path(), &["init"])?;
     run_git(
@@ -360,11 +349,10 @@ fn mktd_save_step_rejects_command_stderr_contaminated_spec() -> anyhow::Result<(
         &["checkout", "-b", "fix/2439-contaminated"],
     )?;
 
-    let output = std::process::Command::new("bash")
+    let output = save_script_command(bin_dir.path())?
         .arg("-c")
         .arg(save_script)
         .current_dir(project_dir.path())
-        .env("PATH", bin_dir.path())
         .env("CSA_SESSION_DIR", session_dir.path())
         .env("STEP_12_OUTPUT", tricky_todo())
         .env(
@@ -424,7 +412,6 @@ fn mktd_save_step_reports_persist_stderr_context_on_failure() -> anyhow::Result<
     let csa_stub = bin_dir.path().join("csa");
     std::fs::write(&csa_stub, csa_failing_persist_stub_script())?;
     make_executable(&csa_stub)?;
-    install_save_script_path_tools(bin_dir.path())?;
 
     run_git(project_dir.path(), &["init"])?;
     run_git(
@@ -432,11 +419,10 @@ fn mktd_save_step_reports_persist_stderr_context_on_failure() -> anyhow::Result<
         &["checkout", "-b", "fix/persist-detail-test"],
     )?;
 
-    let output = std::process::Command::new("bash")
+    let output = save_script_command(bin_dir.path())?
         .arg("-c")
         .arg(save_script)
         .current_dir(project_dir.path())
-        .env("PATH", bin_dir.path())
         .env("CSA_SESSION_DIR", session_dir.path())
         .env("STEP_12_OUTPUT", tricky_todo())
         .env("STEP_8_OUTPUT", spec_toml())
@@ -508,37 +494,41 @@ fn make_executable(path: &Path) -> anyhow::Result<()> {
 }
 
 #[cfg(unix)]
-fn install_save_script_path_tools(bin_dir: &Path) -> anyhow::Result<()> {
-    for tool in [
-        "awk", "bash", "git", "grep", "head", "mkdir", "sed", "tail", "tr", "wc", "perl",
-    ] {
-        let source = resolve_path_tool(tool)?;
-        std::os::unix::fs::symlink(&source, bin_dir.join(tool))?;
-    }
-    Ok(())
+fn save_script_command(bin_dir: &Path) -> anyhow::Result<std::process::Command> {
+    let mut command = std::process::Command::new(system_test_tool("bash")?);
+    command.env_clear().env("PATH", save_script_path(bin_dir)?);
+    Ok(command)
 }
 
 #[cfg(unix)]
-fn resolve_path_tool(tool: &str) -> anyhow::Result<PathBuf> {
-    use std::os::unix::fs::PermissionsExt;
+fn save_script_path(bin_dir: &Path) -> anyhow::Result<std::ffi::OsString> {
+    std::env::join_paths([bin_dir, Path::new("/usr/bin"), Path::new("/bin")])
+        .map_err(anyhow::Error::from)
+}
 
-    for dir in std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()) {
-        let candidate = dir.join(tool);
-        let Ok(metadata) = std::fs::metadata(&candidate) else {
-            continue;
-        };
-        if metadata.is_file() && metadata.permissions().mode() & 0o111 != 0 {
+#[cfg(unix)]
+fn system_test_path() -> anyhow::Result<std::ffi::OsString> {
+    std::env::join_paths([Path::new("/usr/bin"), Path::new("/bin")]).map_err(anyhow::Error::from)
+}
+
+#[cfg(unix)]
+fn system_test_tool(tool: &str) -> anyhow::Result<PathBuf> {
+    for directory in [Path::new("/usr/bin"), Path::new("/bin")] {
+        let candidate = directory.join(tool);
+        if candidate.is_file() {
             return Ok(candidate);
         }
     }
-    anyhow::bail!("required test tool not found on PATH: {tool}")
+    anyhow::bail!("required test tool not found in /usr/bin or /bin: {tool}")
 }
 
 #[cfg(unix)]
 fn run_git(project_dir: &Path, args: &[&str]) -> anyhow::Result<()> {
-    let output = std::process::Command::new("git")
+    let output = std::process::Command::new(system_test_tool("git")?)
         .args(args)
         .current_dir(project_dir)
+        .env_clear()
+        .env("PATH", system_test_path()?)
         .output()?;
     anyhow::ensure!(
         output.status.success(),

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1098"
-weave = "0.1.1098"
+csa = "0.1.1099"
+weave = "0.1.1099"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
Closes #2793

## Summary

- make mktd-save fixtures independent of ambient process/session state
- preserve parser-valid canonicalization and quoted-content coverage
- synchronize the self-hosted version files through the normal commit hook

## Verification

- focused and repeated same-process mktd-save tests passed in CSA writer session `01KXP5SNHGX6E5AACAVYZ2XSVQ`
- dev2merge full gate reached the cumulative review step
- tier-4 Codex review PASS: `01KXP8A2E2RC2FCXAQ9G5VH98W`
- pre-push: 7,294 passed, 3 skipped
- exact candidate: `csa 0.1.1099 (b41a8f7a)`