### PR TITLE
fix: harden detached debate init and document wait cancellation (#2823 #2816)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1113"
+version = "0.1.1114"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1113"
+version = "0.1.1114"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -1,11 +1,12 @@
 //! Tests asserting `CSA:CALLER_HINT` emissions are compact and carry
-//! the essential action/re-wait guidance.
+//! the essential wait and cancellation guidance.
 //!
-//! After #2591, CALLER_HINT markers are compact (≤200 bytes) instead of
+//! After #2591, CALLER_HINT markers are compact (≤300 bytes) instead of
 //! the previous ~1KB verbose rules. The core contract is:
-//!   1. Each daemon entry point emits exactly one CALLER_HINT
-//!   2. The hint contains the re-wait command or action
-//!   3. The hint warns against polling and loops
+//!   1. Each daemon entry point emits a wait hint plus a cancellation handle
+//!   2. The wait hint contains the re-wait command
+//!   3. The cancellation handle contains the exact kill command
+//!   4. The hints warn against polling and loops
 #![cfg(test)]
 
 use std::path::Path;
@@ -79,6 +80,19 @@ fn daemon_wait_command_places_cd_after_single_session_id() {
     assert!(
         !command.contains(&format!("--cd '{session_id}")),
         "session id must not be duplicated into the --cd argument"
+    );
+}
+
+#[test]
+fn daemon_kill_command_keeps_session_and_project_scope() {
+    let command = crate::daemon_caller_hints::format_session_kill_command(
+        "01KAS6M5XG7V4M4M6YDRS7P8R9",
+        Path::new("/receipt-sandbox/project"),
+    );
+
+    assert_eq!(
+        command,
+        "csa session kill --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --cd '/receipt-sandbox/project'"
     );
 }
 
@@ -215,10 +229,41 @@ fn run_cmd_daemon_wait_hint_warns_no_stack_wakeup() {
     let blocks = caller_hint_blocks(DAEMON_STARTED_OUTPUT_SRC);
     assert_eq!(
         blocks.len(),
-        1,
-        "shared daemon output emits one CALLER_HINT"
+        2,
+        "shared daemon output emits wait and cancellation CALLER_HINTs"
     );
-    assert_wait_hint_contract(blocks[0], "run_cmd_daemon");
+    let wait_blocks = blocks
+        .iter()
+        .filter(|block| block.contains("action=\\\"wait\\\""))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        wait_blocks.len(),
+        1,
+        "shared daemon output emits one wait hint"
+    );
+    assert_wait_hint_contract(wait_blocks[0], "run_cmd_daemon");
+}
+
+#[test]
+fn daemon_started_output_includes_a_durable_wait_cancellation_handle() {
+    let blocks = caller_hint_blocks(DAEMON_STARTED_OUTPUT_SRC);
+    let cancellation_blocks = blocks
+        .iter()
+        .filter(|block| block.contains("action=\\\"cancel_session\\\""))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        cancellation_blocks.len(),
+        1,
+        "daemon start output must emit one cancellation handle for a background wait"
+    );
+    let cancellation = cancellation_blocks[0];
+    assert!(cancellation.contains("kill_cmd=\\\""), "{cancellation}");
+    assert!(
+        cancellation.contains("does NOT stop the session"),
+        "{cancellation}"
+    );
+    assert!(cancellation.contains("task cancellation"), "{cancellation}");
 }
 
 #[test]
@@ -240,10 +285,19 @@ fn plan_cmd_daemon_wait_hint_warns_no_stack_wakeup() {
     let blocks = caller_hint_blocks(DAEMON_STARTED_OUTPUT_SRC);
     assert_eq!(
         blocks.len(),
-        1,
-        "shared daemon output emits one CALLER_HINT"
+        2,
+        "shared daemon output emits wait and cancellation CALLER_HINTs"
     );
-    assert_wait_hint_contract(blocks[0], "plan_cmd_daemon");
+    let wait_blocks = blocks
+        .iter()
+        .filter(|block| block.contains("action=\\\"wait\\\""))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        wait_blocks.len(),
+        1,
+        "shared daemon output emits one wait hint"
+    );
+    assert_wait_hint_contract(wait_blocks[0], "plan_cmd_daemon");
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -258,12 +258,18 @@ fn daemon_started_output_includes_a_durable_wait_cancellation_handle() {
         "daemon start output must emit one cancellation handle for a background wait"
     );
     let cancellation = cancellation_blocks[0];
-    assert!(cancellation.contains("kill_cmd=\\\""), "{cancellation}");
+    assert!(
+        !cancellation.contains("session=\\\"") && !cancellation.contains("kill_cmd=\\\""),
+        "cancellation hint must not duplicate the session or kill command already in CSA:SESSION_STARTED: {cancellation}"
+    );
     assert!(
         cancellation.contains("does NOT stop the session"),
         "{cancellation}"
     );
-    assert!(cancellation.contains("task cancellation"), "{cancellation}");
+    assert!(
+        cancellation.contains("CSA:SESSION_STARTED"),
+        "cancellation hint must direct callers to the durable kill command: {cancellation}"
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/daemon_caller_hints.rs
+++ b/crates/cli-sub-agent/src/daemon_caller_hints.rs
@@ -81,6 +81,13 @@ pub(crate) fn format_session_wait_command(
     )
 }
 
+pub(crate) fn format_session_kill_command(session_id: &str, project_root: &Path) -> String {
+    format!(
+        "csa session kill --session {session_id}{}",
+        format_cd_arg(project_root)
+    )
+}
+
 pub(crate) fn format_session_attach_command(session_id: &str, project_root: &Path) -> String {
     format!(
         "csa session attach --session {}{}",

--- a/crates/cli-sub-agent/src/daemon_started_output.rs
+++ b/crates/cli-sub-agent/src/daemon_started_output.rs
@@ -102,38 +102,26 @@ fn publish_to(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 
-    struct EnvVarGuard {
-        key: &'static str,
-        original: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
-            let original = std::env::var(key).ok();
-            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
-            unsafe { std::env::set_var(key, value) };
-            Self { key, original }
-        }
-
-        fn remove(key: &'static str) -> Self {
-            let original = std::env::var(key).ok();
-            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
-            unsafe { std::env::remove_var(key) };
-            Self { key, original }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            // SAFETY: test-scoped env mutation guarded by a process-wide mutex.
-            unsafe {
-                match self.original.as_deref() {
-                    Some(value) => std::env::set_var(self.key, value),
-                    None => std::env::remove_var(self.key),
-                }
-            }
-        }
+    fn isolate_daemon_started_env(
+        temp: &tempfile::TempDir,
+    ) -> (
+        ScopedEnvVarRestore,
+        ScopedEnvVarRestore,
+        ScopedEnvVarRestore,
+        ScopedEnvVarRestore,
+    ) {
+        let config_home = temp.path().join("xdg-config");
+        let state_home = temp.path().join("xdg-state");
+        std::fs::create_dir_all(&config_home).expect("test config home should exist");
+        std::fs::create_dir_all(&state_home).expect("test state home should exist");
+        (
+            ScopedEnvVarRestore::set("HOME", temp.path()),
+            ScopedEnvVarRestore::set("XDG_CONFIG_HOME", &config_home),
+            ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home),
+            ScopedEnvVarRestore::unset("HERMES_MODEL_PROVIDER"),
+        )
     }
 
     fn plan_spawn_result(
@@ -143,7 +131,7 @@ mod tests {
         std::path::PathBuf,
         csa_process::daemon::DaemonSpawnResult,
     ) {
-        let session_id = csa_session::new_session_id();
+        let session_id = "01KAS6M5XG7V4M4M6YDRS7P8R9".to_string();
         let session_root =
             csa_session::get_session_root(project_root).expect("session root should resolve");
         let session_dir = csa_session::get_session_dir(project_root, &session_id)
@@ -158,12 +146,12 @@ mod tests {
 
     #[test]
     fn started_marker_requires_waitable_placeholder() {
-        let _lock = crate::test_env_lock::TEST_ENV_LOCK
-            .clone()
-            .blocking_lock_owned();
+        let _lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
         let temp = tempfile::tempdir().expect("tempdir");
         let project_root = temp.path().join("project");
         std::fs::create_dir_all(&project_root).expect("project root should exist");
+        let (_home_guard, _config_guard, _state_guard, _provider_guard) =
+            isolate_daemon_started_env(&temp);
         let (session_id, session_root, result) = plan_spawn_result(&project_root);
         csa_session::create_session_with_daemon_env(
             &project_root,
@@ -179,7 +167,11 @@ mod tests {
         let output = prepare(&result, &project_root)
             .expect("waitable plan placeholder should permit marker rendering");
         assert_eq!(output.stdout, format!("{session_id}\n"));
-        assert_eq!(output.stderr.matches("CSA:SESSION_STARTED").count(), 1);
+        assert_eq!(
+            output.stderr.matches("<!-- CSA:SESSION_STARTED ").count(),
+            1,
+            "exactly one structured session-start marker must be emitted"
+        );
         assert!(output.stderr.contains("CSA:CALLER_HINT"));
         let _ = std::fs::remove_dir_all(session_root);
     }
@@ -244,17 +236,12 @@ mod tests {
 
     #[test]
     fn started_marker_fails_closed_when_no_configured_provider_matches_context() {
-        let _lock = crate::test_env_lock::TEST_ENV_LOCK
-            .clone()
-            .blocking_lock_owned();
+        let _lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
         let temp = tempfile::tempdir().expect("tempdir");
         let project_root = temp.path().join("project");
-        let config_root = temp.path().join("xdg-config");
         std::fs::create_dir_all(&project_root).expect("create project root");
-        std::fs::create_dir_all(&config_root).expect("create config root");
-        let _home_guard = EnvVarGuard::set("HOME", temp.path());
-        let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
-        let _provider_guard = EnvVarGuard::remove("HERMES_MODEL_PROVIDER");
+        let (_home_guard, _config_guard, _state_guard, _provider_guard) =
+            isolate_daemon_started_env(&temp);
         let config_path =
             csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
         std::fs::create_dir_all(config_path.parent().expect("config parent"))
@@ -297,12 +284,12 @@ mod tests {
 
     #[test]
     fn started_marker_is_suppressed_when_placeholder_is_unreadable() {
-        let _lock = crate::test_env_lock::TEST_ENV_LOCK
-            .clone()
-            .blocking_lock_owned();
+        let _lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
         let temp = tempfile::tempdir().expect("tempdir");
         let project_root = temp.path().join("project");
         std::fs::create_dir_all(&project_root).expect("project root should exist");
+        let (_home_guard, _config_guard, _state_guard, _provider_guard) =
+            isolate_daemon_started_env(&temp);
         let (_session_id, session_root, result) = plan_spawn_result(&project_root);
         std::fs::create_dir_all(&result.session_dir)
             .expect("session dir should exist without state.toml");

--- a/crates/cli-sub-agent/src/daemon_started_output.rs
+++ b/crates/cli-sub-agent/src/daemon_started_output.rs
@@ -65,13 +65,12 @@ pub(crate) fn prepare(
     })
 }
 
-fn render_wait_cancellation_hint(session_id: &str, kill_cmd: &str) -> String {
-    let session_id = crate::daemon_caller_hints::escape_structured_comment_attr(session_id);
-    let kill_cmd = crate::daemon_caller_hints::escape_structured_comment_attr(kill_cmd);
-    format!(
-        "<!-- CSA:CALLER_HINT action=\"cancel_session\" session=\"{session_id}\" kill_cmd=\"{kill_cmd}\" \
-         rule=\"IMPORTANT: stopping a background wait does NOT stop the session. On task cancellation, run kill_cmd.\" -->"
-    )
+fn render_wait_cancellation_hint(_session_id: &str, _kill_cmd: &str) -> String {
+    // SESSION_STARTED immediately precedes this hint and holds the exact,
+    // project-scoped kill command. Keep this repeat warning path-independent.
+    "<!-- CSA:CALLER_HINT action=\"cancel_session\" \
+     rule=\"IMPORTANT: stopping a background wait does NOT stop the session. To cancel it, explicitly run CSA:SESSION_STARTED kill_cmd.\" -->"
+        .to_string()
 }
 
 pub(crate) fn publish(output: DaemonStartedOutput) -> Result<()> {
@@ -185,24 +184,62 @@ mod tests {
         let _ = std::fs::remove_dir_all(session_root);
     }
 
+    const CALLER_HINT_MAX_BYTES: usize = 300;
+
     #[test]
-    fn wait_cancellation_hint_names_the_exact_kill_command() {
+    fn wait_cancellation_hint_uses_started_marker_kill_command_within_budget() {
         let session_id = "01KAS6M5XG7V4M4M6YDRS7P8R9";
         let kill_cmd = crate::daemon_caller_hints::format_session_kill_command(
             session_id,
-            Path::new("/receipt-sandbox/project"),
+            Path::new("/home/obj/project/github/RyderFreeman4Logos/cli-sub-agent"),
         );
 
         let hint = render_wait_cancellation_hint(session_id, &kill_cmd);
 
         assert!(hint.contains("action=\"cancel_session\""), "{hint}");
-        assert!(
-            hint.contains(&format!("session=\"{session_id}\"")),
-            "{hint}"
-        );
-        assert!(hint.contains(&kill_cmd), "{hint}");
+        assert!(!hint.contains(session_id), "{hint}");
+        assert!(!hint.contains(&kill_cmd), "{hint}");
         assert!(hint.contains("does NOT stop the session"), "{hint}");
-        assert!(hint.contains("task cancellation"), "{hint}");
+        assert!(hint.contains("CSA:SESSION_STARTED"), "{hint}");
+        let rendered_bytes = hint.as_bytes().len();
+        assert!(
+            rendered_bytes <= CALLER_HINT_MAX_BYTES,
+            "rendered cancellation hint is {} bytes, exceeds the {} byte budget: {hint}",
+            rendered_bytes,
+            CALLER_HINT_MAX_BYTES,
+        );
+    }
+
+    #[test]
+    fn wait_cancellation_hint_excludes_escaped_special_project_path_within_budget() {
+        let session_id = "01KAS6M5XG7V4M4M6YDRS7P8R9";
+        let kill_cmd = crate::daemon_caller_hints::format_session_kill_command(
+            session_id,
+            Path::new(
+                "/home/obj/project/github/RyderFreeman4Logos/cli-sub-agent/it's-\"quoted\"&<special>",
+            ),
+        );
+        let escaped_kill_cmd =
+            crate::daemon_caller_hints::escape_structured_comment_attr(&kill_cmd);
+
+        let hint = render_wait_cancellation_hint(session_id, &kill_cmd);
+
+        assert!(
+            escaped_kill_cmd.contains("&quot;")
+                && escaped_kill_cmd.contains("&amp;")
+                && escaped_kill_cmd.contains("&lt;")
+                && escaped_kill_cmd.contains("&gt;"),
+            "special project path must be escaped in the durable started marker: {escaped_kill_cmd}"
+        );
+        assert!(!hint.contains(&escaped_kill_cmd), "{hint}");
+        assert!(hint.contains("does NOT stop the session"), "{hint}");
+        let rendered_bytes = hint.as_bytes().len();
+        assert!(
+            rendered_bytes <= CALLER_HINT_MAX_BYTES,
+            "rendered cancellation hint is {} bytes, exceeds the {} byte budget: {hint}",
+            rendered_bytes,
+            CALLER_HINT_MAX_BYTES,
+        );
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/daemon_started_output.rs
+++ b/crates/cli-sub-agent/src/daemon_started_output.rs
@@ -34,20 +34,27 @@ pub(crate) fn prepare(
     };
     let attach_cmd =
         crate::daemon_caller_hints::format_session_attach_command(&result.session_id, project_root);
+    let kill_cmd =
+        crate::daemon_caller_hints::format_session_kill_command(&result.session_id, project_root);
     let session_dir_attr = crate::daemon_caller_hints::escape_structured_comment_attr(
         &result.session_dir.display().to_string(),
     );
     let attach_cmd_attr = crate::daemon_caller_hints::escape_structured_comment_attr(&attach_cmd);
+    let kill_cmd_attr = crate::daemon_caller_hints::escape_structured_comment_attr(&kill_cmd);
+    let cancellation_hint = render_wait_cancellation_hint(&result.session_id, &kill_cmd);
     let mut stderr = format!(
         "<!-- CSA:SESSION_STARTED id={id} pid={pid} dir=\"{dir}\" \
          wait_cmd=\"{wait_cmd}\" \
-         attach_cmd=\"{attach_cmd}\" -->\n\
-         {wait_hint}\n",
+         attach_cmd=\"{attach_cmd}\" \
+         kill_cmd=\"{kill_cmd}\" -->\n\
+         {wait_hint}\n\
+         {cancellation_hint}\n",
         id = result.session_id,
         pid = result.pid,
         dir = session_dir_attr,
         wait_cmd = wait_cmd_attr,
         attach_cmd = attach_cmd_attr,
+        kill_cmd = kill_cmd_attr,
     );
     stderr.push_str(&crate::process_tree::codex_yield_hint(
         wait_command.command(),
@@ -56,6 +63,15 @@ pub(crate) fn prepare(
         stdout: format!("{}\n", result.session_id),
         stderr,
     })
+}
+
+fn render_wait_cancellation_hint(session_id: &str, kill_cmd: &str) -> String {
+    let session_id = crate::daemon_caller_hints::escape_structured_comment_attr(session_id);
+    let kill_cmd = crate::daemon_caller_hints::escape_structured_comment_attr(kill_cmd);
+    format!(
+        "<!-- CSA:CALLER_HINT action=\"cancel_session\" session=\"{session_id}\" kill_cmd=\"{kill_cmd}\" \
+         rule=\"IMPORTANT: stopping a background wait does NOT stop the session. On task cancellation, run kill_cmd.\" -->"
+    )
 }
 
 pub(crate) fn publish(output: DaemonStartedOutput) -> Result<()> {
@@ -167,6 +183,26 @@ mod tests {
         assert_eq!(output.stderr.matches("CSA:SESSION_STARTED").count(), 1);
         assert!(output.stderr.contains("CSA:CALLER_HINT"));
         let _ = std::fs::remove_dir_all(session_root);
+    }
+
+    #[test]
+    fn wait_cancellation_hint_names_the_exact_kill_command() {
+        let session_id = "01KAS6M5XG7V4M4M6YDRS7P8R9";
+        let kill_cmd = crate::daemon_caller_hints::format_session_kill_command(
+            session_id,
+            Path::new("/receipt-sandbox/project"),
+        );
+
+        let hint = render_wait_cancellation_hint(session_id, &kill_cmd);
+
+        assert!(hint.contains("action=\"cancel_session\""), "{hint}");
+        assert!(
+            hint.contains(&format!("session=\"{session_id}\"")),
+            "{hint}"
+        );
+        assert!(hint.contains(&kill_cmd), "{hint}");
+        assert!(hint.contains("does NOT stop the session"), "{hint}");
+        assert!(hint.contains("task cancellation"), "{hint}");
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -11,10 +11,13 @@ use crate::startup_env::StartupSubtreeEnv;
 
 const STDIN_PROMPT_MAX_BYTES: u64 = 10 * 1024 * 1024;
 
+#[path = "run_cmd_daemon_debate_init.rs"]
+mod debate_init;
 #[path = "run_cmd_daemon_review.rs"]
 mod review;
 #[path = "run_cmd_daemon_tier_policy.rs"]
 mod tier_policy;
+use debate_init::prepare_detached_debate_initialization;
 pub(crate) use tier_policy::{
     RunDaemonTierPolicyPreflight, validate_run_tier_policy_before_daemon_spawn,
 };
@@ -319,6 +322,9 @@ pub(crate) fn spawn_and_exit(
     spawn_options: DaemonSpawnOptions,
 ) -> Result<()> {
     let project_root = crate::pipeline::determine_project_root(cd)?;
+    if subcommand == "debate" {
+        prepare_detached_debate_initialization(&project_root)?;
+    }
     if subcommand == "run" {
         validate_run_daemon_writable_sources(&project_root, &spawn_options)?;
     }
@@ -647,6 +653,9 @@ fn remove_prompt_file_arg(args: &mut Vec<String>, flags: &[&str], sentinel_only:
     }
 }
 
+#[cfg(test)]
+#[path = "run_cmd_daemon_debate_init_tests.rs"]
+mod debate_init_tests;
 #[cfg(test)]
 #[path = "run_cmd_daemon_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/run_cmd_daemon_debate_init.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_debate_init.rs
@@ -1,0 +1,77 @@
+//! Detached debate initialization state-directory preflight.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// Prepare the state directories a detached debate needs before the parent
+/// releases control of the child. This turns host path conflicts into a
+/// caller-visible diagnostic instead of a later bare `ENOTDIR` in daemon logs.
+pub(super) fn prepare_detached_debate_initialization(project_root: &Path) -> Result<()> {
+    let state_dir = csa_config::paths::state_dir_write()
+        .context("detached debate initialization could not resolve the CSA state directory")?;
+    ensure_detached_debate_directory(&state_dir, "CSA state directory")?;
+
+    let session_root = csa_session::get_session_root(project_root)
+        .context("detached debate initialization could not resolve the CSA session root")?;
+    ensure_detached_debate_directory(&session_root, "CSA project session directory")?;
+    ensure_detached_debate_directory(&session_root.join("sessions"), "CSA sessions directory")
+}
+
+fn ensure_detached_debate_directory(path: &Path, label: &str) -> Result<()> {
+    let conflict = first_non_directory_component(path)
+        .map_err(|error| detached_debate_directory_error(path, label, error))?;
+    if let Some(conflict) = conflict {
+        return detached_debate_directory_conflict(path, label, &conflict);
+    }
+
+    std::fs::create_dir_all(path)
+        .map_err(|error| detached_debate_directory_error(path, label, error))
+}
+
+fn detached_debate_directory_conflict(path: &Path, label: &str, conflict: &Path) -> Result<()> {
+    anyhow::bail!(
+        "detached debate initialization requires {label} '{}', but conflicting path '{}' is not a directory. \
+         Move or replace that path, then retry the debate.",
+        path.display(),
+        conflict.display(),
+    )
+}
+
+fn detached_debate_directory_error(
+    path: &Path,
+    label: &str,
+    error: std::io::Error,
+) -> anyhow::Error {
+    if error.kind() == std::io::ErrorKind::NotADirectory {
+        let conflict = first_non_directory_component(path)
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| path.to_path_buf());
+        return anyhow::anyhow!(
+            "detached debate initialization could not create {label} '{}'; conflicting path '{}' is not a directory: {error}. \
+             Move or replace that path, then retry the debate.",
+            path.display(),
+            conflict.display(),
+        );
+    }
+
+    anyhow::Error::new(error).context(format!(
+        "detached debate initialization could not create {label} '{}'",
+        path.display()
+    ))
+}
+
+fn first_non_directory_component(path: &Path) -> std::io::Result<Option<PathBuf>> {
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        match std::fs::metadata(&current) {
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => return Ok(Some(current)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(None)
+}

--- a/crates/cli-sub-agent/src/run_cmd_daemon_debate_init_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_debate_init_tests.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+#[test]
+fn detached_debate_initialization_prepares_state_session_directories_before_spawn() {
+    let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.blocking_lock();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project_root = temp.path().join("project");
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&project_root).expect("project root");
+    let _home_guard = crate::test_env_lock::ScopedEnvVarRestore::set("HOME", temp.path());
+    let _state_guard =
+        crate::test_env_lock::ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+
+    prepare_detached_debate_initialization(&project_root)
+        .expect("detached debate initialization should prepare session directories");
+
+    let session_root =
+        csa_session::get_session_root(&project_root).expect("session root should resolve");
+    assert!(
+        session_root.join("sessions").is_dir(),
+        "detached debate preflight should create the sessions directory"
+    );
+}
+
+#[test]
+fn detached_debate_initialization_names_xdg_state_file_conflict() {
+    let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.blocking_lock();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project_root = temp.path().join("project");
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&project_root).expect("project root");
+    std::fs::write(&state_home, "conflicting file").expect("state conflict fixture");
+    let _home_guard = crate::test_env_lock::ScopedEnvVarRestore::set("HOME", temp.path());
+    let _state_guard =
+        crate::test_env_lock::ScopedEnvVarRestore::set("XDG_STATE_HOME", &state_home);
+
+    let error = prepare_detached_debate_initialization(&project_root)
+        .expect_err("state file conflict must fail before daemon detaches");
+    let message = format!("{error:#}");
+
+    assert!(
+        message.contains("detached debate initialization"),
+        "{message}"
+    );
+    assert!(
+        message.contains(&state_home.display().to_string()),
+        "{message}"
+    );
+    assert!(message.contains("not a directory"), "{message}");
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1113"
-weave = "0.1.1113"
+csa = "0.1.1114"
+weave = "0.1.1114"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Validate detached debate state/session directories before daemon launch and report targeted non-directory conflicts.
- Make background wait cancellation lifecycle explicit: stopping `session wait` does not stop the writer; use the structured `kill_cmd`.
- Keep cancellation hint within the rendered 300-byte budget.
- Isolate daemon marker fixtures from host state.

## Validation

- Focused tests and pre-commit-fast passed.
- Exact-head full quality gate PASS on `abcc1bcb` (receipt `62a351dc…`).
- Fresh exact-head review PASS with zero blocking findings.

Closes #2823
Closes #2816