### PR TITLE
fix(run): accept --goal as prompt; honor inherited CSA_MODEL_SPEC (#2813 #2840)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1105"
+version = "0.1.1106"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1105"
+version = "0.1.1106"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_commands.rs
+++ b/crates/cli-sub-agent/src/cli_commands.rs
@@ -21,7 +21,7 @@ pub enum Commands {
         sa_mode: Option<bool>,
         /// Task prompt; reads from stdin if omitted
         prompt: Option<String>,
-        /// Autonomous goal mode: loop until success criteria met or budget exhausted
+        /// Autonomous goal mode: loop until success criteria met or budget exhausted; used as the task prompt when no prompt source is provided.
         #[arg(long)]
         goal: Option<String>,
         /// Task prompt (flag form; same as the positional prompt)

--- a/crates/cli-sub-agent/src/goal_loop.rs
+++ b/crates/cli-sub-agent/src/goal_loop.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::io::{IsTerminal, Read};
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -267,25 +268,60 @@ async fn handle_goal_run(request: GoalRunRequest) -> Result<i32> {
 }
 
 fn resolve_goal_user_prompt(request: &GoalRunRequest) -> Result<String> {
-    let prompt = crate::run_helpers::resolve_positional_stdin_sentinel(request.prompt.clone())?
-        .or_else(|| request.prompt_flag.clone());
+    let mut stdin = std::io::stdin();
+    resolve_goal_user_prompt_from_reader(
+        request.prompt.clone(),
+        request.prompt_flag.clone(),
+        request.prompt_file.as_deref(),
+        request.skill.as_deref(),
+        request.goal_criteria.as_deref(),
+        stdin.is_terminal(),
+        &mut stdin,
+    )
+}
 
-    if request.prompt_file.is_some() {
-        return crate::run_helpers::resolve_prompt_with_file(
+fn resolve_goal_user_prompt_from_reader<R: Read>(
+    prompt: Option<String>,
+    prompt_flag: Option<String>,
+    prompt_file: Option<&Path>,
+    skill: Option<&str>,
+    goal_criteria: Option<&str>,
+    stdin_is_terminal: bool,
+    reader: &mut R,
+) -> Result<String> {
+    let prompt = crate::run_helpers::resolve_positional_stdin_sentinel_from_reader(
+        prompt,
+        stdin_is_terminal,
+        reader,
+    )?
+    .or(prompt_flag);
+
+    if prompt_file.is_some() {
+        return crate::run_helpers::resolve_prompt_with_file_from_reader(
             prompt,
-            request.prompt_file.as_deref(),
+            prompt_file,
+            stdin_is_terminal,
+            reader,
         );
     }
 
     if prompt.is_some() {
-        return crate::run_helpers::read_prompt(prompt);
+        return crate::run_helpers::read_prompt_from_reader(prompt, stdin_is_terminal, reader);
     }
 
-    if request.skill.is_some() {
+    if let Some(goal_criteria) = goal_criteria {
+        return crate::run_helpers::read_prompt_from_reader(
+            Some(goal_criteria.to_string()),
+            stdin_is_terminal,
+            reader,
+        );
+    }
+
+    if skill.is_some() {
         return Ok(String::new());
     }
 
-    crate::run_helpers::read_prompt(None)
+    crate::run_helpers::read_prompt_from_reader(None, stdin_is_terminal, reader)
 }
 
 fn build_goal_prompt(
@@ -481,5 +517,23 @@ mod tests {
         assert!(effective_require_commit(true, Some("review")));
         assert!(!effective_require_commit(false, Some("review")));
         assert!(!effective_require_commit(false, None));
+    }
+
+    #[test]
+    fn goal_only_uses_goal_as_task_prompt_without_reading_empty_stdin() {
+        let mut stdin = std::io::Cursor::new("");
+
+        let prompt = resolve_goal_user_prompt_from_reader(
+            None,
+            None,
+            None,
+            None,
+            Some("do something"),
+            true,
+            &mut stdin,
+        )
+        .expect("--goal alone must provide the task prompt");
+
+        assert_eq!(prompt, "do something");
     }
 }

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -167,7 +167,8 @@ use csa_core::types::OutputFormat;
 #[cfg(test)]
 use main_bootstrap::should_attempt_auto_weave_upgrade;
 use main_bootstrap::{
-    link_bug_class_pipeline, maybe_auto_weave_upgrade, resolve_effective_min_timeout,
+    check_weave_lock_version_alignment, link_bug_class_pipeline, maybe_auto_weave_upgrade,
+    migrate_legacy_xdg_paths_if_needed, resolve_effective_min_timeout,
 };
 pub(crate) use process_exit::exit_current_process;
 use process_exit::report_daemon_error_or_exit_code;
@@ -241,45 +242,11 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
         output_format,
     )?;
 
-    // Check weave.lock version alignment (non-fatal, read-only).
-    if let Ok(cwd) = std::env::current_dir() {
-        let registry = csa_config::default_registry();
-        match csa_config::check_version(
-            &cwd,
-            env!("CARGO_PKG_VERSION"),
-            env!("CARGO_PKG_VERSION"),
-            &registry,
-        ) {
-            Ok(result) => {
-                if let Some(warning) = csa_config::weave_lock::format_version_check_warning(&result)
-                {
-                    eprintln!("{warning}");
-                }
-            }
-            Err(e) => {
-                tracing::debug!("weave.lock version check failed: {e:#}");
-            }
-        }
-    }
+    check_weave_lock_version_alignment();
 
     maybe_auto_weave_upgrade(&command).await;
 
-    let legacy_xdg_paths = csa_config::paths::legacy_paths_requiring_migration();
-    if !legacy_xdg_paths.is_empty() {
-        match csa_config::migrate::run_xdg_migration() {
-            Ok(()) => {
-                tracing::debug!(
-                    "auto-migrated {} legacy XDG path(s)",
-                    legacy_xdg_paths.len()
-                );
-            }
-            Err(e) => {
-                eprintln!(
-                    "WARNING: failed to auto-migrate legacy XDG paths: {e:#}. Run `csa migrate` manually."
-                );
-            }
-        }
-    }
+    migrate_legacy_xdg_paths_if_needed();
 
     match command {
         Commands::Run {
@@ -355,6 +322,25 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
                 exit_current_process(exit_code);
             }
             let effective_no_daemon = no_daemon || goal.is_some();
+            // The daemon preflight runs before `handle_run` resolves model inheritance,
+            // so mirror that trusted pin resolution here before deciding whether the
+            // direct-tool tier policy applies.
+            let inherited_model_pin_resolution = run_cmd_model_pin::apply_inherited_model_pin(
+                run_cmd_model_pin::RunModelPinInput {
+                    model_spec: model_spec.clone(),
+                    tier: tier.clone(),
+                    auto_route: auto_route.clone(),
+                    force_ignore_tier_setting,
+                    no_failover,
+                },
+                run_cmd_model_pin::inherited_model_pin_from_startup(&startup_env),
+            );
+            let inherited_model_pin_active = inherited_model_pin_resolution.inherited_pin.is_some();
+            run_cmd_model_pin::validate_inherited_model_pin_allows_explicit_tool(
+                tool.as_ref(),
+                inherited_model_pin_active,
+                inherited_model_pin_resolution.model_spec.as_deref(),
+            )?;
             run_cmd_daemon::validate_run_tier_policy_before_daemon_spawn(
                 run_cmd_daemon::RunDaemonTierPolicyPreflight {
                     no_daemon: effective_no_daemon,
@@ -368,6 +354,7 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
                     model_spec: model_spec.as_deref(),
                     force,
                     force_ignore_tier_setting,
+                    inherited_model_pin_active,
                 },
             )?;
             run_cmd_preflight::run_before_daemon_spawn_if_needed(

--- a/crates/cli-sub-agent/src/main_bootstrap.rs
+++ b/crates/cli-sub-agent/src/main_bootstrap.rs
@@ -95,6 +95,49 @@ pub(crate) async fn maybe_auto_weave_upgrade(command: &Commands) {
     }
 }
 
+/// Check the local weave.lock version without preventing startup on failure.
+pub(crate) fn check_weave_lock_version_alignment() {
+    if let Ok(cwd) = std::env::current_dir() {
+        let registry = csa_config::default_registry();
+        match csa_config::check_version(
+            &cwd,
+            env!("CARGO_PKG_VERSION"),
+            env!("CARGO_PKG_VERSION"),
+            &registry,
+        ) {
+            Ok(result) => {
+                if let Some(warning) = csa_config::weave_lock::format_version_check_warning(&result)
+                {
+                    eprintln!("{warning}");
+                }
+            }
+            Err(e) => {
+                tracing::debug!("weave.lock version check failed: {e:#}");
+            }
+        }
+    }
+}
+
+/// Migrate legacy XDG paths opportunistically, preserving the CLI's manual fallback.
+pub(crate) fn migrate_legacy_xdg_paths_if_needed() {
+    let legacy_xdg_paths = csa_config::paths::legacy_paths_requiring_migration();
+    if !legacy_xdg_paths.is_empty() {
+        match csa_config::migrate::run_xdg_migration() {
+            Ok(()) => {
+                tracing::debug!(
+                    "auto-migrated {} legacy XDG path(s)",
+                    legacy_xdg_paths.len()
+                );
+            }
+            Err(e) => {
+                eprintln!(
+                    "WARNING: failed to auto-migrate legacy XDG paths: {e:#}. Run `csa migrate` manually."
+                );
+            }
+        }
+    }
+}
+
 pub(crate) fn link_bug_class_pipeline() {
     let _ = crate::bug_class::BugClassCandidate::aggregate_from_review_artifacts(&[]);
     crate::bug_class::link_bug_class_pipeline_symbols();

--- a/crates/cli-sub-agent/src/run_cmd_daemon_tier_policy.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_tier_policy.rs
@@ -13,6 +13,9 @@ pub(crate) struct RunDaemonTierPolicyPreflight<'a> {
     pub(crate) model_spec: Option<&'a str>,
     pub(crate) force: bool,
     pub(crate) force_ignore_tier_setting: bool,
+    /// True only after the trusted inherited pin and any explicit tool have
+    /// been validated as compatible.
+    pub(crate) inherited_model_pin_active: bool,
 }
 
 pub(crate) fn validate_run_tier_policy_before_daemon_spawn(
@@ -28,6 +31,7 @@ pub(crate) fn validate_run_tier_policy_before_daemon_spawn(
         || ctx.model_spec.is_some()
         || ctx.force
         || ctx.force_ignore_tier_setting
+        || ctx.inherited_model_pin_active
     {
         return Ok(());
     }
@@ -44,4 +48,36 @@ pub(crate) fn validate_run_tier_policy_before_daemon_spawn(
         "{}",
         crate::run_helpers::format_run_direct_tool_tier_policy_error(&config)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inherited_matching_model_pin_bypasses_direct_tool_tier_preflight() {
+        let explicit_tool = csa_core::types::ToolArg::Specific(csa_core::types::ToolName::Codex);
+        crate::run_cmd_model_pin::validate_inherited_model_pin_allows_explicit_tool(
+            Some(&explicit_tool),
+            true,
+            Some("codex/openai/gpt-5.5/xhigh"),
+        )
+        .expect("matching explicit tool must be allowed by the inherited model pin");
+
+        validate_run_tier_policy_before_daemon_spawn(RunDaemonTierPolicyPreflight {
+            no_daemon: false,
+            daemon_child: false,
+            session_id: None,
+            cd: None,
+            direct_tool_requested: true,
+            auto_route: None,
+            hint_difficulty: None,
+            tier: None,
+            model_spec: None,
+            force: false,
+            force_ignore_tier_setting: false,
+            inherited_model_pin_active: true,
+        })
+        .expect("matching inherited model pin must bypass the direct-tool tier preflight");
+    }
 }

--- a/crates/cli-sub-agent/src/run_helpers.rs
+++ b/crates/cli-sub-agent/src/run_helpers.rs
@@ -49,11 +49,10 @@ pub(crate) use edit_requirement::{infer_task_edit_requirement, resolve_task_edit
 pub(crate) use executor::{build_executor, model_name_for_tier_validation};
 pub(crate) use inline_review_context::prepend_review_context_to_prompt;
 use model_spec_validation::enforce_model_spec_matches_tool_default;
-#[cfg(test)]
-pub(crate) use prompt::resolve_prompt_with_file_from_reader;
 pub(crate) use prompt::{
-    is_prompt_file_stdin_sentinel, read_prompt, resolve_positional_stdin_sentinel,
-    resolve_prompt_with_file,
+    is_prompt_file_stdin_sentinel, read_prompt, read_prompt_from_reader,
+    resolve_positional_stdin_sentinel, resolve_positional_stdin_sentinel_from_reader,
+    resolve_prompt_with_file, resolve_prompt_with_file_from_reader,
 };
 pub(crate) use routing_conflict::{is_routing_conflict, routing_conflict_error};
 pub(crate) use routing_request::RoutingRequest;

--- a/crates/cli-sub-agent/src/run_helpers_prompt.rs
+++ b/crates/cli-sub-agent/src/run_helpers_prompt.rs
@@ -7,20 +7,7 @@ pub(crate) fn resolve_positional_stdin_sentinel(prompt: Option<String>) -> Resul
     resolve_positional_stdin_sentinel_from_reader(prompt, stdin.is_terminal(), &mut stdin)
 }
 
-#[cfg(test)]
 pub(crate) fn resolve_positional_stdin_sentinel_from_reader<R: Read>(
-    prompt: Option<String>,
-    stdin_is_terminal: bool,
-    reader: &mut R,
-) -> Result<Option<String>> {
-    match prompt.as_deref() {
-        Some("-") => read_prompt_from_reader(None, stdin_is_terminal, reader).map(Some),
-        _ => Ok(prompt),
-    }
-}
-
-#[cfg(not(test))]
-fn resolve_positional_stdin_sentinel_from_reader<R: Read>(
     prompt: Option<String>,
     stdin_is_terminal: bool,
     reader: &mut R,
@@ -41,19 +28,8 @@ pub(crate) fn resolve_prompt_with_file(
     prompt: Option<String>,
     prompt_file: Option<&Path>,
 ) -> Result<String> {
-    if let Some(path) = prompt_file {
-        if is_prompt_file_stdin_sentinel(path) {
-            return read_prompt(None);
-        }
-
-        let content = std::fs::read_to_string(path)
-            .with_context(|| format!("--prompt-file: failed to read '{}'", path.display()))?;
-        if content.trim().is_empty() {
-            anyhow::bail!("--prompt-file '{}' is empty", path.display());
-        }
-        return Ok(content);
-    }
-    read_prompt(prompt)
+    let mut stdin = std::io::stdin();
+    resolve_prompt_with_file_from_reader(prompt, prompt_file, stdin.is_terminal(), &mut stdin)
 }
 
 pub(crate) fn is_prompt_file_stdin_sentinel(path: &Path) -> bool {
@@ -63,7 +39,6 @@ pub(crate) fn is_prompt_file_stdin_sentinel(path: &Path) -> bool {
     )
 }
 
-#[cfg(test)]
 pub(crate) fn resolve_prompt_with_file_from_reader<R: Read>(
     prompt: Option<String>,
     prompt_file: Option<&Path>,

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1105"
-weave = "0.1.1105"
+csa = "0.1.1106"
+weave = "0.1.1106"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
Batch of two small SA-mode validation bugs.

### #2813
`csa run --sa-mode true --goal <non-empty>` was rejected as `Empty prompt from stdin` because prompt resolution ignored `--goal`.

**Fix:** treat non-empty `--goal` as the task prompt when no positional/`--prompt`/`--prompt-file` source is supplied. Help text updated.

### #2840
Nested invocations with inherited trusted `CSA_MODEL_SPEC` still hit `Direct --tool is blocked when tiers are configured` because daemon tier preflight only looked at CLI `--model-spec`.

**Fix:** preflight recognizes a validated inherited model pin and allows matching `--tool`; tool/pin mismatch still fails closed.

## Changes
- `run_helpers_prompt.rs` / `goal_loop.rs` / `cli_commands.rs`: `--goal` as prompt source
- `run_cmd_daemon_tier_policy.rs`: inherited pin bypass for tier direct-tool guard
- `main_bootstrap.rs`: extract startup bootstrap from `main.rs` (monolith ratchet, behavior-preserving)

## Validation
- Focused regressions + existing inherited-pin tests
- `just pre-commit-fast`
- Pre-push `quality-gates` EXIT=0 on `b66b2827` (receipt identity `7ee87cfb…`)

Closes #2813
Closes #2840