### PR TITLE
fix: bare-429 rate-limit, require-commit --sa-mode, tier help (#2747 #2713 #2817)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1106"
+version = "0.1.1107"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1106"
+version = "0.1.1107"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_commands.rs
+++ b/crates/cli-sub-agent/src/cli_commands.rs
@@ -5,6 +5,9 @@ pub enum Commands {
     /// Execute a task using a specific AI tool
     Run {
         /// Tool selection: auto, any-available, or a specific tool.
+        ///
+        /// Tier policy: when tiers are configured, --tool alone is blocked. Use
+        /// --tier <name> (optionally with --tool as a preference).
         #[arg(long)]
         tool: Option<ToolArg>,
         /// Auto-route via `[tier_mapping]` while keeping tool choice automatic.

--- a/crates/cli-sub-agent/src/require_commit_recovery_display.rs
+++ b/crates/cli-sub-agent/src/require_commit_recovery_display.rs
@@ -99,6 +99,10 @@ pub(crate) fn build_require_commit_recovery_guidance(
         "--fork-from".to_string(),
         shell_token(session_id),
         "--require-commit".to_string(),
+        "--sa-mode".to_string(),
+        diagnostic
+            .sa_mode
+            .map_or_else(|| "<true|false>".to_string(), |value| value.to_string()),
         "--prompt-file".to_string(),
         CONTINUATION_PROMPT_PLACEHOLDER.to_string(),
     ];
@@ -192,6 +196,7 @@ mod tests {
             "01KW641KP78VR43SCKJVN6HGDN",
             &csa_session::RequireCommitRecoveryDiagnostic {
                 require_commit: true,
+                sa_mode: Some(false),
                 commit_created: false,
                 dirty_worktree: true,
                 changed_paths: vec!["src/lib.rs".to_string(), "README.md".to_string()],
@@ -218,7 +223,7 @@ mod tests {
             "Work was applied but not committed; use fork-from to continue from this session"
         ));
         assert!(rendered.contains(
-            "Continuation command: csa run --fork-from 01KW641KP78VR43SCKJVN6HGDN --require-commit --prompt-file CONTINUATION_PROMPT.md"
+            "Continuation command: csa run --fork-from 01KW641KP78VR43SCKJVN6HGDN --require-commit --sa-mode false --prompt-file CONTINUATION_PROMPT.md"
         ));
         assert!(rendered.contains("git status --short"));
         assert!(!rendered.contains("<continuation"));
@@ -232,8 +237,9 @@ mod tests {
         let worker_id = csa_session::new_session_id();
         let worker_dir = temp.path().join(&worker_id);
         std::fs::create_dir_all(&worker_dir).expect("worker dir");
-        let diagnostic = csa_session::RequireCommitRecoveryDiagnostic {
+        let mut diagnostic = csa_session::RequireCommitRecoveryDiagnostic {
             require_commit: true,
+            sa_mode: Some(false),
             commit_created: false,
             dirty_worktree: true,
             changed_paths: vec!["src/lib.rs".to_string()],
@@ -263,6 +269,14 @@ mod tests {
                 .continuation_command
                 .contains(&format!("--fork-from {wrapper_id}")),
             "continuation command must not target wrapper session: {guidance:?}"
+        );
+        assert!(guidance.continuation_command.contains("--sa-mode false"));
+
+        diagnostic.sa_mode = None;
+        assert!(
+            build_require_commit_recovery_guidance("01TESTLEGACY", &diagnostic)
+                .continuation_command
+                .contains("--sa-mode <true|false>")
         );
     }
 }

--- a/crates/cli-sub-agent/src/review_convergence/repair_lifecycle.rs
+++ b/crates/cli-sub-agent/src/review_convergence/repair_lifecycle.rs
@@ -331,6 +331,23 @@ mod tests {
         temp
     }
 
+    /// Isolate journal/state writes from the host `XDG_STATE_HOME` before
+    /// `ConvergenceLedgerStore::for_project` resolves secure state paths.
+    fn isolated_project_store(
+        repository: &Path,
+    ) -> (
+        crate::test_env_lock::ScopedTestEnvVar,
+        ConvergenceLedgerStore,
+    ) {
+        let state_home = repository.join("xdg-state");
+        fs::create_dir_all(&state_home).expect("create isolated XDG_STATE_HOME");
+        let state_guard =
+            crate::test_env_lock::ScopedTestEnvVar::set("XDG_STATE_HOME", &state_home);
+        let store = ConvergenceLedgerStore::for_project(repository)
+            .expect("open project convergence store under isolated XDG_STATE_HOME");
+        (state_guard, store)
+    }
+
     fn head(root: &Path) -> csa_session::convergence::GitObjectId {
         let output = Command::new("git")
             .arg("-C")
@@ -353,8 +370,7 @@ mod tests {
         let expected = capture_epoch(repository.path(), &head(repository.path()))
             .expect("capture immutable expected epoch")
             .epoch;
-        let store = ConvergenceLedgerStore::for_project(repository.path())
-            .expect("open project convergence store");
+        let (_state_home, store) = isolated_project_store(repository.path());
         let campaign = CampaignId::generate();
         let policy = Sha256Digest::compute(b"repair lifecycle policy");
         store
@@ -427,8 +443,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let repository = repository();
-        let store = ConvergenceLedgerStore::for_project(repository.path())
-            .expect("open project convergence store");
+        let (_state_home, store) = isolated_project_store(repository.path());
         store
             .initialize_completion_action_journal(
                 campaign.id().clone(),

--- a/crates/cli-sub-agent/src/run_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests.rs
@@ -6,7 +6,7 @@ use crate::run_cmd_tool_selection::{
     take_next_runtime_fallback_tool,
 };
 use chrono::{TimeZone, Utc};
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use csa_core::transport_events::SessionEvent;
 use csa_core::types::{OutputFormat, ToolName};
 use csa_process::ExecutionResult;
@@ -164,6 +164,19 @@ fn run_cli_parses_allow_fallback_flag() {
         crate::cli::Commands::Run { allow_fallback, .. } => assert!(allow_fallback),
         _ => panic!("expected run command"),
     }
+}
+
+#[test]
+fn run_help_explains_tier_policy_for_direct_tool() {
+    let mut command = Cli::command();
+    let run = command
+        .find_subcommand_mut("run")
+        .expect("run subcommand should exist");
+    let help = run.render_long_help().to_string();
+
+    assert!(help.contains("Tier policy:"), "{help}");
+    assert!(help.contains("--tool alone is blocked"), "{help}");
+    assert!(help.contains("--tier <name>"), "{help}");
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -232,6 +232,7 @@ fn record_writer_uncommitted_changes_with_config(
                     commit_created,
                     result.csa_gate_failure.as_deref(),
                     clean_tree_verification_failure,
+                    Some(record.sa_mode),
                 )
             });
             let mut should_save = false;
@@ -307,6 +308,7 @@ pub(crate) fn apply_uncommitted_changes_to_result(
                 false,
                 None,
                 None,
+                None,
             )
         });
         apply_require_commit_contract_failure_to_result(result, recovery);
@@ -329,7 +331,14 @@ fn build_require_commit_recovery_diagnostic(
     result: &csa_session::SessionResult,
     changes: &csa_session::UncommittedChanges,
 ) -> csa_session::RequireCommitRecoveryDiagnostic {
-    build_require_commit_recovery_diagnostic_for_state(result, Some(changes), false, None, None)
+    build_require_commit_recovery_diagnostic_for_state(
+        result,
+        Some(changes),
+        false,
+        None,
+        None,
+        Some(false),
+    )
 }
 
 fn build_require_commit_recovery_diagnostic_for_state(
@@ -338,6 +347,7 @@ fn build_require_commit_recovery_diagnostic_for_state(
     commit_created: bool,
     gate_failure: Option<&str>,
     clean_tree_verification_failure: Option<&str>,
+    sa_mode: Option<bool>,
 ) -> csa_session::RequireCommitRecoveryDiagnostic {
     let termination_exit_code = result.raw_process_exit_code.unwrap_or(result.exit_code);
     let termination_status = result
@@ -346,6 +356,7 @@ fn build_require_commit_recovery_diagnostic_for_state(
         .unwrap_or_else(|| result.status.clone());
     csa_session::RequireCommitRecoveryDiagnostic {
         require_commit: true,
+        sa_mode,
         commit_created,
         dirty_worktree: changes.is_some(),
         changed_paths: changes

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_kill_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_kill_tests.rs
@@ -137,6 +137,7 @@ last_accessed = "2026-06-01T00:00:00Z"
     result.exit_code = 1;
     result.require_commit_recovery = Some(csa_session::RequireCommitRecoveryDiagnostic {
         require_commit: true,
+        sa_mode: Some(false),
         commit_created: false,
         dirty_worktree: true,
         changed_paths: vec!["crates/verbatim-daemon/src/main.rs".to_string()],

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_recovery_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_recovery_tests.rs
@@ -16,6 +16,7 @@ fn compact_summary_and_json_include_require_commit_recovery() {
         completed_at: now + chrono::TimeDelta::seconds(65),
         require_commit_recovery: Some(csa_session::RequireCommitRecoveryDiagnostic {
             require_commit: true,
+            sa_mode: Some(false),
             commit_created: false,
             dirty_worktree: true,
             changed_paths: vec!["src/lib.rs".to_string(), "README.md".to_string()],
@@ -45,7 +46,7 @@ fn compact_summary_and_json_include_require_commit_recovery() {
         "Work was applied but not committed; use fork-from to continue from this session"
     ));
     assert!(summary.contains(
-        "Continuation command: csa run --fork-from 01TESTWAITRECOVER --require-commit --prompt-file CONTINUATION_PROMPT.md"
+        "Continuation command: csa run --fork-from 01TESTWAITRECOVER --require-commit --sa-mode false --prompt-file CONTINUATION_PROMPT.md"
     ));
     assert!(!summary.contains("Review verdict: PASS"));
 
@@ -72,7 +73,7 @@ fn compact_summary_and_json_include_require_commit_recovery() {
     assert_eq!(
         json["require_commit_recovery_guidance"]["continuation_command"],
         serde_json::json!(
-            "csa run --fork-from 01TESTWAITRECOVER --require-commit --prompt-file CONTINUATION_PROMPT.md"
+            "csa run --fork-from 01TESTWAITRECOVER --require-commit --sa-mode false --prompt-file CONTINUATION_PROMPT.md"
         )
     );
     assert!(

--- a/crates/cli-sub-agent/src/session_cmds_result_require_commit_recovery_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_require_commit_recovery_tests.rs
@@ -15,6 +15,7 @@ fn build_result_json_payload_includes_require_commit_recovery() {
             completed_at: now,
             require_commit_recovery: Some(csa_session::RequireCommitRecoveryDiagnostic {
                 require_commit: true,
+                sa_mode: Some(false),
                 commit_created: false,
                 dirty_worktree: true,
                 changed_paths: vec!["src/lib.rs".to_string()],
@@ -68,6 +69,7 @@ fn build_result_json_payload_with_identity_includes_require_commit_recovery_guid
             completed_at: now,
             require_commit_recovery: Some(csa_session::RequireCommitRecoveryDiagnostic {
                 require_commit: true,
+                sa_mode: Some(false),
                 commit_created: false,
                 dirty_worktree: true,
                 changed_paths: vec!["src/lib.rs".to_string()],
@@ -100,7 +102,7 @@ fn build_result_json_payload_with_identity_includes_require_commit_recovery_guid
     assert_eq!(
         payload["require_commit_recovery_guidance"]["continuation_command"],
         serde_json::json!(
-            "csa run --fork-from 01KW641KP78VR43SCKJVN6HGDN --require-commit --prompt-file CONTINUATION_PROMPT.md"
+            "csa run --fork-from 01KW641KP78VR43SCKJVN6HGDN --require-commit --sa-mode false --prompt-file CONTINUATION_PROMPT.md"
         )
     );
     assert!(

--- a/crates/csa-scheduler/src/rate_limit_tests.rs
+++ b/crates/csa-scheduler/src/rate_limit_tests.rs
@@ -734,9 +734,9 @@ fn test_codex_usage_limit_in_stderr_sets_quota_exhausted() {
 fn test_codex_bare_429_requires_http_status_context() {
     let path_error = detect_rate_limit("codex", "/tmp/csa-worktree-lock-429-probe", "", 1, None);
     assert!(path_error.is_none());
-    let detected =
-        detect_rate_limit("codex", "", "statusCode: 429", 1, None).expect("contextual 429");
-    assert_eq!(detected.matched_pattern, "statuscode 429");
+    let detected = detect_rate_limit("codex", "", "HTTP 429 Too Many Requests", 1, None)
+        .expect("contextual 429");
+    assert_eq!(detected.matched_pattern, "http 429");
     assert_eq!(detected.reason, "HTTP 429");
     assert!(!detected.quota_exhausted);
 }

--- a/crates/csa-session/src/result.rs
+++ b/crates/csa-session/src/result.rs
@@ -207,6 +207,12 @@ impl UncommittedChanges {
 pub struct RequireCommitRecoveryDiagnostic {
     /// The run was governed by the require-commit contract.
     pub require_commit: bool,
+    /// The autonomous-mode value from the failed invocation, when known.
+    ///
+    /// Legacy result files omit this field, so recovery guidance must ask the
+    /// caller to provide an explicit value rather than guessing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sa_mode: Option<bool>,
     /// Whether CSA observed a commit satisfying the contract.
     pub commit_created: bool,
     /// Whether dirty tracked worktree changes remained after the run.

--- a/crates/csa-session/src/result_tests.rs
+++ b/crates/csa-session/src/result_tests.rs
@@ -115,6 +115,7 @@ fn test_session_result_require_commit_recovery_roundtrip() {
         completed_at: now,
         require_commit_recovery: Some(RequireCommitRecoveryDiagnostic {
             require_commit: true,
+            sa_mode: Some(false),
             commit_created: false,
             dirty_worktree: true,
             changed_paths: vec!["src/lib.rs".to_string(), "README.md".to_string()],
@@ -132,6 +133,7 @@ fn test_session_result_require_commit_recovery_roundtrip() {
     let toml_str = toml::to_string_pretty(&result).expect("Serialize should succeed");
     assert!(toml_str.contains("[require_commit_recovery]"));
     assert!(toml_str.contains("require_commit = true"));
+    assert!(toml_str.contains("sa_mode = false"));
     assert!(toml_str.contains("commit_created = false"));
     assert!(toml_str.contains("blocker_summary = \"gate=commit-policy-uncommitted\""));
     assert!(!toml_str.contains("file contents"));
@@ -141,6 +143,7 @@ fn test_session_result_require_commit_recovery_roundtrip() {
         .require_commit_recovery
         .expect("recovery diagnostic should roundtrip");
     assert!(recovery.require_commit);
+    assert_eq!(recovery.sa_mode, Some(false));
     assert!(!recovery.commit_created);
     assert!(recovery.dirty_worktree);
     assert_eq!(

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1106"
-weave = "0.1.1106"
+csa = "0.1.1107"
+weave = "0.1.1107"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
S-complexity batch of three independent validation/UX fixes, plus a test isolation harden for a host-XDG flake uncovered under full-suite load.

### #2747
Stop treating a bare `429` substring as Codex rate-limit. Contextual markers (`HTTP 429`, `status 429`, …) still trigger failover. Temp paths containing `429` no longer flip local pre-exec errors into fake rate-limit retries.

### #2713
Generated require-commit continuation/recovery commands now include `--sa-mode true|false` when known. Legacy records without the field surface an explicit placeholder instead of guessing.

### #2817
`csa run --help` documents that when project tiers are configured, `--tool` alone is blocked and `--tier <name>` (optionally with `--tool` as preference) is required.

### Test harden
`repair_lifecycle` journal tests isolate `XDG_STATE_HOME` before opening the convergence store, avoiding host `~/.local/state/cli-sub-agent` secure-open ENOTDIR flakes under static-suite load.

## Validation
- Focused regressions for all three issues
- Pre-push `quality-gates` EXIT=0 on `0ce8cbef` (receipt identity `7d4c3331…`, status executed)

Closes #2747
Closes #2713
Closes #2817