### PR TITLE
fix: slot-exhaustion verdict, false hooksPath hint, fix-finding prompt (#2718 #2729 #2654)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1108"
+version = "0.1.1109"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1108"
+version = "0.1.1109"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -221,6 +221,16 @@ pub struct ReviewArgs {
     pub fix: bool,
 
     /// Apply a caller-confirmed review finding by resuming the exact failed review session.
+    ///
+    /// Prompt sources (first match wins):
+    /// 1. `--prompt` / `--prompt-file` (use `-` or `/dev/stdin` for stdin)
+    /// 2. non-empty stdin body (plain-text confirmed fix instructions)
+    /// 3. when unambiguous: the single structured finding from the source review's
+    ///    `output/findings.toml`
+    ///
+    /// Stdin example:
+    ///   echo "Fix the confirmed HIGH finding in src/foo.rs: preserve error causes" \
+    ///     | csa review --fix-finding --session FAILED_REVIEW_SESSION_ID
     #[arg(long, conflicts_with_all = ["fix", "check_verdict"])]
     pub fix_finding: bool,
 
@@ -343,11 +353,16 @@ pub struct ReviewArgs {
     pub extra_readable: Vec<PathBuf>,
 
     /// Caller-confirmed fix prompt text for --fix-finding.
+    ///
+    /// Optional when the source review has exactly one structured finding in
+    /// `output/findings.toml` (derived automatically). Otherwise required via
+    /// this flag, `--prompt-file`, or stdin (plain-text confirmed instructions).
     #[arg(long, value_name = "PROMPT", conflicts_with = "prompt_file")]
     pub prompt: Option<String>,
 
     /// Read supplementary prompt/context from a file path (bypasses shell quoting issues).
     /// For --fix-finding, use `-` or `/dev/stdin` to read the caller-confirmed prompt from stdin.
+    /// When omitted for --fix-finding, CSA may derive a prompt from a single source finding.
     /// Regular review treats this as a path; stdin sentinels are not resolved.
     #[arg(long, value_name = "PATH")]
     pub prompt_file: Option<PathBuf>,

--- a/crates/cli-sub-agent/src/error_hints.rs
+++ b/crates/cli-sub-agent/src/error_hints.rs
@@ -175,25 +175,23 @@ pub(crate) fn lefthook_core_hookspath_conflict_hint(
     stderr: &str,
     stdout: &str,
 ) -> Option<&'static str> {
-    // Only emit the hint when the session actually attempted a commit.
-    // Without commit context (e.g. a --fork-from session told not to commit),
-    // the hint is noise. Require both the marker and commit-related evidence.
+    // Only emit the hint when a commit was actually attempted and hooksPath
+    // is the concrete failure explanation (#2055, #2729).
+    //
+    // Do NOT treat `git config --unset-all --local core.hooksPath` alone as
+    // commit evidence: that string is part of lefthook's diagnostic template
+    // and can appear (or be paraphrased) without any commit attempt, producing
+    // false session-wait warnings on non-commit runs with empty hooksPath.
     let has_hookspath = stderr.contains(LEFTHOOK_CORE_HOOKSPATH_CONFLICT)
         || stdout.contains(LEFTHOOK_CORE_HOOKSPATH_CONFLICT);
     if !has_hookspath {
         return None;
     }
-    // Require evidence of an actual commit attempt. The lefthook error message
-    // always includes `git config --unset-all` when it blocks a commit, so we
-    // match that specific command rather than the generic word "unset" which
-    // could appear in unrelated output. We also accept `git commit`,
-    // `lefthook run`, and standard hook names.
     let combined = format!("{}\n{}", stderr, stdout).to_ascii_lowercase();
     let has_commit_context = combined.contains("git commit")
         || combined.contains("lefthook run")
         || combined.contains("pre-commit")
-        || combined.contains("commit-msg")
-        || combined.contains("git config --unset-all --local core.hookspath");
+        || combined.contains("commit-msg");
     if has_commit_context {
         return Some(HINT_LEFTHOOK_CORE_HOOKSPATH_CONFLICT);
     }
@@ -376,6 +374,7 @@ mod tests {
 Error: core.hooksPath is set locally to '/x/.git/hooks'
 hint: Unset it:
 hint:   git config --unset-all --local core.hooksPath
+git commit failed during pre-commit
 "#;
         let hint = lefthook_core_hookspath_conflict_hint(stderr, "").unwrap();
         assert!(
@@ -407,25 +406,41 @@ hint:   git config --unset-all --local core.hooksPath
     }
 
     #[test]
-    fn lefthook_core_hookspath_conflict_hint_suppressed_with_generic_unset_text() {
-        // Lefthook diagnostic text contains "Unset it" and ".git/hooks" but no
-        // actual commit attempt — should NOT emit hint (#2055 R2)
+    fn lefthook_core_hookspath_conflict_hint_suppressed_with_unset_template_only() {
+        // Lefthook diagnostic text includes the unset-all template without any
+        // actual commit attempt — must NOT emit the session-wait hint (#2729).
         let stderr = "Error: core.hooksPath is set locally to '/x/.git/hooks'\nhint: Unset it:\nhint:   git config --unset-all --local core.hooksPath\n";
-        // This stderr DOES contain the unset-all command, so it DOES match.
-        // Verify the hint fires correctly here (this is a real commit failure).
         let hint = lefthook_core_hookspath_conflict_hint(stderr, "");
         assert!(
-            hint.is_some(),
-            "hint should fire when git config --unset-all appears"
+            hint.is_none(),
+            "hint must not fire for hooksPath diagnostic template alone (#2729)"
         );
 
-        // But stderr with just "Unset it" without the full command should NOT fire
+        // And stderr with just "Unset it" without commit context should still not fire
         let stderr2 = "core.hooksPath is set locally\nhint: Unset it\nsome other output";
         let hint2 = lefthook_core_hookspath_conflict_hint(stderr2, "");
         assert!(
             hint2.is_none(),
             "hint should be suppressed for generic 'Unset it' without commit command"
         );
+    }
+
+    #[test]
+    fn lefthook_core_hookspath_conflict_hint_suppressed_on_non_commit_run_noise() {
+        // Non-commit run: hooksPath diagnostic phrase with zero staged work and
+        // no commit/hook invocation evidence — session wait must stay quiet (#2729).
+        let stderr = "core.hooksPath is set locally\noutput generated successfully\n0 staged paths";
+        let hint = lefthook_core_hookspath_conflict_hint(stderr, "");
+        assert!(
+            hint.is_none(),
+            "non-commit noise must not force a false positive"
+        );
+        // Positive control: real commit attempt still fires.
+        let real = lefthook_core_hookspath_conflict_hint(
+            "Error: core.hooksPath is set locally to '/x/.git/hooks'\npre-commit hook failed\n",
+            "",
+        );
+        assert!(real.is_some(), "pre-commit context should emit the hint");
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -528,10 +528,17 @@ fn resolved_filesystem_capability(
         })
 }
 
+/// Canonical primary-failure / status reason for pre-provider slot capacity exhaustion.
+pub(crate) const SLOT_UNAVAILABLE_REASON: &str = "slot_unavailable";
+
 /// Acquire global concurrency slot for the executor.
 ///
 /// Returns ToolSlot guard on success.
 /// Returns error if all slots occupied (no failover here).
+///
+/// Recovery guidance stays generic: callers may pin a tool with
+/// `--no-failover` / force-ignore, so the message must not imply that
+/// switching tools is always valid (#2718).
 #[tracing::instrument(skip_all, fields(tool = %executor.tool_name()))]
 pub(crate) fn acquire_slot(
     executor: &Executor,
@@ -544,7 +551,7 @@ pub(crate) fn acquire_slot(
         Ok(csa_lock::slot::SlotAcquireResult::Acquired(slot)) => Ok(slot),
         Ok(csa_lock::slot::SlotAcquireResult::Exhausted(status)) => {
             anyhow::bail!(
-                "All {} slots for '{}' occupied ({}/{}). Try again later or use --tool to switch.",
+                "All {} slots for '{}' occupied ({}/{}). Retry later, free slots with `csa gc`, or wait for an in-flight session to finish.",
                 max_concurrent,
                 executor.tool_name(),
                 status.occupied,
@@ -557,6 +564,18 @@ pub(crate) fn acquire_slot(
             e
         ),
     }
+}
+
+/// Detect local tool-slot capacity exhaustion in error text (pre-provider).
+pub(crate) fn is_slot_unavailable_error_text(error_text: &str) -> bool {
+    let lower = error_text.to_ascii_lowercase();
+    if lower.contains(SLOT_UNAVAILABLE_REASON) {
+        return true;
+    }
+    let mentions_slots = lower.contains("slots for") || lower.contains("slot");
+    let exhausted =
+        lower.contains("occupied") || lower.contains("exhaust") || lower.contains("unavailable");
+    mentions_slots && exhausted && (lower.contains("all ") || lower.contains("slot_unavailable"))
 }
 
 /// Execution result with the resolved CSA meta session ID used by this run.

--- a/crates/cli-sub-agent/src/pipeline_post_exec_lefthook.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec_lefthook.rs
@@ -54,7 +54,7 @@ mod tests {
     #[test]
     fn records_core_hookspath_conflict_hint_in_session_result_warnings() {
         let mut execution = csa_process::ExecutionResult {
-            stderr_output: "Error: core.hooksPath is set locally to '/x/.git/hooks'\nhint: Unset it:\nhint:   git config --unset-all --local core.hooksPath\n".to_string(),
+            stderr_output: "Error: core.hooksPath is set locally to '/x/.git/hooks'\nhint: Unset it:\nhint:   git config --unset-all --local core.hooksPath\ngit commit failed\n".to_string(),
             exit_code: 1,
             summary: "git commit failed".to_string(),
             ..Default::default()
@@ -82,6 +82,25 @@ mod tests {
                 .contains("git config --unset-all --local core.hooksPath"),
             "stderr should include actionable hint: {}",
             execution.stderr_output
+        );
+    }
+
+    #[test]
+    fn ignores_hookspath_template_without_commit_attempt() {
+        let mut execution = csa_process::ExecutionResult {
+            stderr_output: "Error: core.hooksPath is set locally to '/x/.git/hooks'\nhint: Unset it:\nhint:   git config --unset-all --local core.hooksPath\n".to_string(),
+            exit_code: 0,
+            summary: "non-commit success".to_string(),
+            ..Default::default()
+        };
+        let mut result = session_result();
+
+        maybe_record_core_hookspath_conflict(&mut execution, &mut result);
+
+        assert!(
+            result.warnings.is_empty(),
+            "non-commit hooksPath template alone must not warn: {:?}",
+            result.warnings
         );
     }
 

--- a/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failover_classification_tests.rs
@@ -90,6 +90,26 @@ fn classify_review_failover_error_detects_memory_soft_limit_admission() {
 }
 
 #[test]
+fn classify_no_provider_launch_error_text_detects_slot_unavailable() {
+    assert_eq!(
+        classify_no_provider_launch_error_text(
+            "All 5 slots for 'codex' occupied (5/5). Retry later, free slots with `csa gc`, or wait for an in-flight session to finish."
+        ),
+        Some(crate::pipeline::SLOT_UNAVAILABLE_REASON)
+    );
+    assert_eq!(
+        classify_no_provider_launch_error_text(
+            "All 5 slots for 'codex' occupied (5/5). Try again later or use --tool to switch."
+        ),
+        Some(crate::pipeline::SLOT_UNAVAILABLE_REASON)
+    );
+    assert_ne!(
+        classify_no_provider_launch_error_text("tool launch metadata missing"),
+        Some(crate::pipeline::SLOT_UNAVAILABLE_REASON)
+    );
+}
+
+#[test]
 fn classify_review_failover_error_detects_host_memory_admission() {
     let failure = classify_review_failover_error(
         ToolName::Codex,

--- a/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
+++ b/crates/cli-sub-agent/src/review_cmd_execute_failures.rs
@@ -106,6 +106,9 @@ fn classify_memory_admission_error_text(error_text: &str) -> Option<&'static str
 }
 
 pub(super) fn classify_no_provider_launch_error_text(error_text: &str) -> Option<&'static str> {
+    if crate::pipeline::is_slot_unavailable_error_text(error_text) {
+        return Some(crate::pipeline::SLOT_UNAVAILABLE_REASON);
+    }
     classify_memory_admission_error_text(error_text)
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_fix.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix.rs
@@ -43,6 +43,9 @@ use noop::{FixNoOpProbe, apply_fix_loop_noop_signal, is_fix_loop_noop_failure_re
 #[cfg(test)]
 pub(super) use prompt::build_codex_single_fix_prompt;
 use prompt::build_fix_prompt;
+pub(super) use prompt::{
+    load_fix_findings_toml_for_fix_finding, render_fix_findings_summary_for_fix_finding,
+};
 
 /// Context for review fix-loop execution.
 pub(crate) struct FixLoopContext<'a> {

--- a/crates/cli-sub-agent/src/review_cmd_fix_finding.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_finding.rs
@@ -16,7 +16,10 @@ use super::post_review::CONFIRM_THEN_FIX_FINDING_ACTION;
 
 #[path = "review_cmd_fix_finding_prompt.rs"]
 mod prompt;
-use prompt::{build_fix_finding_prompt, resolve_fix_finding_prompt};
+use prompt::{
+    build_fix_finding_prompt, ensure_fix_finding_prompt_available,
+    resolve_fix_finding_prompt_before_daemon,
+};
 
 const FIX_FINDING_TASK_TYPE: &str = "review_fix_finding";
 
@@ -66,6 +69,10 @@ pub(crate) fn validate_fix_finding_before_daemon(args: &ReviewArgs) -> Result<()
         project_config.as_ref(),
         &global_config,
     )?;
+    // Fail closed with documented prompt requirements before daemon spawn / SA
+    // guard. Prefer deriving an unambiguous source finding without consuming
+    // stdin (daemon children resolve the final prompt body themselves).
+    ensure_fix_finding_prompt_available(args, &project_root, &route.session_id)?;
     Ok(())
 }
 
@@ -87,7 +94,8 @@ pub(crate) async fn handle_fix_finding(
     let route = load_fix_finding_route(project_root, session_ref)?;
     validate_fix_finding_route(project_root, &route, config.as_ref(), &global_config)?;
 
-    let caller_prompt = resolve_fix_finding_prompt(&args)?;
+    let caller_prompt =
+        resolve_fix_finding_prompt_before_daemon(&args, project_root, &route.session_id)?;
     let prompt = build_fix_finding_prompt(&caller_prompt);
     let fix_session_id = create_fix_finding_session(project_root, &route)?;
     let stream_mode =

--- a/crates/cli-sub-agent/src/review_cmd_fix_finding_prompt.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_finding_prompt.rs
@@ -1,4 +1,5 @@
 use std::io::{IsTerminal, Read};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 
@@ -6,19 +7,66 @@ use crate::cli::ReviewArgs;
 
 use super::super::resolve::ANTI_RECURSION_PREAMBLE;
 
-pub(super) fn resolve_fix_finding_prompt(args: &ReviewArgs) -> Result<String> {
+/// Resolve the caller-confirmed fix prompt for execution.
+///
+/// Prefer an explicit `--prompt` / `--prompt-file` / non-empty stdin body.
+/// When those are omitted and the source review has an unambiguous structured
+/// findings.toml, derive a confirmed-findings prompt from that artifact (#2654).
+pub(super) fn resolve_fix_finding_prompt_before_daemon(
+    args: &ReviewArgs,
+    project_root: &Path,
+    session_id: &str,
+) -> Result<String> {
     let mut stdin = std::io::stdin();
-    resolve_fix_finding_prompt_from_reader(args, stdin.is_terminal(), &mut stdin)
+    resolve_fix_finding_prompt_from_reader_with_session(
+        args,
+        stdin.is_terminal(),
+        &mut stdin,
+        Some((project_root, session_id)),
+    )
 }
 
-fn resolve_fix_finding_prompt_from_reader<R: Read>(
+/// Preflight check that does not consume stdin (so daemon spawn can still
+/// forward an explicit `--prompt-file -` body). When no explicit prompt is
+/// supplied, require an unambiguous source findings.toml so the child can
+/// derive the confirmed finding without undocumented empty-stdin failure.
+pub(super) fn ensure_fix_finding_prompt_available(
+    args: &ReviewArgs,
+    project_root: &Path,
+    session_id: &str,
+) -> Result<()> {
+    if let Some(path) = args.prompt_file.as_deref() {
+        if crate::run_helpers::is_prompt_file_stdin_sentinel(path) {
+            return Ok(());
+        }
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("--prompt-file: failed to read '{}'", path.display()))?;
+        if content.trim().is_empty() {
+            anyhow::bail!("--prompt-file '{}' is empty", path.display());
+        }
+        return Ok(());
+    }
+    if let Some(prompt) = args.prompt.as_deref() {
+        if prompt.trim().is_empty() {
+            anyhow::bail!("--fix-finding --prompt must not be empty.");
+        }
+        return Ok(());
+    }
+    if derive_prompt_from_source_findings(project_root, session_id).is_some() {
+        return Ok(());
+    }
+    Err(missing_fix_finding_prompt_error(false))
+}
+
+fn resolve_fix_finding_prompt_from_reader_with_session<R: Read>(
     args: &ReviewArgs,
     stdin_is_terminal: bool,
     reader: &mut R,
+    source_session: Option<(&Path, &str)>,
 ) -> Result<String> {
     if let Some(path) = args.prompt_file.as_deref() {
         if crate::run_helpers::is_prompt_file_stdin_sentinel(path) {
-            return read_fix_finding_stdin(stdin_is_terminal, reader);
+            return read_fix_finding_stdin(stdin_is_terminal, reader, source_session);
         }
         let content = std::fs::read_to_string(path)
             .with_context(|| format!("--prompt-file: failed to read '{}'", path.display()))?;
@@ -33,22 +81,99 @@ fn resolve_fix_finding_prompt_from_reader<R: Read>(
         }
         return Ok(prompt.to_string());
     }
-    read_fix_finding_stdin(stdin_is_terminal, reader)
+    if !stdin_is_terminal {
+        match read_optional_fix_finding_stdin(reader)? {
+            Some(prompt) => return Ok(prompt),
+            None => {
+                if let Some((project_root, session_id)) = source_session
+                    && let Some(derived) =
+                        derive_prompt_from_source_findings(project_root, session_id)
+                {
+                    return Ok(derived);
+                }
+                return Err(missing_fix_finding_prompt_error(true));
+            }
+        }
+    }
+    if let Some((project_root, session_id)) = source_session
+        && let Some(derived) = derive_prompt_from_source_findings(project_root, session_id)
+    {
+        return Ok(derived);
+    }
+    Err(missing_fix_finding_prompt_error(false))
 }
 
-fn read_fix_finding_stdin<R: Read>(stdin_is_terminal: bool, reader: &mut R) -> Result<String> {
+fn read_fix_finding_stdin<R: Read>(
+    stdin_is_terminal: bool,
+    reader: &mut R,
+    source_session: Option<(&Path, &str)>,
+) -> Result<String> {
     if stdin_is_terminal {
-        anyhow::bail!(
-            "No fix prompt provided and stdin is a terminal.\n\n\
-             Usage:\n  csa review --fix-finding --session FAILED_REVIEW_SESSION_ID --prompt \"confirmed fix instructions\"\n  csa review --fix-finding --session FAILED_REVIEW_SESSION_ID --prompt-file FIX_PROMPT.md\n  echo \"confirmed fix instructions\" | csa review --fix-finding --session FAILED_REVIEW_SESSION_ID"
-        );
+        if let Some((project_root, session_id)) = source_session
+            && let Some(derived) = derive_prompt_from_source_findings(project_root, session_id)
+        {
+            return Ok(derived);
+        }
+        return Err(missing_fix_finding_prompt_error(false));
     }
+    match read_optional_fix_finding_stdin(reader)? {
+        Some(prompt) => Ok(prompt),
+        None => {
+            if let Some((project_root, session_id)) = source_session
+                && let Some(derived) = derive_prompt_from_source_findings(project_root, session_id)
+            {
+                return Ok(derived);
+            }
+            Err(missing_fix_finding_prompt_error(true))
+        }
+    }
+}
+
+fn read_optional_fix_finding_stdin<R: Read>(reader: &mut R) -> Result<Option<String>> {
     let mut buffer = String::new();
     reader.read_to_string(&mut buffer)?;
     if buffer.trim().is_empty() {
-        anyhow::bail!("Empty fix prompt from stdin. Provide a non-empty prompt.");
+        Ok(None)
+    } else {
+        Ok(Some(buffer))
     }
-    Ok(buffer)
+}
+
+fn derive_prompt_from_source_findings(project_root: &Path, session_id: &str) -> Option<String> {
+    let findings =
+        super::super::fix::load_fix_findings_toml_for_fix_finding(project_root, session_id)?;
+    if findings.findings.is_empty() {
+        return None;
+    }
+    // Unambiguous: a single structured finding can be applied without caller text.
+    // Multiple findings still require an explicit caller-confirmed selection.
+    if findings.findings.len() != 1 {
+        return None;
+    }
+    let summary = super::super::fix::render_fix_findings_summary_for_fix_finding(&findings);
+    Some(format!(
+        "Caller confirmed the single structured review finding below is not a false positive.\n\
+         Apply only that finding.\n\n\
+         {summary}"
+    ))
+}
+
+fn missing_fix_finding_prompt_error(empty_stdin: bool) -> anyhow::Error {
+    let header = if empty_stdin {
+        "Empty fix prompt from stdin."
+    } else {
+        "No fix prompt provided and stdin is a terminal."
+    };
+    anyhow::anyhow!(
+        "{header} Provide a non-empty caller-confirmed prompt, or rely on a single unambiguous finding in the source review's output/findings.toml.\n\n\
+         Usage:\n  \
+         csa review --fix-finding --session FAILED_REVIEW_SESSION_ID --prompt \"confirmed fix instructions\"\n  \
+         csa review --fix-finding --session FAILED_REVIEW_SESSION_ID --prompt-file FIX_PROMPT.md\n  \
+         echo \"confirmed fix instructions\" | csa review --fix-finding --session FAILED_REVIEW_SESSION_ID\n\n\
+         Stdin schema example (plain text):\n  \
+         Fix the confirmed HIGH finding in src/foo.rs: the retry loop must preserve the original error cause.\n\n\
+         When the source review has exactly one structured finding, `--fix-finding --session` may omit the prompt and will derive it from output/findings.toml."
+    )
 }
 
 pub(super) fn build_fix_finding_prompt(caller_prompt: &str) -> String {
@@ -166,7 +291,8 @@ mod tests {
         let mut input = "fix the confirmed finding\n".as_bytes();
 
         let prompt =
-            resolve_fix_finding_prompt_from_reader(&args, false, &mut input).expect("stdin prompt");
+            resolve_fix_finding_prompt_from_reader_with_session(&args, false, &mut input, None)
+                .expect("stdin prompt");
 
         assert_eq!(prompt, "fix the confirmed finding\n");
     }
@@ -177,11 +303,74 @@ mod tests {
         args.session = Some("01TESTFIXFINDINGPROMPT1".to_string());
         let mut input = "".as_bytes();
 
-        let err = resolve_fix_finding_prompt_from_reader(&args, true, &mut input)
-            .expect_err("terminal stdin requires explicit prompt");
+        let err =
+            resolve_fix_finding_prompt_from_reader_with_session(&args, true, &mut input, None)
+                .expect_err("terminal stdin requires explicit prompt");
         let msg = format!("{err:#}");
 
         assert!(msg.contains("No fix prompt provided"), "{msg}");
+        assert!(msg.contains("Stdin schema example"), "{msg}");
+        assert!(msg.contains("output/findings.toml"), "{msg}");
+    }
+
+    #[test]
+    fn fix_finding_prompt_rejects_empty_nonterminal_stdin_without_findings() {
+        let args = fix_finding_prompt_args();
+        let mut input = "".as_bytes();
+        let err =
+            resolve_fix_finding_prompt_from_reader_with_session(&args, false, &mut input, None)
+                .expect_err("empty stdin without findings must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Empty fix prompt from stdin"), "{msg}");
+        assert!(msg.contains("--prompt-file FIX_PROMPT.md"), "{msg}");
+    }
+
+    #[test]
+    fn fix_finding_prompt_derives_single_finding_from_source_session() {
+        let _config_home = ScopedEnvVarRestore::set("XDG_CONFIG_HOME", "/tmp/csa-test-config");
+        let project = tempfile::tempdir().unwrap();
+        let session = csa_session::create_session_fresh(
+            project.path(),
+            Some("review: files:src/lib.rs"),
+            None,
+            Some("codex"),
+        )
+        .unwrap();
+        let session_dir =
+            csa_session::get_session_dir(project.path(), &session.meta_session_id).unwrap();
+        let output = session_dir.join("output");
+        std::fs::create_dir_all(&output).unwrap();
+        std::fs::write(
+            output.join("findings.toml"),
+            r#"
+[[findings]]
+id = "F1"
+severity = "high"
+description = "retry loop drops the original error cause"
+file_ranges = [{ path = "src/lib.rs", start = 10, end = 20 }]
+"#,
+        )
+        .unwrap();
+
+        let mut args = fix_finding_prompt_args();
+        args.session = Some(session.meta_session_id.clone());
+        let mut input = "".as_bytes();
+        let prompt = resolve_fix_finding_prompt_from_reader_with_session(
+            &args,
+            true,
+            &mut input,
+            Some((project.path(), &session.meta_session_id)),
+        )
+        .expect("single finding should derive prompt");
+        assert!(
+            prompt.contains("single structured review finding"),
+            "{prompt}"
+        );
+        assert!(
+            prompt.contains("retry loop drops the original error cause"),
+            "{prompt}"
+        );
+        assert!(prompt.contains("src/lib.rs"), "{prompt}");
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/review_cmd_fix_prompt.rs
+++ b/crates/cli-sub-agent/src/review_cmd_fix_prompt.rs
@@ -61,6 +61,10 @@ pub(crate) fn build_codex_single_fix_prompt(
     )
 }
 
+pub(crate) fn render_fix_findings_summary_for_fix_finding(findings: &FindingsFile) -> String {
+    render_fix_findings_summary(findings)
+}
+
 fn render_fix_findings_summary(findings: &FindingsFile) -> String {
     let mut summary = String::new();
     for finding in &findings.findings {
@@ -140,6 +144,13 @@ fn longest_backtick_run(content: &str) -> usize {
         }
     }
     longest
+}
+
+pub(crate) fn load_fix_findings_toml_for_fix_finding(
+    project_root: &Path,
+    session_id: &str,
+) -> Option<FindingsFile> {
+    load_fix_findings_toml(project_root, session_id)
 }
 
 fn load_fix_findings_toml(project_root: &Path, session_id: &str) -> Option<FindingsFile> {

--- a/crates/cli-sub-agent/src/review_cmd_prior_rounds.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prior_rounds.rs
@@ -124,6 +124,8 @@ pub(super) fn persist_daemon_review_pre_exec_error(
 fn primary_failure_for_pre_exec_error(error_message: &str) -> &'static str {
     if error_message.contains("Direct --tool is restricted when tiers are configured") {
         "direct_tool_tier_restricted"
+    } else if crate::pipeline::is_slot_unavailable_error_text(error_message) {
+        crate::pipeline::SLOT_UNAVAILABLE_REASON
     } else {
         "review_pre_exec_error"
     }

--- a/crates/cli-sub-agent/src/run_cmd_daemon_review.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_review.rs
@@ -6,13 +6,16 @@ impl DaemonSpawnOptions {
     pub(crate) fn for_review_fix_finding(prompt: Option<&str>, prompt_file: Option<&Path>) -> Self {
         let prompt_file_is_stdin =
             prompt_file.is_some_and(crate::run_helpers::is_prompt_file_stdin_sentinel);
+        // When the caller omits --prompt/--prompt-file, the child may derive an
+        // unambiguous prompt from the source review's findings.toml (#2654).
+        // Do not force a parent-side empty-stdin failure in that case.
+        // Explicit `--prompt-file -` still requests stdin via PromptFileSentinel.
         let run_stdin_prompt = if prompt_file_is_stdin {
             RunStdinPrompt::PromptFileSentinel
-        } else if prompt.is_some() || prompt_file.is_some() {
-            RunStdinPrompt::None
         } else {
-            RunStdinPrompt::Omitted
+            RunStdinPrompt::None
         };
+        let _ = (prompt, prompt_file);
 
         Self {
             run_stdin_prompt,

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1108"
-weave = "0.1.1108"
+csa = "0.1.1109"
+weave = "0.1.1109"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
Three S-complexity fixes.

### #2718
Codex slot exhaustion (`All 5 slots occupied`) was masked as `tool_launch_metadata_absent`. Now preserved as primary `slot_unavailable` diagnostic with generic retry guidance (no `--tool` switch suggestion when pinned/no-failover).

### #2729
`session wait` emitted false `core.hooksPath` commit-blocked hint on non-commit runs (0 staged paths, empty hooksPath). Hint now only fires with real commit context (`git commit` / `lefthook run` / `pre-commit` / `commit-msg`).

### #2654
`csa review --fix-finding` failed with `Empty prompt from stdin` without documenting the requirement. Now derives prompt from single unambiguous source `findings.toml`; else documents stdin schema in help + fails validation early with clear example.

## Validation
- Focused tests green for all three
- Pre-push `quality-gates` PASS on `2e502a17` (~1297s)

Closes #2718
Closes #2729
Closes #2654