### PR TITLE
fix(bwrap): preserve resolved session-state destinations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1117"
+version = "0.1.1118"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1117"
+version = "0.1.1118"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -92,7 +92,16 @@ impl BwrapCommandBuilder {
         for path in &self.writable_paths {
             let resolved = resolve_for_bind(path);
             let s = resolved.to_string_lossy();
-            let dest = path.to_string_lossy();
+            // `/tmp` is replaced with a fresh tmpfs before writable binds, so
+            // paths beneath it must keep their logical destination. Elsewhere,
+            // bind at the resolved destination: bwrap cannot create a mount
+            // target by walking a state-path symlink into an autofs mount.
+            let dest_path = if path.starts_with(tmp_prefix) {
+                path.as_path()
+            } else {
+                resolved.as_path()
+            };
+            let dest = dest_path.to_string_lossy();
             if path == tmp_prefix {
                 cmd.args(["--bind", &s, &dest]);
             } else if path.starts_with(tmp_prefix) {
@@ -107,10 +116,10 @@ impl BwrapCommandBuilder {
                 }
                 cmd.args(["--bind", &s, &dest]);
             } else {
-                // Ensure destination parent exists inside the sandbox. When the
-                // writable path involves symlinks or nested state directories,
-                // the logical destination may not exist under the read-only root.
-                if let Some(parent) = path.parent()
+                // Ensure the resolved destination parent exists inside the
+                // sandbox. Creating the logical parent can fail when it is a
+                // symlink into an autofs-backed CSA session-state root.
+                if let Some(parent) = dest_path.parent()
                     && parent != Path::new("/")
                 {
                     cmd.args(["--dir", &parent.to_string_lossy()]);

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -87,26 +87,31 @@ impl BwrapCommandBuilder {
         cmd.args(["--dev", "/dev"]);
         cmd.args(["--proc", "/proc"]);
 
-        // Bind after tmpfs. /tmp itself is an explicit host tmpdir grant.
+        // Bind after the fresh virtual filesystems. A writable path below a
+        // replaced mount must keep its logical destination; otherwise its
+        // canonical destination is hidden once the mount is installed.
         let tmp_prefix = Path::new("/tmp");
         for path in &self.writable_paths {
             let resolved = resolve_for_bind(path);
             let s = resolved.to_string_lossy();
-            // `/tmp` is replaced with a fresh tmpfs before writable binds, so
-            // paths beneath it must keep their logical destination. Elsewhere,
-            // bind at the resolved destination: bwrap cannot create a mount
-            // target by walking a state-path symlink into an autofs mount.
-            let dest_path = if path.starts_with(tmp_prefix) {
+            let fresh_mount_root = fresh_writable_mount_root(path);
+            // Elsewhere, bind at the resolved destination: bwrap cannot
+            // create a mount target by walking a state-path symlink into an
+            // autofs-backed CSA session-state root.
+            let dest_path = if fresh_mount_root.is_some() {
                 path.as_path()
             } else {
                 resolved.as_path()
             };
             let dest = dest_path.to_string_lossy();
-            if path == tmp_prefix {
-                cmd.args(["--bind", &s, &dest]);
-            } else if path.starts_with(tmp_prefix) {
+            if let Some(mount_root) = fresh_mount_root {
+                let mount_root = Path::new(mount_root);
+                if path == mount_root {
+                    cmd.args(["--bind", &s, &dest]);
+                    continue;
+                }
                 if let Some(parent) = path.parent()
-                    && parent != tmp_prefix
+                    && parent != mount_root
                 {
                     let p = parent.to_string_lossy();
                     cmd.args(["--dir", &p]);
@@ -286,6 +291,16 @@ pub fn from_isolation_plan(
 /// is a symlink to `/ssd/.../.claude`, bwrap needs the resolved target.
 fn resolve_for_bind(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Return the fresh writable virtual filesystem containing `path`.
+///
+/// `/proc` is deliberately excluded: it is a read-only process virtual
+/// filesystem and cannot host writable bind destinations.
+fn fresh_writable_mount_root(path: &Path) -> Option<&'static str> {
+    ["/tmp", "/dev"]
+        .into_iter()
+        .find(|mount_root| path.starts_with(Path::new(mount_root)))
 }
 
 #[cfg(all(test, target_os = "linux"))]

--- a/crates/csa-resource/src/bwrap_tests.rs
+++ b/crates/csa-resource/src/bwrap_tests.rs
@@ -15,6 +15,9 @@ fn command_args(cmd: &Command) -> Vec<String> {
         .collect()
 }
 
+#[path = "bwrap_tests_virtual.rs"]
+mod virtual_filesystem;
+
 #[test]
 fn test_bwrap_command_basic() {
     let builder = BwrapCommandBuilder::new("/usr/bin/tool", &["--flag".into(), "arg".into()]);
@@ -657,36 +660,5 @@ fn test_bwrap_auto_ro_binds_gh_aider_config_when_present() {
                 && window[2] == gh_aider.to_string_lossy()
         }),
         "~/.config/gh-aider should be explicitly re-bound read-only so sandboxed gh commands can still read the aider auth config; args: {args:?}"
-    );
-}
-
-#[test]
-fn test_bwrap_binds_non_tmp_symlink_writable_path_at_canonical_destination() {
-    use std::os::unix::fs::symlink;
-
-    let workspace = std::env::current_dir().expect("test working directory");
-    let tmp = tempfile::tempdir_in(workspace).expect("tempdir");
-    let real = tmp.path().join("real-claude");
-    std::fs::create_dir(&real).expect("create real dir");
-    let link = tmp.path().join("link-claude");
-    symlink(&real, &link).expect("create symlink");
-
-    let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
-    builder.with_writable_path(&link);
-
-    let cmd = builder.build();
-    let args = command_args(&cmd);
-
-    let bind_idx = args
-        .iter()
-        .position(|a| a == "--bind")
-        .expect("--bind not found");
-    let src = &args[bind_idx + 1];
-    let dest = &args[bind_idx + 2];
-    let canonical = real.to_string_lossy().to_string();
-    assert_eq!(src, &canonical, "bind source should be canonicalized");
-    assert_eq!(
-        dest, &canonical,
-        "bind destination should be canonicalized so bwrap does not need to create parents through an unresolved state symlink"
     );
 }

--- a/crates/csa-resource/src/bwrap_tests.rs
+++ b/crates/csa-resource/src/bwrap_tests.rs
@@ -661,10 +661,11 @@ fn test_bwrap_auto_ro_binds_gh_aider_config_when_present() {
 }
 
 #[test]
-fn test_bwrap_canonicalizes_symlink_writable_path() {
+fn test_bwrap_binds_non_tmp_symlink_writable_path_at_canonical_destination() {
     use std::os::unix::fs::symlink;
 
-    let tmp = tempfile::tempdir().expect("tempdir");
+    let workspace = std::env::current_dir().expect("test working directory");
+    let tmp = tempfile::tempdir_in(workspace).expect("tempdir");
     let real = tmp.path().join("real-claude");
     std::fs::create_dir(&real).expect("create real dir");
     let link = tmp.path().join("link-claude");
@@ -676,20 +677,16 @@ fn test_bwrap_canonicalizes_symlink_writable_path() {
     let cmd = builder.build();
     let args = command_args(&cmd);
 
-    // The --bind source should be the resolved (canonical) path, not the symlink
     let bind_idx = args
         .iter()
         .position(|a| a == "--bind")
         .expect("--bind not found");
     let src = &args[bind_idx + 1];
     let dest = &args[bind_idx + 2];
-    assert!(
-        src.contains("real-claude"),
-        "bind source should be canonicalized real path, got: {src}"
-    );
+    let canonical = real.to_string_lossy().to_string();
+    assert_eq!(src, &canonical, "bind source should be canonicalized");
     assert_eq!(
-        dest,
-        &link.to_string_lossy().to_string(),
-        "bind destination should preserve original logical path"
+        dest, &canonical,
+        "bind destination should be canonicalized so bwrap does not need to create parents through an unresolved state symlink"
     );
 }

--- a/crates/csa-resource/src/bwrap_tests_virtual.rs
+++ b/crates/csa-resource/src/bwrap_tests_virtual.rs
@@ -7,8 +7,10 @@ use super::command_args;
 fn test_bwrap_binds_non_tmp_symlink_writable_path_at_canonical_destination() {
     use std::os::unix::fs::symlink;
 
-    let workspace = std::env::current_dir().expect("test working directory");
-    let tmp = tempfile::tempdir_in(workspace).expect("tempdir");
+    // The quality gate read-only-binds the checkout. Use a writable fixture
+    // outside the builder's fresh /tmp and /dev virtual mount roots so this
+    // remains a non-virtual-destination regression test.
+    let tmp = tempfile::tempdir_in("/var/tmp").expect("tempdir");
     let real = tmp.path().join("real-state");
     std::fs::create_dir(&real).expect("create real dir");
     let canonical_writable = real.join("claude");
@@ -57,8 +59,7 @@ fn test_bwrap_binds_non_tmp_symlink_writable_path_at_canonical_destination() {
 fn test_bwrap_keeps_dev_shm_symlink_writable_path_at_logical_destination() {
     use std::os::unix::fs::symlink;
 
-    let workspace = std::env::current_dir().expect("test working directory");
-    let source = tempfile::tempdir_in(workspace).expect("source tempdir");
+    let source = tempfile::tempdir().expect("source tempdir");
     let dev_shm = tempfile::tempdir_in("/dev/shm").expect("/dev/shm tempdir");
     let link = dev_shm.path().join("writable-state");
     symlink(source.path(), &link).expect("create /dev/shm symlink");

--- a/crates/csa-resource/src/bwrap_tests_virtual.rs
+++ b/crates/csa-resource/src/bwrap_tests_virtual.rs
@@ -1,0 +1,97 @@
+//! Tests for writable paths under bubblewrap's fresh virtual filesystems.
+
+use super::super::BwrapCommandBuilder;
+use super::command_args;
+
+#[test]
+fn test_bwrap_binds_non_tmp_symlink_writable_path_at_canonical_destination() {
+    use std::os::unix::fs::symlink;
+
+    let workspace = std::env::current_dir().expect("test working directory");
+    let tmp = tempfile::tempdir_in(workspace).expect("tempdir");
+    let real = tmp.path().join("real-state");
+    std::fs::create_dir(&real).expect("create real dir");
+    let canonical_writable = real.join("claude");
+    std::fs::create_dir(&canonical_writable).expect("create writable dir");
+    let link = tmp.path().join("link-state");
+    symlink(&real, &link).expect("create symlink");
+    let logical_writable = link.join("claude");
+
+    let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+    builder.with_writable_path(&logical_writable);
+
+    let cmd = builder.build();
+    let args = command_args(&cmd);
+
+    let bind_idx = args
+        .windows(3)
+        .position(|window| window[0] == "--bind")
+        .expect("--bind not found");
+    let canonical = canonical_writable.to_string_lossy().to_string();
+    let canonical_parent = real.to_string_lossy().to_string();
+    let logical_parent = link.to_string_lossy().to_string();
+    let canonical_dir_idx = args
+        .windows(2)
+        .position(|window| window[0] == "--dir" && window[1] == canonical_parent)
+        .expect("canonical writable parent should be created");
+    assert!(
+        canonical_dir_idx < bind_idx,
+        "canonical parent must be created before the writable bind; args: {args:?}"
+    );
+    assert!(
+        !args
+            .windows(2)
+            .any(|window| window[0] == "--dir" && window[1] == logical_parent),
+        "the logical symlink parent must not be used for --dir; args: {args:?}"
+    );
+    let src = &args[bind_idx + 1];
+    let dest = &args[bind_idx + 2];
+    assert_eq!(src, &canonical, "bind source should be canonicalized");
+    assert_eq!(
+        dest, &canonical,
+        "bind destination should be canonicalized so bwrap does not need to create parents through an unresolved state symlink"
+    );
+}
+
+#[test]
+fn test_bwrap_keeps_dev_shm_symlink_writable_path_at_logical_destination() {
+    use std::os::unix::fs::symlink;
+
+    let workspace = std::env::current_dir().expect("test working directory");
+    let source = tempfile::tempdir_in(workspace).expect("source tempdir");
+    let dev_shm = tempfile::tempdir_in("/dev/shm").expect("/dev/shm tempdir");
+    let link = dev_shm.path().join("writable-state");
+    symlink(source.path(), &link).expect("create /dev/shm symlink");
+
+    let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
+    builder.with_writable_path(&link);
+
+    let cmd = builder.build();
+    let args = command_args(&cmd);
+    let bind_idx = args
+        .windows(3)
+        .position(|window| window[0] == "--bind")
+        .expect("--bind not found");
+    let logical_parent = dev_shm.path().to_string_lossy().to_string();
+    let canonical_source = source.path().to_string_lossy().to_string();
+    let logical_destination = link.to_string_lossy().to_string();
+    let logical_parent_dir_idx = args
+        .windows(2)
+        .position(|window| window[0] == "--dir" && window[1] == logical_parent)
+        .expect("logical /dev/shm parent should be created");
+
+    assert!(
+        logical_parent_dir_idx < bind_idx,
+        "logical /dev/shm parent must be created before the writable bind; args: {args:?}"
+    );
+    assert_eq!(
+        &args[bind_idx + 1],
+        &canonical_source,
+        "bind source should be canonicalized"
+    );
+    assert_eq!(
+        &args[bind_idx + 2],
+        &logical_destination,
+        "bind destination must remain under the fresh /dev mount"
+    );
+}

--- a/scripts/hooks/quality-gates-live.sh
+++ b/scripts/hooks/quality-gates-live.sh
@@ -2,6 +2,11 @@
 # Mutable/current quality checks that must execute on every direct or hook call.
 set -euo pipefail
 
+# Live tests may import local Python gate helpers. Keep their bytecode out of
+# the checkout so the later receipt-contract assertion sees the exact clean
+# source surface.
+export PYTHONDONTWRITEBYTECODE=1
+
 live_cargo_build_jobs=
 live_cargo_build_jobs_resolved=0
 live_partition_validator=scripts/hooks/quality-gates-live-partition.py

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1117"
-weave = "0.1.1117"
+csa = "0.1.1118"
+weave = "0.1.1118"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Bug Description

A sandboxed CSA session whose configured state directory resolves through an autofs/symlinked mount could fail during Bubblewrap setup while creating the bind destination parents.

Closes #2876

## Root Cause

The writable-path builder canonicalized the bind source but continued to use the logical symlinked destination parent for `--dir`. Bubblewrap then walked a path unavailable in its namespace before the resolved mount was bound.

## Fix

- For non-virtual writable destinations, create the canonical parent and bind at the canonical destination.
- Preserve logical destinations below Bubblewrap-created `/tmp` and `/dev` mounts.
- Add regression coverage for both canonical non-virtual and logical virtual destination behavior.
- Prevent live gate tests from leaving ignored Python bytecode directories that invalidate the receipt-contract test.

## Test Plan

- `just pre-push` (including live/static partitions, 7,346 static tests, contract suites, and cargo-deny)
- Exact-head isolated release build at `752709f0`
- Tier-4 Codex review: PASS (`01KYA7C25GFM6XKJVKPGYBMZ4C`), range `main...HEAD`

## Risk Assessment

Low — scope is limited to Bubblewrap writable bind construction and gate Python bytecode hygiene; virtual mount behavior has explicit coverage.