### PR TITLE
fix(session): reconcile authoritative wait status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1118"
+version = "0.1.1119"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1118"
+version = "0.1.1119"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_check_verdict_2236_clean_summary_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_check_verdict_2236_clean_summary_tests.rs
@@ -414,7 +414,7 @@ fn issue_2405_check_verdict_repairs_empty_fail_artifact_for_clean_summaries() {
 }
 
 #[test]
-fn issue_2393_existing_fail_meta_without_artifact_recovers_exact_head_pass_summary() {
+fn issue_2393_existing_fail_meta_without_artifact_remains_authoritative_failure() {
     let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
     let state_home = TempDir::new().unwrap();
     let _xdg = ScopedEnvVarRestore::set("XDG_STATE_HOME", state_home.path());
@@ -484,8 +484,8 @@ fn issue_2393_existing_fail_meta_without_artifact_recovers_exact_head_pass_summa
     let args = parse_review_args(&["csa", "review", "--check-verdict"]);
     let exit = handle_check_verdict(project.path(), &args).unwrap();
     assert_eq!(
-        exit, 0,
-        "check-verdict should recover the exact-head PASS artifact"
+        exit, 1,
+        "check-verdict must not promote a stale FAIL meta from clean prose alone"
     );
 
     let found = check_review_verdict_for_target(
@@ -496,39 +496,35 @@ fn issue_2393_existing_fail_meta_without_artifact_recovers_exact_head_pass_summa
         Some(expected_diff_fingerprint.as_str()),
         None,
     )
-    .unwrap()
-    .expect("recovered PASS should satisfy check-verdict");
-    assert_eq!(found.session_id, session_id);
+    .unwrap();
+    assert!(
+        found.is_none(),
+        "stale FAIL meta must not satisfy check-verdict"
+    );
 
     let meta = read_review_meta(&session_dir)
         .unwrap()
         .expect("review_meta.json should remain present");
-    assert_eq!(meta.decision, ReviewDecision::Pass.as_str());
-    assert_eq!(meta.verdict, "CLEAN");
-    assert_eq!(meta.exit_code, 0);
-    assert_eq!(
-        meta.diff_fingerprint.as_deref(),
-        Some(expected_diff_fingerprint.as_str())
+    assert_eq!(meta.decision, ReviewDecision::Fail.as_str());
+    assert_eq!(meta.verdict, "HAS_ISSUES");
+    assert_eq!(meta.exit_code, 1);
+    assert!(
+        !session_dir
+            .join("output")
+            .join("review-verdict.json")
+            .exists(),
+        "stale FAIL meta must not be overwritten by a derived PASS artifact"
     );
-
-    let artifact: ReviewVerdictArtifact = serde_json::from_str(
-        &std::fs::read_to_string(session_dir.join("output").join("review-verdict.json"))
-            .expect("review-verdict.json should be recovered"),
-    )
-    .expect("recovered review-verdict.json should parse");
-    assert_eq!(artifact.decision, ReviewDecision::Pass);
-    assert_eq!(artifact.verdict_legacy, "CLEAN");
 
     let repaired = csa_session::load_result(project.path(), &session_id)
         .unwrap()
         .expect("result should remain loadable");
-    assert_eq!(repaired.exit_code, 0);
-    assert_eq!(repaired.status, SessionResult::status_from_exit_code(0));
+    assert_eq!(repaired.exit_code, 1);
+    assert_eq!(repaired.status, SessionResult::status_from_exit_code(1));
     let wait_summary = crate::session_cmds_daemon::render_wait_result_summary(
         &session_dir,
         &session_id,
         &repaired,
     );
-    assert!(wait_summary.contains("Review verdict: PASS"));
-    assert!(!wait_summary.contains("Review verdict: FAIL"));
+    assert!(!wait_summary.contains("Review verdict: PASS"));
 }

--- a/crates/cli-sub-agent/src/review_cmd_output.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output.rs
@@ -556,6 +556,8 @@ fn build_review_verdict_artifact(
         failure_reason,
         review_mode: None,
         prior_round_refs,
+        review_iterations: None,
+        fix_rounds: None,
         diff_size: None,
         large_diff_warning: false,
         large_diff_warning_threshold: None,

--- a/crates/cli-sub-agent/src/review_cmd_output_meta.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_meta.rs
@@ -14,6 +14,8 @@ pub(super) fn apply_review_meta_to_artifact(
         .or_else(|| meta.status_reason.clone())
         .or_else(|| artifact.failure_reason.take());
     artifact.review_mode = meta.review_mode.clone();
+    artifact.review_iterations = Some(meta.review_iterations);
+    artifact.fix_rounds = Some(meta.fix_rounds);
 }
 
 pub(in crate::review_cmd) fn review_meta_for_verdict_artifact(

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1981_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1981_tests.rs
@@ -111,6 +111,7 @@ fn persist_pass_meta_review(
     persist_summary(&session_dir, summary);
 
     let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    csa_session::state::write_review_meta(&session_dir, &meta).expect("write review meta");
     persist_review_verdict(&project_root, &meta, &[], Vec::new());
 
     (env_lock, project_root, session_dir)
@@ -284,6 +285,7 @@ fn issue_2002_extracted_empty_findings_with_descriptive_summary_preserves_pass()
     persist_summary(&session_dir, summary);
 
     let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    csa_session::state::write_review_meta(&session_dir, &meta).expect("write review meta");
     persist_review_verdict(&project_root, &meta, &[], Vec::new());
 
     let verdict = read_verdict(&session_dir);
@@ -320,6 +322,7 @@ fn issue_2002_synthetic_empty_findings_with_pass_summary_preserves_pass() {
     persist_summary(&session_dir, summary);
 
     let meta = make_review_meta_with_decision(session_id, ReviewDecision::Pass, "CLEAN");
+    csa_session::state::write_review_meta(&session_dir, &meta).expect("write review meta");
     persist_review_verdict(&project_root, &meta, &[], Vec::new());
 
     let verdict = read_verdict(&session_dir);

--- a/crates/cli-sub-agent/src/session_cmds.rs
+++ b/crates/cli-sub-agent/src/session_cmds.rs
@@ -581,5 +581,5 @@ pub(crate) use crate::session_cmds_daemon::{
 };
 
 #[cfg(test)]
-#[path = "session_cmds_tests.rs"]
+#[path = "session_cmds_tests_root.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_review_label.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_review_label.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 
 use csa_core::types::ReviewDecision;
 use csa_session::{ReviewSessionMeta, ReviewVerdictArtifact};
-use tracing::warn;
 
 pub(super) fn read_review_verdict_label(
     session_dir: &Path,
@@ -17,6 +16,11 @@ pub(super) fn read_review_verdict_label(
         );
     if let Some(artifact) = read_review_verdict_artifact(session_dir) {
         let meta = read_review_meta_for_label(session_dir);
+        let decision = if artifact.severity_counts.values().any(|count| *count > 0) {
+            ReviewDecision::Fail
+        } else {
+            artifact.decision
+        };
         if let Some(label) = meta
             .as_ref()
             .and_then(|meta| format_fix_loop_noop_label(meta.failure_reason.as_deref()))
@@ -27,34 +31,15 @@ pub(super) fn read_review_verdict_label(
         if summary_requires_failed_gate {
             return Some("FAIL".to_string());
         }
-        if artifact.decision == ReviewDecision::Fail
-            && human_summary_is_exact_pass(session_dir, result)
-            && !review_artifact_or_meta_has_failure_diagnostic(meta.as_ref(), &artifact)
-        {
-            warn!(
-                session_dir = %session_dir.display(),
-                "Review verdict artifact is FAIL but the human summary is exactly PASS; showing PASS label"
-            );
-            return Some("PASS".to_string());
-        }
-        if artifact.decision == ReviewDecision::Pass {
-            if meta
-                .as_ref()
-                .is_some_and(|meta| meta.accepts_clean_review_verdict(artifact.decision))
+        if decision == ReviewDecision::Pass {
+            if crate::session_observability::review_sidecars_allow_clean_pass(session_dir)
+                .unwrap_or(false)
             {
                 return Some("PASS".to_string());
             }
-            if !wait_result_allows_pass_verdict(result) {
-                return Some("UNAVAILABLE".to_string());
-            }
-            if meta.as_ref().is_some_and(|meta| {
-                meta.requires_fail_closed_verdict() || !meta.fix_clean_converged()
-            }) {
-                return Some("UNAVAILABLE".to_string());
-            }
-            return Some("PASS".to_string());
+            return Some("UNAVAILABLE".to_string());
         }
-        if artifact.decision == ReviewDecision::Unavailable
+        if decision == ReviewDecision::Unavailable
             && let Some(primary_failure) = artifact.primary_failure.as_deref()
             && !primary_failure.trim().is_empty()
         {
@@ -63,9 +48,9 @@ pub(super) fn read_review_verdict_label(
             let label = compacted.unwrap_or_else(|| redacted.clone());
             return Some(format!("UNAVAILABLE ({label})"));
         }
-        let normalized = normalize_review_verdict_label(artifact.decision.as_str(), result);
+        let normalized = normalize_review_verdict_label(decision.as_str(), result);
         if matches!(
-            artifact.decision,
+            decision,
             ReviewDecision::Fail | ReviewDecision::Uncertain | ReviewDecision::Unavailable
         ) && let Some(reason) = review_failure_reason_label(meta.as_ref(), &artifact)
         {
@@ -86,6 +71,9 @@ pub(super) fn read_review_verdict_label(
             return Some("FAIL".to_string());
         }
         if meta.fix_attempted && !meta.fix_clean_converged() {
+            return Some("UNAVAILABLE".to_string());
+        }
+        if matches!(meta.decision.parse(), Ok(ReviewDecision::Pass)) {
             return Some("UNAVAILABLE".to_string());
         }
         let normalized = normalize_review_verdict_label(&meta.decision, result);
@@ -125,15 +113,20 @@ pub(super) fn review_failure_summary_override(
         return None;
     }
     let artifact = read_review_verdict_artifact(session_dir)?;
-    if artifact.decision == ReviewDecision::Pass {
+    if artifact.decision == ReviewDecision::Pass
+        && !artifact.severity_counts.values().any(|count| *count > 0)
+    {
         return None;
     }
     let meta = read_review_meta_for_label(session_dir);
     let reason = review_failure_reason_label(meta.as_ref(), &artifact)?;
-    let label = normalize_review_verdict_label(
-        artifact.decision.as_str(),
-        &csa_session::SessionResult::default(),
-    );
+    let decision = if artifact.severity_counts.values().any(|count| *count > 0) {
+        ReviewDecision::Fail
+    } else {
+        artifact.decision
+    };
+    let label =
+        normalize_review_verdict_label(decision.as_str(), &csa_session::SessionResult::default());
     Some(format!("Review {label}: {reason}"))
 }
 
@@ -169,8 +162,7 @@ pub(super) fn read_review_verdict_artifact(session_dir: &Path) -> Option<ReviewV
 }
 
 fn review_verdict_artifact_is_pass(session_dir: &Path) -> bool {
-    read_review_verdict_artifact(session_dir)
-        .is_some_and(|artifact| artifact.decision == ReviewDecision::Pass)
+    crate::session_observability::review_sidecars_allow_clean_pass(session_dir).unwrap_or(false)
 }
 
 fn format_fix_loop_noop_label(reason: Option<&str>) -> Option<String> {
@@ -188,29 +180,6 @@ fn read_review_meta_for_label(session_dir: &Path) -> Option<ReviewSessionMeta> {
     }
     let raw = std::fs::read_to_string(&meta_path).ok()?;
     serde_json::from_str::<ReviewSessionMeta>(&raw).ok()
-}
-
-fn human_summary_is_exact_pass(session_dir: &Path, result: &csa_session::SessionResult) -> bool {
-    crate::session_summary_text::human_session_summary(session_dir, &result.summary)
-        .is_some_and(|summary| summary.trim() == "PASS")
-}
-
-fn review_artifact_or_meta_has_failure_diagnostic(
-    meta: Option<&ReviewSessionMeta>,
-    artifact: &ReviewVerdictArtifact,
-) -> bool {
-    artifact.no_provider_launch.is_some()
-        || non_empty_label(artifact.primary_failure.as_deref())
-        || non_empty_label(artifact.failure_reason.as_deref())
-        || meta.is_some_and(|meta| {
-            non_empty_label(meta.status_reason.as_deref())
-                || non_empty_label(meta.primary_failure.as_deref())
-                || non_empty_label(meta.failure_reason.as_deref())
-        })
-}
-
-fn non_empty_label(value: Option<&str>) -> bool {
-    value.is_some_and(|value| !value.trim().is_empty())
 }
 
 fn review_failure_reason_label(
@@ -301,7 +270,7 @@ mod tests {
     }
 
     #[test]
-    fn issue_2601_review_label_exact_pass_summary_overrides_failed_prose_artifact() {
+    fn issue_2825_review_label_keeps_structured_failure_over_exact_pass_prose() {
         let temp = tempfile::tempdir().expect("tempdir");
         csa_session::persist_structured_output(
             temp.path(),
@@ -336,7 +305,7 @@ mod tests {
 
         let label = read_review_verdict_label(temp.path(), &terminal_result("failure", 1, "PASS"));
 
-        assert_eq!(label.as_deref(), Some("PASS"));
+        assert_eq!(label.as_deref(), Some("FAIL"));
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -329,7 +329,9 @@ pub(super) fn reconcile_repaired_review_pass_result_status(
     session_dir: &Path,
     result: &mut csa_session::SessionResult,
 ) -> bool {
-    if result.post_exec_gate.is_some() {
+    if result.post_exec_gate.is_some()
+        || crate::session_observability::require_commit_contract_failed(result)
+    {
         return false;
     }
     if review_label::read_review_verdict_label(session_dir, result).as_deref() != Some("PASS") {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -329,9 +329,10 @@ pub(super) fn reconcile_repaired_review_pass_result_status(
     session_dir: &Path,
     result: &mut csa_session::SessionResult,
 ) -> bool {
-    if result.post_exec_gate.is_some()
-        || crate::session_observability::require_commit_contract_failed(result)
-    {
+    if crate::session_observability::sync_persisted_post_exec_gate_failure(result) {
+        return true;
+    }
+    if crate::session_observability::require_commit_contract_failed(result) {
         return false;
     }
     if review_label::read_review_verdict_label(session_dir, result).as_deref() != Some("PASS") {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_2425.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_2425.rs
@@ -11,6 +11,7 @@ fn write_review_sidecars(
     failure_reason: Option<&str>,
 ) {
     std::fs::create_dir_all(session_dir.join("output")).expect("create output dir");
+    let timestamp = Utc::now();
     csa_session::write_review_meta(
         session_dir,
         &csa_session::ReviewSessionMeta {
@@ -33,7 +34,7 @@ fn write_review_sidecars(
             fix_attempted: false,
             fix_rounds: 0,
             review_iterations: 1,
-            timestamp: Utc::now(),
+            timestamp,
             diff_fingerprint: None,
             fix_convergence: None,
         },
@@ -46,6 +47,9 @@ fn write_review_sidecars(
         &[],
         Vec::new(),
     );
+    artifact.timestamp = timestamp;
+    artifact.review_iterations = Some(1);
+    artifact.fix_rounds = Some(0);
     artifact.failure_reason = failure_reason.map(str::to_string);
     csa_session::write_review_verdict(session_dir, &artifact).expect("write review verdict");
 }
@@ -207,9 +211,12 @@ fn issue_2425_observability_refresh_flips_repaired_empty_findings_result_to_succ
         ),
     )
     .expect("write synthetic fix suggestion");
-    let result = failure_result(
+    let mut result = failure_result(
         r#"{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":10}}"#,
     );
+    let stale_completed_at = Utc::now() - chrono::TimeDelta::seconds(1);
+    result.started_at = stale_completed_at;
+    result.completed_at = stale_completed_at;
     std::fs::write(
         temp.path().join(csa_session::result::RESULT_FILE_NAME),
         toml::to_string_pretty(&result).expect("serialize result"),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_tests.rs
@@ -56,7 +56,7 @@ fn compact_summary_includes_usage_and_review_verdict() {
     std::fs::create_dir_all(&output_dir).expect("output dir should be created");
     std::fs::write(
         output_dir.join("review-verdict.json"),
-        r#"{"schema_version":1,"session_id":"01TESTWAITSUMMARY","timestamp":"2026-04-01T00:00:00Z","decision":"pass","verdict_legacy":"CLEAN","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"prior_round_refs":[]}"#,
+        r#"{"schema_version":1,"session_id":"01TESTWAITSUMMARY","timestamp":"2026-04-01T00:00:00Z","decision":"pass","verdict_legacy":"CLEAN","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"prior_round_refs":[],"review_iterations":1,"fix_rounds":0}"#,
     )
     .expect("review verdict should be written");
     std::fs::write(
@@ -71,6 +71,7 @@ fn compact_summary_includes_usage_and_review_verdict() {
   "exit_code": 0,
   "fix_attempted": false,
   "fix_rounds": 0,
+  "review_iterations": 1,
   "timestamp": "2026-04-01T00:00:00Z"
 }"#,
     )
@@ -379,9 +380,26 @@ fn compact_summary_prints_pass_from_canonical_artifact_when_result_succeeded() {
     std::fs::create_dir_all(&output_dir).expect("output dir should be created");
     std::fs::write(
         output_dir.join("review-verdict.json"),
-        r#"{"schema_version":1,"session_id":"01TESTWAITARTPASS","timestamp":"2026-04-01T00:00:00Z","decision":"pass","verdict_legacy":"CLEAN","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"prior_round_refs":[]}"#,
+        r#"{"schema_version":1,"session_id":"01TESTWAITARTPASS","timestamp":"2026-04-01T00:00:00Z","decision":"pass","verdict_legacy":"CLEAN","severity_counts":{"critical":0,"high":0,"medium":0,"low":0},"prior_round_refs":[],"review_iterations":1,"fix_rounds":0}"#,
     )
     .expect("review verdict should be written");
+    std::fs::write(
+        temp.path().join("review_meta.json"),
+        r#"{
+  "session_id": "01TESTWAITARTPASS",
+  "head_sha": "deadbeef",
+  "decision": "pass",
+  "verdict": "CLEAN",
+  "tool": "codex",
+  "scope": "range:main...HEAD",
+  "exit_code": 0,
+  "fix_attempted": false,
+  "fix_rounds": 0,
+  "review_iterations": 1,
+  "timestamp": "2026-04-01T00:00:00Z"
+}"#,
+    )
+    .expect("review meta should be written");
     let now = Utc::now();
     let result = csa_session::SessionResult {
         post_exec_gate: None,

--- a/crates/cli-sub-agent/src/session_cmds_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result.rs
@@ -181,29 +181,9 @@ pub(crate) fn handle_session_result(
     }
 
     let repaired_result = if is_cross_project || registry_state_loss {
-        match crate::session_observability::refresh_and_repair_result_from_dir(&session_dir) {
-            Ok(result) => result,
-            Err(err) => {
-                tracing::warn!(
-                    session_id = %resolved_id,
-                    error = %err,
-                    "Failed to refresh cross-project session result"
-                );
-                None
-            }
-        }
+        crate::session_observability::refresh_and_repair_result_from_dir(&session_dir)?
     } else {
-        match crate::session_observability::refresh_and_repair_result(&project_root, &resolved_id) {
-            Ok(result) => result,
-            Err(err) => {
-                tracing::warn!(
-                    session_id = %resolved_id,
-                    error = %err,
-                    "Failed to refresh session result contract in session result"
-                );
-                None
-            }
-        }
+        crate::session_observability::refresh_and_repair_result(&project_root, &resolved_id)?
     };
     let repaired_result = repaired_result.or(daemon_completion_result);
 

--- a/crates/cli-sub-agent/src/session_cmds_tests_root.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_root.rs
@@ -1,0 +1,4 @@
+include!("session_cmds_tests.rs");
+
+#[path = "session_cmds_tests_tail_wait_2825.rs"]
+mod w2825;

--- a/crates/cli-sub-agent/src/session_cmds_tests_root.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_root.rs
@@ -2,3 +2,6 @@ include!("session_cmds_tests.rs");
 
 #[path = "session_cmds_tests_tail_wait_2825.rs"]
 mod w2825;
+
+#[path = "session_cmds_tests_tail_wait_2825_authority.rs"]
+mod w2825_authority;

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2183.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2183.rs
@@ -164,6 +164,6 @@ fn issue_2183_wait_preserves_structured_pass_summary_success() {
     assert_eq!(persisted.status, "success");
     assert_eq!(persisted.exit_code, 0);
     let summary = render_wait_result_summary(&session_dir, &session_id, &persisted);
-    assert!(summary.contains("Review verdict: PASS"));
+    assert!(!summary.contains("Review verdict: FAIL"));
     assert!(summary.contains("Summary: PASS"));
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2825.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2825.rs
@@ -1,0 +1,230 @@
+use super::*;
+use crate::session_cmds_daemon::{
+    WaitBehavior, WaitLoopTiming, handle_session_wait_with_hooks, render_wait_result_summary,
+};
+use crate::test_env_lock::TEST_ENV_LOCK;
+use csa_core::types::ReviewDecision;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn write_success_completion(session_dir: &Path) {
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write success completion packet");
+}
+
+fn write_review_meta(
+    session_dir: &Path,
+    session_id: &str,
+    decision: ReviewDecision,
+    verdict: &str,
+    exit_code: i32,
+    failure_reason: Option<&str>,
+) {
+    csa_session::state::write_review_meta(
+        session_dir,
+        &csa_session::ReviewSessionMeta {
+            session_id: session_id.to_string(),
+            head_sha: "deadbeef".to_string(),
+            decision: decision.as_str().to_string(),
+            verdict: verdict.to_string(),
+            review_mode: None,
+            status_reason: None,
+            routed_to: None,
+            primary_failure: None,
+            failure_reason: failure_reason.map(str::to_string),
+            tool: "codex".to_string(),
+            scope: "range:main...HEAD".to_string(),
+            exit_code,
+            fix_attempted: false,
+            fix_rounds: 0,
+            review_iterations: 1,
+            timestamp: chrono::Utc::now(),
+            diff_fingerprint: None,
+            fix_convergence: None,
+        },
+    )
+    .expect("write review metadata");
+}
+
+fn wait_for_terminal_result(project: &Path, session_id: &str) -> i32 {
+    let mut completion = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.to_string(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("existing terminal artifacts should short-circuit before reconciliation");
+        },
+        |session, status, exit, synthetic, _mirror| {
+            completion = Some((session.to_string(), status.to_string(), exit, synthetic));
+        },
+    )
+    .expect("wait should return a terminal result");
+
+    assert_eq!(exit_code, 1);
+    assert_eq!(
+        completion,
+        Some((session_id.to_string(), "failure".to_string(), 1, false,))
+    );
+    exit_code
+}
+
+fn create_success_session(project: &Path, description: &str) -> (String, std::path::PathBuf) {
+    let session =
+        create_session(project, Some(description), None, Some("codex")).expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session directory");
+    write_success_completion(&session_dir);
+    save_result(
+        project,
+        &session_id,
+        &SessionResult {
+            summary: "transport completed successfully".to_string(),
+            ..make_result("success", 0)
+        },
+    )
+    .expect("save provisional success result");
+    (session_id, session_dir)
+}
+
+#[test]
+fn issue_2825_wait_reconciles_late_require_commit_contract_failure() {
+    let temp = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", temp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = temp.path();
+    let (session_id, _session_dir) = create_success_session(project, "wait-require-commit-late");
+
+    let mut terminal = load_result(project, &session_id)
+        .expect("load provisional result")
+        .expect("provisional result");
+    terminal.require_commit_recovery = Some(csa_session::RequireCommitRecoveryDiagnostic {
+        require_commit: true,
+        sa_mode: Some(true),
+        commit_created: false,
+        dirty_worktree: true,
+        changed_paths: vec!["src/lib.rs".to_string()],
+        changed_paths_truncated: 0,
+        termination_status: "failure".to_string(),
+        exit_code: 1,
+        termination_signal: None,
+        kill_hint: None,
+        blocker_summary: Some("gate=commit-policy-uncommitted".to_string()),
+        suggested_recovery_action: "inspect_changed_paths_then_commit_or_revert".to_string(),
+    });
+    save_result(project, &session_id, &terminal).expect("persist late contract failure");
+
+    wait_for_terminal_result(project, &session_id);
+    let result = load_result(project, &session_id)
+        .expect("load reconciled result")
+        .expect("reconciled result");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+    let summary = render_wait_result_summary(
+        &get_session_dir(project, &session_id).expect("session directory"),
+        &session_id,
+        &result,
+    );
+    assert!(summary.contains("Require-commit recovery: CONTRACT FAILURE"));
+    assert!(summary.contains("fork-from"));
+}
+
+#[test]
+fn issue_2825_wait_fails_low_review_finding_from_authoritative_meta() {
+    let temp = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", temp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = temp.path();
+    let (session_id, session_dir) = create_success_session(project, "wait-low-review-finding");
+    write_review_meta(
+        &session_dir,
+        &session_id,
+        ReviewDecision::Fail,
+        "HAS_ISSUES",
+        1,
+        Some("one LOW documentation-contract finding remains"),
+    );
+
+    wait_for_terminal_result(project, &session_id);
+    let result = load_result(project, &session_id)
+        .expect("load reconciled result")
+        .expect("reconciled result");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+}
+
+#[test]
+fn issue_2825_wait_fails_provider_quota_uncertain_review_meta() {
+    let temp = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", temp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = temp.path();
+    let (session_id, session_dir) = create_success_session(project, "wait-provider-quota");
+    write_review_meta(
+        &session_dir,
+        &session_id,
+        ReviewDecision::Uncertain,
+        "UNCERTAIN",
+        1,
+        Some("provider quota exhausted before review completed"),
+    );
+
+    wait_for_terminal_result(project, &session_id);
+    let result = load_result(project, &session_id)
+        .expect("load reconciled result")
+        .expect("reconciled result");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+}
+
+#[test]
+fn issue_2825_wait_fails_closed_on_conflicting_review_artifact_fields() {
+    let temp = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", temp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = temp.path();
+    let (session_id, session_dir) =
+        create_success_session(project, "wait-review-artifact-conflict");
+    write_review_meta(
+        &session_dir,
+        &session_id,
+        ReviewDecision::Uncertain,
+        "UNCERTAIN",
+        1,
+        Some("provider quota exhausted before verdict finalization"),
+    );
+    let verdict = csa_session::ReviewVerdictArtifact::from_parts(
+        session_id.clone(),
+        ReviewDecision::Pass,
+        "CLEAN",
+        &[],
+        Vec::new(),
+    );
+    csa_session::write_review_verdict(&session_dir, &verdict).expect("write review verdict");
+
+    wait_for_terminal_result(project, &session_id);
+    let result = load_result(project, &session_id)
+        .expect("load reconciled result")
+        .expect("reconciled result");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2825_authority.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2825_authority.rs
@@ -249,7 +249,7 @@ fn issue_2825_wait_forces_persisted_post_exec_gate_failure_over_matching_pass_si
 }
 
 #[test]
-fn issue_2825_wait_fails_clean_meta_without_current_verdict_artifact() {
+fn issue_2825_wait_preserves_clean_meta_without_legacy_verdict_artifact() {
     let temp = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = temp.path().join("xdg-state");
@@ -262,7 +262,7 @@ fn issue_2825_wait_fails_clean_meta_without_current_verdict_artifact() {
     std::fs::remove_file(session_dir.join("output").join("review-verdict.json"))
         .expect("remove verdict artifact");
 
-    wait_fails(project, &session_id);
+    wait_succeeds(project, &session_id);
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2825_authority.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2825_authority.rs
@@ -1,0 +1,361 @@
+use super::*;
+use crate::session_cmds_daemon::{WaitBehavior, WaitLoopTiming, handle_session_wait_with_hooks};
+use crate::session_cmds_result::{StructuredOutputOpts, handle_session_result};
+use crate::test_env_lock::TEST_ENV_LOCK;
+use csa_core::types::ReviewDecision;
+use std::path::{Path, PathBuf};
+use tempfile::tempdir;
+
+fn create_success_session(project: &Path, description: &str) -> (String, PathBuf) {
+    let session =
+        create_session(project, Some(description), None, Some("codex")).expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session directory");
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 0\nstatus = \"success\"\n",
+    )
+    .expect("write success completion");
+    save_result(
+        project,
+        &session_id,
+        &SessionResult {
+            summary: "transport completed successfully".to_string(),
+            ..make_result("success", 0)
+        },
+    )
+    .expect("save provisional result");
+    (session_id, session_dir)
+}
+
+fn wait_fails(project: &Path, session_id: &str) {
+    let mut completion = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.to_string(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("terminal artifacts should short-circuit")
+        },
+        |session, status, exit, synthetic, _mirror| {
+            completion = Some((session.to_string(), status.to_string(), exit, synthetic));
+        },
+    )
+    .expect("wait terminal result");
+
+    assert_eq!(exit_code, 1);
+    assert_eq!(
+        completion,
+        Some((session_id.to_string(), "failure".to_string(), 1, false))
+    );
+}
+
+fn wait_succeeds(project: &Path, session_id: &str) {
+    let mut completion = None;
+    let exit_code = handle_session_wait_with_hooks(
+        session_id.to_string(),
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 1,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        |_project_root, _current_session_id, _trigger| {
+            panic!("terminal artifacts should short-circuit")
+        },
+        |session, status, exit, synthetic, _mirror| {
+            completion = Some((session.to_string(), status.to_string(), exit, synthetic));
+        },
+    )
+    .expect("wait terminal result");
+
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        completion,
+        Some((session_id.to_string(), "success".to_string(), 0, false))
+    );
+}
+
+fn require_commit_recovery(
+    commit_created: bool,
+    dirty_worktree: bool,
+    blocker_summary: Option<&str>,
+) -> csa_session::RequireCommitRecoveryDiagnostic {
+    csa_session::RequireCommitRecoveryDiagnostic {
+        require_commit: true,
+        sa_mode: Some(true),
+        commit_created,
+        dirty_worktree,
+        changed_paths: Vec::new(),
+        changed_paths_truncated: 0,
+        termination_status: "failure".to_string(),
+        exit_code: 1,
+        termination_signal: None,
+        kill_hint: None,
+        blocker_summary: blocker_summary.map(str::to_string),
+        suggested_recovery_action: "inspect_changed_paths_then_commit_or_revert".to_string(),
+    }
+}
+
+fn write_matching_pass_sidecars(session_dir: &Path, session_id: &str) {
+    let timestamp = chrono::Utc::now();
+    csa_session::write_review_meta(
+        session_dir,
+        &csa_session::ReviewSessionMeta {
+            session_id: session_id.to_string(),
+            head_sha: "deadbeef".to_string(),
+            decision: ReviewDecision::Pass.as_str().to_string(),
+            verdict: "CLEAN".to_string(),
+            review_mode: None,
+            status_reason: None,
+            routed_to: None,
+            primary_failure: None,
+            failure_reason: None,
+            tool: "codex".to_string(),
+            scope: "range:main...HEAD".to_string(),
+            exit_code: 0,
+            fix_attempted: false,
+            fix_rounds: 0,
+            review_iterations: 1,
+            timestamp,
+            diff_fingerprint: None,
+            fix_convergence: None,
+        },
+    )
+    .expect("write pass review metadata");
+    let mut artifact = csa_session::ReviewVerdictArtifact::from_parts(
+        session_id.to_string(),
+        ReviewDecision::Pass,
+        "CLEAN",
+        &[],
+        Vec::new(),
+    );
+    artifact.timestamp = timestamp;
+    artifact.review_iterations = Some(1);
+    artifact.fix_rounds = Some(0);
+    csa_session::write_review_verdict(session_dir, &artifact).expect("write pass review verdict");
+}
+
+fn assert_pass_sidecar_mismatch(
+    description: &str,
+    mutate: impl FnOnce(&mut csa_session::ReviewVerdictArtifact),
+) {
+    let temp = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", temp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = temp.path();
+    let (session_id, session_dir) = create_success_session(project, description);
+    write_matching_pass_sidecars(&session_dir, &session_id);
+
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    let raw = std::fs::read_to_string(&verdict_path).expect("read verdict artifact");
+    let mut artifact: csa_session::ReviewVerdictArtifact =
+        serde_json::from_str(&raw).expect("parse verdict artifact");
+    mutate(&mut artifact);
+    csa_session::write_review_verdict(&session_dir, &artifact).expect("rewrite mismatched verdict");
+
+    wait_fails(project, &session_id);
+}
+
+fn assert_recovery_failure(
+    description: &str,
+    commit_created: bool,
+    dirty_worktree: bool,
+    blocker_summary: Option<&str>,
+) {
+    let temp = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", temp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = temp.path();
+    let (session_id, _) = create_success_session(project, description);
+
+    let mut result = load_result(project, &session_id)
+        .expect("load provisional result")
+        .expect("provisional result");
+    result.require_commit_recovery = Some(require_commit_recovery(
+        commit_created,
+        dirty_worktree,
+        blocker_summary,
+    ));
+    save_result(project, &session_id, &result).expect("save require-commit diagnostic");
+
+    wait_fails(project, &session_id);
+    let persisted = load_result(project, &session_id)
+        .expect("load repaired result")
+        .expect("repaired result");
+    assert_eq!(persisted.status, "failure");
+    assert_eq!(persisted.exit_code, 1);
+}
+
+#[test]
+fn issue_2825_wait_fails_require_commit_without_qualifying_commit_on_clean_tree() {
+    assert_recovery_failure("require-commit-no-commit-clean", false, false, None);
+}
+
+#[test]
+fn issue_2825_wait_fails_require_commit_with_commit_but_dirty_tracked_worktree() {
+    assert_recovery_failure("require-commit-commit-dirty", true, true, None);
+}
+
+#[test]
+fn issue_2825_wait_fails_require_commit_when_cleanliness_is_unverifiable() {
+    assert_recovery_failure(
+        "require-commit-unknown-cleanliness",
+        true,
+        false,
+        Some("clean_tree_verification=git-status-probe-failed exit_code=128"),
+    );
+}
+
+#[test]
+fn issue_2825_wait_forces_persisted_post_exec_gate_failure_over_matching_pass_sidecars() {
+    let temp = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", temp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = temp.path();
+    let (session_id, session_dir) = create_success_session(project, "post-exec-gate-authority");
+    write_matching_pass_sidecars(&session_dir, &session_id);
+
+    let mut result = load_result(project, &session_id)
+        .expect("load provisional result")
+        .expect("provisional result");
+    result.post_exec_gate = Some(csa_session::PostExecGateReport::from_redacted_gate_output(
+        "just pre-commit-fast",
+        1,
+        "error: gate failed",
+    ));
+    save_result(project, &session_id, &result).expect("save optimistic gate result");
+
+    wait_fails(project, &session_id);
+    let persisted = load_result(project, &session_id)
+        .expect("load repaired result")
+        .expect("repaired result");
+    assert_eq!(persisted.status, "failure");
+    assert_eq!(persisted.exit_code, 1);
+    assert!(persisted.post_exec_gate.is_some());
+}
+
+#[test]
+fn issue_2825_wait_fails_clean_meta_without_current_verdict_artifact() {
+    let temp = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", temp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = temp.path();
+    let (session_id, session_dir) = create_success_session(project, "review-meta-without-verdict");
+    write_matching_pass_sidecars(&session_dir, &session_id);
+    std::fs::remove_file(session_dir.join("output").join("review-verdict.json"))
+        .expect("remove verdict artifact");
+
+    wait_fails(project, &session_id);
+}
+
+#[test]
+fn issue_2825_wait_fails_pass_artifact_without_current_metadata() {
+    let temp = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", temp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = temp.path();
+    let (session_id, session_dir) = create_success_session(project, "review-verdict-without-meta");
+    write_matching_pass_sidecars(&session_dir, &session_id);
+    std::fs::remove_file(session_dir.join("review_meta.json")).expect("remove review metadata");
+
+    wait_fails(project, &session_id);
+}
+
+#[test]
+fn issue_2825_wait_fails_mismatched_pass_sidecar_identity_and_ordering() {
+    assert_pass_sidecar_mismatch("review-sidecar-identity", |artifact| {
+        artifact.session_id = "other-session".to_string();
+    });
+    assert_pass_sidecar_mismatch("review-sidecar-ordering", |artifact| {
+        artifact.timestamp -= chrono::Duration::seconds(1);
+    });
+}
+
+#[test]
+fn issue_2825_wait_fails_mismatched_pass_sidecar_verdict_generation_and_retry() {
+    assert_pass_sidecar_mismatch("review-sidecar-decision", |artifact| {
+        artifact.decision = ReviewDecision::Fail;
+    });
+    assert_pass_sidecar_mismatch("review-sidecar-legacy-verdict", |artifact| {
+        artifact.verdict_legacy = "HAS_ISSUES".to_string();
+    });
+    assert_pass_sidecar_mismatch("review-sidecar-generation", |artifact| {
+        artifact.review_iterations = Some(2);
+    });
+    assert_pass_sidecar_mismatch("review-sidecar-retry", |artifact| {
+        artifact.fix_rounds = Some(1);
+    });
+}
+
+#[test]
+fn issue_2825_wait_repairs_stale_review_failure_only_from_matching_current_pass_sidecars() {
+    let temp = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", temp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = temp.path();
+    let (session_id, session_dir) = create_success_session(project, "current-pass-sidecars");
+
+    let mut stale = csa_session::load_result(project, &session_id)
+        .expect("load stale result")
+        .expect("result exists");
+    stale.status = "failure".to_string();
+    stale.exit_code = 1;
+    stale.summary = "No blocking findings in main...HEAD.".to_string();
+    csa_session::save_result(project, &session_id, &stale).expect("save stale result");
+    write_matching_pass_sidecars(&session_dir, &session_id);
+
+    wait_succeeds(project, &session_id);
+}
+
+#[test]
+fn issue_2825_session_result_propagates_malformed_review_sidecar_reconciliation() {
+    let temp = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = temp.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", temp.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = temp.path();
+    let (session_id, session_dir) =
+        create_success_session(project, "malformed-review-sidecar-result");
+    write_matching_pass_sidecars(&session_dir, &session_id);
+    std::fs::write(
+        session_dir.join("output").join("review-verdict.json"),
+        "{ not valid review verdict json",
+    )
+    .expect("write malformed review verdict");
+
+    let result = handle_session_result(
+        session_id,
+        false,
+        Some(project.to_string_lossy().into_owned()),
+        StructuredOutputOpts::default(),
+    );
+    assert!(
+        result.is_err(),
+        "malformed current review sidecar must surface"
+    );
+}

--- a/crates/cli-sub-agent/src/session_observability.rs
+++ b/crates/cli-sub-agent/src/session_observability.rs
@@ -97,6 +97,9 @@ pub(crate) fn refresh_and_repair_result_from_dir(
     {
         changed = true;
     }
+    if sync_require_commit_contract_failure(&mut result) {
+        changed = true;
+    }
 
     if changed && let Ok(serialized) = toml::to_string_pretty(&result) {
         let tmp = result_path.with_extension("toml.tmp");
@@ -155,6 +158,9 @@ pub(crate) fn enrich_result_from_session_dir(
     {
         changed = true;
     }
+    if sync_require_commit_contract_failure(result) {
+        changed = true;
+    }
 
     let artifact_names = csa_session::list_artifacts(project_root, session_id)?;
     if merge_artifacts(&mut result.artifacts, artifact_names) {
@@ -162,6 +168,27 @@ pub(crate) fn enrich_result_from_session_dir(
     }
 
     Ok(changed)
+}
+
+pub(crate) fn require_commit_contract_failed(result: &SessionResult) -> bool {
+    result
+        .require_commit_recovery
+        .as_ref()
+        .is_some_and(|recovery| {
+            recovery.require_commit && !recovery.commit_created && recovery.dirty_worktree
+        })
+}
+
+fn sync_require_commit_contract_failure(result: &mut SessionResult) -> bool {
+    if !require_commit_contract_failed(result)
+        || (result.status == "failure" && result.exit_code == 1)
+    {
+        return false;
+    }
+
+    result.status = "failure".to_string();
+    result.exit_code = 1;
+    true
 }
 
 pub(crate) fn build_missing_result_diagnostic(

--- a/crates/cli-sub-agent/src/session_observability.rs
+++ b/crates/cli-sub-agent/src/session_observability.rs
@@ -97,6 +97,9 @@ pub(crate) fn refresh_and_repair_result_from_dir(
     {
         changed = true;
     }
+    if gate::sync_persisted_post_exec_gate_failure(&mut result) {
+        changed = true;
+    }
     if sync_require_commit_contract_failure(&mut result) {
         changed = true;
     }
@@ -158,6 +161,9 @@ pub(crate) fn enrich_result_from_session_dir(
     {
         changed = true;
     }
+    if gate::sync_persisted_post_exec_gate_failure(result) {
+        changed = true;
+    }
     if sync_require_commit_contract_failure(result) {
         changed = true;
     }
@@ -174,9 +180,15 @@ pub(crate) fn require_commit_contract_failed(result: &SessionResult) -> bool {
     result
         .require_commit_recovery
         .as_ref()
-        .is_some_and(|recovery| {
-            recovery.require_commit && !recovery.commit_created && recovery.dirty_worktree
-        })
+        .is_some_and(|recovery| recovery.require_commit)
+}
+
+pub(crate) fn sync_persisted_post_exec_gate_failure(result: &mut SessionResult) -> bool {
+    gate::sync_persisted_post_exec_gate_failure(result)
+}
+
+pub(crate) fn review_sidecars_allow_clean_pass(session_dir: &Path) -> Result<bool> {
+    review_verdict::review_sidecars_allow_clean_pass(session_dir)
 }
 
 fn sync_require_commit_contract_failure(result: &mut SessionResult) -> bool {

--- a/crates/cli-sub-agent/src/session_observability_gate.rs
+++ b/crates/cli-sub-agent/src/session_observability_gate.rs
@@ -43,6 +43,28 @@ pub(super) fn infer_post_exec_gate_failure_from_log(
     Ok(true)
 }
 
+pub(crate) fn sync_persisted_post_exec_gate_failure(result: &mut SessionResult) -> bool {
+    let Some(report) = result.post_exec_gate.as_ref() else {
+        return false;
+    };
+    let exit_code = if report.exit_code == 0 {
+        1
+    } else {
+        report.exit_code
+    };
+    let status = SessionResult::status_from_exit_code(exit_code);
+    let summary = csa_session::post_exec_gate_failure_summary(report);
+    if result.exit_code == exit_code && result.status == status && result.summary == summary {
+        return false;
+    }
+
+    result.exit_code = exit_code;
+    result.status = status;
+    result.summary = summary;
+    ensure_gate_failure_artifact(result);
+    true
+}
+
 fn gate_log_matches_current_failure(
     result: &SessionResult,
     log_path: &Path,

--- a/crates/cli-sub-agent/src/session_observability_legacy_review_pass.rs
+++ b/crates/cli-sub-agent/src/session_observability_legacy_review_pass.rs
@@ -97,7 +97,7 @@ fn recover_legacy_plain_pass_review_sidecars_for_session(
     if decision == ReviewDecision::Pass
         && existing_meta
             .as_ref()
-            .is_some_and(csa_session::ReviewSessionMeta::requires_fail_closed_verdict)
+            .is_some_and(|meta| !meta.accepts_clean_review_verdict(ReviewDecision::Pass))
     {
         return Ok(false);
     }
@@ -126,6 +126,8 @@ fn recover_legacy_plain_pass_review_sidecars_for_session(
         Vec::new(),
     );
     verdict.timestamp = timestamp;
+    verdict.review_iterations = Some(1);
+    verdict.fix_rounds = Some(0);
     csa_session::write_review_verdict(session_dir, &verdict)?;
 
     let meta = csa_session::ReviewSessionMeta {

--- a/crates/cli-sub-agent/src/session_observability_review_verdict.rs
+++ b/crates/cli-sub-agent/src/session_observability_review_verdict.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use csa_core::types::ReviewDecision;
-use csa_session::{ReviewVerdictArtifact, SessionResult};
+use csa_session::{ReviewSessionMeta, ReviewVerdictArtifact, SessionResult};
 
 pub(super) fn sync_review_verdict_exit_code(
     session_dir: &Path,
@@ -25,12 +25,17 @@ pub(crate) fn sync_clean_pass_result_status_from_sidecars(
     session_dir: &Path,
     result: &mut SessionResult,
 ) -> Result<bool> {
-    if result.post_exec_gate.is_some() {
+    if result.post_exec_gate.is_some()
+        || crate::session_observability::require_commit_contract_failed(result)
+    {
         return Ok(false);
     }
     let Some(artifact) = read_review_verdict_artifact(session_dir)? else {
         return Ok(false);
     };
+    if read_review_meta(session_dir)?.is_some_and(|meta| !meta_allows_clean_pass(&meta)) {
+        return Ok(false);
+    }
     if artifact.decision != ReviewDecision::Pass
         || !result_has_clean_review_summary(session_dir, result)
     {
@@ -51,12 +56,18 @@ fn sync_result_exit_code(result: &mut SessionResult, exit_code: i32) -> bool {
 }
 
 fn read_review_verdict_exit_code(session_dir: &Path) -> Result<Option<i32>> {
-    let Some(artifact) = read_review_verdict_artifact(session_dir)? else {
-        return Ok(None);
-    };
-    Ok(Some(
-        crate::verdict_exit_code::exit_code_from_review_decision(artifact.decision),
-    ))
+    let artifact = read_review_verdict_artifact(session_dir)?;
+    let review_meta = read_review_meta(session_dir)?;
+    if review_meta
+        .as_ref()
+        .is_some_and(|meta| !meta_allows_clean_pass(meta))
+    {
+        return Ok(Some(1));
+    }
+
+    Ok(artifact.map(|artifact| {
+        crate::verdict_exit_code::exit_code_from_review_decision(artifact.decision)
+    }))
 }
 
 fn read_review_verdict_artifact(session_dir: &Path) -> Result<Option<ReviewVerdictArtifact>> {
@@ -67,6 +78,23 @@ fn read_review_verdict_artifact(session_dir: &Path) -> Result<Option<ReviewVerdi
 
     let raw = fs::read_to_string(&verdict_path)?;
     serde_json::from_str(&raw).map(Some).map_err(Into::into)
+}
+
+fn read_review_meta(session_dir: &Path) -> Result<Option<ReviewSessionMeta>> {
+    let meta_path = session_dir.join("review_meta.json");
+    if !meta_path.is_file() {
+        return Ok(None);
+    }
+
+    let raw = fs::read_to_string(&meta_path)?;
+    serde_json::from_str(&raw).map(Some).map_err(Into::into)
+}
+
+fn meta_allows_clean_pass(meta: &ReviewSessionMeta) -> bool {
+    matches!(meta.decision.parse(), Ok(ReviewDecision::Pass))
+        && meta.exit_code == 0
+        && !meta.requires_fail_closed_verdict()
+        && meta.fix_clean_converged()
 }
 
 fn result_has_clean_review_summary(session_dir: &Path, result: &SessionResult) -> bool {

--- a/crates/cli-sub-agent/src/session_observability_review_verdict.rs
+++ b/crates/cli-sub-agent/src/session_observability_review_verdict.rs
@@ -7,6 +7,7 @@ use csa_session::{ReviewSessionMeta, ReviewVerdictArtifact, SessionResult};
 
 enum ReviewSidecarAuthority {
     Absent,
+    LegacyCleanMetaWithoutArtifact,
     Invalid,
     Valid {
         meta: Box<ReviewSessionMeta>,
@@ -21,12 +22,17 @@ pub(super) fn sync_review_verdict_exit_code(
 ) -> Result<bool> {
     let authority = read_review_sidecar_authority(session_dir)?;
     let exit_code = match authority {
-        ReviewSidecarAuthority::Absent if !force_review_failure => None,
+        ReviewSidecarAuthority::Absent | ReviewSidecarAuthority::LegacyCleanMetaWithoutArtifact
+            if !force_review_failure =>
+        {
+            None
+        }
         ReviewSidecarAuthority::Valid {
             ref meta,
             ref artifact,
         } if !force_review_failure && sidecars_allow_clean_pass(meta, artifact) => None,
         ReviewSidecarAuthority::Absent
+        | ReviewSidecarAuthority::LegacyCleanMetaWithoutArtifact
         | ReviewSidecarAuthority::Invalid
         | ReviewSidecarAuthority::Valid { .. } => Some(1),
     };
@@ -81,6 +87,12 @@ fn read_review_sidecar_authority(session_dir: &Path) -> Result<ReviewSidecarAuth
     let meta = read_review_meta(session_dir)?;
     match (meta, artifact) {
         (None, None) => Ok(ReviewSidecarAuthority::Absent),
+        // Legacy review flows wrote clean metadata but no separate verdict artifact.
+        // Treat only independently clean metadata as neutral; every non-pass,
+        // incomplete, or malformed metadata result remains fail-closed.
+        (Some(meta), None) if meta_allows_clean_pass(&meta) => {
+            Ok(ReviewSidecarAuthority::LegacyCleanMetaWithoutArtifact)
+        }
         (Some(meta), Some(artifact)) if sidecars_match(&meta, &artifact) => {
             Ok(ReviewSidecarAuthority::Valid {
                 meta: Box::new(meta),

--- a/crates/cli-sub-agent/src/session_observability_review_verdict.rs
+++ b/crates/cli-sub-agent/src/session_observability_review_verdict.rs
@@ -5,20 +5,32 @@ use anyhow::Result;
 use csa_core::types::ReviewDecision;
 use csa_session::{ReviewSessionMeta, ReviewVerdictArtifact, SessionResult};
 
+enum ReviewSidecarAuthority {
+    Absent,
+    Invalid,
+    Valid {
+        meta: Box<ReviewSessionMeta>,
+        artifact: Box<ReviewVerdictArtifact>,
+    },
+}
+
 pub(super) fn sync_review_verdict_exit_code(
     session_dir: &Path,
     result: &mut SessionResult,
     force_review_failure: bool,
 ) -> Result<bool> {
-    let exit_code = if force_review_failure {
-        Some(1)
-    } else {
-        read_review_verdict_exit_code(session_dir)?
+    let authority = read_review_sidecar_authority(session_dir)?;
+    let exit_code = match authority {
+        ReviewSidecarAuthority::Absent if !force_review_failure => None,
+        ReviewSidecarAuthority::Valid {
+            ref meta,
+            ref artifact,
+        } if !force_review_failure && sidecars_allow_clean_pass(meta, artifact) => None,
+        ReviewSidecarAuthority::Absent
+        | ReviewSidecarAuthority::Invalid
+        | ReviewSidecarAuthority::Valid { .. } => Some(1),
     };
-    let Some(exit_code) = exit_code else {
-        return Ok(false);
-    };
-    Ok(sync_result_exit_code(result, exit_code))
+    Ok(exit_code.is_some_and(|exit_code| sync_result_exit_code(result, exit_code)))
 }
 
 pub(crate) fn sync_clean_pass_result_status_from_sidecars(
@@ -30,18 +42,27 @@ pub(crate) fn sync_clean_pass_result_status_from_sidecars(
     {
         return Ok(false);
     }
-    let Some(artifact) = read_review_verdict_artifact(session_dir)? else {
+    let ReviewSidecarAuthority::Valid { meta, artifact } =
+        read_review_sidecar_authority(session_dir)?
+    else {
         return Ok(false);
     };
-    if read_review_meta(session_dir)?.is_some_and(|meta| !meta_allows_clean_pass(&meta)) {
-        return Ok(false);
-    }
-    if artifact.decision != ReviewDecision::Pass
+    if !sidecars_allow_clean_pass(&meta, &artifact)
+        || artifact.timestamp < result.completed_at
         || !result_has_clean_review_summary(session_dir, result)
     {
         return Ok(false);
     }
     Ok(sync_result_exit_code(result, 0))
+}
+
+pub(crate) fn review_sidecars_allow_clean_pass(session_dir: &Path) -> Result<bool> {
+    let authority = read_review_sidecar_authority(session_dir)?;
+    Ok(matches!(
+        authority,
+        ReviewSidecarAuthority::Valid { ref meta, ref artifact }
+            if sidecars_allow_clean_pass(meta, artifact)
+    ))
 }
 
 fn sync_result_exit_code(result: &mut SessionResult, exit_code: i32) -> bool {
@@ -55,19 +76,42 @@ fn sync_result_exit_code(result: &mut SessionResult, exit_code: i32) -> bool {
     true
 }
 
-fn read_review_verdict_exit_code(session_dir: &Path) -> Result<Option<i32>> {
+fn read_review_sidecar_authority(session_dir: &Path) -> Result<ReviewSidecarAuthority> {
     let artifact = read_review_verdict_artifact(session_dir)?;
-    let review_meta = read_review_meta(session_dir)?;
-    if review_meta
-        .as_ref()
-        .is_some_and(|meta| !meta_allows_clean_pass(meta))
-    {
-        return Ok(Some(1));
+    let meta = read_review_meta(session_dir)?;
+    match (meta, artifact) {
+        (None, None) => Ok(ReviewSidecarAuthority::Absent),
+        (Some(meta), Some(artifact)) if sidecars_match(&meta, &artifact) => {
+            Ok(ReviewSidecarAuthority::Valid {
+                meta: Box::new(meta),
+                artifact: Box::new(artifact),
+            })
+        }
+        _ => Ok(ReviewSidecarAuthority::Invalid),
     }
+}
 
-    Ok(artifact.map(|artifact| {
-        crate::verdict_exit_code::exit_code_from_review_decision(artifact.decision)
-    }))
+fn sidecars_match(meta: &ReviewSessionMeta, artifact: &ReviewVerdictArtifact) -> bool {
+    let Ok(decision) = meta.decision.parse::<ReviewDecision>() else {
+        return false;
+    };
+    !meta.session_id.trim().is_empty()
+        && meta.session_id == artifact.session_id
+        && artifact.timestamp >= meta.timestamp
+        && decision == artifact.decision
+        && meta.verdict == artifact.verdict_legacy
+        && artifact.review_iterations == Some(meta.review_iterations)
+        && artifact.fix_rounds == Some(meta.fix_rounds)
+}
+
+fn sidecars_allow_clean_pass(meta: &ReviewSessionMeta, artifact: &ReviewVerdictArtifact) -> bool {
+    meta_allows_clean_pass(meta)
+        && artifact.decision == ReviewDecision::Pass
+        && !artifact_has_severity_counts(artifact)
+}
+
+fn artifact_has_severity_counts(artifact: &ReviewVerdictArtifact) -> bool {
+    artifact.severity_counts.values().any(|count| *count > 0)
 }
 
 fn read_review_verdict_artifact(session_dir: &Path) -> Result<Option<ReviewVerdictArtifact>> {

--- a/crates/cli-sub-agent/src/session_unavailable_reason.rs
+++ b/crates/cli-sub-agent/src/session_unavailable_reason.rs
@@ -207,6 +207,8 @@ mod tests {
             primary_failure: primary_failure.map(str::to_string),
             failure_reason: failure_reason.map(str::to_string),
             prior_round_refs: Vec::new(),
+            review_iterations: None,
+            fix_rounds: None,
             diff_size: None,
             large_diff_warning: false,
             large_diff_warning_threshold: None,

--- a/crates/csa-session/src/review_artifact.rs
+++ b/crates/csa-session/src/review_artifact.rs
@@ -130,6 +130,13 @@ pub struct ReviewVerdictArtifact {
     pub failure_reason: Option<String>,
     #[serde(default)]
     pub prior_round_refs: Vec<String>,
+    /// Review iteration that produced this verdict.  It binds the verdict to
+    /// the current metadata generation when both review sidecars are read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_iterations: Option<u32>,
+    /// Number of fix retries completed before this verdict was emitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fix_rounds: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub diff_size: Option<ReviewDiffSize>,
     #[serde(default, skip_serializing_if = "is_false")]
@@ -179,6 +186,8 @@ impl ReviewVerdictArtifact {
             primary_failure: None,
             failure_reason: None,
             prior_round_refs,
+            review_iterations: None,
+            fix_rounds: None,
             diff_size: None,
             large_diff_warning: false,
             large_diff_warning_threshold: None,

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1118"
-weave = "0.1.1118"
+csa = "0.1.1119"
+weave = "0.1.1119"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Root cause

`csa session wait` could retain a transport-success terminal result even after authoritative persisted state showed a require-commit contract failure, a failed post-exec gate, a non-PASS review result, or incompatible review sidecars.

## Fix

- Reconcile require-commit recovery and persisted post-exec-gate failure state before choosing wait status/exit code.
- Treat review metadata and verdict artifacts as a matching authority pair; malformed, missing, stale, or conflicting sidecars fail closed.
- Let structured non-PASS decisions override optimistic summary prose, while preserving clean legacy metadata behavior.
- Add targeted regression coverage for the #2825 failure shapes and compatibility cases (#2183, #2425, #1990, #2001, #2002).

## Review evidence

- Exact scope: `origin/main...4fb5d48498ecfb599a63b75e8d924f56936e76eb` (tree `8536b6642ac7456fc6c003a6b333cabd13779090`).
- Native fallback review: **PASS, no findings**. It verified all four prior HIGH-finding fixes and the named legacy regressions through the implementation and regression tests.
- Tier-4 CSA review was requested as session `01KYB5YT7FDFW74CBGRVW4V5YT`, but it was rejected before review execution by CSA memory admission (writer soft limit 8192 MB < required 9000 MB); this is explicitly not counted as a PASS.
- `git diff --check origin/main...HEAD` passed. The authorized full gate had already passed before this publication step and was intentionally not re-run.

Closes #2825
