### PR TITLE
fix(session): exact provider TTL cost contract (#2867, #2869)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1114"
+version = "0.1.1115"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1114"
+version = "0.1.1115"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_session.rs
+++ b/crates/cli-sub-agent/src/cli_session.rs
@@ -293,9 +293,9 @@ pub enum SessionCommands {
     },
 
     /// Wait for a daemon session to report a terminal result.
-    /// Requires a configured `[kv_cache.provider_ttls]` key with TTL > 0. Pass
-    /// `--model-provider` on every wait; best-effort detection is accepted only
-    /// when it resolves to a configured positive-TTL key.
+    /// Every wait requires an explicit normalized `--model-provider` whose configured
+    /// `[kv_cache.provider_ttls]` entry is > 0. Its TTL is resolved exactly from that
+    /// entry; missing, unconfigured, or zero values fail closed.
     ///
     /// Optional memory early-exit: `--memory-warn-mb <N>` (or config
     /// `[session_wait].memory_warn_mb`) samples the watched session's process-tree RSS

--- a/crates/cli-sub-agent/src/daemon_caller_hints.rs
+++ b/crates/cli-sub-agent/src/daemon_caller_hints.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use csa_config::{GlobalConfig, ModelProvider, detect_model_provider, provider_ttl};
+use csa_config::{GlobalConfig, ModelProvider, provider_ttl};
 
 pub(crate) struct SessionWaitCommand {
     command: Option<String>,
@@ -28,10 +28,10 @@ impl SessionWaitCommand {
 
 /// Resolve a provider-qualified `csa session wait` command for caller hints.
 ///
-/// Explicit caller context takes precedence over best-effort current-process
-/// detection. A command is emitted only when its provider has a positive TTL
-/// in the active user configuration; otherwise the caller must choose from the
-/// legal keys carried by [`SessionWaitCommand::provider_selection_hint`].
+/// A command is emitted only for the explicit launch or wait provider when it
+/// has a positive TTL in the active user configuration. Otherwise the caller
+/// must choose from the legal keys carried by
+/// [`SessionWaitCommand::provider_selection_hint`].
 pub(crate) fn resolve_session_wait_command(
     session_id: &str,
     project_root: &Path,
@@ -51,22 +51,38 @@ pub(crate) fn resolve_session_wait_command(
                 .collect()
         })
         .unwrap_or_default();
-    let provider = preferred_provider
-        .cloned()
-        .or_else(detect_model_provider)
-        .filter(|provider| {
-            config
-                .as_ref()
-                .and_then(|config| provider_ttl(provider, &config.kv_cache))
-                .is_some()
-        });
+    let provider = preferred_provider.filter(|provider| {
+        config
+            .as_ref()
+            .and_then(|config| provider_ttl(provider, &config.kv_cache))
+            .is_some()
+    });
 
     SessionWaitCommand {
-        command: provider.as_ref().map(|provider| {
+        command: provider.map(|provider| {
             format_session_wait_command(session_id, project_root, provider.as_str())
         }),
         legal_provider_keys,
     }
+}
+
+/// Return the normalized provider carried by explicit launch routing only.
+///
+/// A direct `--model-spec` wins. Otherwise, a trusted inherited subtree pin
+/// may carry the launch identity for a nested CSA process. This intentionally
+/// does not inspect ambient provider configuration or environment variables:
+/// an unknown launch provider produces an actionable, non-runnable hint.
+pub(crate) fn explicit_wait_provider_from_launch_routing(
+    model_spec: Option<&str>,
+    startup_env: &crate::startup_env::StartupSubtreeEnv,
+) -> Option<ModelProvider> {
+    let inherited_pin = crate::run_cmd_model_pin::inherited_model_pin_from_startup(startup_env);
+    let model_spec =
+        model_spec.or_else(|| inherited_pin.as_ref().map(|pin| pin.model_spec.as_str()))?;
+    csa_executor::ModelSpec::parse(model_spec)
+        .ok()
+        .map(|spec| ModelProvider::new(&spec.provider))
+        .filter(|provider| !provider.as_str().is_empty())
 }
 
 /// Format every emitted shell wait command in one provider-aware form.
@@ -146,7 +162,7 @@ mod tests {
     }
 
     #[test]
-    fn wait_command_includes_detected_configured_model_provider() {
+    fn wait_command_rejects_ambient_provider_detection_without_explicit_routing_context() {
         let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().expect("tempdir");
         let config_root = dir.path().join("xdg-config");
@@ -161,16 +177,20 @@ mod tests {
         std::fs::write(config_path, "[kv_cache.provider_ttls]\nopenai = 17\n")
             .expect("write provider config");
 
-        assert_eq!(
-            resolve_session_wait_command(
-                "01KAS6M5XG7V4M4M6YDRS7P8R9",
-                Path::new("/tmp/repo"),
-                None,
-            )
-            .command(),
-            Some(
-                "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --model-provider openai --cd '/tmp/repo'"
-            )
+        let command = resolve_session_wait_command(
+            "01KAS6M5XG7V4M4M6YDRS7P8R9",
+            Path::new("/tmp/repo"),
+            None,
+        );
+        assert!(
+            command.command().is_none(),
+            "an initial or retry hint must not infer its provider from HERMES_MODEL_PROVIDER"
+        );
+        assert!(
+            command
+                .provider_selection_hint()
+                .contains("legal_keys=\"openai\""),
+            "missing explicit routing must fail closed with actionable legal keys"
         );
     }
 

--- a/crates/cli-sub-agent/src/daemon_caller_hints.rs
+++ b/crates/cli-sub-agent/src/daemon_caller_hints.rs
@@ -173,4 +173,52 @@ mod tests {
             )
         );
     }
+
+    #[test]
+    fn retry_command_reloads_provider_ttl_config_and_preserves_explicit_provider() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_root = dir.path().join("xdg-config");
+        std::fs::create_dir_all(&config_root).expect("create config root");
+        let _home_guard = EnvVarGuard::set("HOME", dir.path());
+        let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
+        let _provider_guard = EnvVarGuard::set("HERMES_MODEL_PROVIDER", "other");
+        let config_path =
+            csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
+        std::fs::create_dir_all(config_path.parent().expect("config parent"))
+            .expect("create config parent");
+        std::fs::write(&config_path, "[kv_cache.provider_ttls]\nxai = 3300\n")
+            .expect("write provider config");
+
+        let provider = csa_config::ModelProvider::new(" XAI ");
+        let command = resolve_session_wait_command(
+            "01KAS6M5XG7V4M4M6YDRS7P8R9",
+            Path::new("/tmp/repo"),
+            Some(&provider),
+        );
+        assert_eq!(
+            command.command(),
+            Some(
+                "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --model-provider xai --cd '/tmp/repo'"
+            )
+        );
+
+        std::fs::write(&config_path, "[kv_cache.provider_ttls]\nxai = 0\n")
+            .expect("invalidate provider config");
+        let reloaded = resolve_session_wait_command(
+            "01KAS6M5XG7V4M4M6YDRS7P8R9",
+            Path::new("/tmp/repo"),
+            Some(&provider),
+        );
+        assert!(
+            reloaded.command().is_none(),
+            "each retry must re-read current provider TTL configuration"
+        );
+        assert!(
+            reloaded
+                .provider_selection_hint()
+                .contains("legal_keys=\"none\""),
+            "an invalidated explicit provider must fail closed"
+        );
+    }
 }

--- a/crates/cli-sub-agent/src/daemon_started_output.rs
+++ b/crates/cli-sub-agent/src/daemon_started_output.rs
@@ -12,12 +12,13 @@ pub(crate) struct DaemonStartedOutput {
 pub(crate) fn prepare(
     result: &csa_process::daemon::DaemonSpawnResult,
     project_root: &Path,
+    wait_provider: Option<&csa_config::ModelProvider>,
 ) -> Result<DaemonStartedOutput> {
     crate::run_cmd_daemon::verify_daemon_session_waitable(project_root, &result.session_id)?;
     let wait_command = crate::daemon_caller_hints::resolve_session_wait_command(
         &result.session_id,
         project_root,
-        None,
+        wait_provider,
     );
     let wait_cmd_attr = wait_command
         .command()
@@ -164,7 +165,7 @@ mod tests {
         )
         .expect("plan placeholder should persist");
 
-        let output = prepare(&result, &project_root)
+        let output = prepare(&result, &project_root, None)
             .expect("waitable plan placeholder should permit marker rendering");
         assert_eq!(output.stdout, format!("{session_id}\n"));
         assert_eq!(
@@ -173,6 +174,60 @@ mod tests {
             "exactly one structured session-start marker must be emitted"
         );
         assert!(output.stderr.contains("CSA:CALLER_HINT"));
+        let _ = std::fs::remove_dir_all(session_root);
+    }
+
+    #[test]
+    fn root_initial_wait_hint_propagates_normalized_explicit_provider() {
+        let _lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_root = temp.path().join("project");
+        std::fs::create_dir_all(&project_root).expect("create project root");
+        let (_home_guard, _config_guard, _state_guard, _provider_guard) =
+            isolate_daemon_started_env(&temp);
+        let _ambient_provider = ScopedEnvVarRestore::set("HERMES_MODEL_PROVIDER", "custom");
+        let config_path =
+            csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
+        std::fs::create_dir_all(config_path.parent().expect("config parent"))
+            .expect("create config parent");
+        std::fs::write(config_path, "[kv_cache.provider_ttls]\nxai = 17\n")
+            .expect("write provider config");
+        let startup_env =
+            crate::startup_env::StartupSubtreeEnv::from_values(std::collections::HashMap::new());
+        let provider = crate::daemon_caller_hints::explicit_wait_provider_from_launch_routing(
+            Some("codex/XAI/gpt-5.5/xhigh"),
+            &startup_env,
+        )
+        .expect("explicit root model spec must carry a provider");
+        let (session_id, session_root, result) = plan_spawn_result(&project_root);
+        csa_session::create_session_with_daemon_env(
+            &project_root,
+            Some("run: explicit provider"),
+            None,
+            None,
+            Some(&session_id),
+            Some(&result.session_dir),
+            Some(&project_root),
+        )
+        .expect("run placeholder should persist");
+
+        let output =
+            prepare(&result, &project_root, Some(&provider)).expect("render root started marker");
+
+        let expected_wait_command = format!(
+            "wait_cmd=\"csa session wait --session {session_id} --model-provider xai --cd '{}'\"",
+            project_root.display(),
+        );
+        assert!(
+            output.stderr.contains(&expected_wait_command),
+            "root initial wait hint must preserve its normalized launch provider: {:#?}",
+            output.stderr
+        );
+        assert!(
+            !output.stderr.contains("--model-provider custom"),
+            "root initial wait hint must not use the ambient provider: {:#?}",
+            output.stderr
+        );
         let _ = std::fs::remove_dir_all(session_root);
     }
 
@@ -242,6 +297,7 @@ mod tests {
         std::fs::create_dir_all(&project_root).expect("create project root");
         let (_home_guard, _config_guard, _state_guard, _provider_guard) =
             isolate_daemon_started_env(&temp);
+        let _ambient_provider = ScopedEnvVarRestore::set("HERMES_MODEL_PROVIDER", "custom");
         let config_path =
             csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
         std::fs::create_dir_all(config_path.parent().expect("config parent"))
@@ -260,7 +316,7 @@ mod tests {
         )
         .expect("plan placeholder should persist");
 
-        let output = prepare(&result, &project_root).expect("render started marker");
+        let output = prepare(&result, &project_root, None).expect("render started marker");
 
         assert!(
             output
@@ -294,7 +350,7 @@ mod tests {
         std::fs::create_dir_all(&result.session_dir)
             .expect("session dir should exist without state.toml");
 
-        prepare(&result, &project_root)
+        prepare(&result, &project_root, None)
             .expect_err("unreadable placeholder must block marker rendering");
         let _ = std::fs::remove_dir_all(session_root);
     }

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -334,6 +334,11 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
                 },
             )?;
             let effective_no_daemon = no_daemon || goal.is_some();
+            let wait_hint_provider =
+                daemon_caller_hints::explicit_wait_provider_from_launch_routing(
+                    model_spec.as_deref(),
+                    &startup_env,
+                );
             let mut daemon_guard = run_cmd_daemon::check_daemon_flags(
                 "run",
                 effective_no_daemon,
@@ -349,7 +354,8 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
                     no_fs_sandbox,
                     &extra_writable,
                     wait,
-                ),
+                )
+                .with_wait_hint_provider(wait_hint_provider),
             )?;
 
             let stream_mode = if no_stream_stdout {
@@ -523,6 +529,11 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
             if !args.daemon_child && args.session_id.is_none() {
                 review_cmd::preflight::validate_before_session(&args, &startup_env)?;
             }
+            let wait_hint_provider =
+                daemon_caller_hints::explicit_wait_provider_from_launch_routing(
+                    args.model_spec.as_deref(),
+                    &startup_env,
+                );
             let review_daemon_options = if args.fix_finding {
                 run_cmd_daemon::DaemonSpawnOptions::for_review_fix_finding(
                     args.prompt.as_deref(),
@@ -530,7 +541,8 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
                 )
             } else {
                 run_cmd_daemon::DaemonSpawnOptions::default()
-            };
+            }
+            .with_wait_hint_provider(wait_hint_provider);
             let mut daemon_guard = run_cmd_daemon::check_daemon_flags(
                 "review",
                 args.no_daemon || args.check_verdict,
@@ -551,6 +563,11 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
             exit_current_process(exit_code);
         }
         Commands::Debate(args) => {
+            let wait_hint_provider =
+                daemon_caller_hints::explicit_wait_provider_from_launch_routing(
+                    args.model_spec.as_deref(),
+                    &startup_env,
+                );
             let mut daemon_guard = run_cmd_daemon::check_daemon_flags(
                 "debate",
                 args.no_daemon || args.dry_run,
@@ -562,7 +579,8 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
                     args.question.as_deref(),
                     args.topic.as_deref(),
                     args.question_file.as_deref(),
-                ),
+                )
+                .with_wait_hint_provider(wait_hint_provider),
             )?;
             let result =
                 debate_cmd::handle_debate(args, current_depth, output_format, &startup_env).await;

--- a/crates/cli-sub-agent/src/plan_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/plan_cmd_daemon.rs
@@ -252,6 +252,10 @@ pub(crate) fn spawn_and_exit(
     args: &PlanRunArgs,
     forwarded_args: Option<Vec<String>>,
 ) -> Result<()> {
+    let wait_hint_provider = crate::daemon_caller_hints::explicit_wait_provider_from_launch_routing(
+        args.model_spec_override.as_deref(),
+        &args.startup_env,
+    );
     let session_id = csa_session::new_session_id();
     let project_root = determine_project_root(args.cd.as_deref())?;
     let session_root = csa_session::get_session_root(&project_root)?;
@@ -294,7 +298,13 @@ pub(crate) fn spawn_and_exit(
 
     let spawn_result = csa_process::daemon::spawn_daemon_verified_and_publish(
         config,
-        |result| crate::daemon_started_output::prepare(result, &project_root),
+        |result| {
+            crate::daemon_started_output::prepare(
+                result,
+                &project_root,
+                wait_hint_provider.as_ref(),
+            )
+        },
         |_, output| crate::daemon_started_output::publish(output),
     );
     if let Err(error) = spawn_result {

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -31,6 +31,7 @@ pub(crate) struct DaemonSpawnOptions {
     no_fs_sandbox: bool,
     extra_writable: Vec<PathBuf>,
     wait_for_pre_spawn_memory_admission: bool,
+    wait_hint_provider: Option<csa_config::ModelProvider>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -67,6 +68,14 @@ impl PromptFileForwardArg {
 }
 
 impl DaemonSpawnOptions {
+    pub(crate) fn with_wait_hint_provider(
+        mut self,
+        wait_hint_provider: Option<csa_config::ModelProvider>,
+    ) -> Self {
+        self.wait_hint_provider = wait_hint_provider;
+        self
+    }
+
     pub(crate) fn for_run(
         skill: Option<&str>,
         prompt: Option<&str>,
@@ -365,6 +374,7 @@ pub(crate) fn spawn_and_exit(
         args: forwarded_args,
         env: daemon_env,
     };
+    let wait_hint_provider = spawn_options.wait_hint_provider.clone();
 
     let spawn_result = csa_process::daemon::spawn_daemon_verified_and_publish(
         config,
@@ -376,7 +386,11 @@ pub(crate) fn spawn_and_exit(
                     &result.session_dir,
                 )?;
             }
-            crate::daemon_started_output::prepare(result, &project_root)
+            crate::daemon_started_output::prepare(
+                result,
+                &project_root,
+                wait_hint_provider.as_ref(),
+            )
         },
         |_, output| crate::daemon_started_output::publish(output),
     );

--- a/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_tests.rs
@@ -564,6 +564,8 @@ fn daemon_child_startup_env_preserves_trusted_pin_for_run_review_debate() {
     }
 }
 
+include!("run_cmd_daemon_wait_hint_tests.rs");
+
 #[test]
 fn daemon_child_startup_env_does_not_trust_ambient_pin_without_sidecar() {
     let _lock = crate::test_env_lock::TEST_ENV_LOCK

--- a/crates/cli-sub-agent/src/run_cmd_daemon_wait_hint_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_wait_hint_tests.rs
@@ -1,0 +1,44 @@
+#[test]
+fn subagent_initial_wait_hint_preserves_trusted_normalized_provider() {
+    let _lock = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .blocking_lock_owned();
+    let state_home = tempfile::tempdir().expect("state tempdir");
+    let _state_guard =
+        crate::test_env_lock::ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
+    let project = tempfile::tempdir().expect("project tempdir");
+    let (_home_guard, _config_guard) = crate::test_env_lock::isolate_user_config(project.path());
+    let _ambient_provider =
+        crate::test_env_lock::ScopedEnvVarRestore::set("HERMES_MODEL_PROVIDER", "custom");
+    let config_path =
+        csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
+    std::fs::create_dir_all(config_path.parent().expect("config parent"))
+        .expect("create config parent");
+    std::fs::write(&config_path, "[kv_cache.provider_ttls]\nxai = 17\n")
+        .expect("write provider config");
+    let startup_env =
+        trusted_startup_env_for_daemon_parent(project.path(), "codex/XAI/gpt-5.5/xhigh", true);
+    let provider =
+        crate::daemon_caller_hints::explicit_wait_provider_from_launch_routing(None, &startup_env)
+            .expect("trusted subagent model pin must carry a provider");
+    let spawn_options = DaemonSpawnOptions::for_run(None, None, None, None, false, &[], false)
+        .with_wait_hint_provider(Some(provider));
+
+    let command = crate::daemon_caller_hints::resolve_session_wait_command(
+        "01KAS6M5XG7V4M4M6YDRS7P8R9",
+        project.path(),
+        spawn_options.wait_hint_provider.as_ref(),
+    );
+
+    assert_eq!(
+        command.command(),
+        Some(
+            format!(
+                "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --model-provider xai --cd '{}'",
+                project.path().display(),
+            )
+            .as_str()
+        ),
+        "subagent initial wait hint must preserve its trusted normalized launch provider"
+    );
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_completion.rs
@@ -3,6 +3,7 @@
 //! Extracted from `session_cmds_daemon_wait.rs` to reduce module complexity.
 
 use std::borrow::Cow;
+use std::fmt::Write as _;
 use std::path::Path;
 
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -102,6 +103,12 @@ pub(crate) fn terminal_result_wait_exit_code(status: &str, exit_code: i32) -> i3
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RenderedWaitCapOutcome {
+    exit_code: i32,
+    text: String,
+}
+
 pub(crate) fn emit_wait_cap_outcome(
     session_id: &str,
     cd: Option<&str>,
@@ -111,6 +118,29 @@ pub(crate) fn emit_wait_cap_outcome(
     session_dir: &Path,
     session_alive: bool,
 ) -> i32 {
+    let outcome = render_wait_cap_outcome(
+        session_id,
+        cd,
+        context,
+        wait_timeout_secs,
+        elapsed,
+        session_dir,
+        session_alive,
+    );
+    eprint!("{}", outcome.text);
+    outcome.exit_code
+}
+
+fn render_wait_cap_outcome(
+    session_id: &str,
+    cd: Option<&str>,
+    context: WaitCapContext<'_>,
+    wait_timeout_secs: u64,
+    elapsed: u64,
+    session_dir: &Path,
+    session_alive: bool,
+) -> RenderedWaitCapOutcome {
+    let mut text = String::new();
     let cd_arg = cd
         .map(|path| crate::daemon_caller_hints::format_cd_arg(Path::new(path)))
         .unwrap_or_default();
@@ -120,43 +150,55 @@ pub(crate) fn emit_wait_cap_outcome(
             context.project_root,
             context.preferred_provider,
         );
-        eprintln!(
+        let _ = writeln!(
+            text,
             "Session {session_id} still running after {wait_timeout_secs}s wait cap; returning so caller can warm its KV cache before re-waiting."
         );
         if let Some(progress) = WaitProgressDigest::from_session_dir(session_dir) {
-            eprintln!("{}", progress.render());
+            let _ = writeln!(text, "{}", progress.render());
         }
         if let Some(wait_cmd) = wait_command.command() {
             let wait_cmd_attr =
                 crate::daemon_caller_hints::escape_structured_comment_attr(wait_cmd);
-            eprintln!(
+            let _ = writeln!(
+                text,
                 "<!-- CSA:SESSION_WAIT_KV_WARM session={session_id} status=alive elapsed={elapsed}s action=re-wait cmd=\"{wait_cmd_attr}\" -->"
             );
-            eprintln!(
+            let _ = writeln!(
+                text,
                 "<!-- CSA:CALLER_HINT action=\"retry_wait\" rule=\"Session alive; re-wait in a NEW Bash call: {wait_cmd_attr}. Backgrounded? Task-notification is your wake signal — no polling, no loops.\" -->"
             );
             let codex_hint = crate::process_tree::codex_yield_hint(Some(wait_cmd));
             if !codex_hint.is_empty() {
-                eprint!("{codex_hint}");
+                text.push_str(&codex_hint);
             }
         } else {
-            eprintln!(
+            let _ = writeln!(
+                text,
                 "<!-- CSA:SESSION_WAIT_KV_WARM session={session_id} status=alive elapsed={elapsed}s action=select_wait_provider -->"
             );
-            eprintln!("{}", wait_command.provider_selection_hint());
+            let _ = writeln!(text, "{}", wait_command.provider_selection_hint());
         }
-        SESSION_WAIT_KV_WARM_EXIT_CODE
+        RenderedWaitCapOutcome {
+            exit_code: SESSION_WAIT_KV_WARM_EXIT_CODE,
+            text,
+        }
     } else {
-        eprintln!(
+        let _ = writeln!(
+            text,
             "Timeout: session {session_id} did not complete within {wait_timeout_secs}s and no live daemon process remains."
         );
         let result_cmd = format!("csa session result --session {session_id}{cd_arg}");
         let result_cmd_attr =
             crate::daemon_caller_hints::escape_structured_comment_attr(&result_cmd);
-        eprintln!(
+        let _ = writeln!(
+            text,
             "<!-- CSA:SESSION_WAIT_TIMEOUT session={session_id} elapsed={elapsed}s status=dead cmd=\"{result_cmd_attr}\" -->"
         );
-        SESSION_WAIT_TIMEOUT_EXIT_CODE
+        RenderedWaitCapOutcome {
+            exit_code: SESSION_WAIT_TIMEOUT_EXIT_CODE,
+            text,
+        }
     }
 }
 
@@ -218,7 +260,61 @@ fn format_elapsed_compact(seconds: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
     use chrono::TimeZone;
+
+    #[test]
+    fn wait_cap_and_retry_hint_preserve_exact_configured_xai_ttl() {
+        let _lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_home = temp.path().join("xdg-config");
+        std::fs::create_dir_all(&config_home).expect("create config home");
+        let _home = ScopedEnvVarRestore::set("HOME", temp.path());
+        let _config = ScopedEnvVarRestore::set("XDG_CONFIG_HOME", &config_home);
+        let config_path =
+            csa_config::ProjectConfig::user_config_path().expect("resolve config path");
+        std::fs::create_dir_all(config_path.parent().expect("config parent"))
+            .expect("create config parent");
+        std::fs::write(config_path, "[kv_cache.provider_ttls]\nxai = 3300\n")
+            .expect("write config");
+
+        let provider = csa_config::ModelProvider::new(" XAI ");
+        let outcome = render_wait_cap_outcome(
+            "01KAS6M5XG7V4M4M6YDRS7P8R9",
+            None,
+            WaitCapContext {
+                project_root: temp.path(),
+                preferred_provider: Some(&provider),
+            },
+            3300,
+            3300,
+            temp.path(),
+            true,
+        );
+
+        assert_eq!(outcome.exit_code, SESSION_WAIT_KV_WARM_EXIT_CODE);
+        assert!(
+            outcome.text.contains("after 3300s wait cap"),
+            "{}",
+            outcome.text
+        );
+        assert!(
+            outcome.text.contains(
+                "cmd=\"csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --model-provider xai"
+            ),
+            "{}",
+            outcome.text
+        );
+        assert!(
+            outcome
+                .text
+                .contains("CSA:CALLER_HINT action=\"retry_wait\""),
+            "{}",
+            outcome.text
+        );
+        assert!(!outcome.text.contains("240"), "{}", outcome.text);
+        assert!(!outcome.text.contains("3000"), "{}", outcome.text);
+    }
 
     #[test]
     fn progress_digest_renders_elapsed_tool_and_last_event() {

--- a/crates/cli-sub-agent/src/session_cmds_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result.rs
@@ -214,6 +214,7 @@ pub(crate) fn handle_session_result(
             &resolved_id,
             result,
             json,
+            effective_root,
         );
         return Ok(());
     }

--- a/crates/cli-sub-agent/src/session_dispatch.rs
+++ b/crates/cli-sub-agent/src/session_dispatch.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use crate::cli::SessionCommands;
 use crate::session_cmds;
 use crate::startup_env::StartupSubtreeEnv;
-use csa_config::{GlobalConfig, ModelProvider, ProjectConfig, detect_model_provider, provider_ttl};
+use csa_config::{GlobalConfig, ModelProvider, ProjectConfig, provider_ttl};
 use csa_core::types::OutputFormat;
 
 /// Resolve session ID from positional arg or --session flag.
@@ -245,8 +245,10 @@ pub(crate) fn dispatch(
 
 /// Resolve the `csa session wait` cap from provider-aware KV cache config.
 ///
-/// CLI provider override wins over best-effort provider detection. Both paths
-/// must resolve to a configured `[kv_cache.provider_ttls]` key with TTL > 0.
+/// Every invocation reloads the active user configuration and requires an
+/// explicit provider that resolves to a configured `[kv_cache.provider_ttls]`
+/// key with TTL > 0. A retry command therefore observes the latest config,
+/// while an in-flight wait retains its invocation's cap.
 #[cfg(test)]
 fn resolve_wait_ttl(cli_model_provider: Option<ModelProvider>) -> Result<u64> {
     Ok(resolve_wait_provider_and_ttl(cli_model_provider)?.1)
@@ -255,49 +257,27 @@ fn resolve_wait_ttl(cli_model_provider: Option<ModelProvider>) -> Result<u64> {
 fn resolve_wait_provider_and_ttl(
     cli_model_provider: Option<ModelProvider>,
 ) -> Result<(ModelProvider, u64)> {
-    let detected_provider = detect_model_provider();
     let config = match GlobalConfig::load() {
         Ok(config) => config,
         Err(error) => {
             return Err(wait_provider_error(
                 cli_model_provider.as_ref(),
-                detected_provider.as_ref(),
                 None,
                 Some(&error),
             ));
         }
     };
 
-    if let Some(provider) = cli_model_provider.as_ref() {
-        return provider_ttl(provider, &config.kv_cache)
-            .map(|ttl| (provider.clone(), ttl))
-            .ok_or_else(|| {
-                wait_provider_error(
-                    Some(provider),
-                    detected_provider.as_ref(),
-                    Some(&config),
-                    None,
-                )
-            });
-    }
-
-    if let Some(provider) = detected_provider.as_ref()
-        && let Some(ttl) = provider_ttl(provider, &config.kv_cache)
-    {
-        return Ok((provider.clone(), ttl));
-    }
-
-    Err(wait_provider_error(
-        None,
-        detected_provider.as_ref(),
-        Some(&config),
-        None,
-    ))
+    let provider = cli_model_provider
+        .as_ref()
+        .ok_or_else(|| wait_provider_error(None, Some(&config), None))?;
+    provider_ttl(provider, &config.kv_cache)
+        .map(|ttl| (provider.clone(), ttl))
+        .ok_or_else(|| wait_provider_error(Some(provider), Some(&config), None))
 }
 
 fn wait_provider_error(
     requested_provider: Option<&ModelProvider>,
-    detected_provider: Option<&ModelProvider>,
     config: Option<&GlobalConfig>,
     config_error: Option<&anyhow::Error>,
 ) -> anyhow::Error {
@@ -330,24 +310,6 @@ fn wait_provider_error(
             "Requested key: {} (missing from provider_ttls or TTL is not > 0).",
             provider.as_str()
         );
-    }
-    match detected_provider {
-        Some(provider) => {
-            let configured = config
-                .and_then(|config| provider_ttl(provider, &config.kv_cache))
-                .is_some();
-            let status = if configured {
-                "configured"
-            } else {
-                "not a configured key with TTL > 0"
-            };
-            let _ = writeln!(
-                message,
-                "Detected hints (best-effort, not authoritative): {} ({status}).",
-                provider.as_str()
-            );
-        }
-        None => message.push_str("Detected hints (best-effort, not authoritative): none.\n"),
     }
     if let Some(error) = config_error {
         let _ = writeln!(message, "Config load error: {error:#}");
@@ -502,7 +464,7 @@ disabled = 0
     }
 
     #[test]
-    fn resolve_wait_ttl_accepts_only_a_detected_configured_provider() {
+    fn resolve_wait_ttl_requires_cli_provider_even_when_environment_is_configured() {
         let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
@@ -518,11 +480,22 @@ custom = 1666
 "#,
         );
 
-        assert_eq!(resolve_wait_ttl(None).unwrap(), 1666);
+        let error = resolve_wait_ttl(None)
+            .expect_err("configured ambient provider must not bypass --model-provider");
+        let message = error.to_string();
+        assert!(
+            message.contains("requires --model-provider <key>"),
+            "{message}"
+        );
+        assert!(message.contains("custom=1666"), "{message}");
+        assert!(
+            !message.contains("Detected hints"),
+            "ambient provider detection must not affect session waits: {message}"
+        );
     }
 
     #[test]
-    fn resolve_wait_ttl_maps_openai_codex_hint_to_openai() {
+    fn resolve_wait_ttl_requires_cli_provider_even_when_openai_codex_environment_is_configured() {
         let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().unwrap();
         let config_root = dir.path().join("xdg-config");
@@ -538,6 +511,13 @@ openai = 1666
 "#,
         );
 
-        assert_eq!(resolve_wait_ttl(None).unwrap(), 1666);
+        let error = resolve_wait_ttl(None)
+            .expect_err("provider aliases from ambient configuration must not select a wait TTL");
+        assert!(
+            error
+                .to_string()
+                .contains("requires --model-provider <key>"),
+            "{error:#}"
+        );
     }
 }

--- a/crates/cli-sub-agent/src/session_dispatch.rs
+++ b/crates/cli-sub-agent/src/session_dispatch.rs
@@ -8,7 +8,6 @@ use anyhow::Result;
 use crate::cli::SessionCommands;
 use crate::session_cmds;
 use crate::startup_env::StartupSubtreeEnv;
-use csa_config::provider_detection::MAX_WAIT_TTL_SECONDS;
 use csa_config::{GlobalConfig, ModelProvider, ProjectConfig, detect_model_provider, provider_ttl};
 use csa_core::types::OutputFormat;
 
@@ -313,23 +312,16 @@ fn wait_provider_error(
     );
 
     let mut legal_key_count = 0;
-    let mut has_clamped_ttl = false;
     if let Some(config) = config {
         for (provider, ttl) in &config.kv_cache.provider_ttls.0 {
             if *ttl > 0 {
                 let _ = writeln!(message, "  {provider}={ttl}");
                 legal_key_count += 1;
-                has_clamped_ttl |= *ttl > MAX_WAIT_TTL_SECONDS;
             }
         }
     }
     if legal_key_count == 0 {
         message.push_str("  (none with TTL > 0)\n");
-    } else if has_clamped_ttl {
-        let _ = writeln!(
-            message,
-            "Effective wait TTL is capped at {MAX_WAIT_TTL_SECONDS} seconds."
-        );
     }
 
     if let Some(provider) = requested_provider {

--- a/crates/cli-sub-agent/src/session_tier_failover.rs
+++ b/crates/cli-sub-agent/src/session_tier_failover.rs
@@ -26,6 +26,7 @@ pub(crate) fn emit_pending_tier_failover_handoff(
     session_id: &str,
     result: &csa_session::SessionResult,
     json: bool,
+    project_root: &Path,
 ) {
     if json {
         println!(
@@ -40,14 +41,29 @@ pub(crate) fn emit_pending_tier_failover_handoff(
         );
     } else {
         eprintln!(
-            "Session {session_id} is awaiting tier fallback; retry `csa session wait --session {session_id}` for the fallback result."
+            "{}",
+            render_pending_tier_failover_handoff(session_id, project_root)
         );
     }
+}
+
+fn render_pending_tier_failover_handoff(session_id: &str, project_root: &Path) -> String {
+    let wait_command =
+        crate::daemon_caller_hints::resolve_session_wait_command(session_id, project_root, None);
+    debug_assert!(
+        wait_command.command().is_none(),
+        "tier fallback has no trusted provider and must not emit a runnable wait command"
+    );
+    format!(
+        "Session {session_id} is awaiting tier fallback; select a configured provider before retrying.\n{}",
+        wait_command.provider_selection_hint()
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK, isolate_user_config};
 
     #[test]
     fn session_result_hides_tier_failover_superseded_result_while_liveness_present() {
@@ -68,6 +84,43 @@ mod tests {
         assert!(
             is_pending_tier_failover_handoff(tmp.path(), &result),
             "live superseded tier attempts are handoff-pending, not terminal result failures"
+        );
+    }
+
+    #[test]
+    fn pending_tier_failover_handoff_requires_selecting_configured_wait_provider() {
+        let _lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (_home_guard, _config_guard) = isolate_user_config(temp.path());
+        let _ambient_provider =
+            ScopedEnvVarRestore::set("HERMES_MODEL_PROVIDER", "ambient-conflict");
+        let config_path =
+            csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
+        std::fs::create_dir_all(config_path.parent().expect("config parent"))
+            .expect("create config parent");
+        std::fs::write(
+            config_path,
+            "[kv_cache.provider_ttls]\nopenai = 17\nxai = 3300\ndisabled = 0\n",
+        )
+        .expect("write provider config");
+
+        let text = render_pending_tier_failover_handoff("01KAS6M5XG7V4M4M6YDRS7P8R9", temp.path());
+
+        assert!(
+            text.contains("CSA:CALLER_HINT action=\"select_wait_provider\""),
+            "tier fallback without trusted provider must require explicit provider selection: {text}"
+        );
+        assert!(
+            text.contains("legal_keys=\"openai,xai\""),
+            "only positive configured provider keys must be actionable: {text}"
+        );
+        assert!(
+            !text.contains("csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9"),
+            "tier fallback must never emit a bare providerless wait command: {text}"
+        );
+        assert!(
+            !text.contains("ambient-conflict"),
+            "tier fallback must not infer a provider from ambient environment: {text}"
         );
     }
 }

--- a/crates/cli-sub-agent/tests/session_wait_provider_ttl.rs
+++ b/crates/cli-sub-agent/tests/session_wait_provider_ttl.rs
@@ -231,7 +231,7 @@ fn wait_uses_only_explicitly_configured_provider_ttl_keys() {
 }
 
 #[test]
-fn session_wait_help_requires_a_configured_provider_ttl() {
+fn session_wait_help_requires_an_explicit_configured_provider_ttl() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let output = csa_cmd(tmp.path())
         .args(["session", "wait", "--help"])
@@ -241,8 +241,24 @@ fn session_wait_help_requires_a_configured_provider_ttl() {
 
     assert!(output.status.success(), "{stdout}");
     assert!(
-        stdout.contains("configured [kv_cache.provider_ttls] key"),
+        stdout.contains("Every wait requires an explicit normalized `--model-provider`"),
         "{stdout}"
+    );
+    assert!(
+        stdout.contains("configured `[kv_cache.provider_ttls]` entry is > 0"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("Its TTL is resolved exactly from that entry"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("missing, unconfigured, or zero values fail closed"),
+        "{stdout}"
+    );
+    assert!(
+        !stdout.contains("best-effort detection"),
+        "obsolete ambient-provider wording must not appear: {stdout}"
     );
     assert!(!stdout.contains("default_ttl_seconds"), "{stdout}");
 }

--- a/crates/cli-sub-agent/tests/session_wait_provider_ttl.rs
+++ b/crates/cli-sub-agent/tests/session_wait_provider_ttl.rs
@@ -87,29 +87,31 @@ fn wait_without_provider_fails_closed_before_session_lookup() {
 }
 
 #[test]
-fn wait_with_detected_but_unconfigured_provider_fails_closed() {
+fn wait_requires_explicit_provider_even_when_environment_provider_is_configured() {
     let tmp = tempfile::tempdir().expect("tempdir");
     write_wait_config(tmp.path());
 
     let output = csa_cmd(tmp.path())
-        .env("HERMES_MODEL_PROVIDER", "not-configured")
+        .env("HERMES_MODEL_PROVIDER", "custom")
         .args(["session", "wait", "01ARZ3NDEKTSV4RRFFQ69G5FAV"])
         .output()
         .expect("run csa session wait");
 
-    assert!(!output.status.success());
     let stderr = stderr(&output);
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
     assert!(
         stderr.contains("requires --model-provider <key>"),
         "{stderr}"
     );
-    assert!(stderr.contains("not-configured"), "{stderr}");
+    assert!(stderr.contains("custom=17"), "{stderr}");
     assert!(
-        stderr.contains("not a configured key with TTL > 0"),
+        !stderr.contains("Detected hints"),
+        "ambient provider detection must not affect the wait contract: {stderr}"
+    );
+    assert!(
+        !stderr.contains("session registry lookup failed"),
         "{stderr}"
     );
-    assert!(stderr.contains("CSA:CALLER_HINT"), "{stderr}");
-    assert!(!stderr.contains("Session registry entry"), "{stderr}");
 }
 
 #[test]
@@ -131,6 +133,48 @@ fn wait_with_unconfigured_provider_lists_only_positive_legal_keys() {
             "{stderr}"
         );
     }
+}
+
+#[test]
+fn wait_with_explicit_provider_fails_closed_when_config_is_missing_or_invalid() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let missing = run_wait(tmp.path(), &["--model-provider", "xai"]);
+    let missing_stderr = stderr(&missing);
+    assert_eq!(missing.status.code(), Some(1), "{missing_stderr}");
+    assert!(
+        missing_stderr.contains("requires --model-provider <key>"),
+        "{missing_stderr}"
+    );
+    assert!(
+        !missing_stderr.contains("session registry lookup failed"),
+        "{missing_stderr}"
+    );
+
+    let config_path = global_config_path(tmp.path());
+    std::fs::create_dir_all(config_path.parent().expect("config parent"))
+        .expect("create config dir");
+    std::fs::write(
+        &config_path,
+        "[kv_cache.provider_ttls]\nxai = \"invalid\"\n",
+    )
+    .expect("write invalid provider config");
+
+    let invalid = run_wait(tmp.path(), &["--model-provider", "xai"]);
+    let invalid_stderr = stderr(&invalid);
+    assert_eq!(invalid.status.code(), Some(1), "{invalid_stderr}");
+    assert!(
+        invalid_stderr.contains("requires --model-provider <key>"),
+        "{invalid_stderr}"
+    );
+    assert!(
+        invalid_stderr.contains("Config load error"),
+        "{invalid_stderr}"
+    );
+    assert!(
+        !invalid_stderr.contains("session registry lookup failed"),
+        "{invalid_stderr}"
+    );
 }
 
 #[test]

--- a/crates/csa-acp/Cargo.toml
+++ b/crates/csa-acp/Cargo.toml
@@ -10,7 +10,7 @@ agent-client-protocol = { version = "0.10", features = ["unstable_session_usage"
 csa-core.workspace = true
 csa-process.workspace = true
 csa-resource.workspace = true
-tokio = { version = "1.36", features = ["rt", "process", "io-util", "macros"] }
+tokio = { version = "1.36", features = ["rt", "process", "io-util", "macros", "net"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/csa-acp/src/connection_initial_response_tests.rs
+++ b/crates/csa-acp/src/connection_initial_response_tests.rs
@@ -1,8 +1,12 @@
 use std::{
     cell::{Cell, RefCell},
+    ops::Deref,
     rc::Rc,
     time::Duration,
 };
+
+#[cfg(target_os = "linux")]
+use std::path::Path;
 
 use agent_client_protocol::{
     AgentSideConnection, AvailableCommand, AvailableCommandsUpdate, Client as _,
@@ -12,7 +16,8 @@ use agent_client_protocol::{
     SessionUpdate, StopReason, TextContent,
 };
 use tokio::{
-    io::AsyncReadExt,
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{UnixListener, UnixStream},
     process::{Child, Command},
     task::LocalSet,
 };
@@ -85,12 +90,149 @@ impl agent_client_protocol::Agent for HangingTestAgent {
 
 fn spawn_test_child(shell_script: &str) -> Child {
     let mut cmd = Command::new("sh");
-    cmd.arg("-c")
-        .arg(shell_script)
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped());
+    cmd.arg("-c").arg(shell_script);
+    configure_test_child(&mut cmd);
     cmd.spawn().expect("spawn test child")
+}
+
+fn configure_test_child(cmd: &mut Command) {
+    cmd.stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        // The test connection owns the child. Ensure an assertion panic cannot
+        // leave its direct child behind while the nextest worker stays alive.
+        .kill_on_drop(true);
+
+    #[cfg(unix)]
+    {
+        // AcpConnection::kill targets -PID, so fixtures must be process-group
+        // leaders for descendant cleanup to be meaningful.
+        cmd.process_group(0);
+    }
+}
+
+struct TestConnectionGuard {
+    connection: AcpConnection,
+    #[cfg(unix)]
+    process_group_leader: Option<u32>,
+}
+
+impl TestConnectionGuard {
+    fn new(connection: AcpConnection) -> Self {
+        #[cfg(unix)]
+        let process_group_leader = connection.child_pid();
+
+        Self {
+            connection,
+            #[cfg(unix)]
+            process_group_leader,
+        }
+    }
+}
+
+impl Deref for TestConnectionGuard {
+    type Target = AcpConnection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.connection
+    }
+}
+
+impl Drop for TestConnectionGuard {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if self
+            .process_group_leader
+            .is_some_and(|pid| self.connection.child_pid() == Some(pid))
+        {
+            // SAFETY: the unreaped child still owns this process-group ID. This
+            // is test-only panic cleanup; normal timeout cleanup remains in
+            // AcpConnection::kill.
+            unsafe {
+                libc::kill(
+                    -(self.process_group_leader.expect("stored process group") as i32),
+                    libc::SIGKILL,
+                );
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+struct CpuBoundChildFixture {
+    _temp_dir: tempfile::TempDir,
+    control: Option<UnixStream>,
+}
+
+#[cfg(target_os = "linux")]
+impl CpuBoundChildFixture {
+    async fn spawn() -> (Self, Child) {
+        let temp_dir = tempfile::tempdir().expect("create CPU-bound child fixture directory");
+        let control_path = temp_dir.path().join("control.sock");
+        let listener = UnixListener::bind(&control_path).expect("bind CPU-bound child control socket");
+
+        let child = spawn_cpu_bound_test_child(&control_path);
+        let control = wait_for_cpu_fixture_connection(&listener).await;
+
+        (
+            Self {
+                _temp_dir: temp_dir,
+                control: Some(control),
+            },
+            child,
+        )
+    }
+
+    async fn begin_cpu_load(&mut self) {
+        let mut control = self
+            .control
+            .take()
+            .expect("CPU-bound fixture control connection");
+        control
+            .write_all(&[1])
+            .await
+            .expect("release CPU-bound child into its load loop");
+
+        let mut started = [0];
+        tokio::time::timeout(Duration::from_secs(5), control.read_exact(&mut started))
+            .await
+            .expect("CPU-bound child did not begin its load loop")
+            .expect("read CPU-bound child load-loop acknowledgement");
+        assert_eq!(started, [1], "unexpected CPU-bound child load-loop acknowledgement");
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_cpu_bound_test_child(control_path: &Path) -> Child {
+    const CPU_LOAD_FIXTURE: &str = r#"
+import socket
+import sys
+
+control_path = sys.argv[1]
+with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as control:
+    control.connect(control_path)
+    if control.recv(1) != b"\x01":
+        raise RuntimeError("CPU-bound fixture was released without its control byte")
+    for _ in range(1_000_000):
+        pass
+    control.sendall(b"\x01")
+    while True:
+        pass
+"#;
+
+    let mut cmd = Command::new("python3");
+    cmd.arg("-c").arg(CPU_LOAD_FIXTURE).arg(control_path);
+    configure_test_child(&mut cmd);
+    cmd.spawn().expect("spawn CPU-bound test child")
+}
+
+#[cfg(target_os = "linux")]
+async fn wait_for_cpu_fixture_connection(listener: &UnixListener) -> UnixStream {
+    tokio::time::timeout(Duration::from_secs(5), listener.accept())
+        .await
+        .expect("CPU-bound child did not reach its control handshake")
+        .expect("accept CPU-bound child control connection")
+        .0
 }
 
 fn append_test_stderr_tail(stderr_buf: &mut String, chunk: &str) {
@@ -106,7 +248,7 @@ async fn build_test_connection(
     mut child: Child,
     prompt_delay: Duration,
     prompt_behavior: PromptBehavior,
-) -> AcpConnection {
+) -> TestConnectionGuard {
     let stdin = child.stdin.take().expect("child stdin");
     let stdout = child.stdout.take().expect("child stdout");
     let stderr = child.stderr.take().expect("child stderr");
@@ -202,7 +344,7 @@ async fn build_test_connection(
         })
         .await;
 
-    AcpConnection::new_from_parts(
+    TestConnectionGuard::new(AcpConnection::new_from_parts(
         local_set,
         connection,
         child,
@@ -216,7 +358,7 @@ async fn build_test_connection(
             termination_grace_period: Duration::ZERO,
             ..AcpConnectionOptions::default()
         },
-    )
+    ))
 }
 
 #[test]
@@ -396,10 +538,9 @@ async fn idle_timeout_stays_alive_while_child_process_tree_consumes_cpu() {
 #[cfg(target_os = "linux")]
 #[tokio::test]
 async fn initial_response_timeout_fires_while_child_process_tree_consumes_cpu() {
+    let (mut cpu_fixture, child) = CpuBoundChildFixture::spawn().await;
     let connection = build_test_connection(
-        spawn_test_child(
-            "python3 -c 'import time\nend=time.monotonic()+2\nwhile time.monotonic()<end:\n pass'",
-        ),
+        child,
         Duration::from_secs(5),
         PromptBehavior::Silent,
     )
@@ -411,6 +552,8 @@ async fn initial_response_timeout_fires_while_child_process_tree_consumes_cpu() 
         .new_session(None, Some(cwd.as_path()), None)
         .await
         .expect("new session");
+
+    cpu_fixture.begin_cpu_load().await;
 
     let result = tokio::time::timeout(
         Duration::from_millis(700),

--- a/crates/csa-config/src/config.rs
+++ b/crates/csa-config/src/config.rs
@@ -613,6 +613,7 @@ frequent_poll_seconds = 60
 # General long-poll TTL; not a providerless `csa session wait` fallback.
 default_ttl_seconds = 240
 # `csa session wait` requires a positive-TTL key passed via --model-provider.
+# The configured value is used exactly as the wait cap; no source fallback or maximum applies.
 [kv_cache.provider_ttls]
 claude = 3300
 openai = 1700

--- a/crates/csa-config/src/global_template.rs
+++ b/crates/csa-config/src/global_template.rs
@@ -128,6 +128,7 @@ default_ttl_seconds = 240
 
 # `csa session wait` requires one positive-TTL key from this table. Calling agents
 # should derive the current provider dynamically and pass `--model-provider` every time.
+# The configured value is used exactly as the wait cap; no source fallback or maximum applies.
 [kv_cache.provider_ttls]
 claude = 3300
 openai = 1700

--- a/crates/csa-config/src/provider_detection.rs
+++ b/crates/csa-config/src/provider_detection.rs
@@ -46,10 +46,10 @@ pub fn detect_model_provider() -> Option<ModelProvider> {
     detect_model_provider_from_env().or_else(detect_model_provider_from_hermes_config)
 }
 
-/// Maximum allowed wait TTL in seconds (#2538).
-/// Provider TTLs exceeding this cap are clamped to prevent excessively long waits.
-pub const MAX_WAIT_TTL_SECONDS: u64 = 3000;
-
+/// Return the provider-specific session-wait TTL exactly as configured.
+///
+/// A missing or zero value is invalid for session waits; callers must report a
+/// fail-closed diagnostic rather than substitute a generic TTL.
 pub fn provider_ttl(provider: &ModelProvider, config: &KvCacheConfig) -> Option<u64> {
     config
         .provider_ttls
@@ -57,7 +57,6 @@ pub fn provider_ttl(provider: &ModelProvider, config: &KvCacheConfig) -> Option<
         .get(provider.as_str())
         .copied()
         .filter(|seconds| *seconds > 0)
-        .map(|seconds| seconds.min(MAX_WAIT_TTL_SECONDS))
 }
 
 fn detect_model_provider_from_env() -> Option<ModelProvider> {
@@ -268,13 +267,10 @@ model:
     }
 
     #[test]
-    fn issue_2538_provider_ttl_clamped_to_max_cap() {
+    fn provider_ttl_honors_exact_configured_value_above_3000() {
         let provider_ttls = crate::ProviderTtls(std::collections::BTreeMap::from([
-            ("claude".to_string(), 5000),
+            ("xai".to_string(), 3300),
             ("openai".to_string(), 0),
-            ("glm".to_string(), 0),
-            ("xai".to_string(), 0),
-            ("other".to_string(), 0),
         ]));
         let config = KvCacheConfig {
             default_ttl_seconds: 540,
@@ -282,12 +278,12 @@ model:
             frequent_poll_seconds: 30,
             provider_ttls,
         };
-        // Claude TTL 5000 > 3000 cap → clamped to 3000
+
         assert_eq!(
-            provider_ttl(&ModelProvider::new("claude"), &config),
-            Some(3000)
+            provider_ttl(&ModelProvider::new("xai"), &config),
+            Some(3300)
         );
-        // Zero-valued providers remain invalid rather than using the default TTL.
+        // Zero-valued providers remain invalid rather than using the general TTL.
         assert_eq!(provider_ttl(&ModelProvider::new("openai"), &config), None);
     }
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1114"
-weave = "0.1.1114"
+csa = "0.1.1115"
+weave = "0.1.1115"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
Joint cost-contract fix for session-wait provider TTL semantics.

- **Closes #2867** — remove hidden 3000s clamp; configured positive provider TTL is exact (`xai=3300` remains 3300).
- **Closes #2869** — session wait requires explicit/trusted `--model-provider`; no providerless/default 240s fallback; missing/unconfigured/zero TTL fail closed; templates own only user-visible defaults; config re-read per wait invocation/retry; initial/retry/tier-fallback hints carry explicit provider or `select_wait_provider`; CLI help matches runtime contract.

## Commits (`main...HEAD`)
- `182c7c9b` fix(config): honor exact provider TTL without hidden clamp
- `b9ca499a` fix(session): require explicit provider TTL without defaults
- `af8d6d9e` test(acp): stabilize CPU-bound initial-response timeout fixture
- `006e7f74` fix(session): preserve explicit provider in initial wait hints
- `57ef8684` fix(session): fail closed for tier-fallback wait hint
- `b7499ad5` fix(session): document explicit provider wait contract

## Exact-head evidence
- **HEAD:** `b7499ad54124d087e43544341225d66755c3fd65` (`b7499ad5`)
- **Tree:** `855623910c42468571c14c36a80c46808b30516e`
- **Base main:** `2c6bcfa2e3c61b6b3b42e9dd7385a116e1636270`
- **Authoritative full quality-gates:** PASS via pre-push
- **Receipt identity:** `5b302744308a3951338194938dab089fa0f2be9bf625e1c8c891c3937a37ed6a`
- **Review:** native exact-HEAD Tier-4 full-range fallback → **VERDICT: PASS** (`deleg_ee29c9fa`)
  - CSA review twice produced pre-provider no-verdict (bwrap mkdir parents); filed as #2871
  - Native review is **not** labeled CSA PASS
  - REGRESSION findings: none
- Worktree clean at review/push time

## Test plan
- [x] Focused provider/help contract tests (`session_wait_provider_ttl`)
- [x] `just pre-commit-fast`
- [x] Exact-HEAD full quality-gates (pre-push)
- [x] Fresh exact-HEAD whole-range review (native fallback after CSA infra no-verdict)

## Notes
Linux-only scope. Pre-existing out-of-scope items left as follow-ups: MCP providerless `timeout_seconds=6900`; ACP Unix-import Windows concern.
