### PR TITLE
fix(caller-hint): enforce 300-byte host-hint budget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1116"
+version = "0.1.1117"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1116"
+version = "0.1.1117"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -228,6 +228,29 @@ fn rendered_session_wait_caller_hints_stay_under_size_budget() {
 }
 
 #[test]
+fn rendered_session_wait_caller_hint_falls_back_when_provider_exceeds_budget() {
+    let provider = "x".repeat(200);
+    for action in ["wait", "retry_wait"] {
+        let marker = crate::daemon_caller_hints::render_session_wait_caller_hint(action, &provider);
+        let rendered_bytes = marker.len();
+        assert!(
+            rendered_bytes <= CALLER_HINT_MAX_BYTES,
+            "fallback {action} CALLER_HINT is {rendered_bytes} bytes, exceeds \
+             {CALLER_HINT_MAX_BYTES} byte budget: {marker}",
+        );
+        assert_eq!(
+            marker,
+            format!(
+                "<!-- CSA:CALLER_HINT action=\"{action}\" \
+                 forbid=\"process.wait,process.poll,manual_status_loops,short_wrapper_timeouts\" \
+                 note=\"budget_exceeded\" -->"
+            ),
+            "long provider names must use the minimal budget fallback"
+        );
+    }
+}
+
+#[test]
 fn run_cmd_daemon_wait_hint_warns_no_stack_wakeup() {
     assert_eq!(
         RUN_CMD_DAEMON_SRC

--- a/crates/cli-sub-agent/src/caller_hints_tests.rs
+++ b/crates/cli-sub-agent/src/caller_hints_tests.rs
@@ -1,12 +1,13 @@
 //! Tests asserting `CSA:CALLER_HINT` emissions are compact and carry
-//! the essential wait and cancellation guidance.
+//! the structured session-wait host contract plus cancellation guidance.
 //!
 //! After #2591, CALLER_HINT markers are compact (≤300 bytes) instead of
 //! the previous ~1KB verbose rules. The core contract is:
 //!   1. Each daemon entry point emits a wait hint plus a cancellation handle
 //!   2. The wait hint contains the re-wait command
 //!   3. The cancellation handle contains the exact kill command
-//!   4. The hints warn against polling and loops
+//!   4. Session-wait hints state the host execution contract in structured
+//!      attributes, including explicit check-in ownership and forbidden APIs
 #![cfg(test)]
 
 use std::path::Path;
@@ -40,23 +41,34 @@ fn caller_hint_blocks(src: &str) -> Vec<&str> {
         .collect()
 }
 
-fn assert_wait_hint_contract(block: &str, site: &str) {
-    assert!(
-        block.contains("action=\\\"wait\\\""),
-        "{site} emits action=\"wait\""
-    );
-    assert!(
-        block.contains("run_in_background"),
-        "{site} CALLER_HINT must recommend backgrounding session wait"
-    );
-    assert!(
-        block.contains(NO_POLLING_WARNING),
-        "{site} CALLER_HINT must warn against polling"
-    );
-    assert!(
-        block.contains(NO_LOOPS_WARNING),
-        "{site} CALLER_HINT must warn against loops"
-    );
+fn assert_structured_session_wait_hint(marker: &str, action: &str, site: &str) {
+    for required_field in [
+        format!("action=\"{action}\""),
+        "provider=\"xai\"".to_string(),
+        "background=true".to_string(),
+        "timeout_min_sec=7200".to_string(),
+        "notify_on_complete=true".to_string(),
+        "checkin_owner=CSA".to_string(),
+        "checkin_policy=provider_ttl".to_string(),
+        "forbid=\"process.wait,process.poll,manual_status_loops,short_wrapper_timeouts\""
+            .to_string(),
+    ] {
+        assert!(
+            marker.contains(&required_field),
+            "{site} CALLER_HINT missing required field {required_field}: {marker}"
+        );
+    }
+    for forbidden_pattern in [
+        "process.wait",
+        "process.poll",
+        "manual_status_loops",
+        "short_wrapper_timeouts",
+    ] {
+        assert!(
+            marker.contains(forbidden_pattern),
+            "{site} CALLER_HINT forbid list omits {forbidden_pattern}: {marker}"
+        );
+    }
 }
 
 #[test]
@@ -192,21 +204,26 @@ fn codex_yield_hint_prefers_mcp_wait_and_keeps_shell_fallback_yield() {
 const CALLER_HINT_MAX_BYTES: usize = 300;
 
 #[test]
-fn caller_hint_blocks_stay_under_size_budget() {
-    let all_sources = [
-        ("daemon_started_output", DAEMON_STARTED_OUTPUT_SRC),
-        ("session_cmds_daemon_wait", SESSION_CMDS_DAEMON_WAIT_SRC),
-    ];
-    for (site, src) in &all_sources {
-        for block in caller_hint_blocks(src) {
-            assert!(
-                block.len() <= CALLER_HINT_MAX_BYTES,
-                "{site} CALLER_HINT block is {} bytes, exceeds {} byte budget \
-                 (context flooding guard from #2591). Block: {block}",
-                block.len(),
-                CALLER_HINT_MAX_BYTES,
-            );
-        }
+fn rendered_session_wait_caller_hints_have_required_host_contract_at_both_sites() {
+    for (site, action) in [
+        ("daemon_started_output", "wait"),
+        ("session_cmds_daemon_wait_completion", "retry_wait"),
+    ] {
+        let marker = crate::daemon_caller_hints::render_session_wait_caller_hint(action, "xai");
+        assert_structured_session_wait_hint(&marker, action, site);
+    }
+}
+
+#[test]
+fn rendered_session_wait_caller_hints_stay_under_size_budget() {
+    for action in ["wait", "retry_wait"] {
+        let marker = crate::daemon_caller_hints::render_session_wait_caller_hint(action, "xai");
+        let rendered_bytes = marker.len();
+        assert!(
+            rendered_bytes <= CALLER_HINT_MAX_BYTES,
+            "rendered {action} CALLER_HINT is {rendered_bytes} bytes, exceeds \
+             {CALLER_HINT_MAX_BYTES} byte budget (context flooding guard from #2591): {marker}",
+        );
     }
 }
 
@@ -226,22 +243,10 @@ fn run_cmd_daemon_wait_hint_warns_no_stack_wakeup() {
         1,
         "run_cmd_daemon publishes one shared daemon-start output"
     );
-    let blocks = caller_hint_blocks(DAEMON_STARTED_OUTPUT_SRC);
-    assert_eq!(
-        blocks.len(),
-        2,
-        "shared daemon output emits wait and cancellation CALLER_HINTs"
+    assert!(
+        DAEMON_STARTED_OUTPUT_SRC.contains(".caller_hint(\"wait\")"),
+        "shared daemon output must render its wait CALLER_HINT through the structured renderer"
     );
-    let wait_blocks = blocks
-        .iter()
-        .filter(|block| block.contains("action=\\\"wait\\\""))
-        .collect::<Vec<_>>();
-    assert_eq!(
-        wait_blocks.len(),
-        1,
-        "shared daemon output emits one wait hint"
-    );
-    assert_wait_hint_contract(wait_blocks[0], "run_cmd_daemon");
 }
 
 #[test]
@@ -288,49 +293,17 @@ fn plan_cmd_daemon_wait_hint_warns_no_stack_wakeup() {
         1,
         "plan_cmd_daemon publishes one shared daemon-start output"
     );
-    let blocks = caller_hint_blocks(DAEMON_STARTED_OUTPUT_SRC);
-    assert_eq!(
-        blocks.len(),
-        2,
-        "shared daemon output emits wait and cancellation CALLER_HINTs"
+    assert!(
+        DAEMON_STARTED_OUTPUT_SRC.contains(".caller_hint(\"wait\")"),
+        "shared daemon output must render its wait CALLER_HINT through the structured renderer"
     );
-    let wait_blocks = blocks
-        .iter()
-        .filter(|block| block.contains("action=\\\"wait\\\""))
-        .collect::<Vec<_>>();
-    assert_eq!(
-        wait_blocks.len(),
-        1,
-        "shared daemon output emits one wait hint"
-    );
-    assert_wait_hint_contract(wait_blocks[0], "plan_cmd_daemon");
 }
 
 #[test]
 fn session_cmds_daemon_wait_retry_wait_hint_warns_no_stack_wakeup() {
-    let blocks = caller_hint_blocks(SESSION_CMDS_DAEMON_WAIT_SRC);
     assert!(
-        blocks.len() >= 2,
-        "session_cmds_daemon_wait emits both retry_wait and next_session hints; got {} blocks",
-        blocks.len()
-    );
-    let retry_blocks = blocks
-        .iter()
-        .filter(|b| b.contains("action=\\\"retry_wait\\\""))
-        .collect::<Vec<_>>();
-    assert_eq!(
-        retry_blocks.len(),
-        1,
-        "session_cmds_daemon_wait emits exactly one retry_wait CALLER_HINT"
-    );
-    let retry = retry_blocks[0];
-    assert!(
-        retry.contains(NO_POLLING_WARNING),
-        "retry_wait CALLER_HINT must warn against polling"
-    );
-    assert!(
-        retry.contains(NO_LOOPS_WARNING),
-        "retry_wait CALLER_HINT must warn against loops"
+        SESSION_CMDS_DAEMON_WAIT_SRC.contains(".caller_hint(\"retry_wait\")"),
+        "retry wait output must render its CALLER_HINT through the structured renderer"
     );
 }
 

--- a/crates/cli-sub-agent/src/daemon_caller_hints.rs
+++ b/crates/cli-sub-agent/src/daemon_caller_hints.rs
@@ -2,6 +2,10 @@ use std::path::Path;
 
 use csa_config::{GlobalConfig, ModelProvider, provider_ttl};
 
+const MAX_CALLER_HINT_BODY_BYTES: usize = 300;
+const SESSION_WAIT_CALLER_HINT_FORBID: &str =
+    "process.wait,process.poll,manual_status_loops,short_wrapper_timeouts";
+
 pub(crate) struct SessionWaitCommand {
     command: Option<String>,
     provider: Option<String>,
@@ -81,18 +85,27 @@ pub(crate) fn resolve_session_wait_command(
 ///
 /// The command itself remains in the adjacent durable `CSA:SESSION_STARTED`
 /// or `CSA:SESSION_WAIT_KV_WARM` carrier marker, keeping this repeated hint
-/// within the caller-context budget.
+/// within the caller-context budget. When a provider name would exceed that
+/// budget, retain the action and forbidden APIs in a minimal fail-safe marker.
 pub(crate) fn render_session_wait_caller_hint(action: &str, provider: &str) -> String {
     assert!(
         matches!(action, "wait" | "retry_wait"),
         "session wait caller hints only support wait actions"
     );
     let provider = escape_structured_comment_attr(provider);
-    format!(
+    let marker = format!(
         "<!-- CSA:CALLER_HINT action=\"{action}\" provider=\"{provider}\" \
          background=true timeout_min_sec=7200 notify_on_complete=true \
          checkin_owner=CSA checkin_policy=provider_ttl \
-         forbid=\"process.wait,process.poll,manual_status_loops,short_wrapper_timeouts\" -->"
+         forbid=\"{SESSION_WAIT_CALLER_HINT_FORBID}\" -->"
+    );
+    if marker.len() <= MAX_CALLER_HINT_BODY_BYTES {
+        return marker;
+    }
+
+    format!(
+        "<!-- CSA:CALLER_HINT action=\"{action}\" \
+         forbid=\"{SESSION_WAIT_CALLER_HINT_FORBID}\" note=\"budget_exceeded\" -->"
     )
 }
 

--- a/crates/cli-sub-agent/src/daemon_caller_hints.rs
+++ b/crates/cli-sub-agent/src/daemon_caller_hints.rs
@@ -4,12 +4,20 @@ use csa_config::{GlobalConfig, ModelProvider, provider_ttl};
 
 pub(crate) struct SessionWaitCommand {
     command: Option<String>,
+    provider: Option<String>,
     legal_provider_keys: Vec<String>,
 }
 
 impl SessionWaitCommand {
     pub(crate) fn command(&self) -> Option<&str> {
         self.command.as_deref()
+    }
+
+    /// Render the structured host contract for a validated session-wait command.
+    pub(crate) fn caller_hint(&self, action: &str) -> Option<String> {
+        self.provider
+            .as_deref()
+            .map(|provider| render_session_wait_caller_hint(action, provider))
     }
 
     pub(crate) fn provider_selection_hint(&self) -> String {
@@ -51,19 +59,41 @@ pub(crate) fn resolve_session_wait_command(
                 .collect()
         })
         .unwrap_or_default();
-    let provider = preferred_provider.filter(|provider| {
-        config
-            .as_ref()
-            .and_then(|config| provider_ttl(provider, &config.kv_cache))
-            .is_some()
-    });
+    let provider = preferred_provider
+        .filter(|provider| {
+            config
+                .as_ref()
+                .and_then(|config| provider_ttl(provider, &config.kv_cache))
+                .is_some()
+        })
+        .map(|provider| provider.as_str().to_string());
 
     SessionWaitCommand {
-        command: provider.map(|provider| {
-            format_session_wait_command(session_id, project_root, provider.as_str())
-        }),
+        command: provider
+            .as_deref()
+            .map(|provider| format_session_wait_command(session_id, project_root, provider)),
+        provider,
         legal_provider_keys,
     }
+}
+
+/// Render the compact structured contract required to wait for a CSA session.
+///
+/// The command itself remains in the adjacent durable `CSA:SESSION_STARTED`
+/// or `CSA:SESSION_WAIT_KV_WARM` carrier marker, keeping this repeated hint
+/// within the caller-context budget.
+pub(crate) fn render_session_wait_caller_hint(action: &str, provider: &str) -> String {
+    assert!(
+        matches!(action, "wait" | "retry_wait"),
+        "session wait caller hints only support wait actions"
+    );
+    let provider = escape_structured_comment_attr(provider);
+    format!(
+        "<!-- CSA:CALLER_HINT action=\"{action}\" provider=\"{provider}\" \
+         background=true timeout_min_sec=7200 notify_on_complete=true \
+         checkin_owner=CSA checkin_policy=provider_ttl \
+         forbid=\"process.wait,process.poll,manual_status_loops,short_wrapper_timeouts\" -->"
+    )
 }
 
 /// Return the normalized provider carried by explicit launch routing only.
@@ -221,6 +251,13 @@ mod tests {
             Some(
                 "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --model-provider xai --cd '/tmp/repo'"
             )
+        );
+        assert!(
+            command
+                .caller_hint("retry_wait")
+                .expect("validated provider must be retained for the caller hint")
+                .contains("provider=\"xai\""),
+            "caller hint must retain the validated normalized provider"
         );
 
         std::fs::write(&config_path, "[kv_cache.provider_ttls]\nxai = 0\n")

--- a/crates/cli-sub-agent/src/daemon_started_output.rs
+++ b/crates/cli-sub-agent/src/daemon_started_output.rs
@@ -24,15 +24,9 @@ pub(crate) fn prepare(
         .command()
         .map(crate::daemon_caller_hints::escape_structured_comment_attr)
         .unwrap_or_default();
-    let wait_hint = match wait_command.command() {
-        Some(wait_cmd) => {
-            let wait_cmd = crate::daemon_caller_hints::escape_structured_comment_attr(wait_cmd);
-            format!(
-                "<!-- CSA:CALLER_HINT action=\"wait\" rule=\"Call {wait_cmd} with run_in_background: true. Task-notification is your wake signal — no polling, no loops, one wait per Bash call.\" -->"
-            )
-        }
-        None => wait_command.provider_selection_hint(),
-    };
+    let wait_hint = wait_command
+        .caller_hint("wait")
+        .unwrap_or_else(|| wait_command.provider_selection_hint());
     let attach_cmd =
         crate::daemon_caller_hints::format_session_attach_command(&result.session_id, project_root);
     let kill_cmd =

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_completion.rs
@@ -166,7 +166,10 @@ fn render_wait_cap_outcome(
             );
             let _ = writeln!(
                 text,
-                "<!-- CSA:CALLER_HINT action=\"retry_wait\" rule=\"Session alive; re-wait in a NEW Bash call: {wait_cmd_attr}. Backgrounded? Task-notification is your wake signal — no polling, no loops.\" -->"
+                "{}",
+                wait_command
+                    .caller_hint("retry_wait")
+                    .expect("validated wait command must retain its normalized provider")
             );
             let codex_hint = crate::process_tree::codex_yield_hint(Some(wait_cmd));
             if !codex_hint.is_empty() {

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1116"
-weave = "0.1.1116"
+csa = "0.1.1117"
+weave = "0.1.1117"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Add structured `CSA:CALLER_HINT` host contracts for initial and retry session waits, with explicit provider/notification/check-in/forbidden-API fields.
- Keep provider selection fail-closed when launch routing is absent or its configured TTL is invalid.
- Enforce a 300-byte rendered caller-hint budget; long provider names emit the minimal `budget_exceeded` fallback retaining the action and forbid list.

## Validation
- Hook-enabled `CSA_SKIP_REVIEW_CHECK=1 git push origin HEAD` passed the authoritative `just pre-push` quality gate on `95d4aba611f8db6289f415a9f9dd8ea0bc995cdd` (tree `5c0ab217ca74ad1e5f063f49b8682c84081c8f16`): receipt `bd6b439e23fbc5e98fb9e3e5770fc7efdb07bb01d99becbe10546d63b812e899`.
- Read-only `main...HEAD` review: **PASS**. Verified the 300-byte renderer guard/fallback and its 200-character-provider regression test; structured fields at both emission sites; ambient-provider rejection; positive-TTL filtering/reload; and `select_wait_provider` fail-closed behavior. No regressions found.

## Commits
1. `e7edd382` feat(caller-hint): structured host contract for session wait hints (#2837)
2. `95d4aba6` fix(caller-hint): enforce 300-byte budget for long provider names

Closes #2837