### PR TITLE
fix(hooks): isolate post-merge rebuild fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1099"
+version = "0.1.1100"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1100"
+version = "0.1.1101"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1098"
+version = "0.1.1099"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1100"
+version = "0.1.1101"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1099"
+version = "0.1.1100"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1098"
+version = "0.1.1099"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/scripts/tests/post-merge-rebuild-tests.sh
+++ b/scripts/tests/post-merge-rebuild-tests.sh
@@ -97,7 +97,10 @@ run_hook() {
     local install_dir="$1"
     local bin_dir="$2"
     local order_file="$3"
-    CSA_TEST_ORDER_FILE="$order_file" \
+    # Fixture calls must not inherit the outer CSA session's skip markers.
+    # The deliberate session-skip test below invokes the hook directly.
+    env -u CSA_SESSION_ID -u CSA_SESSION_DIR \
+        CSA_TEST_ORDER_FILE="$order_file" \
         CSA_POST_MERGE_INSTALL_DIR="$install_dir" \
         CSA_POST_MERGE_JUST="$bin_dir/just" \
         CSA_POST_MERGE_CARGO="$bin_dir/cargo" \
@@ -183,11 +186,7 @@ order3="$tmp3/order"
 : >"$order3"
 setup_fake_tools "$tmp3/tools" 0 0
 set +e
-CSA_TEST_ORDER_FILE="$order3" \
-    CSA_POST_MERGE_INSTALL_DIR="$install_dir3" \
-    CSA_POST_MERGE_JUST="$tmp3/tools/just" \
-    CSA_POST_MERGE_CARGO="$tmp3/tools/cargo" \
-    bash "$HOOK"
+run_hook "$install_dir3" "$tmp3/tools" "$order3"
 rc=$?
 set -e
 # Match production: hook gates on `test -w`, not UID. Root / CAP_DAC_OVERRIDE /
@@ -246,19 +245,11 @@ order6b="$tmp6/order-b"
 setup_fake_tools "$tmp6/tools" 0 0
 set +e
 (
-    CSA_TEST_ORDER_FILE="$order6a" \
-        CSA_POST_MERGE_INSTALL_DIR="$install_dir6" \
-        CSA_POST_MERGE_JUST="$tmp6/tools/just" \
-        CSA_POST_MERGE_CARGO="$tmp6/tools/cargo" \
-        bash "$HOOK"
+    run_hook "$install_dir6" "$tmp6/tools" "$order6a"
 ) &
 pid_a=$!
 (
-    CSA_TEST_ORDER_FILE="$order6b" \
-        CSA_POST_MERGE_INSTALL_DIR="$install_dir6" \
-        CSA_POST_MERGE_JUST="$tmp6/tools/just" \
-        CSA_POST_MERGE_CARGO="$tmp6/tools/cargo" \
-        bash "$HOOK"
+    run_hook "$install_dir6" "$tmp6/tools" "$order6b"
 ) &
 pid_b=$!
 wait "$pid_a"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1099"
-weave = "0.1.1099"
+csa = "0.1.1100"
+weave = "0.1.1100"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1098"
-weave = "0.1.1098"
+csa = "0.1.1099"
+weave = "0.1.1099"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1100"
-weave = "0.1.1100"
+csa = "0.1.1101"
+weave = "0.1.1101"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
Closes #2791

## Summary
- clear inherited CSA session identity for ordinary post-merge rebuild fixtures
- preserve the explicit CSA-session skip test path
- synchronize workspace version metadata after incorporating current main

## Verification
- normal commit hooks passed inside a CSA employee session
- dev2merge exact-HEAD full gate passed
- pre-push quality gate: 7,294 passed, 3 skipped
- tier-4 Codex full-diff review: PASS (`01KXPTFPVZ9D3ZMXT86X4STBPZ`)
- exact binary: `csa 0.1.1101 (951089d1)`