### PR TITLE
fix(session): fail closed when wait provider TTL is unconfigured (#2843)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1103"
+version = "0.1.1104"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1103"
+version = "0.1.1104"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -61,12 +61,15 @@ fn assert_wait_hint_contract(block: &str, site: &str) {
 #[test]
 fn daemon_wait_command_places_cd_after_single_session_id() {
     let session_id = "01KAS6M5XG7V4M4M6YDRS7P8R9";
-    let command =
-        crate::daemon_caller_hints::format_session_wait_command(session_id, Path::new("/tmp/repo"));
+    let command = crate::daemon_caller_hints::format_session_wait_command(
+        session_id,
+        Path::new("/tmp/repo"),
+        "openai",
+    );
 
     assert_eq!(
         command,
-        "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --cd '/tmp/repo'"
+        "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --model-provider openai --cd '/tmp/repo'"
     );
     assert_eq!(
         command.matches(session_id).count(),
@@ -84,6 +87,7 @@ fn daemon_wait_command_shell_escapes_project_root_single_quotes() {
     let command = crate::daemon_caller_hints::format_session_wait_command(
         "01KAS6M5XG7V4M4M6YDRS7P8R9",
         Path::new("/tmp/csa'; touch /tmp/csa-review-proof; echo '"),
+        "openai",
     );
     assert!(
         command.contains("'\\''; touch /tmp/csa-review-proof; echo '\\'''"),
@@ -100,12 +104,13 @@ fn daemon_caller_hint_attrs_escape_shell_command_values() {
     let command = crate::daemon_caller_hints::format_session_wait_command(
         "01KAS6M5XG7V4M4M6YDRS7P8R9",
         Path::new("/tmp/a\"b&<c>d"),
+        "openai",
     );
     let attr = crate::daemon_caller_hints::escape_structured_comment_attr(&command);
 
     assert_eq!(
         attr,
-        "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --cd '/tmp/a&quot;b&amp;&lt;c&gt;d'"
+        "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --model-provider openai --cd '/tmp/a&quot;b&amp;&lt;c&gt;d'"
     );
     assert!(
         !attr.contains('"') && !attr.contains('<') && !attr.contains('>'),
@@ -140,7 +145,10 @@ fn caller_hint_blocks_ignores_unrelated_mentions_in_comments() {
 
 #[test]
 fn codex_yield_hint_prefers_mcp_wait_and_keeps_shell_fallback_yield() {
-    let hint = crate::process_tree::format_codex_yield_hint(450_000);
+    let hint = crate::process_tree::format_codex_yield_hint(
+        450_000,
+        Some("csa session wait --session <ID> --model-provider openai --cd <PATH>"),
+    );
 
     assert!(hint.contains("mcp_tool=\"csa_session_wait\""), "{hint}");
     assert!(hint.contains("tool_timeout_sec=7200"), "{hint}");

--- a/crates/cli-sub-agent/src/cli_session.rs
+++ b/crates/cli-sub-agent/src/cli_session.rs
@@ -293,8 +293,9 @@ pub enum SessionCommands {
     },
 
     /// Wait for a daemon session to report a terminal result.
-    /// Timeout comes from the caller model provider TTL when detectable, otherwise
-    /// `~/.config/cli-sub-agent/config.toml` `[kv_cache].default_ttl_seconds`.
+    /// Requires a configured `[kv_cache.provider_ttls]` key with TTL > 0. Pass
+    /// `--model-provider` on every wait; best-effort detection is accepted only
+    /// when it resolves to a configured positive-TTL key.
     ///
     /// Optional memory early-exit: `--memory-warn-mb <N>` (or config
     /// `[session_wait].memory_warn_mb`) samples the watched session's process-tree RSS
@@ -318,8 +319,8 @@ pub enum SessionCommands {
         #[arg(long)]
         memory_warn_mb: Option<u64>,
 
-        /// Override the auto-detected caller provider for wait TTL selection.
-        /// Accepted values: any key from [kv_cache.provider_ttls] (e.g. claude, openai, glm, xai, other).
+        /// Caller provider for wait TTL selection. Derive this dynamically on every wait.
+        /// Accepted values: any configured [kv_cache.provider_ttls] key with TTL > 0.
         #[arg(long, value_parser = csa_config::parse_model_provider)]
         model_provider: Option<csa_config::ModelProvider>,
 

--- a/crates/cli-sub-agent/src/daemon_caller_hints.rs
+++ b/crates/cli-sub-agent/src/daemon_caller_hints.rs
@@ -1,9 +1,82 @@
 use std::path::Path;
 
-pub(crate) fn format_session_wait_command(session_id: &str, project_root: &Path) -> String {
+use csa_config::{GlobalConfig, ModelProvider, detect_model_provider, provider_ttl};
+
+pub(crate) struct SessionWaitCommand {
+    command: Option<String>,
+    legal_provider_keys: Vec<String>,
+}
+
+impl SessionWaitCommand {
+    pub(crate) fn command(&self) -> Option<&str> {
+        self.command.as_deref()
+    }
+
+    pub(crate) fn provider_selection_hint(&self) -> String {
+        let legal_keys = if self.legal_provider_keys.is_empty() {
+            "none".to_string()
+        } else {
+            self.legal_provider_keys.join(",")
+        };
+        let legal_keys = escape_structured_comment_attr(&legal_keys);
+        format!(
+            "<!-- CSA:CALLER_HINT action=\"select_wait_provider\" legal_keys=\"{legal_keys}\" \
+             rule=\"Do not issue a bare session wait. Derive the caller provider and pass --model-provider with one legal configured key.\" -->"
+        )
+    }
+}
+
+/// Resolve a provider-qualified `csa session wait` command for caller hints.
+///
+/// Explicit caller context takes precedence over best-effort current-process
+/// detection. A command is emitted only when its provider has a positive TTL
+/// in the active user configuration; otherwise the caller must choose from the
+/// legal keys carried by [`SessionWaitCommand::provider_selection_hint`].
+pub(crate) fn resolve_session_wait_command(
+    session_id: &str,
+    project_root: &Path,
+    preferred_provider: Option<&ModelProvider>,
+) -> SessionWaitCommand {
+    let config = GlobalConfig::load().ok();
+    let legal_provider_keys = config
+        .as_ref()
+        .map(|config| {
+            config
+                .kv_cache
+                .provider_ttls
+                .0
+                .iter()
+                .filter(|(_, ttl)| **ttl > 0)
+                .map(|(provider, _)| provider.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+    let provider = preferred_provider
+        .cloned()
+        .or_else(detect_model_provider)
+        .filter(|provider| {
+            config
+                .as_ref()
+                .and_then(|config| provider_ttl(provider, &config.kv_cache))
+                .is_some()
+        });
+
+    SessionWaitCommand {
+        command: provider.as_ref().map(|provider| {
+            format_session_wait_command(session_id, project_root, provider.as_str())
+        }),
+        legal_provider_keys,
+    }
+}
+
+/// Format every emitted shell wait command in one provider-aware form.
+pub(crate) fn format_session_wait_command(
+    session_id: &str,
+    project_root: &Path,
+    model_provider: &str,
+) -> String {
     format!(
-        "csa session wait --session {}{}",
-        session_id,
+        "csa session wait --session {session_id} --model-provider {model_provider}{}",
         format_cd_arg(project_root)
     )
 }
@@ -31,4 +104,66 @@ pub(crate) fn escape_structured_comment_attr(value: &str) -> String {
 
 fn shell_escape_for_command(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_session_wait_command;
+    use crate::test_env_lock::TEST_ENV_LOCK;
+    use std::path::Path;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+            unsafe {
+                match self.original.as_deref() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn wait_command_includes_detected_configured_model_provider() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_root = dir.path().join("xdg-config");
+        std::fs::create_dir_all(&config_root).expect("create config root");
+        let _home_guard = EnvVarGuard::set("HOME", dir.path());
+        let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
+        let _provider_guard = EnvVarGuard::set("HERMES_MODEL_PROVIDER", "openai-codex");
+        let config_path =
+            csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
+        std::fs::create_dir_all(config_path.parent().expect("config parent"))
+            .expect("create config parent");
+        std::fs::write(config_path, "[kv_cache.provider_ttls]\nopenai = 17\n")
+            .expect("write provider config");
+
+        assert_eq!(
+            resolve_session_wait_command(
+                "01KAS6M5XG7V4M4M6YDRS7P8R9",
+                Path::new("/tmp/repo"),
+                None,
+            )
+            .command(),
+            Some(
+                "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --model-provider openai --cd '/tmp/repo'"
+            )
+        );
+    }
 }

--- a/crates/cli-sub-agent/src/daemon_started_output.rs
+++ b/crates/cli-sub-agent/src/daemon_started_output.rs
@@ -14,27 +14,44 @@ pub(crate) fn prepare(
     project_root: &Path,
 ) -> Result<DaemonStartedOutput> {
     crate::run_cmd_daemon::verify_daemon_session_waitable(project_root, &result.session_id)?;
-    let wait_cmd =
-        crate::daemon_caller_hints::format_session_wait_command(&result.session_id, project_root);
+    let wait_command = crate::daemon_caller_hints::resolve_session_wait_command(
+        &result.session_id,
+        project_root,
+        None,
+    );
+    let wait_cmd_attr = wait_command
+        .command()
+        .map(crate::daemon_caller_hints::escape_structured_comment_attr)
+        .unwrap_or_default();
+    let wait_hint = match wait_command.command() {
+        Some(wait_cmd) => {
+            let wait_cmd = crate::daemon_caller_hints::escape_structured_comment_attr(wait_cmd);
+            format!(
+                "<!-- CSA:CALLER_HINT action=\"wait\" rule=\"Call {wait_cmd} with run_in_background: true. Task-notification is your wake signal — no polling, no loops, one wait per Bash call.\" -->"
+            )
+        }
+        None => wait_command.provider_selection_hint(),
+    };
     let attach_cmd =
         crate::daemon_caller_hints::format_session_attach_command(&result.session_id, project_root);
     let session_dir_attr = crate::daemon_caller_hints::escape_structured_comment_attr(
         &result.session_dir.display().to_string(),
     );
-    let wait_cmd_attr = crate::daemon_caller_hints::escape_structured_comment_attr(&wait_cmd);
     let attach_cmd_attr = crate::daemon_caller_hints::escape_structured_comment_attr(&attach_cmd);
     let mut stderr = format!(
         "<!-- CSA:SESSION_STARTED id={id} pid={pid} dir=\"{dir}\" \
          wait_cmd=\"{wait_cmd}\" \
          attach_cmd=\"{attach_cmd}\" -->\n\
-         <!-- CSA:CALLER_HINT action=\"wait\" rule=\"Call {wait_cmd} with run_in_background: true. Task-notification is your wake signal — no polling, no loops, one wait per Bash call.\" -->\n",
+         {wait_hint}\n",
         id = result.session_id,
         pid = result.pid,
         dir = session_dir_attr,
         wait_cmd = wait_cmd_attr,
         attach_cmd = attach_cmd_attr,
     );
-    stderr.push_str(&crate::process_tree::codex_yield_hint());
+    stderr.push_str(&crate::process_tree::codex_yield_hint(
+        wait_command.command(),
+    ));
     Ok(DaemonStartedOutput {
         stdout: format!("{}\n", result.session_id),
         stderr,
@@ -70,6 +87,39 @@ fn publish_to(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+            unsafe { std::env::remove_var(key) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
+            unsafe {
+                match self.original.as_deref() {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
 
     fn plan_spawn_result(
         project_root: &Path,
@@ -116,6 +166,59 @@ mod tests {
         assert_eq!(output.stdout, format!("{session_id}\n"));
         assert_eq!(output.stderr.matches("CSA:SESSION_STARTED").count(), 1);
         assert!(output.stderr.contains("CSA:CALLER_HINT"));
+        let _ = std::fs::remove_dir_all(session_root);
+    }
+
+    #[test]
+    fn started_marker_fails_closed_when_no_configured_provider_matches_context() {
+        let _lock = crate::test_env_lock::TEST_ENV_LOCK
+            .clone()
+            .blocking_lock_owned();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_root = temp.path().join("project");
+        let config_root = temp.path().join("xdg-config");
+        std::fs::create_dir_all(&project_root).expect("create project root");
+        std::fs::create_dir_all(&config_root).expect("create config root");
+        let _home_guard = EnvVarGuard::set("HOME", temp.path());
+        let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
+        let _provider_guard = EnvVarGuard::remove("HERMES_MODEL_PROVIDER");
+        let config_path =
+            csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
+        std::fs::create_dir_all(config_path.parent().expect("config parent"))
+            .expect("create config parent");
+        std::fs::write(config_path, "[kv_cache.provider_ttls]\ncustom = 17\n")
+            .expect("write provider config");
+        let (session_id, session_root, result) = plan_spawn_result(&project_root);
+        csa_session::create_session_with_daemon_env(
+            &project_root,
+            Some("plan: workflow.toml"),
+            None,
+            None,
+            Some(&session_id),
+            Some(&result.session_dir),
+            Some(&project_root),
+        )
+        .expect("plan placeholder should persist");
+
+        let output = prepare(&result, &project_root).expect("render started marker");
+
+        assert!(
+            output
+                .stderr
+                .contains("CSA:CALLER_HINT action=\"select_wait_provider\""),
+            "{:#?}",
+            output.stderr
+        );
+        assert!(
+            output.stderr.contains("legal_keys=\"custom\""),
+            "{:#?}",
+            output.stderr
+        );
+        assert!(
+            !output.stderr.contains("wait_cmd=\"csa session wait"),
+            "a providerless command must not be emitted: {:#?}",
+            output.stderr
+        );
         let _ = std::fs::remove_dir_all(session_root);
     }
 

--- a/crates/cli-sub-agent/src/process_tree.rs
+++ b/crates/cli-sub-agent/src/process_tree.rs
@@ -71,27 +71,38 @@ pub(crate) fn detect_ancestor_tool() -> Option<String> {
     None
 }
 
-pub(crate) fn codex_yield_hint() -> String {
+pub(crate) fn codex_yield_hint(shell_wait_command: Option<&str>) -> String {
     if detect_ancestor_tool().as_deref() != Some("codex") {
         return String::new();
     }
-    format_codex_yield_hint(csa_config::GlobalConfig::resolve_codex_session_wait_yield_ms())
+    format_codex_yield_hint(
+        csa_config::GlobalConfig::resolve_codex_session_wait_yield_ms(),
+        shell_wait_command,
+    )
 }
 
-pub(crate) fn format_codex_yield_hint(yield_time_ms: u64) -> String {
+pub(crate) fn format_codex_yield_hint(
+    yield_time_ms: u64,
+    shell_wait_command: Option<&str>,
+) -> String {
     let mcp_tool_timeout_sec = csa_config::DEFAULT_CODEX_SESSION_WAIT_MCP_TOOL_TIMEOUT_SEC;
     let mcp_internal_timeout_sec = csa_config::DEFAULT_CODEX_SESSION_WAIT_MCP_INTERNAL_TIMEOUT_SEC;
+    let shell_fallback = shell_wait_command.map_or_else(
+        || "Shell fallback only after deriving a configured provider: include --model-provider; do not issue a bare session wait.".to_string(),
+        |command| format!("Shell fallback only: shell({{ command: '{command}', yield_time_ms: {yield_time_ms} }})"),
+    );
     format!(
         "\n<!-- CSA:CODEX_HINT mcp_tool=\"csa_session_wait\" tool_timeout_sec={mcp_tool_timeout_sec} timeout_seconds={mcp_internal_timeout_sec} yield_time_ms={ms} \
          rule=\"You are running inside Codex. Prefer the CSA MCP tool csa_session_wait with outer tool_timeout_sec: {mcp_tool_timeout_sec} \
          and csa_session_wait timeout_seconds: {mcp_internal_timeout_sec}; it blocks inside the MCP server and avoids repeated shell wakeups. \
-         Shell fallback only: call csa session wait in one shell tool call with yield_time_ms: {ms}. \
+         {shell_fallback}. \
          Do not manually poll every 10-30s or reissue shell waits while a wait is already running. \
          Example MCP tool call: csa_session_wait({{ session_id: '<ID>', cd: '<PATH>', timeout_seconds: {mcp_internal_timeout_sec} }}) with outer tool_timeout_sec: {mcp_tool_timeout_sec}. \
-         Example shell fallback: shell({{ command: 'csa session wait --session <ID> --cd <PATH>', yield_time_ms: {ms} }})\" -->",
+         Example shell fallback is provider-qualified when available.\" -->",
         ms = yield_time_ms,
         mcp_tool_timeout_sec = mcp_tool_timeout_sec,
         mcp_internal_timeout_sec = mcp_internal_timeout_sec,
+        shell_fallback = shell_fallback,
     )
 }
 
@@ -341,7 +352,10 @@ mod tests {
 
     #[test]
     fn test_format_codex_yield_hint_prefers_mcp_wait_with_shell_fallback() {
-        let hint = format_codex_yield_hint(csa_config::DEFAULT_CODEX_SESSION_WAIT_YIELD_MS);
+        let hint = format_codex_yield_hint(
+            csa_config::DEFAULT_CODEX_SESSION_WAIT_YIELD_MS,
+            Some("csa session wait --session <ID> --model-provider openai --cd <PATH>"),
+        );
 
         assert!(hint.contains("CSA:CODEX_HINT"));
         assert!(hint.contains("mcp_tool=\"csa_session_wait\""));
@@ -360,7 +374,10 @@ mod tests {
 
     #[test]
     fn test_format_codex_yield_hint_uses_configured_interval() {
-        let hint = format_codex_yield_hint(450_000);
+        let hint = format_codex_yield_hint(
+            450_000,
+            Some("csa session wait --session <ID> --model-provider openai --cd <PATH>"),
+        );
 
         assert!(hint.contains("mcp_tool=\"csa_session_wait\""));
         assert!(hint.contains("tool_timeout_sec=7200"));

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -88,6 +88,7 @@ pub(crate) fn handle_session_wait_with_memory_warn(
         memory_warn_mb,
         SessionWaitOutputMode::from_flags(false, false),
         WaitCallerIdentity::capture(),
+        None,
     )
 }
 
@@ -98,13 +99,17 @@ pub(crate) fn handle_session_wait_with_options(
     memory_warn_mb: Option<u64>,
     output_mode: SessionWaitOutputMode,
     caller_identity: WaitCallerIdentity,
+    model_provider: Option<csa_config::ModelProvider>,
 ) -> Result<i32> {
     handle_session_wait_with_hooks_output_mode(
         session,
         cd,
-        WaitBehavior::new(wait_timeout_secs, memory_warn_mb),
-        output_mode,
-        caller_identity,
+        WaitExecutionOptions {
+            behavior: WaitBehavior::new(wait_timeout_secs, memory_warn_mb),
+            output_mode,
+            caller_identity,
+            model_provider,
+        },
         |project_root, session_id, trigger| {
             let reconciled = crate::session_cmds::ensure_terminal_result_for_dead_active_session(
                 project_root,
@@ -139,6 +144,7 @@ pub(crate) fn handle_session_wait_for_mcp(
             behavior: WaitBehavior::new(wait_timeout_secs, memory_warn_mb),
             output_mode,
             caller_identity,
+            model_provider: None,
         },
         core::WaitEmitters {
             reconcile_dead_active_session: Box::new(|project_root, session_id, trigger| {
@@ -304,9 +310,12 @@ where
     handle_session_wait_with_hooks_output_mode(
         session,
         cd,
-        wait_behavior,
-        SessionWaitOutputMode::from_flags(false, false),
-        WaitCallerIdentity::capture(),
+        WaitExecutionOptions {
+            behavior: wait_behavior,
+            output_mode: SessionWaitOutputMode::from_flags(false, false),
+            caller_identity: WaitCallerIdentity::capture(),
+            model_provider: None,
+        },
         reconcile_dead_active_session,
         emit_completion_signal,
     )
@@ -315,9 +324,7 @@ where
 fn handle_session_wait_with_hooks_output_mode<R, E>(
     session: String,
     cd: Option<String>,
-    wait_behavior: WaitBehavior,
-    output_mode: SessionWaitOutputMode,
-    caller_identity: WaitCallerIdentity,
+    wait_options: WaitExecutionOptions,
     mut reconcile_dead_active_session: R,
     mut emit_completion_signal: E,
 ) -> Result<i32>
@@ -329,11 +336,7 @@ where
     handle_session_wait_with_hooks_and_sampler_output_mode(
         session,
         cd,
-        WaitExecutionOptions {
-            behavior: wait_behavior,
-            output_mode,
-            caller_identity,
-        },
+        wait_options,
         &mut reconcile_dead_active_session,
         &mut emit_completion_signal,
         |project_root, session_id| {
@@ -375,6 +378,7 @@ where
             behavior: wait_behavior,
             output_mode: SessionWaitOutputMode::from_flags(false, false),
             caller_identity: WaitCallerIdentity::capture(),
+            model_provider: None,
         },
         reconcile_dead_active_session,
         emit_completion_signal,
@@ -423,6 +427,7 @@ pub(crate) fn handle_session_wait_with_identity_for_test(
         None,
         SessionWaitOutputMode::from_flags(false, false),
         caller_identity,
+        None,
     )
 }
 
@@ -451,7 +456,7 @@ fn emit_wait_completion_signal(
     eprintln!(
         "<!-- CSA:CALLER_HINT action=\"next_session\" rule=\"More sessions? Wait each in a SEPARATE Bash call. Backgrounded? Task-notification is your wake signal — no polling, no loops.\" -->"
     );
-    let codex_hint = crate::process_tree::codex_yield_hint();
+    let codex_hint = crate::process_tree::codex_yield_hint(None);
     if !codex_hint.is_empty() {
         eprint!("{codex_hint}");
     }

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_completion.rs
@@ -18,6 +18,11 @@ pub(crate) const SESSION_WAIT_KV_WARM_EXIT_CODE: i32 = 0;
 /// daemon is no longer alive and no result.toml was produced.
 pub(crate) const SESSION_WAIT_TIMEOUT_EXIT_CODE: i32 = 124;
 
+pub(crate) struct WaitCapContext<'a> {
+    pub(crate) project_root: &'a Path,
+    pub(crate) preferred_provider: Option<&'a csa_config::ModelProvider>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct WaitProgressDigest {
     elapsed_secs: u64,
@@ -100,6 +105,7 @@ pub(crate) fn terminal_result_wait_exit_code(status: &str, exit_code: i32) -> i3
 pub(crate) fn emit_wait_cap_outcome(
     session_id: &str,
     cd: Option<&str>,
+    context: WaitCapContext<'_>,
     wait_timeout_secs: u64,
     elapsed: u64,
     session_dir: &Path,
@@ -109,24 +115,35 @@ pub(crate) fn emit_wait_cap_outcome(
         .map(|path| crate::daemon_caller_hints::format_cd_arg(Path::new(path)))
         .unwrap_or_default();
     if session_alive {
-        let wait_cmd = format!("csa session wait --session {session_id}{cd_arg}");
-        let wait_cmd_attr = crate::daemon_caller_hints::escape_structured_comment_attr(&wait_cmd);
+        let wait_command = crate::daemon_caller_hints::resolve_session_wait_command(
+            session_id,
+            context.project_root,
+            context.preferred_provider,
+        );
         eprintln!(
             "Session {session_id} still running after {wait_timeout_secs}s wait cap; returning so caller can warm its KV cache before re-waiting."
         );
         if let Some(progress) = WaitProgressDigest::from_session_dir(session_dir) {
             eprintln!("{}", progress.render());
         }
-        eprintln!(
-            "<!-- CSA:SESSION_WAIT_KV_WARM session={session_id} status=alive elapsed={elapsed}s action=re-wait cmd=\"{wait_cmd_attr}\" -->"
-        );
-        eprintln!(
-            "<!-- CSA:CALLER_HINT action=\"retry_wait\" rule=\"Session alive; re-wait in a NEW Bash call: {wait_cmd}. Backgrounded? Task-notification is your wake signal — no polling, no loops.\" -->",
-            wait_cmd = wait_cmd_attr,
-        );
-        let codex_hint = crate::process_tree::codex_yield_hint();
-        if !codex_hint.is_empty() {
-            eprint!("{codex_hint}");
+        if let Some(wait_cmd) = wait_command.command() {
+            let wait_cmd_attr =
+                crate::daemon_caller_hints::escape_structured_comment_attr(wait_cmd);
+            eprintln!(
+                "<!-- CSA:SESSION_WAIT_KV_WARM session={session_id} status=alive elapsed={elapsed}s action=re-wait cmd=\"{wait_cmd_attr}\" -->"
+            );
+            eprintln!(
+                "<!-- CSA:CALLER_HINT action=\"retry_wait\" rule=\"Session alive; re-wait in a NEW Bash call: {wait_cmd_attr}. Backgrounded? Task-notification is your wake signal — no polling, no loops.\" -->"
+            );
+            let codex_hint = crate::process_tree::codex_yield_hint(Some(wait_cmd));
+            if !codex_hint.is_empty() {
+                eprint!("{codex_hint}");
+            }
+        } else {
+            eprintln!(
+                "<!-- CSA:SESSION_WAIT_KV_WARM session={session_id} status=alive elapsed={elapsed}s action=select_wait_provider -->"
+            );
+            eprintln!("{}", wait_command.provider_selection_hint());
         }
         SESSION_WAIT_KV_WARM_EXIT_CODE
     } else {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -10,8 +10,8 @@ use std::path::Path;
 use anyhow::Result;
 
 use super::completion::{
-    SESSION_WAIT_FAILURE_EXIT_CODE, SESSION_WAIT_MEMORY_WARN_EXIT_CODE, emit_wait_cap_outcome,
-    resolve_wait_completion_status_and_exit,
+    SESSION_WAIT_FAILURE_EXIT_CODE, SESSION_WAIT_MEMORY_WARN_EXIT_CODE, WaitCapContext,
+    emit_wait_cap_outcome, resolve_wait_completion_status_and_exit,
 };
 use super::liveness::{resume_handoff_blocks_target_reconcile, session_has_live_execution};
 use super::registry_loss::{
@@ -19,6 +19,7 @@ use super::registry_loss::{
     session_registry_state_loss,
 };
 use super::target::resolve_wait_target;
+pub(crate) use super::types::WaitEmitters;
 use super::types::{WaitExecutionOptions, WaitReconciliationOutcome};
 use super::{
     emit_wait_terminal_output, load_completed_daemon_result_with_fallback, refresh_result_for_wait,
@@ -29,31 +30,6 @@ use crate::session_cmds_daemon::{
     emit_failure_summary_for_empty_output, finalize_daemon_completion_if_present,
     load_daemon_completion_packet,
 };
-
-type ReconcileEmitter<'a> =
-    Box<dyn FnMut(&Path, &str, &str) -> Result<WaitReconciliationOutcome> + 'a>;
-type CompletionSignalEmitter<'a> = Box<dyn FnMut(&str, &str, i32, bool, bool) + 'a>;
-type MemorySampler<'a> = Box<dyn FnMut(&Path, &str) -> std::io::Result<u64> + 'a>;
-type MemoryWarnEmitter<'a> = Box<dyn FnMut(&str, u64, u64) + 'a>;
-type TerminalOutputEmitter<'a> = Box<
-    dyn FnMut(
-            &Path,
-            &str,
-            Option<&csa_session::SessionResult>,
-            super::SessionWaitOutputMode,
-        ) -> Result<bool>
-        + 'a,
->;
-type NextStepEmitter<'a> = Box<dyn FnMut(&Path) -> Result<()> + 'a>;
-
-pub(crate) struct WaitEmitters<'a> {
-    pub(crate) reconcile_dead_active_session: ReconcileEmitter<'a>,
-    pub(crate) emit_completion_signal: CompletionSignalEmitter<'a>,
-    pub(crate) sample_session_tree_rss_mb: MemorySampler<'a>,
-    pub(crate) emit_memory_warn_marker: MemoryWarnEmitter<'a>,
-    pub(crate) emit_terminal_output: TerminalOutputEmitter<'a>,
-    pub(crate) emit_next_step: NextStepEmitter<'a>,
-}
 
 /// Core polling loop implementation for session wait.
 ///
@@ -556,6 +532,10 @@ pub(crate) fn handle_session_wait_with_emitters(
             return Ok(emit_wait_cap_outcome(
                 &resolved.session_id,
                 cd.as_deref(),
+                WaitCapContext {
+                    project_root: effective_root,
+                    preferred_provider: wait_options.model_provider.as_ref(),
+                },
                 wait_options.behavior.wait_timeout_secs,
                 elapsed,
                 result_session_dir,

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_types.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_types.rs
@@ -1,3 +1,7 @@
+use std::path::Path;
+
+use anyhow::Result;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SessionWaitOutputMode {
     CompactText,
@@ -49,15 +53,42 @@ impl WaitBehavior {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(super) struct WaitExecutionOptions {
     pub(super) behavior: WaitBehavior,
     pub(super) output_mode: SessionWaitOutputMode,
     pub(super) caller_identity: super::WaitCallerIdentity,
+    pub(super) model_provider: Option<csa_config::ModelProvider>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct WaitReconciliationOutcome {
     pub(crate) result_became_available: bool,
     pub(crate) synthetic: bool,
+}
+
+type ReconcileEmitter<'a> =
+    Box<dyn FnMut(&Path, &str, &str) -> Result<WaitReconciliationOutcome> + 'a>;
+type CompletionSignalEmitter<'a> = Box<dyn FnMut(&str, &str, i32, bool, bool) + 'a>;
+type MemorySampler<'a> = Box<dyn FnMut(&Path, &str) -> std::io::Result<u64> + 'a>;
+type MemoryWarnEmitter<'a> = Box<dyn FnMut(&str, u64, u64) + 'a>;
+type TerminalOutputEmitter<'a> = Box<
+    dyn FnMut(
+            &Path,
+            &str,
+            Option<&csa_session::SessionResult>,
+            SessionWaitOutputMode,
+        ) -> Result<bool>
+        + 'a,
+>;
+type NextStepEmitter<'a> = Box<dyn FnMut(&Path) -> Result<()> + 'a>;
+
+/// Testable side effects and probes used by the session-wait polling loop.
+pub(crate) struct WaitEmitters<'a> {
+    pub(crate) reconcile_dead_active_session: ReconcileEmitter<'a>,
+    pub(crate) emit_completion_signal: CompletionSignalEmitter<'a>,
+    pub(crate) sample_session_tree_rss_mb: MemorySampler<'a>,
+    pub(crate) emit_memory_warn_marker: MemoryWarnEmitter<'a>,
+    pub(crate) emit_terminal_output: TerminalOutputEmitter<'a>,
+    pub(crate) emit_next_step: NextStepEmitter<'a>,
 }

--- a/crates/cli-sub-agent/src/session_dispatch.rs
+++ b/crates/cli-sub-agent/src/session_dispatch.rs
@@ -187,7 +187,8 @@ pub(crate) fn dispatch(
         } => {
             let wait_caller_identity = wait_caller_identity.validate_for_wait()?;
             let sid = resolve_session_id(session_id, session)?;
-            let wait_timeout = resolve_wait_ttl(model_provider)?;
+            let (wait_model_provider, wait_timeout) =
+                resolve_wait_provider_and_ttl(model_provider)?;
             let resolved_memory_warn_mb =
                 resolve_session_wait_memory_warn_mb(memory_warn_mb, cd.as_deref());
             let output_mode = session_cmds::SessionWaitOutputMode::from_flags(verbose, json);
@@ -198,6 +199,7 @@ pub(crate) fn dispatch(
                 resolved_memory_warn_mb,
                 output_mode,
                 wait_caller_identity,
+                Some(wait_model_provider),
             )?;
             let _ = std::io::stdout().flush();
             let _ = std::io::stderr().flush();
@@ -246,7 +248,14 @@ pub(crate) fn dispatch(
 ///
 /// CLI provider override wins over best-effort provider detection. Both paths
 /// must resolve to a configured `[kv_cache.provider_ttls]` key with TTL > 0.
+#[cfg(test)]
 fn resolve_wait_ttl(cli_model_provider: Option<ModelProvider>) -> Result<u64> {
+    Ok(resolve_wait_provider_and_ttl(cli_model_provider)?.1)
+}
+
+fn resolve_wait_provider_and_ttl(
+    cli_model_provider: Option<ModelProvider>,
+) -> Result<(ModelProvider, u64)> {
     let detected_provider = detect_model_provider();
     let config = match GlobalConfig::load() {
         Ok(config) => config,
@@ -261,20 +270,22 @@ fn resolve_wait_ttl(cli_model_provider: Option<ModelProvider>) -> Result<u64> {
     };
 
     if let Some(provider) = cli_model_provider.as_ref() {
-        return provider_ttl(provider, &config.kv_cache).ok_or_else(|| {
-            wait_provider_error(
-                Some(provider),
-                detected_provider.as_ref(),
-                Some(&config),
-                None,
-            )
-        });
+        return provider_ttl(provider, &config.kv_cache)
+            .map(|ttl| (provider.clone(), ttl))
+            .ok_or_else(|| {
+                wait_provider_error(
+                    Some(provider),
+                    detected_provider.as_ref(),
+                    Some(&config),
+                    None,
+                )
+            });
     }
 
     if let Some(provider) = detected_provider.as_ref()
         && let Some(ttl) = provider_ttl(provider, &config.kv_cache)
     {
-        return Ok(ttl);
+        return Ok((provider.clone(), ttl));
     }
 
     Err(wait_provider_error(

--- a/crates/cli-sub-agent/src/session_dispatch.rs
+++ b/crates/cli-sub-agent/src/session_dispatch.rs
@@ -8,10 +8,8 @@ use anyhow::Result;
 use crate::cli::SessionCommands;
 use crate::session_cmds;
 use crate::startup_env::StartupSubtreeEnv;
-use csa_config::{
-    GlobalConfig, KvCacheValueSource, ModelProvider, ProjectConfig, detect_model_provider,
-    provider_ttl,
-};
+use csa_config::provider_detection::MAX_WAIT_TTL_SECONDS;
+use csa_config::{GlobalConfig, ModelProvider, ProjectConfig, detect_model_provider, provider_ttl};
 use csa_core::types::OutputFormat;
 
 /// Resolve session ID from positional arg or --session flag.
@@ -189,7 +187,7 @@ pub(crate) fn dispatch(
         } => {
             let wait_caller_identity = wait_caller_identity.validate_for_wait()?;
             let sid = resolve_session_id(session_id, session)?;
-            let wait_timeout = resolve_wait_ttl(model_provider, cd.as_deref());
+            let wait_timeout = resolve_wait_ttl(model_provider)?;
             let resolved_memory_warn_mb =
                 resolve_session_wait_memory_warn_mb(memory_warn_mb, cd.as_deref());
             let output_mode = session_cmds::SessionWaitOutputMode::from_flags(verbose, json);
@@ -246,58 +244,117 @@ pub(crate) fn dispatch(
 
 /// Resolve the `csa session wait` cap from provider-aware KV cache config.
 ///
-/// CLI provider override wins over best-effort provider detection. If no provider
-/// can be detected, fall back to the global default TTL and then the deprecated
-/// project/user `session.daemon_wait_seconds` compatibility key.
-fn resolve_wait_ttl(cli_model_provider: Option<ModelProvider>, cd: Option<&str>) -> u64 {
-    if let Some(provider) = cli_model_provider.or_else(detect_model_provider) {
-        let config = match GlobalConfig::load() {
-            Ok(config) => config,
-            Err(error) => {
-                tracing::warn!(
-                    error = %error,
-                    "Failed to load global config while resolving provider wait TTL; using defaults"
-                );
-                GlobalConfig::default()
-            }
-        };
-        return provider_ttl(&provider, &config.kv_cache);
+/// CLI provider override wins over best-effort provider detection. Both paths
+/// must resolve to a configured `[kv_cache.provider_ttls]` key with TTL > 0.
+fn resolve_wait_ttl(cli_model_provider: Option<ModelProvider>) -> Result<u64> {
+    let detected_provider = detect_model_provider();
+    let config = match GlobalConfig::load() {
+        Ok(config) => config,
+        Err(error) => {
+            return Err(wait_provider_error(
+                cli_model_provider.as_ref(),
+                detected_provider.as_ref(),
+                None,
+                Some(&error),
+            ));
+        }
+    };
+
+    if let Some(provider) = cli_model_provider.as_ref() {
+        return provider_ttl(provider, &config.kv_cache).ok_or_else(|| {
+            wait_provider_error(
+                Some(provider),
+                detected_provider.as_ref(),
+                Some(&config),
+                None,
+            )
+        });
     }
 
-    resolve_daemon_wait_timeout(cd)
-}
-
-/// Resolve the `csa session wait` fallback cap from global KV cache config.
-///
-/// Use the global KV cache setting when it differs from the documented default.
-/// Deprecated `session.daemon_wait_seconds` remains a compatibility fallback.
-fn resolve_daemon_wait_timeout(cd: Option<&str>) -> u64 {
-    let global_timeout = GlobalConfig::resolve_session_wait_long_poll_seconds_with_source();
-    if !matches!(global_timeout.source, KvCacheValueSource::DocumentedDefault) {
-        return global_timeout.seconds;
-    }
-
-    resolve_legacy_session_wait_timeout(cd).unwrap_or(global_timeout.seconds)
-}
-
-fn resolve_legacy_session_wait_timeout(cd: Option<&str>) -> Option<u64> {
-    let project_root = crate::pipeline::determine_project_root(cd).ok();
-    let project_path = project_root
-        .as_deref()
-        .map(ProjectConfig::config_path)
-        .filter(|path| path.exists());
-    let user_path = ProjectConfig::user_config_path().filter(|path| path.exists());
-
-    if let Some(timeout) = project_path
-        .as_deref()
-        .and_then(|path| read_legacy_session_wait_timeout(path, "project"))
+    if let Some(provider) = detected_provider.as_ref()
+        && let Some(ttl) = provider_ttl(provider, &config.kv_cache)
     {
-        return Some(timeout);
+        return Ok(ttl);
     }
 
-    user_path
-        .as_deref()
-        .and_then(|path| read_legacy_session_wait_timeout(path, "user"))
+    Err(wait_provider_error(
+        None,
+        detected_provider.as_ref(),
+        Some(&config),
+        None,
+    ))
+}
+
+fn wait_provider_error(
+    requested_provider: Option<&ModelProvider>,
+    detected_provider: Option<&ModelProvider>,
+    config: Option<&GlobalConfig>,
+    config_error: Option<&anyhow::Error>,
+) -> anyhow::Error {
+    use std::fmt::Write as _;
+
+    let config_path = ProjectConfig::user_config_path()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "unavailable global config path".to_string());
+    let mut message = format!(
+        "csa session wait requires --model-provider <key>.\n\
+         Configured keys (from {config_path} [kv_cache.provider_ttls]):\n"
+    );
+
+    let mut legal_key_count = 0;
+    let mut has_clamped_ttl = false;
+    if let Some(config) = config {
+        for (provider, ttl) in &config.kv_cache.provider_ttls.0 {
+            if *ttl > 0 {
+                let _ = writeln!(message, "  {provider}={ttl}");
+                legal_key_count += 1;
+                has_clamped_ttl |= *ttl > MAX_WAIT_TTL_SECONDS;
+            }
+        }
+    }
+    if legal_key_count == 0 {
+        message.push_str("  (none with TTL > 0)\n");
+    } else if has_clamped_ttl {
+        let _ = writeln!(
+            message,
+            "Effective wait TTL is capped at {MAX_WAIT_TTL_SECONDS} seconds."
+        );
+    }
+
+    if let Some(provider) = requested_provider {
+        let _ = writeln!(
+            message,
+            "Requested key: {} (missing from provider_ttls or TTL is not > 0).",
+            provider.as_str()
+        );
+    }
+    match detected_provider {
+        Some(provider) => {
+            let configured = config
+                .and_then(|config| provider_ttl(provider, &config.kv_cache))
+                .is_some();
+            let status = if configured {
+                "configured"
+            } else {
+                "not a configured key with TTL > 0"
+            };
+            let _ = writeln!(
+                message,
+                "Detected hints (best-effort, not authoritative): {} ({status}).",
+                provider.as_str()
+            );
+        }
+        None => message.push_str("Detected hints (best-effort, not authoritative): none.\n"),
+    }
+    if let Some(error) = config_error {
+        let _ = writeln!(message, "Config load error: {error:#}");
+    }
+    message.push_str(
+        "Action: re-run with --model-provider <one configured key> matching the caller model provider.\n\
+         Do not omit this flag; provider can change mid-session when the user switches models.\n\
+         <!-- CSA:CALLER_HINT action=\"select_wait_provider\" rule=\"Derive the caller model provider dynamically on every wait; pass --model-provider with a configured provider_ttls key.\" -->",
+    );
+    anyhow::anyhow!(message)
 }
 
 fn resolve_session_wait_memory_warn_mb(cli_override: Option<u64>, cd: Option<&str>) -> Option<u64> {
@@ -309,36 +366,9 @@ fn resolve_session_wait_memory_warn_mb(cli_override: Option<u64>, cd: Option<&st
     ProjectConfig::resolve_session_wait_memory_warn_mb(&project_root)
 }
 
-fn read_legacy_session_wait_timeout(path: &std::path::Path, source: &str) -> Option<u64> {
-    let content = std::fs::read_to_string(path).ok()?;
-    let raw: toml::Value = toml::from_str(&content).ok()?;
-    let value = raw
-        .get("session")
-        .and_then(|session| session.get("daemon_wait_seconds"))
-        .and_then(toml::Value::as_integer)?;
-
-    if value <= 0 {
-        tracing::warn!(
-            path = %path.display(),
-            source,
-            "Ignoring deprecated session.daemon_wait_seconds because it is not > 0"
-        );
-        return None;
-    }
-
-    let timeout = value as u64;
-    tracing::warn!(
-        path = %path.display(),
-        source,
-        timeout,
-        "Using deprecated session.daemon_wait_seconds; migrate to global kv_cache.default_ttl_seconds"
-    );
-    Some(timeout)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{resolve_daemon_wait_timeout, resolve_wait_ttl};
+    use super::resolve_wait_ttl;
     use crate::test_env_lock::TEST_ENV_LOCK;
     use csa_config::ModelProvider;
 
@@ -402,13 +432,13 @@ openai = 1666
         );
 
         assert_eq!(
-            resolve_wait_ttl(Some(ModelProvider::new("openai")), None),
+            resolve_wait_ttl(Some(ModelProvider::new("openai"))).unwrap(),
             1666
         );
     }
 
     #[test]
-    fn resolve_wait_ttl_falls_back_to_default_ttl_without_provider() {
+    fn resolve_wait_ttl_fails_closed_without_provider() {
         let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
@@ -421,200 +451,87 @@ openai = 1666
             r#"
 [kv_cache]
 default_ttl_seconds = 555
+
+[kv_cache.provider_ttls]
+custom = 1666
 "#,
         );
 
-        assert_eq!(resolve_wait_ttl(None, None), 555);
+        let error = resolve_wait_ttl(None).expect_err("missing provider must fail closed");
+        let message = error.to_string();
+        assert!(message.contains("requires --model-provider <key>"));
+        assert!(message.contains("custom=1666"));
+        assert!(message.contains("capped at 3000 seconds"));
+        assert!(message.contains("CSA:CALLER_HINT"));
+        assert!(message.contains("dynamically on every wait"));
+        assert!(!message.contains("default_ttl_seconds = 555"));
     }
 
     #[test]
-    fn resolve_daemon_wait_timeout_uses_global_kv_cache_long_poll_seconds() {
+    fn resolve_wait_ttl_rejects_unconfigured_and_zero_ttl_providers() {
         let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
         std::fs::create_dir_all(&config_root).unwrap();
+        let _provider_guard = EnvVarGuard::remove("HERMES_MODEL_PROVIDER");
         let _home_guard = EnvVarGuard::set("HOME", dir.path());
         let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
         write_user_config(
             r#"
-[kv_cache]
-long_poll_seconds = 3000
+[kv_cache.provider_ttls]
+custom = 1666
+disabled = 0
 "#,
         );
 
-        assert_eq!(resolve_daemon_wait_timeout(None), 3000);
+        for provider in ["missing", "disabled"] {
+            let error = resolve_wait_ttl(Some(ModelProvider::new(provider)))
+                .expect_err("provider must be configured with TTL > 0");
+            let message = error.to_string();
+            assert!(message.contains(&format!("Requested key: {provider}")));
+            assert!(message.contains("custom=1666"));
+            assert!(!message.contains("disabled=0"));
+        }
     }
 
     #[test]
-    fn resolve_daemon_wait_timeout_uses_documented_default_without_kv_cache_section() {
+    fn resolve_wait_ttl_accepts_only_a_detected_configured_provider() {
         let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
         std::fs::create_dir_all(&config_root).unwrap();
+        let _provider_guard = EnvVarGuard::set("HERMES_MODEL_PROVIDER", "custom");
         let _home_guard = EnvVarGuard::set("HOME", dir.path());
         let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
         write_user_config(
             r#"
-[review]
-tool = "auto"
+[kv_cache.provider_ttls]
+custom = 1666
 "#,
         );
 
-        assert_eq!(resolve_daemon_wait_timeout(None), 240);
+        assert_eq!(resolve_wait_ttl(None).unwrap(), 1666);
     }
 
     #[test]
-    fn resolve_daemon_wait_timeout_prefers_global_kv_cache_over_legacy_session_key() {
+    fn resolve_wait_ttl_maps_openai_codex_hint_to_openai() {
         let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
         std::fs::create_dir_all(&config_root).unwrap();
+        let _provider_guard = EnvVarGuard::set("HERMES_MODEL_PROVIDER", "openai-codex");
         let _home_guard = EnvVarGuard::set("HOME", dir.path());
         let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
 
         write_user_config(
             r#"
-[kv_cache]
-long_poll_seconds = 3000
+[kv_cache.provider_ttls]
+openai = 1666
 "#,
         );
 
-        let csa_dir = dir.path().join(".csa");
-        std::fs::create_dir_all(&csa_dir).unwrap();
-        std::fs::write(
-            csa_dir.join("config.toml"),
-            r#"
-schema_version = 1
-[session]
-daemon_wait_seconds = 600
-"#,
-        )
-        .unwrap();
-
-        assert_eq!(
-            resolve_daemon_wait_timeout(Some(dir.path().to_str().unwrap())),
-            3000
-        );
-    }
-
-    #[test]
-    fn resolve_daemon_wait_timeout_treats_explicit_default_as_higher_priority_than_legacy_key() {
-        let _env_lock = TEST_ENV_LOCK.blocking_lock();
-        let dir = tempfile::tempdir().unwrap();
-        let config_root = dir.path().join("xdg-config");
-        std::fs::create_dir_all(&config_root).unwrap();
-        let _home_guard = EnvVarGuard::set("HOME", dir.path());
-        let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
-
-        write_user_config(
-            r#"
-[kv_cache]
-long_poll_seconds = 240
-"#,
-        );
-
-        let csa_dir = dir.path().join(".csa");
-        std::fs::create_dir_all(&csa_dir).unwrap();
-        std::fs::write(
-            csa_dir.join("config.toml"),
-            r#"
-schema_version = 1
-[session]
-daemon_wait_seconds = 600
-"#,
-        )
-        .unwrap();
-
-        assert_eq!(
-            resolve_daemon_wait_timeout(Some(dir.path().to_str().unwrap())),
-            240
-        );
-    }
-
-    #[test]
-    fn resolve_daemon_wait_timeout_treats_kv_cache_section_default_as_higher_priority_than_legacy_key()
-     {
-        let _env_lock = TEST_ENV_LOCK.blocking_lock();
-        let dir = tempfile::tempdir().unwrap();
-        let config_root = dir.path().join("xdg-config");
-        std::fs::create_dir_all(&config_root).unwrap();
-        let _home_guard = EnvVarGuard::set("HOME", dir.path());
-        let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
-
-        write_user_config(
-            r#"
-[kv_cache]
-frequent_poll_seconds = 45
-"#,
-        );
-
-        let csa_dir = dir.path().join(".csa");
-        std::fs::create_dir_all(&csa_dir).unwrap();
-        std::fs::write(
-            csa_dir.join("config.toml"),
-            r#"
-schema_version = 1
-[session]
-daemon_wait_seconds = 600
-"#,
-        )
-        .unwrap();
-
-        assert_eq!(
-            resolve_daemon_wait_timeout(Some(dir.path().to_str().unwrap())),
-            240
-        );
-    }
-
-    #[test]
-    fn resolve_daemon_wait_timeout_honors_legacy_project_session_override_with_warning_path() {
-        let _env_lock = TEST_ENV_LOCK.blocking_lock();
-        let dir = tempfile::tempdir().unwrap();
-        let config_root = dir.path().join("xdg-config");
-        std::fs::create_dir_all(&config_root).unwrap();
-        let _home_guard = EnvVarGuard::set("HOME", dir.path());
-        let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
-
-        let csa_dir = dir.path().join(".csa");
-        std::fs::create_dir_all(&csa_dir).unwrap();
-        std::fs::write(
-            csa_dir.join("config.toml"),
-            r#"
-schema_version = 1
-[session]
-daemon_wait_seconds = 600
-"#,
-        )
-        .unwrap();
-
-        assert_eq!(
-            resolve_daemon_wait_timeout(Some(dir.path().to_str().unwrap())),
-            600
-        );
-    }
-
-    #[test]
-    fn resolve_daemon_wait_timeout_honors_legacy_user_session_override_when_project_missing() {
-        let _env_lock = TEST_ENV_LOCK.blocking_lock();
-        let dir = tempfile::tempdir().unwrap();
-        let config_root = dir.path().join("xdg-config");
-        std::fs::create_dir_all(&config_root).unwrap();
-        let _home_guard = EnvVarGuard::set("HOME", dir.path());
-        let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
-
-        write_user_config(
-            r#"
-schema_version = 1
-[session]
-daemon_wait_seconds = 480
-"#,
-        );
-
-        assert_eq!(
-            resolve_daemon_wait_timeout(Some(dir.path().to_str().unwrap())),
-            480
-        );
+        assert_eq!(resolve_wait_ttl(None).unwrap(), 1666);
     }
 }

--- a/crates/cli-sub-agent/src/session_dispatch.rs
+++ b/crates/cli-sub-agent/src/session_dispatch.rs
@@ -461,7 +461,10 @@ custom = 1666
         let message = error.to_string();
         assert!(message.contains("requires --model-provider <key>"));
         assert!(message.contains("custom=1666"));
-        assert!(message.contains("capped at 3000 seconds"));
+        assert!(
+            !message.contains("capped at 3000 seconds"),
+            "explicit-only provider_ttls must not inherit an implicit clamped default: {message}"
+        );
         assert!(message.contains("CSA:CALLER_HINT"));
         assert!(message.contains("dynamically on every wait"));
         assert!(!message.contains("default_ttl_seconds = 555"));

--- a/crates/cli-sub-agent/tests/session_registry_loss.rs
+++ b/crates/cli-sub-agent/tests/session_registry_loss.rs
@@ -28,6 +28,13 @@ fn global_config_path(tmp: &Path) -> PathBuf {
     }
 }
 
+fn write_wait_provider_config(tmp: &Path) {
+    let path = global_config_path(tmp);
+    std::fs::create_dir_all(path.parent().expect("config parent")).expect("create config dir");
+    std::fs::write(path, "[kv_cache.provider_ttls]\nopenai = 1\n")
+        .expect("write short provider wait config");
+}
+
 fn session_dir_for(tmp: &Path, project: &Path, session_id: &str) -> PathBuf {
     let canonical_project = project.canonicalize().expect("canonical project path");
     let storage_key = canonical_project
@@ -286,6 +293,7 @@ fn session_result_lookup_miss_uses_exact_id_registry_loss_without_list_hint() {
 #[test]
 fn session_wait_lookup_miss_reports_structured_gc_pruned_registry_loss() {
     let tmp = tempfile::tempdir().expect("tempdir");
+    write_wait_provider_config(tmp.path());
     let project = tmp.path().join("project");
     std::fs::create_dir_all(&project).expect("create project");
     let session_id = "01ARZ3NDEKTSV4RRFFQ69G5FBG";
@@ -294,6 +302,8 @@ fn session_wait_lookup_miss_reports_structured_gc_pruned_registry_loss() {
         .args([
             "session",
             "wait",
+            "--model-provider",
+            "openai",
             "--session",
             session_id,
             "--cd",
@@ -321,11 +331,7 @@ fn session_wait_lookup_miss_reports_structured_gc_pruned_registry_loss() {
 #[test]
 fn session_wait_classifies_corrupt_state_as_registry_loss() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let config_path = global_config_path(tmp.path());
-    std::fs::create_dir_all(config_path.parent().expect("config parent"))
-        .expect("create config dir");
-    std::fs::write(&config_path, "[kv_cache.provider_ttls]\nopenai = 1\n")
-        .expect("write short provider wait config");
+    write_wait_provider_config(tmp.path());
 
     let project = tmp.path().join("project");
     std::fs::create_dir_all(&project).expect("create project");
@@ -339,6 +345,8 @@ fn session_wait_classifies_corrupt_state_as_registry_loss() {
         .args([
             "session",
             "wait",
+            "--model-provider",
+            "openai",
             "--session",
             &session_id,
             "--cd",

--- a/crates/cli-sub-agent/tests/session_registry_loss.rs
+++ b/crates/cli-sub-agent/tests/session_registry_loss.rs
@@ -7,6 +7,7 @@ fn csa_cmd(tmp: &Path) -> Command {
     cmd.env("HOME", tmp)
         .env("XDG_STATE_HOME", tmp.join(".local/state"))
         .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("HERMES_MODEL_PROVIDER", "openai")
         .env("TOKIO_WORKER_THREADS", "1");
     cmd
 }
@@ -323,8 +324,8 @@ fn session_wait_classifies_corrupt_state_as_registry_loss() {
     let config_path = global_config_path(tmp.path());
     std::fs::create_dir_all(config_path.parent().expect("config parent"))
         .expect("create config dir");
-    std::fs::write(&config_path, "[kv_cache]\nlong_poll_seconds = 1\n")
-        .expect("write short wait config");
+    std::fs::write(&config_path, "[kv_cache.provider_ttls]\nopenai = 1\n")
+        .expect("write short provider wait config");
 
     let project = tmp.path().join("project");
     std::fs::create_dir_all(&project).expect("create project");

--- a/crates/cli-sub-agent/tests/session_summary_visibility.rs
+++ b/crates/cli-sub-agent/tests/session_summary_visibility.rs
@@ -91,6 +91,17 @@ fn csa_cmd(tmp: &Path) -> Command {
     cmd
 }
 
+fn write_wait_provider_config(tmp: &Path) {
+    let path = if cfg!(target_os = "macos") {
+        tmp.join("Library/Application Support/cli-sub-agent/config.toml")
+    } else {
+        tmp.join(".config/cli-sub-agent/config.toml")
+    };
+    std::fs::create_dir_all(path.parent().expect("config parent")).expect("create config dir");
+    std::fs::write(path, "[kv_cache.provider_ttls]\nopenai = 1\n")
+        .expect("write short provider wait config");
+}
+
 fn scrub_inherited_csa_env(cmd: &mut Command) {
     for (key, _) in std::env::vars_os() {
         if key.to_string_lossy().starts_with("CSA_") {
@@ -140,6 +151,7 @@ fn create_empty_output_failure_session(
     tmp: &Path,
     name: &str,
 ) -> (std::path::PathBuf, String, std::path::PathBuf) {
+    write_wait_provider_config(tmp);
     let state_home = tmp.join(".local/state");
     std::fs::create_dir_all(&state_home).expect("create state home");
     let _home_guard = EnvVarGuard::set("HOME", tmp);
@@ -189,15 +201,13 @@ fn assert_subcommand_surfaces_summary_for_session(
     subcommand: &str,
     session_id: &str,
 ) {
+    let mut args = vec!["session", subcommand, "--session", session_id];
+    if subcommand == "wait" {
+        args.extend(["--model-provider", "openai"]);
+    }
+    args.extend(["--cd", project.to_str().expect("project path utf8")]);
     let output = csa_cmd(tmp)
-        .args([
-            "session",
-            subcommand,
-            "--session",
-            session_id,
-            "--cd",
-            project.to_str().expect("project path utf8"),
-        ])
+        .args(args)
         .current_dir(project)
         .output()
         .expect("run csa session command");
@@ -300,6 +310,8 @@ fn session_wait_default_bounds_output_and_hides_stdout_log() {
         .args([
             "session",
             "wait",
+            "--model-provider",
+            "openai",
             "--session",
             &session_id,
             "--cd",
@@ -487,6 +499,8 @@ fn session_wait_verbose_streams_stdout_log() {
             "session",
             "wait",
             "--verbose",
+            "--model-provider",
+            "openai",
             "--session",
             &session_id,
             "--cd",
@@ -518,6 +532,8 @@ fn session_wait_env_verbose_streams_stdout_log() {
         .args([
             "session",
             "wait",
+            "--model-provider",
+            "openai",
             "--session",
             &session_id,
             "--cd",
@@ -546,6 +562,8 @@ fn session_wait_json_outputs_parseable_summary() {
             "session",
             "wait",
             "--json",
+            "--model-provider",
+            "openai",
             "--session",
             &session_id,
             "--cd",

--- a/crates/cli-sub-agent/tests/session_summary_visibility.rs
+++ b/crates/cli-sub-agent/tests/session_summary_visibility.rs
@@ -86,6 +86,7 @@ fn csa_cmd(tmp: &Path) -> Command {
     cmd.env("HOME", tmp)
         .env("XDG_STATE_HOME", tmp.join(".local/state"))
         .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("HERMES_MODEL_PROVIDER", "openai")
         .env("TOKIO_WORKER_THREADS", "1");
     cmd
 }

--- a/crates/cli-sub-agent/tests/session_wait_provider_ttl.rs
+++ b/crates/cli-sub-agent/tests/session_wait_provider_ttl.rs
@@ -153,6 +153,40 @@ fn wait_with_legal_custom_provider_reaches_session_lookup() {
 }
 
 #[test]
+fn wait_uses_only_explicitly_configured_provider_ttl_keys() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = global_config_path(tmp.path());
+    std::fs::create_dir_all(path.parent().expect("config parent")).expect("create config dir");
+    std::fs::write(path, "[kv_cache.provider_ttls]\ncustom = 17\n")
+        .expect("write explicit-only wait config");
+
+    let rejected = run_wait(tmp.path(), &["--model-provider", "claude"]);
+    let rejected_stderr = stderr(&rejected);
+    assert_eq!(rejected.status.code(), Some(1), "{rejected_stderr}");
+    assert!(
+        rejected_stderr.contains("requires --model-provider <key>"),
+        "{rejected_stderr}"
+    );
+    assert!(rejected_stderr.contains("custom=17"), "{rejected_stderr}");
+    assert!(
+        !rejected_stderr.contains("session registry lookup failed"),
+        "{rejected_stderr}"
+    );
+
+    let accepted = run_wait(tmp.path(), &["--model-provider", "custom"]);
+    let accepted_stderr = stderr(&accepted);
+    assert_eq!(accepted.status.code(), Some(1), "{accepted_stderr}");
+    assert!(
+        accepted_stderr.contains("session registry lookup failed"),
+        "{accepted_stderr}"
+    );
+    assert!(
+        !accepted_stderr.contains("requires --model-provider <key>"),
+        "{accepted_stderr}"
+    );
+}
+
+#[test]
 fn session_wait_help_requires_a_configured_provider_ttl() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let output = csa_cmd(tmp.path())

--- a/crates/cli-sub-agent/tests/session_wait_provider_ttl.rs
+++ b/crates/cli-sub-agent/tests/session_wait_provider_ttl.rs
@@ -1,0 +1,170 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn csa_cmd(tmp: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("CSA_") {
+            cmd.env_remove(key);
+        }
+    }
+    cmd.env_remove("HERMES_MODEL_PROVIDER")
+        .env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
+    cmd
+}
+
+fn global_config_path(tmp: &Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        tmp.join("Library/Application Support/cli-sub-agent/config.toml")
+    } else {
+        tmp.join(".config/cli-sub-agent/config.toml")
+    }
+}
+
+fn write_wait_config(tmp: &Path) {
+    let path = global_config_path(tmp);
+    std::fs::create_dir_all(path.parent().expect("config parent")).expect("create config dir");
+    std::fs::write(
+        path,
+        r#"[kv_cache]
+default_ttl_seconds = 240
+
+[kv_cache.provider_ttls]
+custom = 17
+openai = 0
+"#,
+    )
+    .expect("write wait config");
+}
+
+fn run_wait(tmp: &Path, extra_args: &[&str]) -> Output {
+    let project = tmp.join("project");
+    std::fs::create_dir_all(&project).expect("create project");
+    let mut args = vec![
+        "session",
+        "wait",
+        "--session",
+        "01ARZ3NDEKTSV4RRFFQ69G5FBG",
+        "--cd",
+        project.to_str().expect("project path utf8"),
+    ];
+    args.extend_from_slice(extra_args);
+    csa_cmd(tmp)
+        .args(args)
+        .output()
+        .expect("run csa session wait")
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn wait_without_provider_fails_closed_before_session_lookup() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_wait_config(tmp.path());
+
+    let output = run_wait(tmp.path(), &[]);
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    assert!(
+        stderr.contains("csa session wait requires --model-provider <key>"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("Configured keys"), "{stderr}");
+    assert!(stderr.contains("custom=17"), "{stderr}");
+    assert!(stderr.contains("CSA:CALLER_HINT"), "{stderr}");
+    assert!(stderr.contains("dynamically on every wait"), "{stderr}");
+    assert!(
+        !stderr.contains("session registry lookup failed"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("default_ttl_seconds = 240"), "{stderr}");
+}
+
+#[test]
+fn wait_with_detected_but_unconfigured_provider_fails_closed() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_wait_config(tmp.path());
+
+    let output = csa_cmd(tmp.path())
+        .env("HERMES_MODEL_PROVIDER", "not-configured")
+        .args(["session", "wait", "01ARZ3NDEKTSV4RRFFQ69G5FAV"])
+        .output()
+        .expect("run csa session wait");
+
+    assert!(!output.status.success());
+    let stderr = stderr(&output);
+    assert!(
+        stderr.contains("requires --model-provider <key>"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("not-configured"), "{stderr}");
+    assert!(
+        stderr.contains("not a configured key with TTL > 0"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("CSA:CALLER_HINT"), "{stderr}");
+    assert!(!stderr.contains("Session registry entry"), "{stderr}");
+}
+
+#[test]
+fn wait_with_unconfigured_provider_lists_only_positive_legal_keys() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_wait_config(tmp.path());
+
+    for provider in ["not-configured", "openai"] {
+        let output = run_wait(tmp.path(), &["--model-provider", provider]);
+        let stderr = stderr(&output);
+
+        assert_eq!(output.status.code(), Some(1), "{stderr}");
+        assert!(stderr.contains(provider), "{stderr}");
+        assert!(stderr.contains("custom=17"), "{stderr}");
+        assert!(!stderr.contains("openai=0"), "{stderr}");
+        assert!(stderr.contains("CSA:CALLER_HINT"), "{stderr}");
+        assert!(
+            !stderr.contains("session registry lookup failed"),
+            "{stderr}"
+        );
+    }
+}
+
+#[test]
+fn wait_with_legal_custom_provider_reaches_session_lookup() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    write_wait_config(tmp.path());
+
+    let output = run_wait(tmp.path(), &["--model-provider", "custom"]);
+    let stderr = stderr(&output);
+
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    assert!(
+        stderr.contains("session registry lookup failed"),
+        "{stderr}"
+    );
+    assert!(
+        !stderr.contains("requires --model-provider <key>"),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn session_wait_help_requires_a_configured_provider_ttl() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = csa_cmd(tmp.path())
+        .args(["session", "wait", "--help"])
+        .output()
+        .expect("run csa session wait --help");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    assert!(
+        stdout.contains("configured [kv_cache.provider_ttls] key"),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("default_ttl_seconds"), "{stdout}");
+}

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -605,7 +605,9 @@ stdin_write_timeout_seconds = 30
 termination_grace_period_seconds = 5
 [kv_cache]
 frequent_poll_seconds = 60
+# General long-poll TTL; not a providerless `csa session wait` fallback.
 default_ttl_seconds = 240
+# `csa session wait` requires a positive-TTL key passed via --model-provider.
 [kv_cache.provider_ttls]
 claude = 3300
 openai = 1700

--- a/crates/csa-config/src/global_impl.rs
+++ b/crates/csa-config/src/global_impl.rs
@@ -70,11 +70,12 @@ impl GlobalConfig {
         Ok(config.sanitized(Some(path)))
     }
 
-    /// Resolve the `csa session wait` fallback TTL from the global config.
+    /// Resolve the general long-poll TTL from the global config.
     ///
     /// Missing or invalid config falls back to the documented KV cache default.
     /// Once `[kv_cache]` exists, `default_ttl_seconds` still defaults to 240 if omitted.
-    /// Deprecated `long_poll_seconds` remains a config-file alias.
+    /// Deprecated `long_poll_seconds` remains a config-file alias. This value is
+    /// not a providerless fallback for `csa session wait`.
     pub fn resolve_session_wait_long_poll_seconds() -> u64 {
         Self::resolve_session_wait_long_poll_seconds_with_source().seconds
     }

--- a/crates/csa-config/src/global_kv_cache.rs
+++ b/crates/csa-config/src/global_kv_cache.rs
@@ -71,12 +71,21 @@ impl<'de> Deserialize<'de> for ProviderTtls {
 }
 
 impl ProviderTtls {
-    fn sanitized(mut self, path: Option<&Path>) -> Self {
-        for (provider, default) in DEFAULT_PROVIDER_TTLS {
-            let entry = self.0.entry(provider.to_string()).or_insert(default);
-            if *entry == 0 {
+    fn sanitized(self, path: Option<&Path>) -> Self {
+        for (provider, seconds) in &self.0 {
+            if *seconds == 0 {
                 let key = format!("kv_cache.provider_ttls.{provider}");
-                *entry = sanitize_kv_cache_seconds(*entry, &key, default, path);
+                match path {
+                    Some(path) => tracing::warn!(
+                        path = %path.display(),
+                        key,
+                        "Provider TTL is zero; csa session wait will reject this provider"
+                    ),
+                    None => tracing::warn!(
+                        key,
+                        "Provider TTL is zero; csa session wait will reject this provider"
+                    ),
+                }
             }
         }
         self
@@ -88,13 +97,13 @@ pub struct KvCacheConfig {
     /// Poll interval for fast-changing external state such as GitHub bot events.
     #[serde(default = "default_kv_cache_frequent_poll_seconds")]
     pub frequent_poll_seconds: u64,
-    /// Fallback TTL for `csa session wait` when the caller model provider is unknown.
+    /// General long-poll TTL. `csa session wait` requires a provider-specific TTL.
     #[serde(default = "default_kv_cache_long_poll_seconds")]
     pub default_ttl_seconds: u64,
     /// Deprecated alias for `default_ttl_seconds`.
     ///
     /// Kept so old config readers and `csa config get kv_cache.long_poll_seconds`
-    /// continue to see the effective fallback TTL.
+    /// continue to see the effective general long-poll TTL.
     #[serde(default = "default_kv_cache_long_poll_seconds")]
     pub long_poll_seconds: u64,
     /// Provider-specific TTL caps for model-aware `csa session wait` calls.
@@ -248,7 +257,7 @@ gemini = 900
     }
 
     #[test]
-    fn provider_ttls_sanitize_zero_known_defaults_and_keep_custom() {
+    fn provider_ttls_keep_zero_values_invalid_for_strict_wait_lookup() {
         let provider_ttls = ProviderTtls(BTreeMap::from([
             ("claude".to_string(), 0),
             ("custom".to_string(), 0),
@@ -256,9 +265,8 @@ gemini = 900
 
         let provider_ttls = provider_ttls.sanitized(None);
 
-        assert_eq!(provider_ttls.0["claude"], 3300);
+        assert_eq!(provider_ttls.0["claude"], 0);
         assert_eq!(provider_ttls.0["custom"], 0);
-        assert_eq!(provider_ttls.0["xai"], 1700);
     }
 
     #[test]

--- a/crates/csa-config/src/global_kv_cache.rs
+++ b/crates/csa-config/src/global_kv_cache.rs
@@ -4,20 +4,7 @@ use std::path::Path;
 
 pub const DEFAULT_KV_CACHE_FREQUENT_POLL_SECS: u64 = 60;
 pub const DEFAULT_KV_CACHE_LONG_POLL_SECS: u64 = 240;
-pub const DEFAULT_KV_CACHE_CLAUDE_TTL_SECS: u64 = 3300;
-pub const DEFAULT_KV_CACHE_OPENAI_TTL_SECS: u64 = 1700;
-pub const DEFAULT_KV_CACHE_GLM_TTL_SECS: u64 = 540;
-pub const DEFAULT_KV_CACHE_XAI_TTL_SECS: u64 = 1700;
-pub const DEFAULT_KV_CACHE_OTHER_TTL_SECS: u64 = 270;
 pub const LEGACY_SESSION_WAIT_FALLBACK_SECS: u64 = 250;
-
-const DEFAULT_PROVIDER_TTLS: [(&str, u64); 5] = [
-    ("claude", DEFAULT_KV_CACHE_CLAUDE_TTL_SECS),
-    ("openai", DEFAULT_KV_CACHE_OPENAI_TTL_SECS),
-    ("glm", DEFAULT_KV_CACHE_GLM_TTL_SECS),
-    ("xai", DEFAULT_KV_CACHE_XAI_TTL_SECS),
-    ("other", DEFAULT_KV_CACHE_OTHER_TTL_SECS),
-];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KvCacheValueSource {
@@ -48,27 +35,9 @@ impl ResolvedKvCacheValue {
     }
 }
 
-/// Provider-specific TTL values keyed by normalized provider name.
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+/// Explicitly configured provider TTL values keyed by normalized provider name.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ProviderTtls(pub BTreeMap<String, u64>);
-
-impl Default for ProviderTtls {
-    fn default() -> Self {
-        Self(default_provider_ttls())
-    }
-}
-
-impl<'de> Deserialize<'de> for ProviderTtls {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let overrides = BTreeMap::<String, u64>::deserialize(deserializer)?;
-        let mut provider_ttls = default_provider_ttls();
-        provider_ttls.extend(overrides);
-        Ok(Self(provider_ttls))
-    }
-}
 
 impl ProviderTtls {
     fn sanitized(self, path: Option<&Path>) -> Self {
@@ -152,13 +121,6 @@ fn default_kv_cache_long_poll_seconds() -> u64 {
     DEFAULT_KV_CACHE_LONG_POLL_SECS
 }
 
-fn default_provider_ttls() -> BTreeMap<String, u64> {
-    DEFAULT_PROVIDER_TTLS
-        .into_iter()
-        .map(|(provider, seconds)| (provider.to_string(), seconds))
-        .collect()
-}
-
 impl Default for KvCacheConfig {
     fn default() -> Self {
         let default_ttl_seconds = default_kv_cache_long_poll_seconds();
@@ -218,16 +180,12 @@ mod tests {
     use std::collections::BTreeMap;
 
     #[test]
-    fn kv_cache_defaults_include_provider_ttls() {
+    fn kv_cache_defaults_have_no_explicit_provider_ttls() {
         let config = KvCacheConfig::default();
 
         assert_eq!(config.default_ttl_seconds, 240);
         assert_eq!(config.long_poll_seconds, 240);
-        assert_eq!(config.provider_ttls.0["claude"], 3300);
-        assert_eq!(config.provider_ttls.0["openai"], 1700);
-        assert_eq!(config.provider_ttls.0["glm"], 540);
-        assert_eq!(config.provider_ttls.0["xai"], 1700);
-        assert_eq!(config.provider_ttls.0["other"], 270);
+        assert!(config.provider_ttls.0.is_empty());
     }
 
     #[test]
@@ -240,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_ttls_parse_defaults_and_custom_keys() {
+    fn provider_ttls_parse_only_explicit_keys() {
         let config: KvCacheConfig = toml::from_str(
             r#"
 [provider_ttls]
@@ -250,10 +208,11 @@ gemini = 900
         )
         .unwrap();
 
-        assert_eq!(config.provider_ttls.0["claude"], 3300);
+        assert_eq!(config.provider_ttls.0.len(), 2);
         assert_eq!(config.provider_ttls.0["openai"], 1800);
-        assert_eq!(config.provider_ttls.0["xai"], 1700);
         assert_eq!(config.provider_ttls.0["gemini"], 900);
+        assert!(!config.provider_ttls.0.contains_key("claude"));
+        assert!(!config.provider_ttls.0.contains_key("xai"));
     }
 
     #[test]

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -120,12 +120,14 @@ task_pool_workers = 1
 
 # KV cache-aware polling defaults.
 # `frequent_poll_seconds`: fast external state (GitHub API, bot responses).
-# `default_ttl_seconds`: fallback when caller model provider detection is unavailable.
+# `default_ttl_seconds`: general long-poll TTL; it is not a providerless session-wait fallback.
 # `long_poll_seconds` is a deprecated alias for `default_ttl_seconds`.
 [kv_cache]
 frequent_poll_seconds = 60
 default_ttl_seconds = 240
 
+# `csa session wait` requires one positive-TTL key from this table. Calling agents
+# should derive the current provider dynamically and pass `--model-provider` every time.
 [kv_cache.provider_ttls]
 claude = 3300
 openai = 1700

--- a/crates/csa-config/src/provider_detection.rs
+++ b/crates/csa-config/src/provider_detection.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::global::{DEFAULT_KV_CACHE_LONG_POLL_SECS, KvCacheConfig};
+use crate::global::KvCacheConfig;
 
 const HERMES_MODEL_PROVIDER_ENV: &str = "HERMES_MODEL_PROVIDER";
 
@@ -23,7 +23,7 @@ impl ModelProvider {
         }
         Some(match normalized.as_str() {
             "anthropic" | "claude" => Self::new("claude"),
-            "openai" => Self::new("openai"),
+            "openai" | "openai-codex" => Self::new("openai"),
             "zai" | "zhipu" | "zhipuai" | "glm" => Self::new("glm"),
             "xai" | "xai-oauth" | "grok" => Self::new("xai"),
             _ => Self(normalized),
@@ -50,19 +50,14 @@ pub fn detect_model_provider() -> Option<ModelProvider> {
 /// Provider TTLs exceeding this cap are clamped to prevent excessively long waits.
 pub const MAX_WAIT_TTL_SECONDS: u64 = 3000;
 
-pub fn provider_ttl(provider: &ModelProvider, config: &KvCacheConfig) -> u64 {
-    let provider_seconds = config
+pub fn provider_ttl(provider: &ModelProvider, config: &KvCacheConfig) -> Option<u64> {
+    config
         .provider_ttls
         .0
         .get(provider.as_str())
         .copied()
-        .unwrap_or_default();
-    let resolved = if provider_seconds > 0 {
-        provider_seconds
-    } else {
-        fallback_default_ttl(config)
-    };
-    resolved.min(MAX_WAIT_TTL_SECONDS)
+        .filter(|seconds| *seconds > 0)
+        .map(|seconds| seconds.min(MAX_WAIT_TTL_SECONDS))
 }
 
 fn detect_model_provider_from_env() -> Option<ModelProvider> {
@@ -140,16 +135,6 @@ fn normalize_provider_name(value: &str) -> String {
         .to_ascii_lowercase()
 }
 
-fn fallback_default_ttl(config: &KvCacheConfig) -> u64 {
-    if config.default_ttl_seconds > 0 {
-        config.default_ttl_seconds
-    } else if config.long_poll_seconds > 0 {
-        config.long_poll_seconds
-    } else {
-        DEFAULT_KV_CACHE_LONG_POLL_SECS
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,7 +206,10 @@ model:
         let mut config = KvCacheConfig::default();
         config.provider_ttls.0.insert("openai".to_string(), 1800);
 
-        assert_eq!(provider_ttl(&ModelProvider::new("openai"), &config), 1800);
+        assert_eq!(
+            provider_ttl(&ModelProvider::new("openai"), &config),
+            Some(1800)
+        );
     }
 
     #[test]
@@ -229,6 +217,14 @@ model:
         assert_eq!(
             ModelProvider::from_hermes_value("xai-oauth"),
             Some(ModelProvider::new("xai"))
+        );
+    }
+
+    #[test]
+    fn from_hermes_value_maps_openai_codex_to_openai() {
+        assert_eq!(
+            ModelProvider::from_hermes_value("openai-codex"),
+            Some(ModelProvider::new("openai"))
         );
     }
 
@@ -249,7 +245,7 @@ model:
     }
 
     #[test]
-    fn provider_ttl_falls_back_to_default() {
+    fn provider_ttl_rejects_zero_ttl() {
         let mut provider_ttls = crate::ProviderTtls::default();
         provider_ttls.0.insert("glm".to_string(), 0);
         let config = KvCacheConfig {
@@ -258,17 +254,17 @@ model:
             ..Default::default()
         };
 
-        assert_eq!(provider_ttl(&ModelProvider::new("glm"), &config), 123);
+        assert_eq!(provider_ttl(&ModelProvider::new("glm"), &config), None);
     }
 
     #[test]
-    fn provider_ttl_missing_custom_provider_falls_back_to_default() {
+    fn provider_ttl_rejects_missing_custom_provider() {
         let config = KvCacheConfig {
             default_ttl_seconds: 123,
             ..Default::default()
         };
 
-        assert_eq!(provider_ttl(&ModelProvider::new("gemini"), &config), 123);
+        assert_eq!(provider_ttl(&ModelProvider::new("gemini"), &config), None);
     }
 
     #[test]
@@ -287,8 +283,11 @@ model:
             provider_ttls,
         };
         // Claude TTL 5000 > 3000 cap → clamped to 3000
-        assert_eq!(provider_ttl(&ModelProvider::new("claude"), &config), 3000);
-        // OpenAI falls back to default 540 < 3000 → not clamped
-        assert_eq!(provider_ttl(&ModelProvider::new("openai"), &config), 540);
+        assert_eq!(
+            provider_ttl(&ModelProvider::new("claude"), &config),
+            Some(3000)
+        );
+        // Zero-valued providers remain invalid rather than using the default TTL.
+        assert_eq!(provider_ttl(&ModelProvider::new("openai"), &config), None);
     }
 }

--- a/crates/csa-process/src/daemon_tests.rs
+++ b/crates/csa-process/src/daemon_tests.rs
@@ -175,7 +175,12 @@ fn test_daemon_spawn_supports_multi_word_subcommand() {
         session_dir: session_dir.clone(),
         csa_binary: wrapper,
         subcommand: "plan run".to_string(),
-        args: vec!["--".to_string(), "echo got=$1,$2,$3,$4,$5".to_string()],
+        // Keep the wrapper alive through spawn_daemon's initial liveness
+        // inspection. The argument log is emitted before this command runs.
+        args: vec![
+            "--".to_string(),
+            "echo got=$1,$2,$3,$4,$5; sleep 2".to_string(),
+        ],
         env: HashMap::new(),
     };
 

--- a/justfile
+++ b/justfile
@@ -15,9 +15,7 @@ set dotenv-load := true
 # Calculate repo root (compatible with submodules)
 _repo_root := `git rev-parse --show-superproject-working-tree 2>/dev/null | grep . || git rev-parse --show-toplevel`
 _cargo := _repo_root + "/scripts/cargo-env-normalize.sh cargo"
-# Auto-detect Cargo fan-out; callers may override CARGO_BUILD_JOBS.
-_auto_build_jobs := `scripts/detect-build-jobs.sh`
-export CARGO_BUILD_JOBS := env_var_or_default("CARGO_BUILD_JOBS", _auto_build_jobs)
+# Cargo parallelism controlled by ~/.cargo/config.toml.
 # Disable nextest double-spawn for symlinked target directories (#1742).
 export NEXTEST_DOUBLE_SPAWN := "0"
 # Trust this repository's mise config in non-interactive sandboxes.
@@ -226,7 +224,7 @@ deny:
 _nextest_threads := `_v="${NEXTEST_TEST_THREADS:-16}"; case "$_v" in *[!0-9]*|'') echo 16 ;; *) echo "$_v" ;; esac`
 
 # Run all tests in the workspace across default and feature builds.
-# Env: CARGO_BUILD_JOBS defaults to auto-detected safe parallelism;
+# Cargo parallelism controlled by ~/.cargo/config.toml.
 # NEXTEST_TEST_THREADS caps nextest parallelism (default 16, see #2650).
 test:
     just check-cargo-target-writable
@@ -236,7 +234,7 @@ test:
     {{_io_prefix}} {{_cargo}} nextest run --workspace --all-features --test-threads {{_nextest_threads}}
 
 # Run e2e tests only.
-# Env: CARGO_BUILD_JOBS defaults to auto-detected safe parallelism;
+# Cargo parallelism controlled by ~/.cargo/config.toml.
 # NEXTEST_TEST_THREADS is caller-controlled.
 test-e2e:
     just check-cargo-target-writable
@@ -244,7 +242,7 @@ test-e2e:
     {{_io_prefix}} {{_cargo}} nextest run --package cli-sub-agent --test e2e --all-features
 
 # Run tests for a specific package.
-# Env: CARGO_BUILD_JOBS defaults to auto-detected safe parallelism;
+# Cargo parallelism controlled by ~/.cargo/config.toml.
 # NEXTEST_TEST_THREADS is caller-controlled.
 # Usage: just test-p my-crate
 test-p package:
@@ -253,7 +251,7 @@ test-p package:
     {{_io_prefix}} {{_cargo}} nextest run -p {{package}} --all-features
 
 # Run tests matching a specific pattern/name.
-# Env: CARGO_BUILD_JOBS defaults to auto-detected safe parallelism;
+# Cargo parallelism controlled by ~/.cargo/config.toml.
 # NEXTEST_TEST_THREADS is caller-controlled.
 # Usage: just test-f login_validation
 test-f pattern:

--- a/justfile
+++ b/justfile
@@ -1,12 +1,12 @@
-# Justfile for Rust Workspace
-# Generic helpers for Rust monorepo management.
+# Rust workspace helpers.
 # ⚠️ AI AGENT: Do NOT modify this file or use `git commit -n`/`--no-verify` to bypass pre-commit. Fix the actual code.
 
 set shell := ["bash", "-c"]
-# Keep Just's transient scripts inside the repo so sandboxed commit paths
-# do not depend on a writable XDG runtime dir such as /run/user/$UID.
-# Use the repo root itself so the temp path exists in both normal clones and
-# linked worktrees, where `.git` may be a file instead of a directory.
+
+# IO scheduling: run cargo at idle priority to avoid starving interactive processes
+_io_prefix := "ionice -c 3 nice -n 19"
+
+# Keep Just temp scripts repo-local for sandbox and linked-worktree compatibility.
 set tempdir := "."
 # Automatically load .env file if present
 set dotenv-load := true
@@ -15,19 +15,12 @@ set dotenv-load := true
 # Calculate repo root (compatible with submodules)
 _repo_root := `git rev-parse --show-superproject-working-tree 2>/dev/null | grep . || git rev-parse --show-toplevel`
 _cargo := _repo_root + "/scripts/cargo-env-normalize.sh cargo"
-# Default Cargo/rustc fan-out for Just recipes is auto-detected from available
-# memory; override with `CARGO_BUILD_JOBS=<n> just ...`.
-# NEXTEST_TEST_THREADS defaults to 16 in the `test` recipe below (#2650);
-# see comment there for rationale.
+# Auto-detect Cargo fan-out; callers may override CARGO_BUILD_JOBS.
 _auto_build_jobs := `scripts/detect-build-jobs.sh`
 export CARGO_BUILD_JOBS := env_var_or_default("CARGO_BUILD_JOBS", _auto_build_jobs)
-# Disable nextest's double-spawn test execution mode. With symlinked target/
-# directories the double-spawn re-exec fails with "No such file or directory"
-# (#1742). The `double-spawn` key was removed from nextest's TOML config schema;
-# the NEXTEST_DOUBLE_SPAWN environment variable is the official replacement.
+# Disable nextest double-spawn for symlinked target directories (#1742).
 export NEXTEST_DOUBLE_SPAWN := "0"
-# Just already executes repository-controlled code, so trust this checkout's
-# mise config and avoid interactive trust prompts on sandboxed commit paths.
+# Trust this repository's mise config in non-interactive sandboxes.
 export MISE_TRUSTED_CONFIG_PATHS := _repo_root
 
 # Keep cargo state local to avoid host pollution (Optional)
@@ -187,19 +180,19 @@ fmt:
     if (( ${#staged_rs[@]} == 0 )); then
         exit 0
     fi
-    {{_cargo}} fmt --all
+    {{_io_prefix}} {{_cargo}} fmt --all
     printf '%s\0' "${staged_rs[@]}" | xargs -0 git add --
 
 # Run clippy for the entire workspace (strict mode).
 clippy:
     just check-cargo-target-writable
-    {{_cargo}} clippy --workspace --all-features -- -D warnings
+    {{_io_prefix}} {{_cargo}} clippy --workspace --all-features -- -D warnings
 
 # Run clippy for a specific package.
 # Usage: just clippy-p my-crate
 clippy-p package:
     just check-cargo-target-writable
-    {{_cargo}} clippy -p {{package}} --all-features -- -D warnings
+    {{_io_prefix}} {{_cargo}} clippy -p {{package}} --all-features -- -D warnings
 
 # Security audit (requires cargo-deny)
 deny:
@@ -212,7 +205,7 @@ deny:
     fi; \
     deny_output="$(mktemp "${TMPDIR:-/tmp}/csa-deny-output.XXXXXX")"; \
     trap 'rm -f "$deny_output"' EXIT; \
-    if {{_cargo}} deny check $deny_args >"$deny_output" 2>&1; then \
+    if {{_io_prefix}} {{_cargo}} deny check $deny_args >"$deny_output" 2>&1; then \
         echo "cargo deny check passed (success output suppressed)"; \
     else \
         status=$?; \
@@ -238,9 +231,9 @@ _nextest_threads := `_v="${NEXTEST_TEST_THREADS:-16}"; case "$_v" in *[!0-9]*|''
 test:
     just check-cargo-target-writable
     just check-nextest-state-writable
-    {{_cargo}} nextest run --workspace --test-threads {{_nextest_threads}}
+    {{_io_prefix}} {{_cargo}} nextest run --workspace --test-threads {{_nextest_threads}}
     just check-nextest-state-writable
-    {{_cargo}} nextest run --workspace --all-features --test-threads {{_nextest_threads}}
+    {{_io_prefix}} {{_cargo}} nextest run --workspace --all-features --test-threads {{_nextest_threads}}
 
 # Run e2e tests only.
 # Env: CARGO_BUILD_JOBS defaults to auto-detected safe parallelism;
@@ -248,7 +241,7 @@ test:
 test-e2e:
     just check-cargo-target-writable
     just check-nextest-state-writable
-    {{_cargo}} nextest run --package cli-sub-agent --test e2e --all-features
+    {{_io_prefix}} {{_cargo}} nextest run --package cli-sub-agent --test e2e --all-features
 
 # Run tests for a specific package.
 # Env: CARGO_BUILD_JOBS defaults to auto-detected safe parallelism;
@@ -257,7 +250,7 @@ test-e2e:
 test-p package:
     just check-cargo-target-writable
     just check-nextest-state-writable
-    {{_cargo}} nextest run -p {{package}} --all-features
+    {{_io_prefix}} {{_cargo}} nextest run -p {{package}} --all-features
 
 # Run tests matching a specific pattern/name.
 # Env: CARGO_BUILD_JOBS defaults to auto-detected safe parallelism;
@@ -266,7 +259,7 @@ test-p package:
 test-f pattern:
     just check-cargo-target-writable
     just check-nextest-state-writable
-    {{_cargo}} nextest run --workspace --all-features -E 'test({{pattern}})'
+    {{_io_prefix}} {{_cargo}} nextest run --workspace --all-features -E 'test({{pattern}})'
 
 # ==============================================================================
 # 🛠 Git Helpers
@@ -421,7 +414,7 @@ git-push-all:
 release-dry-run:
     #!/usr/bin/env bash
     set -euo pipefail
-    version=$({{_cargo}} metadata --no-deps --format-version 1 \
+    version=$({{_io_prefix}} {{_cargo}} metadata --no-deps --format-version 1 \
         | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')
     tag="v${version}"
     echo "Release dry run only (no changes made)."
@@ -435,7 +428,7 @@ release-dry-run:
 release-tag-local:
     #!/usr/bin/env bash
     set -euo pipefail
-    version=$({{_cargo}} metadata --no-deps --format-version 1 \
+    version=$({{_io_prefix}} {{_cargo}} metadata --no-deps --format-version 1 \
         | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')
     tag="v${version}"
 
@@ -453,7 +446,7 @@ release-tag-local:
 release-tag:
     #!/usr/bin/env bash
     set -euo pipefail
-    version=$({{_cargo}} metadata --no-deps --format-version 1 \
+    version=$({{_io_prefix}} {{_cargo}} metadata --no-deps --format-version 1 \
         | jq -r '.packages[] | select(.name == "cli-sub-agent") | .version')
     tag="v${version}"
 
@@ -488,7 +481,7 @@ install install_dir="/usr/local/bin":
     set -euo pipefail
     d={{quote(install_dir)}}; t="${CARGO_TARGET_DIR:-{{_repo_root}}/target}"
     just check-cargo-target-writable
-    {{_cargo}} build --release --all-features -p cli-sub-agent -p weave
+    {{_io_prefix}} {{_cargo}} build --release --all-features -p cli-sub-agent -p weave
     install -m 755 "$t/release/csa" "$d/csa"
     install -m 755 "$t/release/weave" "$d/weave"
     "{{_repo_root}}/scripts/verify-csa-install-provenance.sh" "$t/release/csa" "$d/csa"
@@ -498,11 +491,11 @@ install install_dir="/usr/local/bin":
 # All crates inherit version.workspace, so a single workspace bump suffices.
 # Requires: cargo-edit (cargo install cargo-edit)
 bump-patch:
-    {{_cargo}} set-version --bump patch -p cli-sub-agent
-    @{{_cargo}} run --quiet -p cli-sub-agent -- migrate
+    {{_io_prefix}} {{_cargo}} set-version --bump patch -p cli-sub-agent
+    @{{_io_prefix}} {{_cargo}} run --quiet -p cli-sub-agent -- migrate
     git add Cargo.toml Cargo.lock weave.lock
     @echo "Bumped workspace version:"
-    @{{_cargo}} metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent" or .name == "weave") | "  \(.name) = \(.version)"'
+    @{{_io_prefix}} {{_cargo}} metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "cli-sub-agent" or .name == "weave") | "  \(.name) = \(.version)"'
 
 # Generate CHANGELOG.md from Conventional Commits (requires git-cliff).
 changelog:

--- a/weave.lock
+++ b/weave.lock
@@ -1,9 +1,7 @@
-package = []
-
 [versions]
-csa = "0.1.1103"
+csa = "0.1.1104"
+weave = "0.1.1104"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
-weave = "0.1.1103"
 
 [migrations]
 applied = [


### PR DESCRIPTION
## Summary
`csa session wait` no longer silently falls back to a hardcoded 240s TTL. Wait requires a provider key that exists in the live `[kv_cache.provider_ttls]` map with TTL > 0, or fails closed with legal keys + `CALLER_HINT`.

## Changes
- Fail closed when `--model-provider` missing/unconfigured/zero-TTL (no `DEFAULT_KV_CACHE_LONG_POLL_SECS=240` success path)
- Legal keys = **explicitly configured** `provider_ttls` only (not serde built-in defaults)
- Optional detect may suggest a key only if it maps to a configured positive TTL (`openai-codex` → `openai` when `openai` is configured)
- Generated wait commands (`SESSION_STARTED`, re-wait, shell fallbacks) include `--model-provider` or emit fail-closed CALLER_HINT
- Help/template no longer teach silent 240 as the happy path
- justfile: ionice idle-class for cargo; remove per-justfile `CARGO_BUILD_JOBS` (defer to `~/.cargo/config.toml`)
- Harden flaky multi-word daemon spawn test under Live suite load

## Validation
- Full `just quality-gates` EXIT=0 on `d4c07e39` / tree `858efbc1750e267d085a7d388c8accbfcf88da65`
- Release binary: `csa 0.1.1104 (d4c07e39)`
- Native review: core AC PASS; generated-wait finding fixed and re-gated
- CSA tier-4 blocked by infrastructure #2848; native fallback per rule 068

Closes #2843