### PR TITLE
fix(bwrap): ensure writable-path destination parents exist inside sandbox (#2857, #2866, #2871)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1115"
+version = "0.1.1116"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1115"
+version = "0.1.1116"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -107,6 +107,14 @@ impl BwrapCommandBuilder {
                 }
                 cmd.args(["--bind", &s, &dest]);
             } else {
+                // Ensure destination parent exists inside the sandbox. When the
+                // writable path involves symlinks or nested state directories,
+                // the logical destination may not exist under the read-only root.
+                if let Some(parent) = path.parent()
+                    && parent != Path::new("/")
+                {
+                    cmd.args(["--dir", &parent.to_string_lossy()]);
+                }
                 cmd.args(["--bind", &s, &dest]);
             }
         }

--- a/crates/csa-resource/src/bwrap_tests.rs
+++ b/crates/csa-resource/src/bwrap_tests.rs
@@ -67,6 +67,30 @@ fn test_bwrap_command_with_writable_paths() {
 }
 
 #[test]
+fn test_bwrap_non_tmp_writable_path_creates_parent_dir_before_bind() {
+    let path = "/home/user/.local/state/cli-sub-agent/project/sessions/session-id";
+    let parent = "/home/user/.local/state/cli-sub-agent/project/sessions";
+
+    let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+    builder.with_writable_path(Path::new(path));
+    let args = command_args(&builder.build());
+
+    let dir_pos = args
+        .windows(2)
+        .position(|window| window == ["--dir", parent])
+        .expect("--dir writable path parent must be present");
+    let bind_pos = args
+        .windows(3)
+        .position(|window| window == ["--bind", path, path])
+        .expect("--bind writable path must be present");
+
+    assert!(
+        dir_pos < bind_pos,
+        "--dir parent must precede --bind; args: {args:?}"
+    );
+}
+
+#[test]
 fn test_bwrap_from_isolation_plan_bwrap() {
     let plan = IsolationPlan {
         resource: ResourceCapability::None,

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1115"
-weave = "0.1.1115"
+csa = "0.1.1116"
+weave = "0.1.1116"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- **Root cause:** Bubblewrap received `--bind` for non-`/tmp` writable destinations whose logical parent was absent under the read-only `/ → /` sandbox root. This caused nested state/session paths to fail before the provider started.
- **Fix:** Before each non-`/tmp` writable `--bind`, emit `--dir <path.parent()>` (except `/`) so the logical destination parent exists in the sandbox. Bind sources still use their resolved path; destinations retain the logical path.
- Bump workspace and lockfile versions to `0.1.1116`.

## Verification

- Full pre-push quality gate passed on exact HEAD `00902fdaf9002bf1110cc10c602582904aa842ae` (receipt `d1c98a53502be72294c87c64c3d469cc5d72249eec6eba39a637f142ce4899db`).
- Focused bwrap tests: 35/35 passed.
- Exact-head review: PASS — non-`/tmp` parent creation is ordered before the bind; `/tmp` behavior and read-only binds are unchanged.

Closes #2857
Closes #2866
Closes #2871
