### PR TITLE
fix: debate liveness terminal-first + session wait liveness deadline (#2827 #2841)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1111"
+version = "0.1.1112"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1112"
+version = "0.1.1113"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1111"
+version = "0.1.1112"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1112"
+version = "0.1.1113"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/debate_errors.rs
+++ b/crates/cli-sub-agent/src/debate_errors.rs
@@ -20,6 +20,10 @@ pub(crate) fn classify_execution_outcome(
     session_state: Option<&MetaSessionState>,
     session_dir: &Path,
 ) -> DebateErrorKind {
+    if has_persisted_pre_exec_failure(session_dir) {
+        return DebateErrorKind::Deterministic("persisted pre-exec failure".to_string());
+    }
+
     if ToolLiveness::is_alive(session_dir) {
         return DebateErrorKind::StillWorking;
     }
@@ -80,10 +84,28 @@ pub(crate) fn classify_execution_outcome(
     DebateErrorKind::Deterministic(format!("exit code {}", execution.exit_code))
 }
 
+/// A pre-exec failure result is terminal evidence for this attempt. Its diagnostic
+/// lock may retain the launching test/process PID after release, so it must win
+/// over lock-based liveness and prevent an endless StillWorking retry.
+fn has_persisted_pre_exec_failure(session_dir: &Path) -> bool {
+    let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
+    let Ok(contents) = std::fs::read_to_string(result_path) else {
+        return false;
+    };
+    let Ok(result) = toml::from_str::<csa_session::SessionResult>(&contents) else {
+        return false;
+    };
+    result.status == "failure" && result.summary.trim_start().starts_with("pre-exec:")
+}
+
 pub(crate) fn classify_execution_error(
     error: &anyhow::Error,
     session_dir: Option<&Path>,
 ) -> DebateErrorKind {
+    if session_dir.is_some_and(has_persisted_pre_exec_failure) {
+        return DebateErrorKind::Deterministic(error.to_string());
+    }
+
     if session_dir.is_some_and(ToolLiveness::is_alive) {
         return DebateErrorKind::StillWorking;
     }

--- a/crates/cli-sub-agent/src/debate_errors_tests.rs
+++ b/crates/cli-sub-agent/src/debate_errors_tests.rs
@@ -91,6 +91,67 @@ fn classify_timeout_error_with_alive_pid_as_still_working() {
 }
 
 #[test]
+fn classify_pre_exec_failure_with_persisted_result_before_live_lock_as_deterministic() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let locks_dir = tmp.path().join("locks");
+    std::fs::create_dir_all(&locks_dir).expect("create locks");
+    let lock_path = locks_dir.join("codex.lock");
+    std::fs::write(&lock_path, format!("{{\"pid\": {}}}", std::process::id())).expect("write");
+
+    let result = csa_session::SessionResult {
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "pre-exec: provider rejected".to_string(),
+        ..Default::default()
+    };
+    std::fs::write(
+        tmp.path().join(csa_session::result::RESULT_FILE_NAME),
+        toml::to_string_pretty(&result).expect("serialize result"),
+    )
+    .expect("persist terminal result");
+
+    let classified = classify_execution_error(
+        &anyhow::anyhow!("pre-exec: provider rejected"),
+        Some(tmp.path()),
+    );
+    assert!(
+        matches!(classified, DebateErrorKind::Deterministic(_)),
+        "persisted terminal result must win over a live released-lock PID, got {classified:?}"
+    );
+}
+
+#[test]
+fn classify_pre_exec_result_before_live_lock_as_deterministic_outcome() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let locks_dir = tmp.path().join("locks");
+    std::fs::create_dir_all(&locks_dir).expect("create locks");
+    let lock_path = locks_dir.join("codex.lock");
+    std::fs::write(&lock_path, format!("{{\"pid\": {}}}", std::process::id())).expect("write");
+
+    let result = csa_session::SessionResult {
+        status: "failure".to_string(),
+        exit_code: 1,
+        summary: "pre-exec: provider rejected".to_string(),
+        ..Default::default()
+    };
+    std::fs::write(
+        tmp.path().join(csa_session::result::RESULT_FILE_NAME),
+        toml::to_string_pretty(&result).expect("serialize result"),
+    )
+    .expect("persist terminal result");
+
+    let execution = ExecutionResult {
+        exit_code: 1,
+        ..Default::default()
+    };
+    let classified = classify_execution_outcome(&execution, None, tmp.path());
+    assert!(
+        matches!(classified, DebateErrorKind::Deterministic(_)),
+        "persisted terminal result must win over a live released-lock PID, got {classified:?}"
+    );
+}
+
+#[test]
 fn classify_exit_144_sigstkflt_as_transient() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let execution = ExecutionResult {

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -52,8 +52,9 @@ pub(crate) use wait::resolve_wait_completion_status_and_exit;
 pub(crate) use wait::{
     SESSION_WAIT_MEMORY_WARN_EXIT_CODE, WaitBehavior, WaitLoopTiming, WaitReconciliationOutcome,
     handle_session_wait, handle_session_wait_with_hooks,
-    handle_session_wait_with_hooks_and_sampler, handle_session_wait_with_identity_for_test,
-    process_start_time_ticks, synthesized_wait_next_step, try_acquire_session_wait_lock,
+    handle_session_wait_with_hooks_and_sampler, handle_session_wait_with_hooks_at,
+    handle_session_wait_with_identity_for_test, process_start_time_ticks,
+    synthesized_wait_next_step, try_acquire_session_wait_lock,
     try_acquire_session_wait_lock_with_caller,
 };
 pub(crate) use wait::{

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -1,5 +1,4 @@
 use super::*;
-use chrono::Utc;
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::time::{Duration, Instant, SystemTime};
@@ -22,6 +21,9 @@ mod result_loader;
 mod summary;
 #[path = "session_cmds_daemon_wait_target.rs"]
 mod target;
+#[cfg(test)]
+#[path = "session_cmds_daemon_wait_test_support.rs"]
+mod test_support;
 #[path = "session_cmds_daemon_wait_types.rs"]
 mod types;
 // Re-export the memory warning exit code constant for other modules
@@ -51,6 +53,8 @@ use result_loader::{
 #[cfg(test)]
 pub(crate) use summary::render_wait_result_summary;
 use summary::{emit_wait_terminal_output, render_wait_terminal_output};
+#[cfg(test)]
+pub(crate) use test_support::handle_session_wait_with_hooks_at;
 use types::WaitExecutionOptions;
 #[cfg(test)]
 pub(crate) use types::WaitLoopTiming;
@@ -109,6 +113,10 @@ pub(crate) fn handle_session_wait_with_options(
             output_mode,
             caller_identity,
             model_provider,
+            #[cfg(test)]
+            current_time_for_test: None,
+            #[cfg(test)]
+            session_live_for_test: None,
         },
         |project_root, session_id, trigger| {
             let reconciled = crate::session_cmds::ensure_terminal_result_for_dead_active_session(
@@ -145,6 +153,10 @@ pub(crate) fn handle_session_wait_for_mcp(
             output_mode,
             caller_identity,
             model_provider: None,
+            #[cfg(test)]
+            current_time_for_test: None,
+            #[cfg(test)]
+            session_live_for_test: None,
         },
         core::WaitEmitters {
             reconcile_dead_active_session: Box::new(|project_root, session_id, trigger| {
@@ -315,6 +327,10 @@ where
             output_mode: SessionWaitOutputMode::from_flags(false, false),
             caller_identity: WaitCallerIdentity::capture(),
             model_provider: None,
+            #[cfg(test)]
+            current_time_for_test: None,
+            #[cfg(test)]
+            session_live_for_test: None,
         },
         reconcile_dead_active_session,
         emit_completion_signal,
@@ -379,6 +395,10 @@ where
             output_mode: SessionWaitOutputMode::from_flags(false, false),
             caller_identity: WaitCallerIdentity::capture(),
             model_provider: None,
+            #[cfg(test)]
+            current_time_for_test: None,
+            #[cfg(test)]
+            session_live_for_test: None,
         },
         reconcile_dead_active_session,
         emit_completion_signal,
@@ -470,19 +490,25 @@ fn check_session_stale_before_wait(
     project_root: &Path,
     session_id: &str,
     session_dir: &Path,
-    wait_behavior: WaitBehavior,
+    wait_options: &WaitExecutionOptions,
     liveness_dead_seconds: u64,
     worktree_lock_root: Option<&Path>,
     worktree_lock_session_ids: &[&str],
 ) -> anyhow::Result<()> {
-    match load_session_for_stale_precheck(project_root, session_id, session_dir, wait_behavior) {
+    match load_session_for_stale_precheck(
+        project_root,
+        session_id,
+        session_dir,
+        wait_options.behavior,
+    ) {
         Ok(session) => {
             if matches!(session.phase, csa_session::SessionPhase::Active) {
                 // A durable terminal result or completion marker is authoritative.
                 // Otherwise, verify the event age before accepting a live PID or
                 // worktree lock as proof that the session is still healthy.
-                if super::daemon_completion_exists(session_dir)
-                    && !session_has_terminal_process(session_dir)
+                if super::legacy_complete_marker_is_valid(session_dir)
+                    || (super::daemon_completion_exists(session_dir)
+                        && !session_has_terminal_process(session_dir))
                 {
                     return Ok(());
                 }
@@ -491,7 +517,9 @@ fn check_session_stale_before_wait(
                     Ok(None) => {}
                 }
 
-                let elapsed = Utc::now().signed_duration_since(session.last_accessed);
+                let elapsed = wait_options
+                    .current_time()
+                    .signed_duration_since(session.last_accessed);
                 if elapsed > chrono::Duration::seconds(liveness_dead_seconds as i64) {
                     return Err(anyhow::anyhow!(
                         "no new session event for {}s exceeds configured liveness_dead_seconds={}s",

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -462,61 +462,51 @@ fn emit_wait_completion_signal(
     }
 }
 
-/// Check if a session is stale before starting to wait.
-/// Returns Err if the session is stale (daemon not running, no recent progress).
+/// Check whether the session's last event remains within its configured
+/// liveness deadline while waiting. A live PID or diagnostic lock does not
+/// override a stale event: callers need a liveness failure instead of repeated
+/// `status=alive` outcomes for a stuck worker.
 fn check_session_stale_before_wait(
     project_root: &Path,
     session_id: &str,
     session_dir: &Path,
     wait_behavior: WaitBehavior,
+    liveness_dead_seconds: u64,
     worktree_lock_root: Option<&Path>,
     worktree_lock_session_ids: &[&str],
 ) -> anyhow::Result<()> {
-    // Load the session to check its phase and last_accessed time.
-    // Only flag truly stale sessions (Active phase, no daemon, no recent progress).
-    // Sessions with an existing result.toml are NOT stale — they completed, and the
-    // main polling loop will return the result correctly.
     match load_session_for_stale_precheck(project_root, session_id, session_dir, wait_behavior) {
         Ok(session) => {
-            // Only check Active sessions for staleness
             if matches!(session.phase, csa_session::SessionPhase::Active) {
-                // If there's already a terminal result (or a result file exists but
-                // fails to parse), let the main loop handle it rather than flagging
-                // as stale. The session completed normally; parse errors are handled
-                // downstream with better diagnostics.
+                // A durable terminal result or completion marker is authoritative.
+                // Otherwise, verify the event age before accepting a live PID or
+                // worktree lock as proof that the session is still healthy.
                 if super::daemon_completion_exists(session_dir)
                     && !session_has_terminal_process(session_dir)
                 {
                     return Ok(());
                 }
-                if csa_process::ToolLiveness::is_alive(session_dir) {
-                    return Ok(());
-                }
                 match csa_session::load_result(project_root, session_id) {
-                    Ok(Some(_)) => return Ok(()),
-                    Err(_) => return Ok(()), // result file exists but unparseable
-                    Ok(None) => {}           // no result yet
+                    Ok(Some(_)) | Err(_) => return Ok(()),
+                    Ok(None) => {}
                 }
 
-                let stale_threshold_seconds = wait_behavior.wait_timeout_secs.saturating_mul(2);
-                let now = Utc::now();
-                let elapsed = now.signed_duration_since(session.last_accessed);
-
-                if any_session_holds_worktree_write_lock(
-                    worktree_lock_root,
-                    worktree_lock_session_ids,
-                ) {
-                    return Ok(());
-                }
-                if elapsed > chrono::Duration::seconds(stale_threshold_seconds as i64) {
-                    if session_has_terminal_process(session_dir) {
-                        return Ok(());
-                    }
+                let elapsed = Utc::now().signed_duration_since(session.last_accessed);
+                if elapsed > chrono::Duration::seconds(liveness_dead_seconds as i64) {
                     return Err(anyhow::anyhow!(
-                        "daemon not running, no recent progress ({}s > {}s threshold)",
+                        "no new session event for {}s exceeds configured liveness_dead_seconds={}s",
                         elapsed.num_seconds(),
-                        stale_threshold_seconds
+                        liveness_dead_seconds
                     ));
+                }
+
+                if csa_process::ToolLiveness::is_alive(session_dir)
+                    || any_session_holds_worktree_write_lock(
+                        worktree_lock_root,
+                        worktree_lock_session_ids,
+                    )
+                {
+                    return Ok(());
                 }
             }
         }

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -152,6 +152,16 @@ pub(crate) fn handle_session_wait_with_emitters(
             result_session_id
         };
         let result_session_dir = &wait_target.session_dir;
+        #[cfg(test)]
+        let session_live = wait_options.session_live_for_test.unwrap_or_else(|| {
+            session_has_live_execution(
+                worktree_lock_root.as_deref(),
+                result_session_dir,
+                &resolved.session_id,
+                result_session_id,
+            )
+        });
+        #[cfg(not(test))]
         let session_live = session_has_live_execution(
             worktree_lock_root.as_deref(),
             result_session_dir,
@@ -168,7 +178,7 @@ pub(crate) fn handle_session_wait_with_emitters(
                 effective_root,
                 result_session_id,
                 result_session_dir,
-                wait_options.behavior,
+                &wait_options,
                 liveness_dead_seconds,
                 worktree_lock_root.as_deref(),
                 &[resolved.session_id.as_str(), result_session_id],

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -83,6 +83,9 @@ pub(crate) fn handle_session_wait_with_emitters(
     let is_cross_project = resolved.foreign_project_root.is_some();
     let mut wait_target = resolve_wait_target(effective_root, &resolved.session_id, &session_dir)?;
     let worktree_lock_root = super::resolve_session_wait_worktree_lock_root(effective_root);
+    let project_config = csa_config::ProjectConfig::load(effective_root)?;
+    let liveness_dead_seconds =
+        crate::pipeline::resolve_liveness_dead_seconds(project_config.as_ref());
     if wait_options.caller_identity.is_dead() {
         eprintln!(
             "ERROR: session wait caller output closed before lock acquisition; re-issue from the current caller."
@@ -110,45 +113,6 @@ pub(crate) fn handle_session_wait_with_emitters(
         .filter(|limit| *limit > 0);
     let mut next_memory_sample_at =
         memory_warn_mb.map(|_| start + wait_options.behavior.timing.memory_sample_interval);
-    let handoff_blocks_initial_stale_precheck = resume_handoff_blocks_target_reconcile(
-        wait_target.follows_resume_target,
-        &session_dir,
-        &wait_target.session_dir,
-    );
-
-    // Check if the session is Stale before entering the polling loop.
-    // This prevents indefinite polling of sessions that have no live daemon process
-    // and no progress for an extended period.
-    //
-    // A resume wrapper may write resume-target.toml before the target session has
-    // target-local liveness. While the wrapper daemon is still alive, its process
-    // owns that bootstrap window, so target-local silence is not stale yet.
-    if !handoff_blocks_initial_stale_precheck
-        && let Err(stale_err) = super::check_session_stale_before_wait(
-            effective_root,
-            &wait_target.session_id,
-            &wait_target.session_dir,
-            wait_options.behavior,
-            worktree_lock_root.as_deref(),
-            &[resolved.session_id.as_str(), &wait_target.session_id],
-        )
-    {
-        if !crate::session_observability::emit_session_registry_state_loss_diagnostic(
-            effective_root,
-            &wait_target.session_id,
-            &wait_target.session_dir,
-        ) {
-            eprintln!(
-                "Session {} appears stale: {}",
-                wait_target.session_id, stale_err
-            );
-            eprintln!(
-                "Run `csa session result --session {}` for diagnostics.",
-                wait_target.session_id
-            );
-        }
-        return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
-    }
 
     loop {
         if wait_options.caller_identity.is_dead() {
@@ -199,6 +163,29 @@ pub(crate) fn handle_session_wait_with_emitters(
             &session_dir,
             result_session_dir,
         );
+        if !handoff_blocks_target_reconcile
+            && let Err(stale_err) = super::check_session_stale_before_wait(
+                effective_root,
+                result_session_id,
+                result_session_dir,
+                wait_options.behavior,
+                liveness_dead_seconds,
+                worktree_lock_root.as_deref(),
+                &[resolved.session_id.as_str(), result_session_id],
+            )
+        {
+            if !crate::session_observability::emit_session_registry_state_loss_diagnostic(
+                effective_root,
+                result_session_id,
+                result_session_dir,
+            ) {
+                eprintln!("Session {result_session_id} liveness failure: {stale_err}");
+                eprintln!(
+                    "Run `csa session result --session {result_session_id}` for diagnostics."
+                );
+            }
+            return Ok(SESSION_WAIT_FAILURE_EXIT_CODE);
+        }
         let result_registry_state_loss =
             session_registry_state_loss(effective_root, result_session_id, result_session_dir);
         let result_uses_direct_session_dir = is_cross_project || result_registry_state_loss;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_test_support.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_test_support.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use chrono::Utc;
+use std::path::Path;
+
+use super::{
+    SessionWaitOutputMode, WaitBehavior, WaitCallerIdentity, WaitExecutionOptions,
+    WaitReconciliationOutcome, emit_wait_memory_warn_marker,
+    handle_session_wait_with_hooks_and_sampler_output_mode,
+};
+
+pub(crate) fn handle_session_wait_with_hooks_at<R, E>(
+    session: String,
+    cd: Option<String>,
+    wait_behavior: WaitBehavior,
+    current_time: chrono::DateTime<Utc>,
+    session_live_for_test: Option<bool>,
+    mut reconcile_dead_active_session: R,
+    mut emit_completion_signal: E,
+) -> Result<i32>
+where
+    R: for<'a, 'b, 'c> FnMut(&'a Path, &'b str, &'c str) -> Result<WaitReconciliationOutcome>,
+    E: for<'a, 'b> FnMut(&'a str, &'b str, i32, bool, bool),
+{
+    let mut cached_memory_sampler: Option<csa_session::SessionTreeMemorySampler> = None;
+    handle_session_wait_with_hooks_and_sampler_output_mode(
+        session,
+        cd,
+        WaitExecutionOptions {
+            behavior: wait_behavior,
+            output_mode: SessionWaitOutputMode::from_flags(false, false),
+            caller_identity: WaitCallerIdentity::capture(),
+            model_provider: None,
+            current_time_for_test: Some(current_time),
+            session_live_for_test,
+        },
+        &mut reconcile_dead_active_session,
+        &mut emit_completion_signal,
+        |project_root, session_id| {
+            if cached_memory_sampler.is_none() {
+                cached_memory_sampler = Some(csa_session::SessionTreeMemorySampler::new(
+                    project_root,
+                    session_id,
+                )?);
+            }
+            cached_memory_sampler
+                .as_ref()
+                .expect("cached sampler initialized above")
+                .sample_rss_mb()
+        },
+        emit_wait_memory_warn_marker,
+    )
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_types.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_types.rs
@@ -59,6 +59,21 @@ pub(super) struct WaitExecutionOptions {
     pub(super) output_mode: SessionWaitOutputMode,
     pub(super) caller_identity: super::WaitCallerIdentity,
     pub(super) model_provider: Option<csa_config::ModelProvider>,
+    #[cfg(test)]
+    pub(super) current_time_for_test: Option<chrono::DateTime<chrono::Utc>>,
+    #[cfg(test)]
+    pub(super) session_live_for_test: Option<bool>,
+}
+
+impl WaitExecutionOptions {
+    pub(super) fn current_time(&self) -> chrono::DateTime<chrono::Utc> {
+        #[cfg(test)]
+        if let Some(current_time) = self.current_time_for_test {
+            return current_time;
+        }
+
+        chrono::Utc::now()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::session_cmds::{StructuredOutputOpts, handle_session_result};
 use crate::session_cmds_daemon::{
     WaitBehavior, WaitLoopTiming, WaitReconciliationOutcome, handle_session_wait_with_hooks,
+    handle_session_wait_with_hooks_at,
 };
 use crate::test_env_lock::TEST_ENV_LOCK;
 use tempfile::tempdir;
@@ -385,7 +386,7 @@ fn exact_id_wait_and_result_survive_repeated_kv_warm_after_registry_state_loss()
 
 #[cfg(target_os = "linux")]
 #[test]
-fn stale_precheck_does_not_fail_live_daemon_session() {
+fn stale_precheck_fails_live_daemon_after_liveness_deadline() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
@@ -394,6 +395,9 @@ fn stale_precheck_does_not_fail_live_daemon_session() {
     let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
     let project = td.path();
 
+    let fixed_now = chrono::DateTime::parse_from_rfc3339("2030-01-01T02:00:00Z")
+        .expect("fixed liveness clock")
+        .with_timezone(&chrono::Utc);
     let session = create_session(
         project,
         Some("wait-stale-precheck-live-daemon"),
@@ -402,24 +406,12 @@ fn stale_precheck_does_not_fail_live_daemon_session() {
     )
     .expect("create");
     let session_id = session.meta_session_id;
-    let session_dir = get_session_dir(project, &session_id).expect("session dir");
     let mut state = load_session(project, &session_id).expect("load session");
     state.phase = SessionPhase::Active;
-    state.last_accessed = chrono::Utc::now() - chrono::Duration::seconds(7_200);
-    save_session(&state).expect("save stale active session");
+    state.last_accessed = fixed_now - chrono::Duration::seconds(7_200);
+    save_session(&state).expect("save fixed-time stale active session");
 
-    let mut child = std::process::Command::new("sleep")
-        .arg("30")
-        .spawn()
-        .expect("spawn child");
-    std::fs::write(
-        session_dir.join("daemon.pid"),
-        daemon_pid_record(child.id()),
-    )
-    .expect("write daemon pid");
-    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
-
-    let exit_code = handle_session_wait_with_hooks(
+    let exit_code = handle_session_wait_with_hooks_at(
         session_id,
         Some(project.to_string_lossy().into_owned()),
         WaitBehavior {
@@ -430,6 +422,8 @@ fn stale_precheck_does_not_fail_live_daemon_session() {
                 memory_sample_interval: std::time::Duration::from_secs(15),
             },
         },
+        fixed_now,
+        Some(true),
         |_project_root, _current_session_id, _trigger| {
             Ok(WaitReconciliationOutcome {
                 result_became_available: false,
@@ -440,14 +434,11 @@ fn stale_precheck_does_not_fail_live_daemon_session() {
             panic!("stale precheck must not emit a synthetic completion for a live daemon");
         },
     )
-    .expect("wait should skip stale precheck for live daemon");
-
-    let _ = child.kill();
-    let _ = child.wait();
+    .expect("wait should reject the stale event before accepting liveness");
 
     assert_eq!(
-        exit_code, 0,
-        "live daemon must not be pre-failed solely because last_accessed is stale"
+        exit_code, 1,
+        "a live daemon must not override the configured liveness deadline"
     );
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2016.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2016.rs
@@ -1,33 +1,7 @@
 use super::*;
+use crate::session_cmds_daemon::{WaitBehavior, WaitLoopTiming, handle_session_wait_with_hooks_at};
 use crate::test_env_lock::ScopedEnvVarRestore;
-use std::process::Command;
 
-#[cfg(target_os = "linux")]
-fn read_process_start_time_ticks(pid: u32) -> u64 {
-    let stat_path = format!("/proc/{pid}/stat");
-    let content = std::fs::read_to_string(stat_path).expect("read /proc stat");
-    let close_paren = content.rfind(')').expect("stat comm terminator");
-    let after_comm = &content[close_paren + 1..];
-    let mut parts = after_comm.split_whitespace();
-    parts.next().expect("state");
-    parts.next().expect("ppid");
-    parts.next().expect("pgrp");
-    for _ in 0..16 {
-        parts.next().expect("intermediate stat field");
-    }
-    parts
-        .next()
-        .expect("starttime")
-        .parse::<u64>()
-        .expect("starttime parse")
-}
-
-#[cfg(target_os = "linux")]
-fn daemon_pid_record(pid: u32) -> String {
-    format!("{pid} {}\n", read_process_start_time_ticks(pid))
-}
-
-#[cfg(target_os = "linux")]
 #[test]
 fn handle_session_wait_retires_active_session_after_legacy_complete_marker_143_even_with_live_daemon_pid()
  {
@@ -49,21 +23,29 @@ fn handle_session_wait_retires_active_session_after_legacy_complete_marker_143_e
     let session_id = session.meta_session_id;
     let session_dir = get_session_dir(project, &session_id).unwrap();
     let mut stale_session = load_session(project, &session_id).unwrap();
-    stale_session.last_accessed = chrono::Utc::now() - chrono::Duration::seconds(7_200);
+    stale_session.last_accessed = chrono::DateTime::parse_from_rfc3339("2000-01-01T00:00:00Z")
+        .expect("fixed stale event")
+        .with_timezone(&chrono::Utc);
     save_session(&stale_session).unwrap();
     std::fs::write(session_dir.join(".complete"), "143\n").unwrap();
-    let mut child = Command::new("sleep").arg("5").spawn().unwrap();
-    std::fs::write(
-        session_dir.join("daemon.pid"),
-        daemon_pid_record(child.id()),
-    )
-    .unwrap();
-    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
 
-    let exit_code = handle_session_wait(
+    let fixed_now = chrono::DateTime::parse_from_rfc3339("2030-01-01T00:00:00Z")
+        .expect("fixed liveness clock")
+        .with_timezone(&chrono::Utc);
+    let exit_code = handle_session_wait_with_hooks_at(
         session_id.clone(),
         Some(project.to_string_lossy().into_owned()),
-        1,
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        fixed_now,
+        Some(true),
+        |_project_root, _current_session_id, _trigger| {
+            panic!("legacy complete marker must resolve before dead-session reconciliation")
+        },
+        |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {},
     )
     .unwrap();
 
@@ -81,12 +63,8 @@ fn handle_session_wait_retires_active_session_after_legacy_complete_marker_143_e
         persisted.termination_reason.as_deref(),
         Some("legacy_complete_marker")
     );
-
-    child.kill().ok();
-    let _ = child.wait();
 }
 
-#[cfg(target_os = "linux")]
 #[test]
 fn handle_session_wait_retires_existing_result_after_legacy_complete_marker_with_live_daemon_pid() {
     let td = tempdir().unwrap();
@@ -108,18 +86,24 @@ fn handle_session_wait_retires_existing_result_after_legacy_complete_marker_with
     let session_dir = get_session_dir(project, &session_id).unwrap();
     save_result(project, &session_id, &make_result("success", 0)).unwrap();
     std::fs::write(session_dir.join(".complete"), "143\n").unwrap();
-    let mut child = Command::new("sleep").arg("5").spawn().unwrap();
-    std::fs::write(
-        session_dir.join("daemon.pid"),
-        daemon_pid_record(child.id()),
-    )
-    .unwrap();
-    assert!(csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir));
 
-    let exit_code = handle_session_wait(
+    let fixed_now = chrono::DateTime::parse_from_rfc3339("2030-01-01T00:00:00Z")
+        .expect("fixed liveness clock")
+        .with_timezone(&chrono::Utc);
+    let exit_code = handle_session_wait_with_hooks_at(
         session_id.clone(),
         Some(project.to_string_lossy().into_owned()),
-        1,
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        fixed_now,
+        Some(true),
+        |_project_root, _current_session_id, _trigger| {
+            panic!("legacy complete marker must resolve before dead-session reconciliation")
+        },
+        |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {},
     )
     .unwrap();
 
@@ -133,7 +117,4 @@ fn handle_session_wait_retires_existing_result_after_legacy_complete_marker_with
     let persisted = load_session(project, &session_id).unwrap();
     assert_eq!(persisted.phase, SessionPhase::Retired);
     assert_eq!(persisted.termination_reason.as_deref(), Some("completed"));
-
-    child.kill().ok();
-    let _ = child.wait();
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_liveness.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_liveness.rs
@@ -127,6 +127,80 @@ fn handle_session_wait_continues_polling_when_pid_missing_but_liveness_signals_p
 
 #[cfg(target_os = "linux")]
 #[test]
+fn handle_session_wait_fails_when_live_daemon_event_exceeds_configured_liveness_deadline() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+    let config_path = csa_config::ProjectConfig::config_path(project);
+    std::fs::create_dir_all(config_path.parent().expect("config parent"))
+        .expect("create config parent");
+    std::fs::write(
+        config_path,
+        "schema_version = 1\n[resources]\nliveness_dead_seconds = 1\n",
+    )
+    .expect("write liveness config");
+
+    let mut session = create_session(
+        project,
+        Some("wait-stale-event-live-daemon"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    session.last_accessed = chrono::Utc::now() - chrono::Duration::seconds(2);
+    save_session(&session).expect("backdate last event");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+
+    let mut child = std::process::Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .expect("spawn live daemon stand-in");
+    std::fs::write(
+        session_dir.join("daemon.pid"),
+        daemon_pid_record(child.id()),
+    )
+    .expect("write daemon pid");
+    assert!(
+        csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir),
+        "test setup requires a live daemon PID"
+    );
+
+    let wait_result = handle_session_wait_with_hooks(
+        session_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("stale live session must fail liveness before reconciliation")
+        },
+        |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {
+            panic!("stale live session must not emit a terminal completion")
+        },
+    );
+
+    child.kill().ok();
+    child.wait().ok();
+
+    assert_eq!(
+        wait_result.expect("wait should classify stale liveness"),
+        1,
+        "a live PID with no new session event past liveness_dead_seconds must not return alive"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
 fn handle_session_wait_defers_terminal_result_while_daemon_pid_still_alive() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_liveness.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_liveness.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::session_cmds_daemon::{
     WaitBehavior, WaitLoopTiming, WaitReconciliationOutcome, handle_session_wait_with_hooks,
+    handle_session_wait_with_hooks_at,
 };
 use crate::test_env_lock::TEST_ENV_LOCK;
 use tempfile::tempdir;
@@ -144,6 +145,9 @@ fn handle_session_wait_fails_when_live_daemon_event_exceeds_configured_liveness_
     )
     .expect("write liveness config");
 
+    let fixed_now = chrono::DateTime::parse_from_rfc3339("2030-01-01T00:00:02Z")
+        .expect("fixed liveness clock")
+        .with_timezone(&chrono::Utc);
     let mut session = create_session(
         project,
         Some("wait-stale-event-live-daemon"),
@@ -151,26 +155,11 @@ fn handle_session_wait_fails_when_live_daemon_event_exceeds_configured_liveness_
         Some("codex"),
     )
     .expect("create session");
-    session.last_accessed = chrono::Utc::now() - chrono::Duration::seconds(2);
-    save_session(&session).expect("backdate last event");
+    session.last_accessed = fixed_now - chrono::Duration::seconds(2);
+    save_session(&session).expect("persist stale event at fixed time");
     let session_id = session.meta_session_id;
-    let session_dir = get_session_dir(project, &session_id).expect("session dir");
 
-    let mut child = std::process::Command::new("sleep")
-        .arg("60")
-        .spawn()
-        .expect("spawn live daemon stand-in");
-    std::fs::write(
-        session_dir.join("daemon.pid"),
-        daemon_pid_record(child.id()),
-    )
-    .expect("write daemon pid");
-    assert!(
-        csa_process::ToolLiveness::daemon_pid_is_alive(&session_dir),
-        "test setup requires a live daemon PID"
-    );
-
-    let wait_result = handle_session_wait_with_hooks(
+    let wait_result = handle_session_wait_with_hooks_at(
         session_id,
         Some(project.to_string_lossy().into_owned()),
         WaitBehavior {
@@ -181,6 +170,8 @@ fn handle_session_wait_fails_when_live_daemon_event_exceeds_configured_liveness_
                 memory_sample_interval: std::time::Duration::from_secs(15),
             },
         },
+        fixed_now,
+        Some(true),
         |_project_root, _current_session_id, _trigger| {
             panic!("stale live session must fail liveness before reconciliation")
         },
@@ -188,9 +179,6 @@ fn handle_session_wait_fails_when_live_daemon_event_exceeds_configured_liveness_
             panic!("stale live session must not emit a terminal completion")
         },
     );
-
-    child.kill().ok();
-    child.wait().ok();
 
     assert_eq!(
         wait_result.expect("wait should classify stale liveness"),

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::session_cmds_daemon::{
     WaitBehavior, WaitCallerIdentity, WaitLoopTiming, WaitReconciliationOutcome,
-    handle_session_wait_with_hooks, handle_session_wait_with_identity_for_test,
-    try_acquire_session_wait_lock, try_acquire_session_wait_lock_with_caller,
+    handle_session_wait_with_hooks, handle_session_wait_with_hooks_at,
+    handle_session_wait_with_identity_for_test, try_acquire_session_wait_lock,
+    try_acquire_session_wait_lock_with_caller,
 };
 use crate::test_env_lock::TEST_ENV_LOCK;
 use std::io::Write;
@@ -320,7 +321,7 @@ fn handle_session_wait_rejects_duplicate_wait_before_entering_loop() {
 }
 
 #[test]
-fn handle_session_wait_treats_live_worktree_lock_as_progress_during_stale_precheck() {
+fn handle_session_wait_fails_stale_session_despite_live_worktree_lock() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
@@ -329,6 +330,9 @@ fn handle_session_wait_treats_live_worktree_lock_as_progress_during_stale_preche
     let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
     let project = td.path();
 
+    let fixed_now = chrono::DateTime::parse_from_rfc3339("2030-01-02T00:00:00Z")
+        .expect("fixed liveness clock")
+        .with_timezone(&chrono::Utc);
     let mut session = create_session(
         project,
         Some("wait-live-lock-not-stale"),
@@ -336,7 +340,7 @@ fn handle_session_wait_treats_live_worktree_lock_as_progress_during_stale_preche
         Some("codex"),
     )
     .expect("create session");
-    session.last_accessed = chrono::Utc::now() - chrono::Duration::hours(24);
+    session.last_accessed = fixed_now - chrono::Duration::hours(24);
     let session_id = session.meta_session_id.clone();
     save_session(&session).expect("save stale active session");
     let _worktree_lock = csa_lock::acquire_worktree_write_lock(
@@ -350,7 +354,7 @@ fn handle_session_wait_treats_live_worktree_lock_as_progress_during_stale_preche
     .expect("worktree write lock should be held by session");
 
     let mut emitted_completion: Option<(String, String, i32, bool)> = None;
-    let exit_code = handle_session_wait_with_hooks(
+    let exit_code = handle_session_wait_with_hooks_at(
         session_id.clone(),
         Some(project.to_string_lossy().into_owned()),
         WaitBehavior {
@@ -358,19 +362,21 @@ fn handle_session_wait_treats_live_worktree_lock_as_progress_during_stale_preche
             memory_warn_mb: None,
             timing: WaitLoopTiming::default(),
         },
+        fixed_now,
+        None,
         |_project_root, _current_session_id, _trigger| {
-            panic!("live worktree lock should keep stale precheck from reconciling")
+            panic!("stale liveness failure must happen before reconciliation")
         },
         |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
             emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
         },
     )
-    .expect("wait should not classify a live worktree lock as stale");
+    .expect("wait should fail the stale session despite its live lock");
 
-    assert_eq!(exit_code, 0);
+    assert_eq!(exit_code, 1);
     assert_eq!(
         emitted_completion, None,
-        "live lock should produce a healthy wait cap, not a stale failure"
+        "live lock must not override the configured liveness deadline"
     );
 }
 
@@ -387,6 +393,9 @@ fn handle_session_wait_sees_git_toplevel_worktree_lock_from_subdirectory() {
     std::fs::create_dir_all(&project).expect("create nested project dir");
     init_git_repo(&repo_root);
 
+    let fixed_now = chrono::DateTime::parse_from_rfc3339("2030-01-02T00:00:00Z")
+        .expect("fixed liveness clock")
+        .with_timezone(&chrono::Utc);
     let mut session = create_session(
         &project,
         Some("wait-subdir-live-lock-not-stale"),
@@ -394,9 +403,9 @@ fn handle_session_wait_sees_git_toplevel_worktree_lock_from_subdirectory() {
         Some("codex"),
     )
     .expect("create session");
-    session.last_accessed = chrono::Utc::now() - chrono::Duration::hours(24);
+    session.last_accessed = fixed_now - chrono::Duration::seconds(1);
     let session_id = session.meta_session_id.clone();
-    save_session(&session).expect("save stale active session");
+    save_session(&session).expect("save fixed-time fresh active session");
     let _worktree_lock = csa_lock::acquire_worktree_write_lock(
         &repo_root,
         &session_id,
@@ -418,7 +427,7 @@ fn handle_session_wait_sees_git_toplevel_worktree_lock_from_subdirectory() {
     );
 
     let mut emitted_completion: Option<(String, String, i32, bool)> = None;
-    let exit_code = handle_session_wait_with_hooks(
+    let exit_code = handle_session_wait_with_hooks_at(
         session_id.clone(),
         Some(project.to_string_lossy().into_owned()),
         WaitBehavior {
@@ -426,6 +435,8 @@ fn handle_session_wait_sees_git_toplevel_worktree_lock_from_subdirectory() {
             memory_warn_mb: None,
             timing: WaitLoopTiming::default(),
         },
+        fixed_now,
+        None,
         |_project_root, _current_session_id, _trigger| {
             panic!("live git-toplevel worktree lock should keep session nonterminal")
         },

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1112"
-weave = "0.1.1112"
+csa = "0.1.1113"
+weave = "0.1.1113"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1111"
-weave = "0.1.1111"
+csa = "0.1.1112"
+weave = "0.1.1112"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
Two S-complexity fixes + test hardening.

### #2827
Debate liveness now honors persisted terminal pre-exec results BEFORE checking diagnostic lock/PID liveness. A released lock with a live PID no longer overrides a durable terminal failure, preventing StillWorking misclassification until 1800s timeout.

### #2841
`session wait` now enforces `liveness_dead_seconds` against stale events. When no new events arrive for longer than the configured deadline, it reports a liveness failure and exits nonzero instead of indefinitely returning `status=alive`.

### Test fix
Liveness deadline tests made deterministic under receipt sandbox: injected fixed timestamps and test-only session-liveness overrides replace real wall-clock timing, `/proc` reads, and spawned `sleep` children.

## Validation
- Focused tests green for both fixes
- Receipt-wrapped gate verified exit 0 (7330 passed)
- Pre-push `quality-gates` PASS on `af9ae1df` (~1013s)

Closes #2827
Closes #2841