### PR TITLE
fix: stop lefthook.yml injection + dynamic memory projection (#2836 #2818 #2828)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1110"
+version = "0.1.1111"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1110"
+version = "0.1.1111"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/resource_admission.rs
+++ b/crates/cli-sub-agent/src/resource_admission.rs
@@ -37,15 +37,11 @@ enum SessionMemorySample {
     Unavailable,
 }
 
-#[cfg(test)]
-pub(crate) fn spawn_memory_projection_mb(config: Option<&ProjectConfig>, tool_name: &str) -> u64 {
-    spawn_memory_projection_mb_with_overrides(config, tool_name, RunResourceOverrides::absent())
-}
-
-pub(crate) fn spawn_memory_projection_mb_with_overrides(
+fn spawn_memory_projection_mb_for_physical_available(
     config: Option<&ProjectConfig>,
     tool_name: &str,
     resource_overrides: RunResourceOverrides,
+    physical_available_mb: u64,
 ) -> u64 {
     let configured_projection_mb = resource_overrides
         .resolve_memory_max_mb(config, tool_name)
@@ -58,11 +54,32 @@ pub(crate) fn spawn_memory_projection_mb_with_overrides(
         return configured_projection_mb;
     }
 
-    let mut resource_guard = ResourceGuard::new(ResourceLimits::default());
     bound_default_spawn_projection_mb(
         configured_projection_mb,
-        resource_guard.available_physical_memory_mb(),
+        physical_available_mb,
         resource_overrides.resolve_min_free_memory_mb(config),
+    )
+}
+
+pub(crate) fn spawn_memory_projection_mb_with_overrides(
+    config: Option<&ProjectConfig>,
+    tool_name: &str,
+    resource_overrides: RunResourceOverrides,
+) -> u64 {
+    if resource_overrides.has_memory_max_override()
+        || config_has_explicit_memory_max_mb(config, tool_name)
+    {
+        return resource_overrides
+            .resolve_memory_max_mb(config, tool_name)
+            .unwrap_or(FALLBACK_SPAWN_PROJECTION_MB);
+    }
+
+    let mut resource_guard = ResourceGuard::new(ResourceLimits::default());
+    spawn_memory_projection_mb_for_physical_available(
+        config,
+        tool_name,
+        resource_overrides,
+        resource_guard.available_physical_memory_mb(),
     )
 }
 
@@ -391,7 +408,15 @@ mod tests {
         let cfg: ProjectConfig =
             toml::from_str("[resources]\nmemory_max_mb = 8192\n").expect("config should parse");
 
-        assert_eq!(spawn_memory_projection_mb(Some(&cfg), "codex"), 8192);
+        assert_eq!(
+            spawn_memory_projection_mb_for_physical_available(
+                Some(&cfg),
+                "codex",
+                RunResourceOverrides::absent(),
+                1,
+            ),
+            8192
+        );
     }
 
     #[test]
@@ -430,8 +455,15 @@ memory_max_mb = 16384
 
     #[test]
     fn spawn_projection_uses_tool_default_without_config() {
-        let projection_mb = spawn_memory_projection_mb(None, "codex");
-        assert!((MIN_DEFAULT_SPAWN_PROJECTION_MB..=16_384).contains(&projection_mb));
+        assert_eq!(
+            spawn_memory_projection_mb_for_physical_available(
+                None,
+                "codex",
+                RunResourceOverrides::absent(),
+                12_000,
+            ),
+            7904
+        );
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/resource_admission.rs
+++ b/crates/cli-sub-agent/src/resource_admission.rs
@@ -3,13 +3,14 @@ use std::{io, path::Path};
 use anyhow::Context;
 use chrono::{DateTime, TimeDelta, Utc};
 use csa_config::ProjectConfig;
-use csa_resource::SpawnMemoryAdmission;
+use csa_resource::{ResourceGuard, ResourceLimits, SpawnMemoryAdmission};
 use csa_session::{MetaSessionState, SandboxInfo, SessionPhase, SessionTreeMemorySampler};
 use tracing::warn;
 
 use crate::run_resource_overrides::RunResourceOverrides;
 
 const FALLBACK_SPAWN_PROJECTION_MB: u64 = 4096;
+const MIN_DEFAULT_SPAWN_PROJECTION_MB: u64 = 256;
 const RECENT_ACTIVE_FALLBACK_PROJECTION_MB: u64 = 4096;
 const RECENT_ACTIVE_FALLBACK_WINDOW_SECS: i64 = 15 * 60;
 const PRE_SPAWN_ADMISSION_MODE: &str = "admission";
@@ -46,9 +47,45 @@ pub(crate) fn spawn_memory_projection_mb_with_overrides(
     tool_name: &str,
     resource_overrides: RunResourceOverrides,
 ) -> u64 {
-    resource_overrides
+    let configured_projection_mb = resource_overrides
         .resolve_memory_max_mb(config, tool_name)
-        .unwrap_or(FALLBACK_SPAWN_PROJECTION_MB)
+        .unwrap_or(FALLBACK_SPAWN_PROJECTION_MB);
+    // Explicit command or config limits are user contracts; only profile defaults
+    // are reduced to the host's immediately safe launch envelope.
+    if resource_overrides.has_memory_max_override()
+        || config_has_explicit_memory_max_mb(config, tool_name)
+    {
+        return configured_projection_mb;
+    }
+
+    let mut resource_guard = ResourceGuard::new(ResourceLimits::default());
+    bound_default_spawn_projection_mb(
+        configured_projection_mb,
+        resource_guard.available_physical_memory_mb(),
+        resource_overrides.resolve_min_free_memory_mb(config),
+    )
+}
+
+fn config_has_explicit_memory_max_mb(config: Option<&ProjectConfig>, tool_name: &str) -> bool {
+    config.is_some_and(|cfg| {
+        cfg.tools
+            .get(tool_name)
+            .and_then(|tool| tool.memory_max_mb)
+            .is_some()
+            || cfg.resources.memory_max_mb.is_some()
+    })
+}
+
+fn bound_default_spawn_projection_mb(
+    configured_projection_mb: u64,
+    physical_available_mb: u64,
+    reserve_mb: u64,
+) -> u64 {
+    configured_projection_mb.min(
+        physical_available_mb
+            .saturating_sub(reserve_mb)
+            .max(MIN_DEFAULT_SPAWN_PROJECTION_MB),
+    )
 }
 
 pub(crate) fn persist_spawn_memory_projection(
@@ -375,8 +412,26 @@ memory_max_mb = 16384
     }
 
     #[test]
+    fn default_projection_is_bounded_by_physical_memory_after_reserve() {
+        assert_eq!(
+            bound_default_spawn_projection_mb(14_000, 12_000, 1024),
+            10_976
+        );
+        assert_eq!(
+            bound_default_spawn_projection_mb(14_000, 32_000, 1024),
+            14_000
+        );
+    }
+
+    #[test]
+    fn default_projection_uses_a_minimum_when_host_headroom_is_exhausted() {
+        assert_eq!(bound_default_spawn_projection_mb(14_000, 1024, 2048), 256);
+    }
+
+    #[test]
     fn spawn_projection_uses_tool_default_without_config() {
-        assert_eq!(spawn_memory_projection_mb(None, "codex"), 16_384);
+        let projection_mb = spawn_memory_projection_mb(None, "codex");
+        assert!((MIN_DEFAULT_SPAWN_PROJECTION_MB..=16_384).contains(&projection_mb));
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/setup_cmds.rs
+++ b/crates/cli-sub-agent/src/setup_cmds.rs
@@ -4,7 +4,6 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::SystemTime;
 use tracing::{debug, info, warn};
 
 /// Handle setup for Claude Code MCP integration
@@ -200,11 +199,6 @@ const REVIEW_CHECK_TEMPLATE: &str = include_str!("setup_cmds/review-check.sh");
 
 const REVIEW_GATE_INSTALL_MARKER: &str = "Installed by: csa setup review-gate";
 
-/// Rate-limit interval for auto-setup checks (1 hour).
-const REVIEW_GATE_CHECK_INTERVAL_SECS: u64 = 3600;
-/// Timestamp file name stored in the project state dir.
-const REVIEW_GATE_TIMESTAMP_FILE: &str = "review-gate-check-ts";
-
 /// Handle `csa setup review-gate [--check]`.
 pub(crate) fn handle_setup_review_gate(project_root: &Path, check: bool) -> Result<()> {
     if check {
@@ -242,39 +236,21 @@ pub(crate) fn spawn_review_gate_setup_if_needed(
         }
     }
 
-    let project_root = project_root.to_path_buf();
-    tokio::spawn(async move {
-        if let Err(e) = check_and_setup_review_gate_bg(&project_root).await {
-            debug!("review-gate auto-setup: background task failed: {e:#}");
-        }
-    });
+    auto_setup_review_gate(project_root);
 }
 
-/// Background async task: rate-limited auto-setup of the review gate.
-async fn check_and_setup_review_gate_bg(project_root: &Path) -> anyhow::Result<()> {
+/// Check launcher eligibility for the review gate without changing the repository.
+fn auto_setup_review_gate(project_root: &Path) {
     match review_gate_opt_in_signal(project_root) {
         Some(signal) => debug!("review-gate auto-setup: opt-in detected ({signal})"),
         None => {
             debug!("review-gate auto-setup: skipping (repo is not CSA-managed / opted in)");
-            return Ok(());
+            return;
         }
     }
-
-    let state_dir = csa_session::get_session_root(project_root)?;
-    let ts_path = state_dir.join(REVIEW_GATE_TIMESTAMP_FILE);
-
-    if !needs_review_gate_check(&ts_path)? {
-        debug!(
-            "review-gate auto-setup: skipped (checked < {REVIEW_GATE_CHECK_INTERVAL_SECS}s ago)"
-        );
-        return Ok(());
-    }
-    write_review_gate_timestamp(&ts_path)?;
-
-    info!("review-gate auto-setup: running setup");
-    install_review_gate(project_root, /*verbose=*/ false)?;
-    info!("review-gate auto-setup: complete");
-    Ok(())
+    // Launcher-to-provider handoff must not change the worktree. Explicit setup
+    // remains available for users who intentionally want repository hook changes.
+    info!("review-gate auto-setup: skipped; run `csa setup review-gate` explicitly");
 }
 
 pub(crate) fn review_gate_opt_in_signal(project_root: &Path) -> Option<&'static str> {
@@ -371,29 +347,6 @@ fn should_install_hook(
             }
         },
     }
-}
-
-/// Returns true when the timestamp file is absent or older than CHECK_INTERVAL_SECS.
-fn needs_review_gate_check(ts_path: &Path) -> anyhow::Result<bool> {
-    let metadata = match std::fs::metadata(ts_path) {
-        Ok(m) => m,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(true),
-        Err(e) => return Err(e.into()),
-    };
-    let modified = metadata.modified()?;
-    let age = SystemTime::now()
-        .duration_since(modified)
-        .unwrap_or(std::time::Duration::MAX);
-    Ok(age.as_secs() >= REVIEW_GATE_CHECK_INTERVAL_SECS)
-}
-
-/// Write (or touch) the rate-limit timestamp file.
-fn write_review_gate_timestamp(ts_path: &Path) -> anyhow::Result<()> {
-    if let Some(parent) = ts_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    std::fs::write(ts_path, b"")?;
-    Ok(())
 }
 
 /// Install all review gate components in `project_root`.

--- a/crates/cli-sub-agent/src/setup_cmds/review_gate_tests.rs
+++ b/crates/cli-sub-agent/src/setup_cmds/review_gate_tests.rs
@@ -110,33 +110,6 @@ where
     buffer.contents()
 }
 
-#[cfg(unix)]
-fn install_fake_lefthook(bin_dir: &Path, log_path: &Path) {
-    use std::os::unix::fs::PermissionsExt;
-
-    fs::create_dir_all(bin_dir).expect("create fake bin dir");
-    let fake = bin_dir.join("lefthook");
-    fs::write(
-        &fake,
-        format!(
-            "#!/bin/sh\n\
-printf '%s\\n' \"$PWD $*\" >> '{}'\n\
-mkdir -p .git/hooks\n\
-cat > .git/hooks/pre-push <<'HOOK'\n\
-#!/bin/sh\n\
-# lefthook test stub\n\
-HOOK\n",
-            log_path.display()
-        ),
-    )
-    .expect("write fake lefthook");
-    let mut perms = fs::metadata(&fake)
-        .expect("fake lefthook metadata")
-        .permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(fake, perms).expect("chmod fake lefthook");
-}
-
 #[test]
 fn adds_branch_protection_when_review_check_already_present() {
     let input =
@@ -491,29 +464,11 @@ fn untracked_different_branch_protection_without_marker_is_not_overwritten_and_w
 }
 
 #[test]
-fn needs_check_true_when_no_file() {
-    let td = TempDir::new().unwrap();
-    let ts = td.path().join(REVIEW_GATE_TIMESTAMP_FILE);
-    assert!(needs_review_gate_check(&ts).unwrap());
-}
-
-#[test]
-fn needs_check_false_after_recent_write() {
-    let td = TempDir::new().unwrap();
-    let ts = td.path().join(REVIEW_GATE_TIMESTAMP_FILE);
-    fs::write(&ts, b"").unwrap();
-    assert!(!needs_review_gate_check(&ts).unwrap());
-}
-
-#[tokio::test]
-async fn auto_setup_skips_repo_without_review_gate_opt_in() {
-    let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.lock().await;
+fn auto_setup_skips_repo_without_review_gate_opt_in() {
     let td = TempDir::new().expect("create tempdir");
     init_git_repo(td.path());
 
-    check_and_setup_review_gate_bg(td.path())
-        .await
-        .expect("skip should not fail");
+    auto_setup_review_gate(td.path());
 
     assert!(
         !td.path().join("lefthook.yml").exists(),
@@ -535,52 +490,37 @@ async fn auto_setup_skips_repo_without_review_gate_opt_in() {
     );
 }
 
-#[cfg(unix)]
-#[tokio::test]
-async fn auto_setup_installs_when_lefthook_yml_is_tracked() {
-    let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.lock().await;
+#[test]
+fn auto_setup_leaves_tracked_lefthook_yml_clean() {
     let td = TempDir::new().expect("create tempdir");
     init_git_repo(td.path());
-    track_file(td.path(), "lefthook.yml", "pre-commit:\n");
+    let original_lefthook = "pre-commit:\n";
+    track_file(td.path(), "lefthook.yml", original_lefthook);
 
-    let bin_dir = td.path().join("bin");
-    let log_path = td.path().join("lefthook.log");
-    install_fake_lefthook(&bin_dir, &log_path);
-    let inherited_path = std::env::var("PATH").unwrap_or_default();
-    let patched_path = format!("{}:{inherited_path}", bin_dir.display());
-    let _path_guard = crate::test_env_lock::ScopedEnvVarRestore::set("PATH", &patched_path);
+    auto_setup_review_gate(td.path());
 
-    check_and_setup_review_gate_bg(td.path())
-        .await
-        .expect("opted-in repo should install review gate");
-
-    let lefthook_yml =
-        fs::read_to_string(td.path().join("lefthook.yml")).expect("read updated lefthook.yml");
-    assert!(
-        lefthook_yml.contains("review-check:"),
-        "opted-in repo keeps existing merge behavior"
+    assert_eq!(
+        fs::read_to_string(td.path().join("lefthook.yml")).expect("read lefthook.yml"),
+        original_lefthook,
+        "launcher auto-setup must leave tracked lefthook.yml byte-for-byte unchanged"
+    );
+    assert_eq!(
+        git_status_short(td.path()),
+        "",
+        "launcher auto-setup must leave no tracked worktree drift"
     );
     assert!(
-        lefthook_yml.contains("branch-protection:"),
-        "opted-in repo receives pre-push branch protection"
-    );
-    assert!(
-        td.path()
+        !td.path()
             .join("scripts/hooks/branch-protection.sh")
             .exists(),
-        "opted-in repo receives branch-protection.sh"
+        "launcher auto-setup must not write a tracked branch-protection hook"
     );
     assert!(
-        td.path().join("scripts/hooks/review-check.sh").exists(),
-        "opted-in repo receives review-check.sh"
+        !td.path().join("scripts/hooks/review-check.sh").exists(),
+        "launcher auto-setup must not write a tracked review-check hook"
     );
     assert!(
-        td.path().join(".git/hooks/pre-push").exists(),
-        "opted-in repo receives installed pre-push hook"
-    );
-    let lefthook_log = fs::read_to_string(log_path).expect("read fake lefthook log");
-    assert!(
-        lefthook_log.contains("install"),
-        "opted-in repo should invoke lefthook install"
+        !td.path().join(".git/hooks/pre-push").exists(),
+        "launcher auto-setup must not install a repository hook"
     );
 }

--- a/crates/cli-sub-agent/tests/run_noop_tracked_drift.rs
+++ b/crates/cli-sub-agent/tests/run_noop_tracked_drift.rs
@@ -1,0 +1,173 @@
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn csa_cmd(home: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("CSA_") {
+            cmd.env_remove(key);
+        }
+    }
+    cmd.env("HOME", home)
+        .env("XDG_STATE_HOME", home.join(".local/state"))
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1")
+        .env_remove("CI");
+    cmd
+}
+
+fn run_git(project_root: &Path, args: &[&str]) -> Output {
+    Command::new("git")
+        .args(args)
+        .current_dir(project_root)
+        .output()
+        .expect("git should run")
+}
+
+fn require_git(project_root: &Path, args: &[&str]) {
+    let output = run_git(project_root, args);
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_tracked_project(project_root: &Path) {
+    std::fs::create_dir_all(project_root.join(".csa")).expect("create project config dir");
+    std::fs::write(project_root.join("README.md"), "# test project\n").expect("write readme");
+    std::fs::write(project_root.join("lefthook.yml"), "pre-commit:\n")
+        .expect("write tracked lefthook config");
+    std::fs::write(
+        project_root.join(".csa/config.toml"),
+        r#"schema_version = 1
+
+[resources]
+min_free_memory_mb = 0
+soft_limit_percent = 100
+
+[filesystem_sandbox]
+enforcement_mode = "off"
+
+[tools.codex]
+enabled = true
+transport = "cli"
+default_model = "gpt-5.4-mini"
+
+[run.post_exec_gate]
+enabled = false
+"#,
+    )
+    .expect("write project config");
+
+    let output = Command::new("git")
+        .args(["-c", "init.defaultBranch=main", "init"])
+        .current_dir(project_root)
+        .output()
+        .expect("git init should run");
+    assert!(
+        output.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    require_git(project_root, &["config", "user.email", "test@example.com"]);
+    require_git(project_root, &["config", "user.name", "Test User"]);
+    require_git(project_root, &["add", "."]);
+    require_git(project_root, &["commit", "-m", "initial"]);
+    require_git(project_root, &["checkout", "-b", "feat/noop-drift"]);
+}
+
+#[cfg(unix)]
+fn install_noop_codex(bin_dir: &Path) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::create_dir_all(bin_dir).expect("create fake tool directory");
+    let codex = bin_dir.join("codex");
+    std::fs::write(
+        &codex,
+        r#"#!/bin/sh
+printf '%s\n' \
+  '{"type":"thread.started","thread_id":"no-op-tracked-drift"}' \
+  '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}' \
+  '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+"#,
+    )
+    .expect("write fake codex");
+    let mut permissions = std::fs::metadata(&codex)
+        .expect("fake codex metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&codex, permissions).expect("make fake codex executable");
+    bin_dir.to_path_buf()
+}
+
+#[cfg(unix)]
+fn prepend_path(bin_dir: &Path) -> OsString {
+    let current = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![bin_dir.to_path_buf()];
+    paths.extend(std::env::split_paths(&current));
+    std::env::join_paths(paths).expect("join PATH")
+}
+
+fn global_config_path(home: &Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        home.join("Library/Application Support/cli-sub-agent/config.toml")
+    } else {
+        home.join(".config/cli-sub-agent/config.toml")
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn noop_writer_session_leaves_zero_tracked_lefthook_drift() {
+    let home = tempfile::tempdir().expect("create temporary home");
+    let project = home.path().join("project");
+    init_tracked_project(&project);
+
+    let config_path = global_config_path(home.path());
+    std::fs::create_dir_all(config_path.parent().expect("global config parent"))
+        .expect("create global config dir");
+    std::fs::write(config_path, "[hooks]\nauto_setup_review_gate = true\n")
+        .expect("enable launcher review-gate path");
+
+    let fake_bin = install_noop_codex(&home.path().join("bin"));
+    let output = csa_cmd(home.path())
+        .current_dir(&project)
+        .env("PATH", prepend_path(&fake_bin))
+        .args([
+            "run",
+            "--no-daemon",
+            "--sa-mode",
+            "true",
+            "--tool",
+            "codex",
+            "--memory-max-mb",
+            "9000",
+            "--min-free-memory-mb",
+            "0",
+            "reply without tool calls",
+        ])
+        .output()
+        .expect("run no-op writer session");
+
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("no-op-tracked-drift"),
+        "writer provider must start before the no-op result: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        std::fs::read_to_string(project.join("lefthook.yml")).expect("read lefthook config"),
+        "pre-commit:\n",
+        "no-op writer session must preserve the tracked lefthook config"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(
+            &run_git(&project, &["status", "--porcelain", "--untracked-files=no"]).stdout
+        ),
+        "",
+        "no-op writer session must leave zero tracked worktree drift"
+    );
+}

--- a/crates/cli-sub-agent/tests/run_noop_tracked_drift.rs
+++ b/crates/cli-sub-agent/tests/run_noop_tracked_drift.rs
@@ -3,6 +3,11 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 fn csa_cmd(home: &Path) -> Command {
+    let cargo_home = home.join(".cargo");
+    let rustup_home = home.join(".rustup");
+    std::fs::create_dir_all(&cargo_home).expect("create isolated cargo home");
+    std::fs::create_dir_all(&rustup_home).expect("create isolated rustup home");
+
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
     for (key, _) in std::env::vars_os() {
         if key.to_string_lossy().starts_with("CSA_") {
@@ -12,6 +17,8 @@ fn csa_cmd(home: &Path) -> Command {
     cmd.env("HOME", home)
         .env("XDG_STATE_HOME", home.join(".local/state"))
         .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("CARGO_HOME", cargo_home)
+        .env("RUSTUP_HOME", rustup_home)
         .env("TOKIO_WORKER_THREADS", "1")
         .env_remove("CI");
     cmd
@@ -46,6 +53,7 @@ fn init_tracked_project(project_root: &Path) {
 
 [resources]
 min_free_memory_mb = 0
+memory_max_mb = 9000
 soft_limit_percent = 100
 
 [filesystem_sandbox]
@@ -143,8 +151,6 @@ fn noop_writer_session_leaves_zero_tracked_lefthook_drift() {
             "true",
             "--tool",
             "codex",
-            "--memory-max-mb",
-            "9000",
             "--min-free-memory-mb",
             "0",
             "reply without tool calls",

--- a/crates/csa-resource/src/guard.rs
+++ b/crates/csa-resource/src/guard.rs
@@ -146,6 +146,13 @@ impl ResourceGuard {
         Self { sys, limits }
     }
 
+    /// Read effective physical memory available to this process, including an
+    /// enclosing cgroup limit when one is present.
+    pub fn available_physical_memory_mb(&mut self) -> u64 {
+        self.sys.refresh_memory();
+        effective_available_memory_bytes(self.sys.available_memory()) / 1024 / 1024
+    }
+
     /// Check if enough resources are available to launch a tool.
     ///
     /// Two-tier threshold:

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1110"
-weave = "0.1.1110"
+csa = "0.1.1111"
+weave = "0.1.1111"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
Three S-complexity fixes + one test hardening.

### #2836
CSA launcher no longer mutates tracked `lefthook.yml` during the launcher-to-provider handoff. Auto-setup is state-only before provider handoff.

### #2818
Regression test proving a no-op writer session (0 tool calls) leaves zero tracked lefthook drift.

### #2828
Default memory projection now dynamically bounded to host physical available memory minus reserve, instead of a hardcoded tier default that exceeds physical capacity.

### Test fix
Memory projection test made deterministic under receipt sandbox (no host memory probe). Noop drift test isolated from host CARGO_HOME/RUSTUP_HOME leakage.

## Validation
- Focused tests green
- Receipt-wrapped gate verified exit 0 by writer
- Pre-push `quality-gates` PASS on `1c9e21c8` (~1749s)

Closes #2836
Closes #2818
Closes #2828