### PR TITLE
fix(config): redact tools api_key in config show output (#2839)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1104"
+version = "0.1.1105"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1104"
+version = "0.1.1105"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/tests/config_redaction_e2e.rs
+++ b/crates/cli-sub-agent/tests/config_redaction_e2e.rs
@@ -1,0 +1,69 @@
+use std::process::Command;
+
+fn csa_cmd(tmp: &std::path::Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    scrub_inherited_csa_env(&mut cmd);
+    cmd.env("HOME", tmp)
+        .env("XDG_STATE_HOME", tmp.join(".local/state"))
+        .env("XDG_CONFIG_HOME", tmp.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1");
+    cmd
+}
+
+fn scrub_inherited_csa_env(cmd: &mut Command) {
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("CSA_") {
+            cmd.env_remove(key);
+        }
+    }
+}
+
+#[test]
+fn config_show_and_get_redact_project_tool_api_key() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config_path = csa_config::ProjectConfig::config_path(tmp.path());
+    std::fs::create_dir_all(config_path.parent().expect("config dir")).expect("create config dir");
+    std::fs::write(
+        &config_path,
+        r#"
+schema_version = 1
+[tools.openai-compat]
+api_key = "sk-test-secret-12345"
+"#,
+    )
+    .expect("write project config");
+
+    let show_output = csa_cmd(tmp.path())
+        .args(["config", "show"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run csa config show");
+
+    assert!(show_output.status.success(), "config show should exit 0");
+    let show_stdout = String::from_utf8_lossy(&show_output.stdout);
+    assert!(
+        !show_stdout.contains("sk-test-secret-12345"),
+        "config show leaked the project tool api key"
+    );
+    assert!(
+        show_stdout.contains("***REDACTED***"),
+        "config show should mask the project tool api key"
+    );
+
+    let get_output = csa_cmd(tmp.path())
+        .args(["config", "get", "tools.openai-compat.api_key"])
+        .current_dir(tmp.path())
+        .output()
+        .expect("failed to run csa config get tools.openai-compat.api_key");
+
+    assert!(get_output.status.success(), "config get should exit 0");
+    let get_stdout = String::from_utf8_lossy(&get_output.stdout);
+    assert!(
+        !get_stdout.contains("sk-test-secret-12345"),
+        "config get leaked the project tool api key"
+    );
+    assert!(
+        get_stdout.contains("***REDACTED***"),
+        "config get should mask the project tool api key"
+    );
+}

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -245,6 +245,11 @@ impl ProjectConfig {
     pub fn redacted_for_display(&self) -> Self {
         let mut redacted = self.clone();
         redacted.memory.llm = redacted.memory.llm.redacted_for_display();
+        for tool_cfg in redacted.tools.values_mut() {
+            if tool_cfg.api_key.is_some() {
+                tool_cfg.api_key = Some("***REDACTED***".to_string());
+            }
+        }
         redacted
     }
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1104"
-weave = "0.1.1104"
+csa = "0.1.1105"
+weave = "0.1.1105"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
`csa config show` and `csa config get` leaked plaintext `[tools.*].api_key` values because `ProjectConfig::redacted_for_display()` only redacted `memory.llm.api_key`, not tool-level API keys.

## Fix
Mirror `GlobalConfig::redacted_for_display()` logic: loop over all tools and mask `api_key` when present.

## Changes
- `crates/csa-config/src/config.rs`: add tools api_key redaction loop to `ProjectConfig::redacted_for_display()`
- `crates/cli-sub-agent/tests/config_redaction_e2e.rs`: e2e test verifying both `config show` and `config get tools.openai-compat.api_key` redact the secret

## Validation
- Full `just quality-gates` EXIT=0 on tree `254f624d`
- Pre-push hook: quality-gates reused, branch-protection PASS, version-check PASS

Closes #2839