### PR TITLE
fix: clarify review --commit base scope + infer prior tier on resume (#2829 #2811)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1109"
+version = "0.1.1110"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1109"
+version = "0.1.1110"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -200,7 +200,9 @@ pub struct ReviewArgs {
     #[arg(long, conflicts_with_all = ["diff", "commit", "range", "files"])]
     pub branch: Option<String>,
 
-    /// Review specific commit
+    /// Review one commit's diff (`<sha>^..<sha>`). `--base` is not accepted in this mode.
+    /// Merge commits are rejected because their base is ambiguous; use `--range main...HEAD`
+    /// (or another explicit range) when the desired base is not the commit's first parent.
     #[arg(long)]
     pub commit: Option<String>,
 

--- a/crates/cli-sub-agent/src/review_cmd_handle.rs
+++ b/crates/cli-sub-agent/src/review_cmd_handle.rs
@@ -17,6 +17,9 @@ async fn handle_review_inner(
         return review_convergence::emit_report_only(args.range.as_deref());
     }
     validate_review_prompt_file(args.prompt_file.as_deref())?;
+    if let Some(commit) = args.commit.as_deref() {
+        super::resolve::validate_single_parent_commit_scope(&project_root, commit)?;
+    }
     let project_root_for_hooks = project_root.display().to_string();
     let Some((config, global_config, model_catalog, project_completion_policy)) =
         crate::pipeline::load_and_validate(&project_root, current_depth)?

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -321,7 +321,10 @@ Reason: CSA enforces heterogeneity in auto mode and will not fall back."
 mod scope;
 #[cfg(test)]
 pub(crate) use scope::derive_scope;
-pub(crate) use scope::{derive_scope_for_project, review_scope_allows_auto_discovery};
+pub(crate) use scope::{
+    derive_scope_for_project, review_scope_allows_auto_discovery,
+    validate_single_parent_commit_scope,
+};
 
 /// Review-only safety preamble injected into every review subprocess prompt.
 ///

--- a/crates/cli-sub-agent/src/review_cmd_resolve_scope.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve_scope.rs
@@ -35,6 +35,40 @@ pub(crate) fn derive_scope_for_project(args: &ReviewArgs, project_root: &Path) -
     derive_diff_scope_for_project(project_root)
 }
 
+pub(crate) fn validate_single_parent_commit_scope(
+    project_root: &Path,
+    commit: &str,
+) -> anyhow::Result<()> {
+    let output = git_output_with_timeout(
+        project_root,
+        &["rev-list", "--parents", "-n", "1", commit],
+    )
+    .ok_or_else(|| {
+        anyhow::anyhow!(
+            "could not inspect --commit {commit}; use an explicit range such as --range main...HEAD"
+        )
+    })?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "could not inspect --commit {commit}; use an explicit range such as --range main...HEAD"
+        );
+    }
+
+    let parent_count = String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .skip(1)
+        .count();
+    if parent_count > 1 {
+        anyhow::bail!(
+            "--commit {commit} is a merge commit with {parent_count} parents. \
+             --commit reviews a single commit diff (<sha>^..<sha>), so its base would be ambiguous. \
+             Use an explicit range such as --range main...HEAD instead."
+        );
+    }
+
+    Ok(())
+}
+
 fn derive_diff_scope_for_project(project_root: &Path) -> String {
     if git_diff_has_output(project_root, &["diff", "HEAD"]).unwrap_or(true) {
         return "uncommitted".to_string();
@@ -157,6 +191,21 @@ pub(crate) fn review_scope_allows_auto_discovery(args: &ReviewArgs) -> bool {
 mod timeout_tests {
     use super::*;
 
+    fn run_git(project_root: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(project_root)
+            .output()
+            .expect("git command should start");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
     #[test]
     fn command_capture_returns_none_after_deadline() {
         let mut command = Command::new("sleep");
@@ -165,5 +214,38 @@ mod timeout_tests {
 
         assert!(run_command_with_timeout(&mut command, Duration::from_millis(20)).is_none());
         assert!(started.elapsed() < Duration::from_secs(2));
+    }
+
+    #[test]
+    fn merge_commit_scope_is_rejected_with_explicit_range_guidance() {
+        let project = tempfile::tempdir().expect("tempdir");
+        run_git(project.path(), &["init", "-b", "main"]);
+        run_git(
+            project.path(),
+            &["config", "user.email", "test@example.com"],
+        );
+        run_git(project.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(project.path().join("base.txt"), "base\n").expect("write base file");
+        run_git(project.path(), &["add", "base.txt"]);
+        run_git(project.path(), &["commit", "-m", "base"]);
+        run_git(project.path(), &["checkout", "-b", "topic"]);
+        std::fs::write(project.path().join("topic.txt"), "topic\n").expect("write topic file");
+        run_git(project.path(), &["add", "topic.txt"]);
+        run_git(project.path(), &["commit", "-m", "topic"]);
+        run_git(project.path(), &["checkout", "main"]);
+        std::fs::write(project.path().join("main.txt"), "main\n").expect("write main file");
+        run_git(project.path(), &["add", "main.txt"]);
+        run_git(project.path(), &["commit", "-m", "main"]);
+        run_git(
+            project.path(),
+            &["merge", "--no-ff", "topic", "-m", "merge topic"],
+        );
+        let merge_commit = run_git(project.path(), &["rev-parse", "HEAD"]);
+
+        let err = validate_single_parent_commit_scope(project.path(), &merge_commit)
+            .expect_err("merge commit scope must be rejected");
+        let message = err.to_string();
+        assert!(message.contains("merge commit"), "{message}");
+        assert!(message.contains("--range main...HEAD"), "{message}");
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -35,6 +35,8 @@ use crate::run_helpers_branch_guard::{
 use crate::startup_env::StartupSubtreeEnv;
 #[path = "run_cmd_execute_post_exec_gate.rs"]
 mod post_exec_gate;
+#[path = "run_cmd_execute_resume_tier.rs"]
+mod resume_tier;
 #[path = "run_cmd_execute_reuse_hint.rs"]
 mod reuse_hint;
 #[path = "run_cmd_execute_routing.rs"]
@@ -53,6 +55,7 @@ use post_exec_gate::{
     PostExecGateApplyOptions, apply_post_exec_gate_after_success_with_runner,
     execute_post_exec_gate_command,
 };
+use resume_tier::infer_resume_tier_for_matching_tool;
 use reuse_hint::emit_reusable_session_hint;
 use routing::{
     RunModelSelectionFlags, resolve_primary_writer_spec_for_run, resolve_run_effective_tier,

--- a/crates/cli-sub-agent/src/run_cmd_execute_handle.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_handle.rs
@@ -63,6 +63,7 @@ pub(crate) async fn handle_run(
     let mut tier = tier;
     let mut force_ignore_tier_setting = force_ignore_tier_setting;
     let mut no_failover = no_failover;
+    let explicit_session_requested = session_arg.is_some();
 
     let project_root = pipeline::determine_project_root(cd.as_deref())?;
     let effective_repo =
@@ -153,6 +154,14 @@ pub(crate) async fn handle_run(
     )?;
     let pre_session_hook = csa_hooks::load_global_pre_session_hook_invocation();
     let cli_tool_arg = tool.clone();
+    if explicit_session_requested && !is_fork && tier.is_none() {
+        tier = infer_resume_tier_for_matching_tool(
+            &project_root,
+            config.as_ref(),
+            session_arg.as_deref(),
+            cli_tool_arg.as_ref(),
+        );
+    }
     let mut user_explicit_tool = tool.is_some();
     let prompt = resolve_positional_stdin_sentinel(prompt)?.or(prompt_flag);
 

--- a/crates/cli-sub-agent/src/run_cmd_execute_resume_tier.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_resume_tier.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+use csa_config::ProjectConfig;
+use csa_core::types::ToolArg;
+
+/// Reuse a tier only when an explicit resume names the same tool recorded in
+/// the existing session. Other tool selectors remain fresh routing requests.
+pub(super) fn infer_resume_tier_for_matching_tool(
+    project_root: &Path,
+    config: Option<&ProjectConfig>,
+    session_ref: Option<&str>,
+    tool_arg: Option<&ToolArg>,
+) -> Option<String> {
+    let config = config?;
+    let session_ref = session_ref?;
+    let tool_name = match tool_arg? {
+        ToolArg::Specific(tool) => tool.as_str(),
+        ToolArg::Auto | ToolArg::AnyAvailable | ToolArg::Alias(_) => return None,
+    };
+    let resolution =
+        csa_session::resolve_resume_session(project_root, session_ref, tool_name).ok()?;
+    let session = csa_session::load_session(project_root, &resolution.meta_session_id).ok()?;
+    let tier_name = session.task_context.tier_name?;
+
+    session
+        .tools
+        .contains_key(tool_name)
+        .then(|| config.resolve_tier_selector(&tier_name))
+        .flatten()
+}

--- a/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tier_tests.rs
@@ -197,3 +197,151 @@ async fn handle_run_persists_result_for_direct_tool_tier_rejection() {
     assert!(result.summary.contains("pre-exec:"));
     assert!(result.summary.contains("Direct --tool is blocked"));
 }
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn handle_run_reuses_matching_session_tier_for_direct_tool() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let project_dir = tempfile::Builder::new()
+        .prefix("csa-resume-tier-2811")
+        .tempdir()
+        .unwrap();
+    let mut sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    sandbox.track_env(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV);
+    sandbox.track_env("PATH");
+    // SAFETY: ScopedSessionSandbox holds TEST_ENV_LOCK for the full test.
+    unsafe {
+        std::env::set_var(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    }
+    let bin_dir = project_dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let fake_codex = bin_dir.join("codex");
+    let execution_marker = bin_dir.join("codex.executed");
+    std::fs::write(&fake_codex, "#!/bin/sh\n: > \"$0.executed\"\nexit 0\n").unwrap();
+    let mut permissions = std::fs::metadata(&fake_codex).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_codex, permissions).unwrap();
+    let inherited_path = std::env::var("PATH").unwrap_or_default();
+    // SAFETY: ScopedSessionSandbox holds TEST_ENV_LOCK for the full test.
+    unsafe {
+        std::env::set_var("PATH", format!("{}:{inherited_path}", bin_dir.display()));
+    }
+
+    let config = run_config_with_tier(
+        "tier-3-complex",
+        vec!["codex/openai/gpt-5.5/high"],
+        &["codex"],
+    );
+    write_project_config(project_dir.path(), &config);
+    let mut resumed_session = csa_session::create_session(
+        project_dir.path(),
+        Some("tiered session"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    resumed_session.task_context = csa_session::TaskContext {
+        task_type: Some("run".to_string()),
+        tier_name: Some("tier-3-complex".to_string()),
+    };
+    resumed_session.tools.insert(
+        "codex".to_string(),
+        csa_session::ToolState {
+            provider_session_id: Some("prior-codex-session".to_string()),
+            last_action_summary: "prior tiered run".to_string(),
+            last_exit_code: 0,
+            updated_at: chrono::Utc::now(),
+            tool_version: None,
+            token_usage: None,
+        },
+    );
+    csa_session::save_session(&resumed_session).unwrap();
+
+    let lock_holder =
+        csa_session::create_session(project_dir.path(), Some("lock holder"), None, Some("codex"))
+            .unwrap();
+    let _holder_lock = csa_lock::acquire_worktree_write_lock(
+        project_dir.path(),
+        &lock_holder.meta_session_id,
+        &[],
+        |_| false,
+        |_| false,
+        |_| false,
+    )
+    .expect("holder worktree write lock should succeed");
+
+    let err = handle_run(
+        Some(ToolArg::Specific(ToolName::Codex)),
+        None,
+        None,
+        None,
+        Some("fix the repository".to_string()),
+        None,
+        None,
+        None,
+        Some(resumed_session.meta_session_id.clone()),
+        false,
+        None,
+        false,
+        false,
+        None,
+        false,
+        None,
+        None,
+        false,
+        true,
+        Some(project_dir.path().display().to_string()),
+        None,
+        None,
+        None,
+        false,
+        false,
+        false,
+        false,
+        false,
+        None,
+        crate::run_resource_overrides::RunResourceOverrides::absent(),
+        false,
+        None,
+        None,
+        None,
+        false,
+        false,
+        None,
+        0,
+        OutputFormat::Text,
+        csa_process::StreamMode::BufferOnly,
+        None,
+        false,
+        false,
+        false,
+        None,
+        false,
+        true,
+        false,
+        false,
+        false,
+        Vec::new(),
+        Vec::new(),
+        crate::startup_env::StartupSubtreeEnv::default(),
+    )
+    .await
+    .expect_err("worktree lock should stop the resumed run before tool execution");
+    let message = err
+        .chain()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        !execution_marker.exists(),
+        "Codex must not execute when worktree preflight fails: {}",
+        execution_marker.display()
+    );
+    assert!(
+        message.contains("concurrent write session blocked"),
+        "matching tiered session should bypass the direct-tool policy: {message}"
+    );
+    assert!(message.contains(&lock_holder.meta_session_id), "{message}");
+}

--- a/crates/cli-sub-agent/tests/e2e.rs
+++ b/crates/cli-sub-agent/tests/e2e.rs
@@ -689,6 +689,10 @@ fn review_help_shows_options() {
     assert!(stdout.contains("--diff"));
     assert!(stdout.contains("--branch"));
     assert!(stdout.contains("--commit"));
+    assert!(stdout.contains("<sha>^..<sha>"));
+    assert!(stdout.contains("--base"));
+    assert!(stdout.contains("not accepted"));
+    assert!(stdout.contains("--range main...HEAD"));
     assert!(stdout.contains("--model"));
 }
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1109"
-weave = "0.1.1109"
+csa = "0.1.1110"
+weave = "0.1.1110"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
Two S-complexity UX fixes.

### #2829
`csa review --commit <sha>` now documents that it reviews `<sha>^..<sha>` and that `--base` is not accepted in that mode. Merge commits are rejected with a diagnostic suggesting explicit `--range main...HEAD`.

### #2811
Resuming a tiered session with `--session <id> --tool <tool>` no longer fails with "Direct --tool is blocked when tiers are configured." When the session + tool unambiguously match the prior routing context, the prior tier is inferred automatically.

## Validation
- Focused tests green for both fixes
- Pre-push `quality-gates` PASS on `8fc04e15` (~1278s)

Closes #2829
Closes #2811