### PR TITLE
fix(hooks): harden hermetic fixture Git transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1119"
+version = "0.1.1120"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1119"
+version = "0.1.1120"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -160,8 +160,105 @@ done
 
 strip_hook_bypass_env
 
-if [ "${COMMAND}" = "push" ] && [ "${CSA_GIT_PUSH_ALLOWED:-}" != "true" ]; then
-  echo "CSA git-guard: git push blocked for leaf-worker sessions." >&2
+push_destination() {
+  PUSH_COMMAND_SEEN=false
+  PUSH_EXPECT_VALUE=""
+  for arg do
+    if [ "${PUSH_COMMAND_SEEN}" = "false" ]; then
+      if [ -n "${PUSH_EXPECT_VALUE}" ]; then
+        PUSH_EXPECT_VALUE=""
+        continue
+      fi
+
+      case "${arg}" in
+        -c|--config|-C|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix|--config-env)
+          PUSH_EXPECT_VALUE="global-option"
+          continue
+          ;;
+        --config=*|--git-dir=*|--work-tree=*|--namespace=*|--exec-path=*|--super-prefix=*|--config-env=*)
+          continue
+          ;;
+        --help|-h|--*|-*)
+          continue
+          ;;
+        *)
+          [ "${arg}" = "push" ] || return 1
+          PUSH_COMMAND_SEEN=true
+          continue
+          ;;
+      esac
+    fi
+
+    # The narrow local-fixture exception intentionally permits only the plain
+    # `git push <destination> <refspec...>` form. Any push option, including
+    # --force, remains behind CSA's explicit push authorization.
+    case "${arg}" in
+      --|-*) return 1 ;;
+      *) printf '%s\n' "${arg}"; return 0 ;;
+    esac
+  done
+
+  return 1
+}
+
+canonical_directory() {
+  CDPATH= cd "${1}" 2>/dev/null && pwd -P
+}
+
+is_descendant_of() {
+  case "${1}" in
+    "${2}"/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_hermetic_local_bare_push() {
+  destination="$(push_destination "$@")" || return 1
+
+  # Accept only an explicit filesystem path or a local file URL without a
+  # hostname. Colons otherwise admit scp-style and named Git transports.
+  case "${destination}" in
+    file:///*) destination_path="${destination#file://}" ;;
+    *://*|*:*) return 1 ;;
+    *) destination_path="${destination}" ;;
+  esac
+
+  session_dir="${CSA_SESSION_DIR:-}"
+  [ -n "${session_dir}" ] || return 1
+  session_dir="$(canonical_directory "${session_dir}")" || return 1
+  guard_dir="$(canonical_directory "$(dirname "$0")")" || return 1
+  expected_guard_dir="$(canonical_directory "${session_dir}/bin")" || return 1
+  [ "${guard_dir}" = "${expected_guard_dir}" ] || return 1
+
+  fixture_root="$(canonical_directory "${session_dir}/git-fixtures")" || return 1
+  is_descendant_of "${fixture_root}" "${session_dir}" || return 1
+  destination_path="$(canonical_directory "${destination_path}")" || return 1
+  is_descendant_of "${destination_path}" "${fixture_root}" || return 1
+
+  # A fixture must never be a ref/remote location inside the worktree that is
+  # being guarded. Check both the executing worktree and CSA's session root.
+  if worktree="$("${REAL_GIT}" rev-parse --show-toplevel 2>/dev/null)"; then
+    worktree="$(canonical_directory "${worktree}")" || return 1
+    is_descendant_of "${destination_path}" "${worktree}" && return 1
+  fi
+  if [ -n "${CSA_PROJECT_ROOT:-}" ]     && project_root="$(canonical_directory "${CSA_PROJECT_ROOT}")"; then
+    is_descendant_of "${destination_path}" "${project_root}" && return 1
+  fi
+
+  [ "$("${REAL_GIT}" -C "${destination_path}" rev-parse --is-bare-repository 2>/dev/null)" = "true" ]
+}
+
+format_git_command() {
+  printf 'git'
+  for arg do
+    printf ' %s' "${arg}"
+  done
+}
+
+if [ "${COMMAND}" = "push" ] && [ "${CSA_GIT_PUSH_ALLOWED:-}" != "true" ]   && ! is_hermetic_local_bare_push "$@"; then
+  rejected_command="$(format_git_command "$@")"
+  echo "CSA git-guard: blocked command: ${rejected_command}" >&2
+  echo "Use a hermetic local bare fixture under \$CSA_SESSION_DIR/git-fixtures and push to its direct canonical path or file:// URL." >&2
   exit 128
 fi
 

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -160,57 +160,6 @@ done
 
 strip_hook_bypass_env
 
-push_destination() {
-  PUSH_COMMAND_SEEN=false
-  PUSH_EXPECT_VALUE=""
-  PUSH_DESTINATION=""
-  for arg do
-    if [ "${PUSH_COMMAND_SEEN}" = "false" ]; then
-      if [ -n "${PUSH_EXPECT_VALUE}" ]; then
-        PUSH_EXPECT_VALUE=""
-        continue
-      fi
-
-      case "${arg}" in
-        -c|--config|-C|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix|--config-env)
-          PUSH_EXPECT_VALUE="global-option"
-          continue
-          ;;
-        --config=*|--git-dir=*|--work-tree=*|--namespace=*|--exec-path=*|--super-prefix=*|--config-env=*)
-          continue
-          ;;
-        --help|-h|--*|-*)
-          continue
-          ;;
-        *)
-          [ "${arg}" = "push" ] || return 1
-          PUSH_COMMAND_SEEN=true
-          continue
-          ;;
-      esac
-    fi
-
-    if [ -z "${PUSH_DESTINATION}" ]; then
-      # The narrow local-fixture exception intentionally permits only the
-      # `git push <destination> <refspec...>` form.
-      case "${arg}" in
-        --|-*) return 1 ;;
-        *) PUSH_DESTINATION="${arg}" ;;
-      esac
-      continue
-    fi
-
-    # Forced updates remain behind CSA's explicit push authorization, even
-    # when their option or refspec follows an otherwise valid destination.
-    case "${arg}" in
-      --force|-f|--force-with-lease|--force-with-lease=*|+*) return 1 ;;
-    esac
-  done
-
-  [ -n "${PUSH_DESTINATION}" ] || return 1
-  printf '%s\n' "${PUSH_DESTINATION}"
-}
-
 canonical_directory() {
   CDPATH= cd "${1}" 2>/dev/null && pwd -P
 }
@@ -222,17 +171,70 @@ is_descendant_of() {
   esac
 }
 
-is_hermetic_local_bare_push() {
-  destination="$(push_destination "$@")" || return 1
-
-  # Accept only an explicit filesystem path or a local file URL without a
-  # hostname. Colons otherwise admit scp-style and named Git transports.
-  case "${destination}" in
-    file:///*) destination_path="${destination#file://}" ;;
-    *://*|*:*) return 1 ;;
-    /*|.*|*/*) destination_path="${destination}" ;;
+has_control_bytes() {
+  case "${1}" in
+    *[!\ -~]*) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+reset_hermetic_git_environment() {
+  # The projected local transport must not inherit invocation-scoped config
+  # injected through Git's environment protocol, nor a caller-selected Git
+  # directory/worktree. The remaining repository-local config is inspected
+  # explicitly for destination rewrites before execution.
+  unset GIT_CONFIG_PARAMETERS GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_NAMESPACE || true
+  for env_name in $(env | sed -n -e 's/^\(GIT_CONFIG_[A-Za-z0-9_]*\)=.*/\1/p'); do
+    unset "${env_name}" || true
+  done
+  export GIT_CONFIG_NOSYSTEM=1
+  export GIT_CONFIG_SYSTEM=/dev/null
+  export GIT_CONFIG_GLOBAL=/dev/null
+  export XDG_CONFIG_HOME=/dev/null
+  export GIT_ALLOW_PROTOCOL=file
+}
+
+url_rewrite_applies() {
+  rewrite_destination="${1}"
+  for rewrite_key in $("${REAL_GIT}" config --name-only --get-regexp '^url\..*\.(insteadof|pushinsteadof)$' 2>/dev/null || true); do
+    if "${REAL_GIT}" config --get-all "${rewrite_key}" 2>/dev/null | (
+      while IFS= read -r rewrite_prefix || [ -n "${rewrite_prefix}" ]; do
+        # An empty prefix rewrites every URL/path. The shell pattern is quoted
+        # so configuration values are compared as literal prefixes.
+        case "${rewrite_destination}" in
+          "${rewrite_prefix}"*) exit 0 ;;
+        esac
+      done
+      exit 1
+    ); then
+      return 0
+    fi
+  done
+  return 1
+}
+
+is_hermetic_local_bare_push() {
+  # Closed grammar for the one fixture exception: no global options, exactly
+  # `push <absolute-path|file:///local> <non-force-refspec...>`. Requiring a
+  # refspec also prevents repository push defaults from becoming policy input.
+  [ "${1:-}" = "push" ] || return 1
+  [ "$#" -ge 3 ] || return 1
+  destination="${2}"
+  shift 2
+  has_control_bytes "${destination}" && return 1
+  case "${destination}" in
+    file:///*) destination_path="${destination#file://}" ;;
+    /*) destination_path="${destination}" ;;
+    *) return 1 ;;
+  esac
+  for refspec do
+    has_control_bytes "${refspec}" && return 1
+    case "${refspec}" in
+      ""|-*|+*|:*) return 1 ;;
+    esac
+  done
+
+  reset_hermetic_git_environment
 
   session_dir="${CSA_SESSION_DIR:-}"
   [ -n "${session_dir}" ] || return 1
@@ -256,13 +258,55 @@ is_hermetic_local_bare_push() {
     is_descendant_of "${destination_path}" "${project_root}" && return 1
   fi
 
-  [ "$("${REAL_GIT}" -C "${destination_path}" rev-parse --is-bare-repository 2>/dev/null)" = "true" ]
+  [ "$("${REAL_GIT}" -C "${destination_path}" rev-parse --is-bare-repository 2>/dev/null)" = "true" ] || return 1
+  HERMETIC_PUSH_DESTINATION="${destination_path}"
+  return 0
+}
+
+format_git_argument() {
+  case "${1}" in
+    *[!\ -~]*)
+      printf '%s' '<escaped-control-argument>'
+      ;;
+    *://*@*)
+      url_scheme="${1%%://*}://"
+      url_remainder="${1#*://}"
+      url_userinfo="${url_remainder%%@*}"
+      url_after_at="${url_remainder#*@}"
+      case "${url_userinfo}" in
+        */*) printf '%s' "${1}" ;;
+        *) printf '%s<redacted>@%s' "${url_scheme}" "${url_after_at}" ;;
+      esac
+      ;;
+    *) printf '%s' "${1}" ;;
+  esac
 }
 
 format_git_command() {
+  REDACT_CONFIG_VALUE=false
   printf 'git'
   for arg do
-    printf ' %s' "${arg}"
+    if [ "${REDACT_CONFIG_VALUE}" = "true" ]; then
+      printf ' %s' '<redacted-config>'
+      REDACT_CONFIG_VALUE=false
+      continue
+    fi
+    case "${arg}" in
+      -c|--config|--config-env)
+        printf ' %s' "${arg}"
+        REDACT_CONFIG_VALUE=true
+        ;;
+      --config=*|--config-env=*)
+        printf ' %s=<redacted-config>' "${arg%%=*}"
+        ;;
+      -c?*)
+        printf ' %s' '-c<redacted-config>'
+        ;;
+      *)
+        printf ' '
+        format_git_argument "${arg}"
+        ;;
+    esac
   done
 }
 
@@ -274,10 +318,16 @@ if [ "${COMMAND}" = "push" ] && [ "${CSA_GIT_PUSH_ALLOWED:-}" != "true" ]; then
     exit 128
   fi
 
-  if "${REAL_GIT}" config --get-regexp '^url\..*\.insteadof$' >/dev/null 2>&1; then
-    echo "CSA git-guard: blocked: git url.insteadOf rewrite detected; remove url.*.insteadOf config for hermetic fixture pushes" >&2
+  if url_rewrite_applies "${HERMETIC_PUSH_DESTINATION}"; then
+    echo "CSA git-guard: blocked: git URL rewrite detected for hermetic fixture push" >&2
     exit 128
   fi
+
+  # Execute only the validated projection: the original destination token and
+  # all global options are discarded, while the closed, validated refspec tail
+  # is preserved exactly. The environment was reset before rewrite inspection.
+  shift 2
+  exec "${REAL_GIT}" push "${HERMETIC_PUSH_DESTINATION}" "$@"
 fi
 
 if [ "${COMMAND}" != "commit" ]; then

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -266,11 +266,18 @@ format_git_command() {
   done
 }
 
-if [ "${COMMAND}" = "push" ] && [ "${CSA_GIT_PUSH_ALLOWED:-}" != "true" ]   && ! is_hermetic_local_bare_push "$@"; then
-  rejected_command="$(format_git_command "$@")"
-  echo "CSA git-guard: blocked command: ${rejected_command}" >&2
-  echo "Use a hermetic local bare fixture under \$CSA_SESSION_DIR/git-fixtures and push to its direct canonical path or file:// URL." >&2
-  exit 128
+if [ "${COMMAND}" = "push" ] && [ "${CSA_GIT_PUSH_ALLOWED:-}" != "true" ]; then
+  if ! is_hermetic_local_bare_push "$@"; then
+    rejected_command="$(format_git_command "$@")"
+    echo "CSA git-guard: blocked command: ${rejected_command}" >&2
+    echo "Use a hermetic local bare fixture under \$CSA_SESSION_DIR/git-fixtures and push to its direct canonical path or file:// URL." >&2
+    exit 128
+  fi
+
+  if "${REAL_GIT}" config --get-regexp '^url\..*\.insteadof$' >/dev/null 2>&1; then
+    echo "CSA git-guard: blocked: git url.insteadOf rewrite detected; remove url.*.insteadOf config for hermetic fixture pushes" >&2
+    exit 128
+  fi
 fi
 
 if [ "${COMMAND}" != "commit" ]; then

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -51,6 +51,13 @@ is_hooks_path_config() {
   esac
 }
 
+is_alias_config() {
+  case "${1%%=*}" in
+    [Aa][Ll][Ii][Aa][Ss].*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 strip_hook_bypass_env() {
   unset LEFTHOOK || true
   unset LEFTHOOK_DISABLED || true
@@ -109,11 +116,17 @@ strip_commit_short_arg() {
 
 COMMAND=""
 BLOCK_HOOKS_PATH_OVERRIDE=false
+ALIAS_CONFIG_OVERRIDE=false
 EXPECT_VALUE=""
 for arg do
   if [ -n "${EXPECT_VALUE}" ]; then
-    if [ "${EXPECT_VALUE}" = "config" ] && is_hooks_path_config "${arg}"; then
-      BLOCK_HOOKS_PATH_OVERRIDE=true
+    if [ "${EXPECT_VALUE}" = "config" ]; then
+      if is_hooks_path_config "${arg}"; then
+        BLOCK_HOOKS_PATH_OVERRIDE=true
+      fi
+      if is_alias_config "${arg}"; then
+        ALIAS_CONFIG_OVERRIDE=true
+      fi
     fi
     EXPECT_VALUE=""
     continue
@@ -132,10 +145,17 @@ for arg do
       if is_hooks_path_config "${value}"; then
         BLOCK_HOOKS_PATH_OVERRIDE=true
       fi
+      if is_alias_config "${value}"; then
+        ALIAS_CONFIG_OVERRIDE=true
+      fi
       continue
       ;;
     -ccore.hooksPath=*|-ccore.hookspath=*)
       BLOCK_HOOKS_PATH_OVERRIDE=true
+      continue
+      ;;
+    -calias.*=-*|-calias.*=*|-c[Aa][Ll][Ii][Aa][Ss].*=*)
+      ALIAS_CONFIG_OVERRIDE=true
       continue
       ;;
     -C|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix|--config-env)
@@ -178,39 +198,81 @@ has_control_bytes() {
   esac
 }
 
+descriptor_path_for() {
+  descriptor_number="${1}"
+  for descriptor_root in /proc/self/fd /dev/fd; do
+    if [ -d "${descriptor_root}/${descriptor_number}" ]; then
+      printf '%s\n' "${descriptor_root}/${descriptor_number}"
+      return 0
+    fi
+  done
+  return 1
+}
+
 reset_hermetic_git_environment() {
-  # The projected local transport must not inherit invocation-scoped config
-  # injected through Git's environment protocol, nor a caller-selected Git
-  # directory/worktree. The remaining repository-local config is inspected
-  # explicitly for destination rewrites before execution.
-  unset GIT_CONFIG_PARAMETERS GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_NAMESPACE || true
+  # The projected local transport must not inherit caller-selected repository,
+  # config, protocol, or helper-routing inputs. The final push runs from an
+  # empty temporary Git directory, so repository-local remotes and URL
+  # rewrites never enter the transport decision.
+  unset GIT_CONFIG GIT_CONFIG_PARAMETERS GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_NAMESPACE || true
+  unset GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM GIT_TEMPLATE_DIR || true
+  unset GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES || true
+  unset GIT_EXEC_PATH GIT_SSH GIT_SSH_COMMAND GIT_SSH_VARIANT GIT_PROXY_COMMAND || true
+  unset GIT_ASKPASS SSH_ASKPASS GIT_TRANSPORT_HELPER_DIR GIT_REMOTE_HELPER_DIR || true
   for env_name in $(env | sed -n -e 's/^\(GIT_CONFIG_[A-Za-z0-9_]*\)=.*/\1/p'); do
     unset "${env_name}" || true
   done
+
+  trusted_exec_path="$("${REAL_GIT}" --exec-path 2>/dev/null)" || return 1
+  case "${trusted_exec_path}" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  trusted_exec_path="$(canonical_directory "${trusted_exec_path}")" || return 1
+
   export GIT_CONFIG_NOSYSTEM=1
   export GIT_CONFIG_SYSTEM=/dev/null
   export GIT_CONFIG_GLOBAL=/dev/null
   export XDG_CONFIG_HOME=/dev/null
   export GIT_ALLOW_PROTOCOL=file
+  export GIT_PROTOCOL_FROM_USER=0
+  export GIT_EXEC_PATH="${trusted_exec_path}"
 }
 
-url_rewrite_applies() {
-  rewrite_destination="${1}"
-  for rewrite_key in $("${REAL_GIT}" config --name-only --get-regexp '^url\..*\.(insteadof|pushinsteadof)$' 2>/dev/null || true); do
-    if "${REAL_GIT}" config --get-all "${rewrite_key}" 2>/dev/null | (
-      while IFS= read -r rewrite_prefix || [ -n "${rewrite_prefix}" ]; do
-        # An empty prefix rewrites every URL/path. The shell pattern is quoted
-        # so configuration values are compared as literal prefixes.
-        case "${rewrite_destination}" in
-          "${rewrite_prefix}"*) exit 0 ;;
-        esac
-      done
-      exit 1
-    ); then
-      return 0
-    fi
-  done
-  return 1
+create_hermetic_push_projection() {
+  # Git has no switch to ignore only the source repository's config. Build a
+  # minimal, configless source snapshot instead: object alternates plus copied
+  # refs give real pack negotiation without allowing local remote/pushurl or
+  # URL-rewrite settings into the final invocation.
+  source_common_dir="$("${REAL_GIT}" rev-parse --git-common-dir 2>/dev/null)" || return 1
+  source_common_dir="$(canonical_directory "${source_common_dir}")" || return 1
+  source_objects="${source_common_dir}/objects"
+  [ -d "${source_objects}" ] || return 1
+  source_head="$("${REAL_GIT}" rev-parse --verify HEAD 2>/dev/null)" || return 1
+
+  umask 077
+  HERMETIC_PUSH_PROJECTION="$(mktemp -d "${session_dir}/.git-guard-projection.XXXXXX")" || return 1
+  mkdir -p "${HERMETIC_PUSH_PROJECTION}/objects/info" "${HERMETIC_PUSH_PROJECTION}/refs" || return 1
+  : > "${HERMETIC_PUSH_PROJECTION}/config" || return 1
+  printf '%s\n' "${source_objects}" > "${HERMETIC_PUSH_PROJECTION}/objects/info/alternates" || return 1
+  printf '%s\n' "${source_head}" > "${HERMETIC_PUSH_PROJECTION}/HEAD" || return 1
+
+  refs_snapshot="${HERMETIC_PUSH_PROJECTION}/refs.snapshot"
+  "${REAL_GIT}" for-each-ref --format='%(refname) %(objectname)' > "${refs_snapshot}" || return 1
+  while IFS=' ' read -r refname object_id remainder || [ -n "${refname:-}" ]; do
+    [ -n "${refname:-}" ] || continue
+    [ -n "${object_id:-}" ] || return 1
+    [ -z "${remainder:-}" ] || return 1
+    "${REAL_GIT}" --git-dir="${HERMETIC_PUSH_PROJECTION}" update-ref "${refname}" "${object_id}" || return 1
+  done < "${refs_snapshot}"
+  rm -f "${refs_snapshot}"
+}
+
+cleanup_hermetic_push_projection() {
+  if [ -n "${HERMETIC_PUSH_PROJECTION:-}" ]; then
+    rm -rf "${HERMETIC_PUSH_PROJECTION}"
+    HERMETIC_PUSH_PROJECTION=""
+  fi
 }
 
 is_hermetic_local_bare_push() {
@@ -234,7 +296,7 @@ is_hermetic_local_bare_push() {
     esac
   done
 
-  reset_hermetic_git_environment
+  reset_hermetic_git_environment || return 1
 
   session_dir="${CSA_SESSION_DIR:-}"
   [ -n "${session_dir}" ] || return 1
@@ -258,76 +320,117 @@ is_hermetic_local_bare_push() {
     is_descendant_of "${destination_path}" "${project_root}" && return 1
   fi
 
-  [ "$("${REAL_GIT}" -C "${destination_path}" rev-parse --is-bare-repository 2>/dev/null)" = "true" ] || return 1
-  HERMETIC_PUSH_DESTINATION="${destination_path}"
+  # Keep both the fixture root and bare destination open. Re-canonicalizing
+  # their descriptor paths after open makes a concurrent symlink/rename swap
+  # fail closed; the transfer receives the pinned destination descriptor.
+  exec 8<"${fixture_root}" || return 1
+  exec 9<"${destination_path}" || return 1
+  fixture_root_descriptor="$(descriptor_path_for 8)" || return 1
+  destination_descriptor="$(descriptor_path_for 9)" || return 1
+  fixture_root="$(canonical_directory "${fixture_root_descriptor}")" || return 1
+  destination_path="$(canonical_directory "${destination_descriptor}")" || return 1
+  is_descendant_of "${fixture_root}" "${session_dir}" || return 1
+  is_descendant_of "${destination_path}" "${fixture_root}" || return 1
+  [ "$("${REAL_GIT}" -C "${destination_descriptor}" rev-parse --is-bare-repository 2>/dev/null)" = "true" ] || return 1
+
+  HERMETIC_PUSH_DESTINATION="${destination_descriptor}"
+  create_hermetic_push_projection || return 1
   return 0
 }
 
-format_git_argument() {
-  case "${1}" in
-    *[!\ -~]*)
-      printf '%s' '<escaped-control-argument>'
-      ;;
-    *://*@*)
-      url_scheme="${1%%://*}://"
-      url_remainder="${1#*://}"
-      url_userinfo="${url_remainder%%@*}"
-      url_after_at="${url_remainder#*@}"
-      case "${url_userinfo}" in
-        */*) printf '%s' "${1}" ;;
-        *) printf '%s<redacted>@%s' "${url_scheme}" "${url_after_at}" ;;
-      esac
-      ;;
-    *) printf '%s' "${1}" ;;
-  esac
-}
-
 format_git_command() {
-  REDACT_CONFIG_VALUE=false
+  # Diagnostics are intentionally structural: a blocked command must never
+  # echo user-controlled destination, refspec, path, query, or config values.
+  command_seen=false
+  expected_value=false
   printf 'git'
   for arg do
-    if [ "${REDACT_CONFIG_VALUE}" = "true" ]; then
-      printf ' %s' '<redacted-config>'
-      REDACT_CONFIG_VALUE=false
+    if [ "${expected_value}" = "true" ]; then
+      printf ' <value>'
+      expected_value=false
       continue
     fi
     case "${arg}" in
-      -c|--config|--config-env)
+      -c|--config|--config-env|-C|--git-dir|--work-tree|--namespace|--exec-path|--super-prefix)
         printf ' %s' "${arg}"
-        REDACT_CONFIG_VALUE=true
+        expected_value=true
         ;;
-      --config=*|--config-env=*)
-        printf ' %s=<redacted-config>' "${arg%%=*}"
+      --config=*|--config-env=*|--git-dir=*|--work-tree=*|--namespace=*|--exec-path=*|--super-prefix=*)
+        printf ' %s=<value>' "${arg%%=*}"
         ;;
-      -c?*)
-        printf ' %s' '-c<redacted-config>'
+      --help|-h)
+        printf ' %s' "${arg}"
+        ;;
+      --*)
+        printf ' <option>'
+        ;;
+      -*)
+        printf ' <option>'
         ;;
       *)
-        printf ' '
-        format_git_argument "${arg}"
+        if [ "${command_seen}" = "false" ]; then
+          case "${arg}" in
+            push|send-pack|receive-pack|status|add|diff|log|commit) printf ' %s' "${arg}" ;;
+            *) printf ' <command>' ;;
+          esac
+          command_seen=true
+        else
+          printf ' <argument>'
+        fi
         ;;
     esac
   done
 }
 
-if [ "${COMMAND}" = "push" ] && [ "${CSA_GIT_PUSH_ALLOWED:-}" != "true" ]; then
-  if ! is_hermetic_local_bare_push "$@"; then
-    rejected_command="$(format_git_command "$@")"
-    echo "CSA git-guard: blocked command: ${rejected_command}" >&2
-    echo "Use a hermetic local bare fixture under \$CSA_SESSION_DIR/git-fixtures and push to its direct canonical path or file:// URL." >&2
-    exit 128
+is_safe_local_command() {
+  case "${1}" in
+    ""|add|am|annotate|apply|bisect|blame|branch|cat-file|check-attr|check-ignore|check-mailmap|check-ref-format|checkout|cherry|cherry-pick|clean|commit|config|count-objects|describe|diff|difftool|fast-export|fast-import|format-patch|fsck|gc|grep|hash-object|log|ls-files|ls-tree|merge|merge-base|merge-file|merge-index|merge-tree|mv|name-rev|notes|pack-objects|prune|read-tree|rebase|reflog|reset|restore|rev-list|rev-parse|rm|show|show-branch|sparse-checkout|stash|status|switch|symbolic-ref|tag|update-index|update-ref|verify-commit|verify-pack|verify-tag|worktree|write-tree)
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+block_untrusted_git_command() {
+  rejected_command="$(format_git_command "$@")"
+  echo "CSA git-guard: blocked command: ${rejected_command}" >&2
+  echo "Use a hermetic local bare fixture under \$CSA_SESSION_DIR/git-fixtures and push to its direct canonical path or file:// URL." >&2
+  exit 128
+}
+
+if [ "${CSA_GIT_PUSH_ALLOWED:-}" != "true" ]; then
+  # Aliases are expanded by Git after this wrapper chooses a command. Reject
+  # caller-supplied alias definitions and fail closed for unknown subcommands,
+  # so `git -c alias.publish=push publish …` cannot re-enter publication.
+  if [ "${ALIAS_CONFIG_OVERRIDE}" = "true" ]; then
+    block_untrusted_git_command "$@"
   fi
 
-  if url_rewrite_applies "${HERMETIC_PUSH_DESTINATION}"; then
-    echo "CSA git-guard: blocked: git URL rewrite detected for hermetic fixture push" >&2
-    exit 128
+  if [ "${COMMAND}" = "push" ]; then
+    if ! is_hermetic_local_bare_push "$@"; then
+      cleanup_hermetic_push_projection
+      block_untrusted_git_command "$@"
+    fi
+
+    # Execute only the pinned, configless projection. The original destination,
+    # global options, source config, and helper routing are absent from this
+    # invocation; refspecs are from the closed grammar above.
+    shift 2
+    if "${REAL_GIT}" --git-dir="${HERMETIC_PUSH_PROJECTION}" push "${HERMETIC_PUSH_DESTINATION}" "$@"; then
+      push_status=0
+    else
+      push_status=$?
+    fi
+    cleanup_hermetic_push_projection
+    exit "${push_status}"
   fi
 
-  # Execute only the validated projection: the original destination token and
-  # all global options are discarded, while the closed, validated refspec tail
-  # is preserved exactly. The environment was reset before rewrite inspection.
-  shift 2
-  exec "${REAL_GIT}" push "${HERMETIC_PUSH_DESTINATION}" "$@"
+  # A publication-capable plumbing command or unknown external subcommand can
+  # bypass literal `push` interception. Permit only common local-only Git
+  # commands; all other command surfaces are denied while leaf pushes are off.
+  if ! is_safe_local_command "${COMMAND}"; then
+    block_untrusted_git_command "$@"
+  fi
 fi
 
 if [ "${COMMAND}" != "commit" ]; then
@@ -539,10 +642,9 @@ pub fn inject_git_guard_env(env: &mut HashMap<String, String>) {
 }
 
 fn real_git_binary(guard_dir: &Path) -> Option<PathBuf> {
-    if let Some(path) = std::env::var_os("CSA_REAL_GIT").filter(|value| !value.is_empty()) {
-        return Some(PathBuf::from(path));
-    }
-
+    // The guard's child environment is attacker-controlled. Resolve a known
+    // host Git rather than inheriting an ambient CSA_REAL_GIT override; this
+    // is the trust anchor used to pin the projected transfer's libexec path.
     let guard_dir_str = guard_dir.to_string_lossy();
     let is_not_guard = |path: &Path| !path.to_string_lossy().starts_with(guard_dir_str.as_ref());
 

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -163,6 +163,7 @@ strip_hook_bypass_env
 push_destination() {
   PUSH_COMMAND_SEEN=false
   PUSH_EXPECT_VALUE=""
+  PUSH_DESTINATION=""
   for arg do
     if [ "${PUSH_COMMAND_SEEN}" = "false" ]; then
       if [ -n "${PUSH_EXPECT_VALUE}" ]; then
@@ -189,16 +190,25 @@ push_destination() {
       esac
     fi
 
-    # The narrow local-fixture exception intentionally permits only the plain
-    # `git push <destination> <refspec...>` form. Any push option, including
-    # --force, remains behind CSA's explicit push authorization.
+    if [ -z "${PUSH_DESTINATION}" ]; then
+      # The narrow local-fixture exception intentionally permits only the
+      # `git push <destination> <refspec...>` form.
+      case "${arg}" in
+        --|-*) return 1 ;;
+        *) PUSH_DESTINATION="${arg}" ;;
+      esac
+      continue
+    fi
+
+    # Forced updates remain behind CSA's explicit push authorization, even
+    # when their option or refspec follows an otherwise valid destination.
     case "${arg}" in
-      --|-*) return 1 ;;
-      *) printf '%s\n' "${arg}"; return 0 ;;
+      --force|-f|--force-with-lease|--force-with-lease=*|+*) return 1 ;;
     esac
   done
 
-  return 1
+  [ -n "${PUSH_DESTINATION}" ] || return 1
+  printf '%s\n' "${PUSH_DESTINATION}"
 }
 
 canonical_directory() {
@@ -220,7 +230,8 @@ is_hermetic_local_bare_push() {
   case "${destination}" in
     file:///*) destination_path="${destination#file://}" ;;
     *://*|*:*) return 1 ;;
-    *) destination_path="${destination}" ;;
+    /*|.*|*/*) destination_path="${destination}" ;;
+    *) return 1 ;;
   esac
 
   session_dir="${CSA_SESSION_DIR:-}"

--- a/crates/csa-hooks/src/git_guard_tests.rs
+++ b/crates/csa-hooks/src/git_guard_tests.rs
@@ -50,6 +50,47 @@ printf '%s\n' "$*"
     );
 }
 
+#[cfg(unix)]
+fn run_git(current_dir: &Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .output()
+        .expect("run git fixture command");
+    assert!(
+        output.status.success(),
+        "git {} failed:\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[cfg(unix)]
+fn init_worktree_repo(repo: &Path) {
+    std::fs::create_dir_all(repo).expect("create worktree fixture");
+    run_git(repo, &["init", "--initial-branch=main"]);
+    run_git(repo, &["config", "user.name", "CSA Test"]);
+    run_git(repo, &["config", "user.email", "csa-test@example.invalid"]);
+    std::fs::write(repo.join("fixture.txt"), "fixture\n").expect("write fixture file");
+    run_git(repo, &["add", "fixture.txt"]);
+    run_git(repo, &["commit", "-m", "fixture commit"]);
+}
+
+#[cfg(unix)]
+fn init_bare_repo(parent: &Path, bare: &Path) {
+    std::fs::create_dir_all(parent).expect("create bare fixture parent");
+    run_git(
+        parent,
+        &[
+            "init",
+            "--bare",
+            bare.to_str().expect("UTF-8 bare fixture path"),
+        ],
+    );
+}
+
 #[test]
 fn inject_git_guard_env_sets_real_git_and_path() {
     let mut env = HashMap::new();
@@ -265,10 +306,9 @@ fn wrapper_blocks_push_without_permission() {
         .unwrap();
 
     assert_eq!(output.status.code(), Some(128));
-    assert_eq!(
-        String::from_utf8_lossy(&output.stderr).trim(),
-        "CSA git-guard: git push blocked for leaf-worker sessions."
-    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("blocked command: git push"), "{stderr}");
+    assert!(stderr.contains("hermetic local bare fixture"), "{stderr}");
     assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
 }
 
@@ -294,6 +334,7 @@ fn wrapper_allows_push_with_permission() {
     assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "push");
 }
 
+include!("git_guard_tests_hermetic_push.rs");
 #[cfg(unix)]
 #[test]
 fn wrapper_allows_pre_push_only_lefthook_config_without_pre_commit() {

--- a/crates/csa-hooks/src/git_guard_tests.rs
+++ b/crates/csa-hooks/src/git_guard_tests.rs
@@ -4,13 +4,80 @@ use crate::test_support::ENV_LOCK;
 use crate::{git_wrapper_script, inject_git_guard_env};
 use std::collections::HashMap;
 #[cfg(unix)]
+use std::io;
+#[cfg(unix)]
 use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use std::path::Path;
 #[cfg(unix)]
-use std::time::Duration;
+use std::process::{Command, Output, Stdio};
+#[cfg(unix)]
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+const GIT_CHILD_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Run a fixture child with a bounded lifetime and a configuration surface
+/// that is independent of the developer's global, system, and XDG Git state.
+#[cfg(unix)]
+trait CommandOutputWithTimeout {
+    fn output_with_timeout(&mut self) -> io::Result<Output>;
+}
+
+#[cfg(unix)]
+impl CommandOutputWithTimeout for Command {
+    fn output_with_timeout(&mut self) -> io::Result<Output> {
+        for (name, _) in std::env::vars_os() {
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            if name == "GIT_CONFIG_PARAMETERS" || name.starts_with("GIT_CONFIG_") {
+                self.env_remove(name);
+            }
+        }
+        for name in [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_COMMON_DIR",
+            "GIT_NAMESPACE",
+            "GIT_CEILING_DIRECTORIES",
+            "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+            "GIT_TEMPLATE_DIR",
+            "GIT_EXEC_PATH",
+            "GIT_INDEX_FILE",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        ] {
+            self.env_remove(name);
+        }
+        self.env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("XDG_CONFIG_HOME", "/dev/null")
+            .env("GIT_ALLOW_PROTOCOL", "file")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = self.spawn()?;
+        let deadline = Instant::now() + GIT_CHILD_TIMEOUT;
+        loop {
+            if child.try_wait()?.is_some() {
+                return child.wait_with_output();
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "fixture child exceeded bounded Git test timeout",
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
 
 #[cfg(unix)]
 fn write_executable(path: &Path, contents: impl AsRef<[u8]>) {
@@ -52,11 +119,10 @@ printf '%s\n' "$*"
 
 #[cfg(unix)]
 fn run_git(current_dir: &Path, args: &[&str]) {
-    let output = std::process::Command::new("git")
+    let output = Command::new("git")
         .args(args)
         .current_dir(current_dir)
-        .env("GIT_CONFIG_NOSYSTEM", "1")
-        .output()
+        .output_with_timeout()
         .expect("run git fixture command");
     assert!(
         output.status.success(),
@@ -144,7 +210,7 @@ fn wrapper_script_parses_with_sh_n() {
     let output = std::process::Command::new("sh")
         .arg("-n")
         .arg(&wrapper)
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert!(
@@ -171,7 +237,7 @@ fn wrapper_strips_no_verify_before_real_git() {
         .arg("-m")
         .arg("test")
         .env("CSA_REAL_GIT", &fake_git)
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert!(output.status.success());
@@ -202,7 +268,7 @@ fn wrapper_strips_short_no_verify_before_real_git() {
         .arg("-m")
         .arg("test")
         .env("CSA_REAL_GIT", &fake_git)
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert!(output.status.success());
@@ -230,7 +296,7 @@ fn wrapper_strips_combined_short_no_verify_before_real_git() {
             .arg(flag)
             .arg("test")
             .env("CSA_REAL_GIT", &fake_git)
-            .output()
+            .output_with_timeout()
             .unwrap();
 
         assert!(output.status.success());
@@ -276,7 +342,7 @@ echo "$@"
         .env("SKIP_GIT_HOOKS", "1")
         .env("PRE_COMMIT_ALLOW_NO_CONFIG", "1")
         .env("LEFTHOOK_SKIP_PRE_COMMIT", "1")
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert!(
@@ -302,7 +368,7 @@ fn wrapper_blocks_push_without_permission() {
         .arg("push")
         .env("CSA_REAL_GIT", &fake_git)
         .env_remove("CSA_GIT_PUSH_ALLOWED")
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert_eq!(output.status.code(), Some(128));
@@ -327,7 +393,7 @@ fn wrapper_allows_push_with_permission() {
         .arg("push")
         .env("CSA_REAL_GIT", &fake_git)
         .env("CSA_GIT_PUSH_ALLOWED", "true")
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert!(output.status.success());
@@ -335,6 +401,7 @@ fn wrapper_allows_push_with_permission() {
 }
 
 include!("git_guard_tests_hermetic_push.rs");
+include!("git_guard_tests_hermetic_push_projection.rs");
 #[cfg(unix)]
 #[test]
 fn wrapper_allows_pre_push_only_lefthook_config_without_pre_commit() {
@@ -365,7 +432,7 @@ fn wrapper_allows_pre_push_only_lefthook_config_without_pre_commit() {
         .current_dir(&repo)
         .env("CSA_REAL_GIT", &fake_git)
         .env("FAKE_TOP", &repo)
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert!(
@@ -401,7 +468,7 @@ fn wrapper_blocks_missing_defined_pre_push_lefthook_hook() {
         .current_dir(&repo)
         .env("CSA_REAL_GIT", &fake_git)
         .env("FAKE_TOP", &repo)
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -436,7 +503,7 @@ fn wrapper_requires_pre_commit_when_lefthook_config_defines_it() {
         .current_dir(&repo)
         .env("CSA_REAL_GIT", &fake_git)
         .env("FAKE_TOP", &repo)
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -459,7 +526,7 @@ fn wrapper_allows_long_commit_options_containing_n() {
         .arg("commit")
         .arg("--amend")
         .env("CSA_REAL_GIT", &fake_git)
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert!(output.status.success());
@@ -491,7 +558,7 @@ fn wrapper_allows_markdown_bullet_after_long_message_option() {
         .arg("--message")
         .arg(body_msg)
         .env("CSA_REAL_GIT", &fake_git)
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert!(output.status.success());
@@ -520,7 +587,7 @@ fn wrapper_allows_leading_dash_after_short_message_option() {
         .arg("-m")
         .arg(msg)
         .env("CSA_REAL_GIT", &fake_git)
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert!(output.status.success());
@@ -546,7 +613,7 @@ fn wrapper_allows_leading_dash_after_file_option() {
         .arg("-F")
         .arg("-")
         .env("CSA_REAL_GIT", &fake_git)
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert!(output.status.success());
@@ -571,7 +638,7 @@ fn wrapper_forwards_non_commit_commands() {
         let output = std::process::Command::new(&wrapper)
             .arg(subcommand)
             .env("CSA_REAL_GIT", &fake_git)
-            .output()
+            .output_with_timeout()
             .unwrap();
 
         assert!(output.status.success());

--- a/crates/csa-hooks/src/git_guard_tests_hermetic_push.rs
+++ b/crates/csa-hooks/src/git_guard_tests_hermetic_push.rs
@@ -30,7 +30,7 @@ fn wrapper_allows_real_push_to_session_owned_local_bare_fixture() {
             .current_dir(&source)
             .env("CSA_SESSION_DIR", &session_dir)
             .env_remove("CSA_GIT_PUSH_ALLOWED")
-            .output()
+            .output_with_timeout()
             .expect("push to local bare fixture through guard");
         assert!(
             output.status.success(),
@@ -47,7 +47,7 @@ fn wrapper_allows_real_push_to_session_owned_local_bare_fixture() {
                 "--verify",
                 reference,
             ])
-            .output()
+            .output_with_timeout()
             .expect("inspect received fixture ref");
         assert!(
             received.status.success(),
@@ -76,7 +76,7 @@ fn wrapper_blocks_remote_push_with_hermetic_fixture_diagnostic() {
         .env("CSA_REAL_GIT", &fake_git)
         .env("CSA_SESSION_DIR", &session_dir)
         .env_remove("CSA_GIT_PUSH_ALLOWED")
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert_eq!(output.status.code(), Some(128));
@@ -122,7 +122,7 @@ fn wrapper_blocks_push_to_working_repository_git_dir() {
         .current_dir(&source)
         .env("CSA_SESSION_DIR", &session_dir)
         .env_remove("CSA_GIT_PUSH_ALLOWED")
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert_eq!(output.status.code(), Some(128));
@@ -139,7 +139,7 @@ fn wrapper_blocks_push_to_working_repository_git_dir() {
             "--quiet",
             "refs/heads/should-not-publish",
         ])
-        .output()
+        .output_with_timeout()
         .expect("inspect rejected working-repository ref");
     assert_eq!(ref_check.status.code(), Some(1));
 }
@@ -172,7 +172,7 @@ fn wrapper_blocks_fixture_path_that_canonicalizes_outside_session() {
         .current_dir(&source)
         .env("CSA_SESSION_DIR", &session_dir)
         .env_remove("CSA_GIT_PUSH_ALLOWED")
-        .output()
+        .output_with_timeout()
         .unwrap();
 
     assert_eq!(output.status.code(), Some(128));
@@ -185,7 +185,7 @@ fn wrapper_blocks_fixture_path_that_canonicalizes_outside_session() {
             "--quiet",
             "refs/heads/should-not-publish",
         ])
-        .output()
+        .output_with_timeout()
         .expect("inspect rejected escaped-fixture ref");
     assert_eq!(ref_check.status.code(), Some(1));
 }
@@ -239,7 +239,7 @@ fn wrapper_blocks_forced_push_variants_to_session_owned_local_bare_fixture() {
             command.arg(force_flag);
         }
         let output = command
-            .output()
+            .output_with_timeout()
             .expect("forced push to local bare fixture through guard");
 
         assert_eq!(
@@ -259,7 +259,7 @@ fn wrapper_blocks_forced_push_variants_to_session_owned_local_bare_fixture() {
                 "--quiet",
                 reference,
             ])
-            .output()
+            .output_with_timeout()
             .expect("inspect rejected force-push ref");
         assert_eq!(
             received.status.code(),
@@ -330,7 +330,7 @@ fn wrapper_blocks_named_remote_even_when_a_fixture_directory_matches_it() {
         .current_dir(&fixture_root)
         .env("CSA_SESSION_DIR", &session_dir)
         .env_remove("CSA_GIT_PUSH_ALLOWED")
-        .output()
+        .output_with_timeout()
         .expect("configured remote push through guard");
 
     assert_eq!(
@@ -350,7 +350,7 @@ fn wrapper_blocks_named_remote_even_when_a_fixture_directory_matches_it() {
             "--quiet",
             reference,
         ])
-        .output()
+        .output_with_timeout()
         .expect("inspect rejected configured-remote ref");
     assert_eq!(
         received.status.code(),
@@ -400,7 +400,7 @@ fn wrapper_blocks_fixture_push_when_url_instead_of_rewrites_destination() {
         .env("GIT_CONFIG_NOSYSTEM", "1")
         .env("GIT_CONFIG_GLOBAL", &empty_global_config)
         .env_remove("CSA_GIT_PUSH_ALLOWED")
-        .output()
+        .output_with_timeout()
         .expect("rewrite push through guard");
 
     assert_eq!(
@@ -412,9 +412,7 @@ fn wrapper_blocks_fixture_push_when_url_instead_of_rewrites_destination() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains(
-            "blocked: git url.insteadOf rewrite detected; remove url.*.insteadOf config for hermetic fixture pushes"
-        ),
+        stderr.contains("blocked: git URL rewrite detected for hermetic fixture push"),
         "{stderr}"
     );
 
@@ -427,7 +425,7 @@ fn wrapper_blocks_fixture_push_when_url_instead_of_rewrites_destination() {
             "--quiet",
             reference,
         ])
-        .output()
+        .output_with_timeout()
         .expect("inspect rejected rewrite destination ref");
     assert_eq!(
         received.status.code(),

--- a/crates/csa-hooks/src/git_guard_tests_hermetic_push.rs
+++ b/crates/csa-hooks/src/git_guard_tests_hermetic_push.rs
@@ -82,7 +82,11 @@ fn wrapper_blocks_remote_push_with_hermetic_fixture_diagnostic() {
     assert_eq!(output.status.code(), Some(128));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("blocked command: git push https://example.invalid/publication.git HEAD:main"),
+        stderr.contains("blocked command: git push <argument> <argument>"),
+        "{stderr}"
+    );
+    assert!(
+        !stderr.contains("https://example.invalid/publication.git"),
         "{stderr}"
     );
     assert!(stderr.contains("hermetic local bare fixture"), "{stderr}");
@@ -361,7 +365,7 @@ fn wrapper_blocks_named_remote_even_when_a_fixture_directory_matches_it() {
 
 #[cfg(unix)]
 #[test]
-fn wrapper_blocks_fixture_push_when_url_instead_of_rewrites_destination() {
+fn wrapper_ignores_source_url_instead_of_rewrite_for_projected_fixture_push() {
     let _lock = ENV_LOCK.lock().expect("env lock poisoned");
     let temp = tempfile::tempdir().unwrap();
     let session_dir = temp.path().join("session");
@@ -403,17 +407,11 @@ fn wrapper_blocks_fixture_push_when_url_instead_of_rewrites_destination() {
         .output_with_timeout()
         .expect("rewrite push through guard");
 
-    assert_eq!(
-        output.status.code(),
-        Some(128),
-        "url.insteadOf rewrite was not blocked:\nstdout:\n{}\nstderr:\n{}",
+    assert!(
+        output.status.success(),
+        "source url.insteadOf rewrite escaped projection:\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("blocked: git URL rewrite detected for hermetic fixture push"),
-        "{stderr}"
     );
 
     let received = std::process::Command::new("git")
@@ -426,10 +424,25 @@ fn wrapper_blocks_fixture_push_when_url_instead_of_rewrites_destination() {
             reference,
         ])
         .output_with_timeout()
-        .expect("inspect rejected rewrite destination ref");
+        .expect("inspect rewrite outside sentinel ref");
     assert_eq!(
         received.status.code(),
         Some(1),
-        "url.insteadOf rewrite unexpectedly updated external ref {reference}",
+        "source url.insteadOf rewrite unexpectedly updated external ref {reference}",
+    );
+    let fixture_ref = std::process::Command::new("git")
+        .args([
+            "-C",
+            fixture.to_str().expect("UTF-8 fixture path"),
+            "show-ref",
+            "--verify",
+            "--quiet",
+            reference,
+        ])
+        .output_with_timeout()
+        .expect("inspect projected fixture ref");
+    assert!(
+        fixture_ref.status.success(),
+        "projected fixture did not receive {reference}"
     );
 }

--- a/crates/csa-hooks/src/git_guard_tests_hermetic_push.rs
+++ b/crates/csa-hooks/src/git_guard_tests_hermetic_push.rs
@@ -189,3 +189,172 @@ fn wrapper_blocks_fixture_path_that_canonicalizes_outside_session() {
         .expect("inspect rejected escaped-fixture ref");
     assert_eq!(ref_check.status.code(), Some(1));
 }
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_forced_push_variants_to_session_owned_local_bare_fixture() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    let source = temp.path().join("source");
+    init_worktree_repo(&source);
+    let fixture_root = session_dir.join("git-fixtures");
+    let bare = fixture_root.join("transport.git");
+    init_bare_repo(&fixture_root, &bare);
+    let destination = bare.to_str().expect("UTF-8 bare fixture path");
+
+    for (refspec, force_flag, reference) in [
+        (
+            "HEAD:refs/heads/force-long",
+            Some("--force"),
+            "refs/heads/force-long",
+        ),
+        (
+            "HEAD:refs/heads/force-short",
+            Some("-f"),
+            "refs/heads/force-short",
+        ),
+        (
+            "HEAD:refs/heads/force-with-lease",
+            Some("--force-with-lease"),
+            "refs/heads/force-with-lease",
+        ),
+        (
+            "+HEAD:refs/heads/force-refspec",
+            None,
+            "refs/heads/force-refspec",
+        ),
+    ] {
+        let mut command = std::process::Command::new(&wrapper);
+        command
+            .args(["push", destination, refspec])
+            .current_dir(&source)
+            .env("CSA_SESSION_DIR", &session_dir)
+            .env_remove("CSA_GIT_PUSH_ALLOWED");
+        if let Some(force_flag) = force_flag {
+            command.arg(force_flag);
+        }
+        let output = command
+            .output()
+            .expect("forced push to local bare fixture through guard");
+
+        assert_eq!(
+            output.status.code(),
+            Some(128),
+            "forced push variant {refspec} {force_flag:?} was not blocked:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+
+        let received = std::process::Command::new("git")
+            .args([
+                "-C",
+                destination,
+                "show-ref",
+                "--verify",
+                "--quiet",
+                reference,
+            ])
+            .output()
+            .expect("inspect rejected force-push ref");
+        assert_eq!(
+            received.status.code(),
+            Some(1),
+            "force-push variant unexpectedly updated {reference}",
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_named_remote_even_when_a_fixture_directory_matches_it() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    let source = temp.path().join("source");
+    init_worktree_repo(&source);
+    let fixture_root = session_dir.join("git-fixtures");
+    std::fs::create_dir_all(&fixture_root).unwrap();
+    let configured_fixture = fixture_root.join("configured.git");
+    run_git(
+        &fixture_root,
+        &[
+            "clone",
+            "--bare",
+            source.to_str().expect("UTF-8 source path"),
+            configured_fixture
+                .to_str()
+                .expect("UTF-8 configured fixture path"),
+        ],
+    );
+
+    // This decoy makes the old guard canonicalize "origin" as a valid local
+    // fixture path, even though Git resolves the configured remote instead.
+    let decoy_origin = fixture_root.join("origin");
+    init_bare_repo(&fixture_root, &decoy_origin);
+    let outside_bare = temp.path().join("outside.git");
+    init_bare_repo(temp.path(), &outside_bare);
+    run_git(
+        &fixture_root,
+        &[
+            "--git-dir",
+            configured_fixture
+                .to_str()
+                .expect("UTF-8 configured fixture path"),
+            "remote",
+            "set-url",
+            "origin",
+            outside_bare.to_str().expect("UTF-8 outside bare path"),
+        ],
+    );
+
+    let reference = "refs/heads/should-not-publish";
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "--git-dir",
+            configured_fixture
+                .to_str()
+                .expect("UTF-8 configured fixture path"),
+            "push",
+            "origin",
+            "refs/heads/main:refs/heads/should-not-publish",
+        ])
+        .current_dir(&fixture_root)
+        .env("CSA_SESSION_DIR", &session_dir)
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output()
+        .expect("configured remote push through guard");
+
+    assert_eq!(
+        output.status.code(),
+        Some(128),
+        "configured named remote was not blocked:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let received = std::process::Command::new("git")
+        .args([
+            "-C",
+            outside_bare.to_str().expect("UTF-8 outside bare path"),
+            "show-ref",
+            "--verify",
+            "--quiet",
+            reference,
+        ])
+        .output()
+        .expect("inspect rejected configured-remote ref");
+    assert_eq!(
+        received.status.code(),
+        Some(1),
+        "configured named remote unexpectedly updated {reference}",
+    );
+}

--- a/crates/csa-hooks/src/git_guard_tests_hermetic_push.rs
+++ b/crates/csa-hooks/src/git_guard_tests_hermetic_push.rs
@@ -358,3 +358,80 @@ fn wrapper_blocks_named_remote_even_when_a_fixture_directory_matches_it() {
         "configured named remote unexpectedly updated {reference}",
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_fixture_push_when_url_instead_of_rewrites_destination() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    let source = temp.path().join("source");
+    init_worktree_repo(&source);
+    let fixture_root = session_dir.join("git-fixtures");
+    let fixture = fixture_root.join("transport.git");
+    init_bare_repo(&fixture_root, &fixture);
+    let outside_bare = temp.path().join("outside.git");
+    init_bare_repo(temp.path(), &outside_bare);
+
+    let rewrite_config = format!("url.{}.insteadOf", outside_bare.display());
+    run_git(
+        &source,
+        &[
+            "config",
+            rewrite_config.as_str(),
+            fixture.to_str().expect("UTF-8 fixture path"),
+        ],
+    );
+
+    let reference = "refs/heads/should-not-publish";
+    let empty_global_config = temp.path().join("empty-global-config");
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "push",
+            fixture.to_str().expect("UTF-8 fixture path"),
+            "HEAD:refs/heads/should-not-publish",
+        ])
+        .current_dir(&source)
+        .env("CSA_SESSION_DIR", &session_dir)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", &empty_global_config)
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output()
+        .expect("rewrite push through guard");
+
+    assert_eq!(
+        output.status.code(),
+        Some(128),
+        "url.insteadOf rewrite was not blocked:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "blocked: git url.insteadOf rewrite detected; remove url.*.insteadOf config for hermetic fixture pushes"
+        ),
+        "{stderr}"
+    );
+
+    let received = std::process::Command::new("git")
+        .args([
+            "-C",
+            outside_bare.to_str().expect("UTF-8 outside bare path"),
+            "show-ref",
+            "--verify",
+            "--quiet",
+            reference,
+        ])
+        .output()
+        .expect("inspect rejected rewrite destination ref");
+    assert_eq!(
+        received.status.code(),
+        Some(1),
+        "url.insteadOf rewrite unexpectedly updated external ref {reference}",
+    );
+}

--- a/crates/csa-hooks/src/git_guard_tests_hermetic_push.rs
+++ b/crates/csa-hooks/src/git_guard_tests_hermetic_push.rs
@@ -1,0 +1,191 @@
+#[cfg(unix)]
+#[test]
+fn wrapper_allows_real_push_to_session_owned_local_bare_fixture() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    let source = temp.path().join("source");
+    init_worktree_repo(&source);
+    let fixture_root = session_dir.join("git-fixtures");
+    let bare = fixture_root.join("transport.git");
+    init_bare_repo(&fixture_root, &bare);
+
+    for (destination, reference) in [
+        (
+            bare.display().to_string(),
+            "refs/heads/hermetic-path-fixture",
+        ),
+        (
+            format!("file://{}", bare.display()),
+            "refs/heads/hermetic-file-url-fixture",
+        ),
+    ] {
+        let refspec = format!("HEAD:{reference}");
+        let output = std::process::Command::new(&wrapper)
+            .args(["push", destination.as_str(), refspec.as_str()])
+            .current_dir(&source)
+            .env("CSA_SESSION_DIR", &session_dir)
+            .env_remove("CSA_GIT_PUSH_ALLOWED")
+            .output()
+            .expect("push to local bare fixture through guard");
+        assert!(
+            output.status.success(),
+            "push to {destination} failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+
+        let received = std::process::Command::new("git")
+            .args([
+                "-C",
+                bare.to_str().expect("UTF-8 bare fixture path"),
+                "rev-parse",
+                "--verify",
+                reference,
+            ])
+            .output()
+            .expect("inspect received fixture ref");
+        assert!(
+            received.status.success(),
+            "fixture ref {reference} was not received:\n{}",
+            String::from_utf8_lossy(&received.stderr),
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_remote_push_with_hermetic_fixture_diagnostic() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    std::fs::create_dir_all(session_dir.join("git-fixtures")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\necho \"$@\"\n");
+
+    let output = std::process::Command::new(&wrapper)
+        .args(["push", "https://example.invalid/publication.git", "HEAD:main"])
+        .env("CSA_REAL_GIT", &fake_git)
+        .env("CSA_SESSION_DIR", &session_dir)
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(128));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("blocked command: git push https://example.invalid/publication.git HEAD:main"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("hermetic local bare fixture"), "{stderr}");
+    assert!(
+        stderr.contains("git-fixtures"),
+        "diagnostic should name the session-owned fixture root: {stderr}"
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_push_to_working_repository_git_dir() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    let fixture_root = session_dir.join("git-fixtures");
+    std::fs::create_dir_all(&fixture_root).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    // The destination is deliberately under the fixture root and is bare, so
+    // this proves the separate worktree exclusion rather than fixture-root or
+    // bare-repository rejection.
+    let source = fixture_root.join("working-repository");
+    init_worktree_repo(&source);
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "push",
+            source
+                .join(".git")
+                .to_str()
+                .expect("UTF-8 working repository git dir"),
+            "HEAD:refs/heads/should-not-publish",
+        ])
+        .current_dir(&source)
+        .env("CSA_SESSION_DIR", &session_dir)
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(128));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("blocked command: git push"), "{stderr}");
+    assert!(stderr.contains("hermetic local bare fixture"), "{stderr}");
+
+    let ref_check = std::process::Command::new("git")
+        .args([
+            "-C",
+            source.to_str().expect("UTF-8 source path"),
+            "show-ref",
+            "--verify",
+            "--quiet",
+            "refs/heads/should-not-publish",
+        ])
+        .output()
+        .expect("inspect rejected working-repository ref");
+    assert_eq!(ref_check.status.code(), Some(1));
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_fixture_path_that_canonicalizes_outside_session() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    let fixture_root = session_dir.join("git-fixtures");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    std::fs::create_dir_all(&fixture_root).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    let source = temp.path().join("source");
+    init_worktree_repo(&source);
+    let outside_bare = temp.path().join("outside.git");
+    init_bare_repo(temp.path(), &outside_bare);
+    let escaped_fixture = fixture_root.join("escaped.git");
+    std::os::unix::fs::symlink(&outside_bare, &escaped_fixture).unwrap();
+
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "push",
+            escaped_fixture.to_str().expect("UTF-8 escaped fixture path"),
+            "HEAD:refs/heads/should-not-publish",
+        ])
+        .current_dir(&source)
+        .env("CSA_SESSION_DIR", &session_dir)
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(128));
+    let ref_check = std::process::Command::new("git")
+        .args([
+            "-C",
+            outside_bare.to_str().expect("UTF-8 outside bare path"),
+            "show-ref",
+            "--verify",
+            "--quiet",
+            "refs/heads/should-not-publish",
+        ])
+        .output()
+        .expect("inspect rejected escaped-fixture ref");
+    assert_eq!(ref_check.status.code(), Some(1));
+}

--- a/crates/csa-hooks/src/git_guard_tests_hermetic_push_projection.rs
+++ b/crates/csa-hooks/src/git_guard_tests_hermetic_push_projection.rs
@@ -18,7 +18,7 @@ fn wrapper_redacts_credentials_and_control_bytes_in_blocked_push_diagnostic() {
             "-c",
             "http.extraHeader=Authorization: Bearer configuration-secret",
             "push",
-            "https://alice:url-secret@example.invalid/publication.git\nforged-log-line",
+            "git@scm.invalid:private/path?token=query-secret\nforged-log-line",
             "HEAD:refs/heads/main",
         ])
         .env("CSA_SESSION_DIR", &session_dir)
@@ -29,10 +29,15 @@ fn wrapper_redacts_credentials_and_control_bytes_in_blocked_push_diagnostic() {
     assert_eq!(output.status.code(), Some(128));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("blocked command: git"), "{stderr}");
-    assert!(!stderr.contains("configuration-secret"), "{stderr}");
-    assert!(!stderr.contains("url-secret"), "{stderr}");
-    assert!(!stderr.contains("alice:"), "{stderr}");
-    assert!(!stderr.contains("\nforged-log-line"), "{stderr}");
+    for secret in [
+        "configuration-secret",
+        "private/path",
+        "query-secret",
+        "git@scm.invalid",
+        "\nforged-log-line",
+    ] {
+        assert!(!stderr.contains(secret), "diagnostic leaked {secret:?}: {stderr}");
+    }
 }
 
 #[cfg(unix)]
@@ -267,7 +272,7 @@ fn wrapper_blocks_invocation_scoped_url_rewrites_without_touching_outside_sentin
 
 #[cfg(unix)]
 #[test]
-fn wrapper_blocks_push_instead_of_rewrite_without_touching_outside_sentinel() {
+fn wrapper_ignores_source_push_instead_of_rewrite_for_projected_fixture_push() {
     let _lock = ENV_LOCK.lock().expect("env lock poisoned");
     let temp = tempfile::tempdir().unwrap();
     let session_dir = temp.path().join("session");
@@ -305,10 +310,9 @@ fn wrapper_blocks_push_instead_of_rewrite_without_touching_outside_sentinel() {
         .output_with_timeout()
         .expect("pushInsteadOf rewrite push through guard");
 
-    assert_eq!(
-        output.status.code(),
-        Some(128),
-        "pushInsteadOf rewrite was not blocked:\nstdout:\n{}\nstderr:\n{}",
+    assert!(
+        output.status.success(),
+        "source pushInsteadOf rewrite escaped projection:\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
@@ -323,10 +327,297 @@ fn wrapper_blocks_push_instead_of_rewrite_without_touching_outside_sentinel() {
             reference,
         ])
         .output_with_timeout()
-        .expect("inspect blocked pushInsteadOf rewrite sentinel");
+        .expect("inspect pushInsteadOf outside sentinel");
     assert_eq!(
         received.status.code(),
         Some(1),
-        "pushInsteadOf rewrite unexpectedly updated outside sentinel",
+        "source pushInsteadOf rewrite unexpectedly updated outside sentinel",
     );
+    let fixture_ref = std::process::Command::new("git")
+        .args([
+            "-C",
+            fixture.to_str().expect("UTF-8 fixture path"),
+            "show-ref",
+            "--verify",
+            "--quiet",
+            reference,
+        ])
+        .output_with_timeout()
+        .expect("inspect projected fixture ref");
+    assert!(
+        fixture_ref.status.success(),
+        "projected fixture did not receive {reference}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_alias_and_publication_plumbing_surfaces() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+    let source = temp.path().join("source");
+    init_worktree_repo(&source);
+    let fixture_root = session_dir.join("git-fixtures");
+    let fixture = fixture_root.join("transport.git");
+    init_bare_repo(&fixture_root, &fixture);
+    let reference = "refs/heads/alias-or-plumbing-must-not-publish";
+    let refspec = format!("HEAD:{reference}");
+    run_git(&source, &["config", "alias.publish", "push"]);
+
+    for args in [
+        vec![
+            "publish".to_owned(),
+            fixture.display().to_string(),
+            refspec.clone(),
+        ],
+        vec![
+            "-c".to_owned(),
+            "alias.publish=push".to_owned(),
+            "publish".to_owned(),
+            fixture.display().to_string(),
+            refspec.clone(),
+        ],
+        vec!["send-pack".to_owned(), fixture.display().to_string()],
+        vec!["receive-pack".to_owned(), fixture.display().to_string()],
+        vec!["remote".to_owned(), "update".to_owned()],
+    ] {
+        let output = std::process::Command::new(&wrapper)
+            .args(&args)
+            .current_dir(&source)
+            .env("CSA_SESSION_DIR", &session_dir)
+            .env_remove("CSA_GIT_PUSH_ALLOWED")
+            .output_with_timeout()
+            .expect("publication-capable command through guard");
+        assert_eq!(
+            output.status.code(),
+            Some(128),
+            "publication-capable command escaped guard: {args:?}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    let fixture_ref = std::process::Command::new("git")
+        .args([
+            "-C",
+            fixture.to_str().expect("UTF-8 fixture path"),
+            "show-ref",
+            "--verify",
+            "--quiet",
+            reference,
+        ])
+        .output_with_timeout()
+        .expect("inspect alias fixture sentinel");
+    assert_eq!(fixture_ref.status.code(), Some(1));
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_ignores_path_named_remote_pushurl_and_spaced_rewrite_config() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+    let source = temp.path().join("source");
+    init_worktree_repo(&source);
+    let fixture_root = session_dir.join("git-fixtures");
+    let fixture = fixture_root.join("transport.git");
+    init_bare_repo(&fixture_root, &fixture);
+    let outside_bare = temp.path().join("outside rewrite.git");
+    init_bare_repo(temp.path(), &outside_bare);
+
+    let pushurl_key = format!(r#"remote."{}".pushurl"#, fixture.display());
+    run_git(
+        &source,
+        &[
+            "config",
+            pushurl_key.as_str(),
+            outside_bare.to_str().expect("UTF-8 outside bare path"),
+        ],
+    );
+    let rewrite_key = format!(r#"url."{}".insteadOf"#, outside_bare.display());
+    run_git(
+        &source,
+        &[
+            "config",
+            rewrite_key.as_str(),
+            fixture.to_str().expect("UTF-8 fixture path"),
+        ],
+    );
+
+    let reference = "refs/heads/configless-projection";
+    let refspec = format!("HEAD:{reference}");
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "push",
+            fixture.to_str().expect("UTF-8 fixture path"),
+            refspec.as_str(),
+        ])
+        .current_dir(&source)
+        .env("CSA_SESSION_DIR", &session_dir)
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output_with_timeout()
+        .expect("configured fixture push through guard");
+    assert!(
+        output.status.success(),
+        "projection used source remote/rewrite config:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    for (repository, expected, label) in [
+        (&fixture, true, "fixture"),
+        (&outside_bare, false, "outside sentinel"),
+    ] {
+        let ref_check = std::process::Command::new("git")
+            .args([
+                "-C",
+                repository.to_str().expect("UTF-8 bare path"),
+                "show-ref",
+                "--verify",
+                "--quiet",
+                reference,
+            ])
+            .output_with_timeout()
+            .expect("inspect config projection destination");
+        assert_eq!(
+            ref_check.status.success(),
+            expected,
+            "unexpected ref state in {label}"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_pins_trusted_git_exec_path_for_projected_push() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+    let source = temp.path().join("source");
+    init_worktree_repo(&source);
+    let fixture_root = session_dir.join("git-fixtures");
+    let fixture = fixture_root.join("transport.git");
+    init_bare_repo(&fixture_root, &fixture);
+    let hostile_exec_path = temp.path().join("hostile-git-exec-path");
+    std::fs::create_dir_all(&hostile_exec_path).expect("create hostile git exec path");
+    let hostile_marker = temp.path().join("hostile-helper-ran");
+    write_executable(
+        &hostile_exec_path.join("git-receive-pack"),
+        "#!/bin/sh\nprintf hostile > \"$CSA_GIT_GUARD_HOSTILE_MARKER\"\nexit 91\n",
+    );
+
+    let reference = "refs/heads/trusted-exec-path";
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "push",
+            fixture.to_str().expect("UTF-8 fixture path"),
+            "HEAD:refs/heads/trusted-exec-path",
+        ])
+        .current_dir(&source)
+        .env("CSA_SESSION_DIR", &session_dir)
+        .env("GIT_EXEC_PATH", &hostile_exec_path)
+        .env("CSA_GIT_GUARD_HOSTILE_MARKER", &hostile_marker)
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output_with_timeout()
+        .expect("hostile helper fixture push through guard");
+    assert!(
+        output.status.success(),
+        "hostile GIT_EXEC_PATH controlled projected push:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        !hostile_marker.exists(),
+        "hostile git-receive-pack helper was invoked"
+    );
+    let fixture_ref = std::process::Command::new("git")
+        .args([
+            "-C",
+            fixture.to_str().expect("UTF-8 fixture path"),
+            "show-ref",
+            "--verify",
+            "--quiet",
+            reference,
+        ])
+        .output_with_timeout()
+        .expect("inspect trusted exec path fixture ref");
+    assert!(fixture_ref.status.success());
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_keeps_descriptor_pinned_across_final_destination_swap() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+    let source = temp.path().join("source");
+    init_worktree_repo(&source);
+    let fixture_root = session_dir.join("git-fixtures");
+    let fixture = fixture_root.join("transport.git");
+    init_bare_repo(&fixture_root, &fixture);
+    let held_fixture = fixture_root.join("held.git");
+    let outside_bare = temp.path().join("outside.git");
+    init_bare_repo(temp.path(), &outside_bare);
+    let swapping_git = temp.path().join("swapping-real-git");
+    write_executable(
+        &swapping_git,
+        "#!/bin/sh\nif [ \"${2:-}\" = push ] && [ -n \"${CSA_GIT_GUARD_SWAP_FROM:-}\" ]; then\n  mv \"$CSA_GIT_GUARD_SWAP_FROM\" \"$CSA_GIT_GUARD_HELD\"\n  ln -s \"$CSA_GIT_GUARD_OUTSIDE\" \"$CSA_GIT_GUARD_SWAP_FROM\"\nfi\nexec /usr/bin/git \"$@\"\n",
+    );
+
+    let reference = "refs/heads/descriptor-pinned";
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "push",
+            fixture.to_str().expect("UTF-8 fixture path"),
+            "HEAD:refs/heads/descriptor-pinned",
+        ])
+        .current_dir(&source)
+        .env("CSA_REAL_GIT", &swapping_git)
+        .env("CSA_SESSION_DIR", &session_dir)
+        .env("CSA_GIT_GUARD_SWAP_FROM", &fixture)
+        .env("CSA_GIT_GUARD_HELD", &held_fixture)
+        .env("CSA_GIT_GUARD_OUTSIDE", &outside_bare)
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output_with_timeout()
+        .expect("racing fixture push through guard");
+    assert!(
+        output.status.success(),
+        "descriptor-pinned push failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    for (repository, expected, label) in [
+        (&held_fixture, true, "descriptor-pinned fixture"),
+        (&outside_bare, false, "outside swap target"),
+    ] {
+        let ref_check = std::process::Command::new("git")
+            .args([
+                "-C",
+                repository.to_str().expect("UTF-8 bare path"),
+                "show-ref",
+                "--verify",
+                "--quiet",
+                reference,
+            ])
+            .output_with_timeout()
+            .expect("inspect post-swap destination");
+        assert_eq!(
+            ref_check.status.success(),
+            expected,
+            "unexpected ref state in {label}"
+        );
+    }
 }

--- a/crates/csa-hooks/src/git_guard_tests_hermetic_push_projection.rs
+++ b/crates/csa-hooks/src/git_guard_tests_hermetic_push_projection.rs
@@ -1,0 +1,332 @@
+// Focused adversarial regressions for the fail-closed hermetic push projection.
+// This file is included from git_guard_tests.rs and intentionally shares its
+// fixture helpers, timeout wrapper, and process-wide environment lock.
+
+#[cfg(unix)]
+#[test]
+fn wrapper_redacts_credentials_and_control_bytes_in_blocked_push_diagnostic() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    std::fs::create_dir_all(session_dir.join("git-fixtures")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "-c",
+            "http.extraHeader=Authorization: Bearer configuration-secret",
+            "push",
+            "https://alice:url-secret@example.invalid/publication.git\nforged-log-line",
+            "HEAD:refs/heads/main",
+        ])
+        .env("CSA_SESSION_DIR", &session_dir)
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output_with_timeout()
+        .expect("credential-bearing blocked push through guard");
+
+    assert_eq!(output.status.code(), Some(128));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("blocked command: git"), "{stderr}");
+    assert!(!stderr.contains("configuration-secret"), "{stderr}");
+    assert!(!stderr.contains("url-secret"), "{stderr}");
+    assert!(!stderr.contains("alice:"), "{stderr}");
+    assert!(!stderr.contains("\nforged-log-line"), "{stderr}");
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_closed_push_grammar_after_destination() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    let source = temp.path().join("source");
+    init_worktree_repo(&source);
+    let fixture_root = session_dir.join("git-fixtures");
+    let bare = fixture_root.join("transport.git");
+    init_bare_repo(&fixture_root, &bare);
+    let destination = bare.to_str().expect("UTF-8 bare fixture path");
+
+    for (refspec, trailing, reference) in [
+        (
+            "HEAD:refs/heads/mirror",
+            "--mirror",
+            "refs/heads/mirror",
+        ),
+        (
+            "HEAD:refs/heads/delete",
+            "--delete",
+            "refs/heads/delete",
+        ),
+        (
+            "HEAD:refs/heads/no-verify",
+            "--no-verify",
+            "refs/heads/no-verify",
+        ),
+        (
+            "HEAD:refs/heads/combined-force",
+            "-fv",
+            "refs/heads/combined-force",
+        ),
+        (
+            "HEAD:refs/heads/valued-force",
+            "--force-with-lease=refs/heads/main",
+            "refs/heads/valued-force",
+        ),
+    ] {
+        let output = std::process::Command::new(&wrapper)
+            .args(["push", destination, refspec, trailing])
+            .current_dir(&source)
+            .env("CSA_SESSION_DIR", &session_dir)
+            .env_remove("CSA_GIT_PUSH_ALLOWED")
+            .output_with_timeout()
+            .expect("closed grammar push through guard");
+
+        assert_eq!(
+            output.status.code(),
+            Some(128),
+            "open push grammar {refspec} {trailing} was not blocked:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+
+        let received = std::process::Command::new("git")
+            .args([
+                "-C",
+                destination,
+                "show-ref",
+                "--verify",
+                "--quiet",
+                reference,
+            ])
+            .output_with_timeout()
+            .expect("inspect rejected closed-grammar ref");
+        assert_eq!(
+            received.status.code(),
+            Some(1),
+            "open push grammar unexpectedly updated {reference}",
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_executes_the_canonical_projected_fixture_destination() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    let source = temp.path().join("source");
+    init_worktree_repo(&source);
+    let fixture_root = session_dir.join("git-fixtures");
+    let fixture = fixture_root.join("transport.git");
+    init_bare_repo(&fixture_root, &fixture);
+    let outside_bare = temp.path().join("outside.git");
+    init_bare_repo(temp.path(), &outside_bare);
+
+    let dotted_destination = fixture_root.join(".").join("transport.git");
+    let dotted_destination = dotted_destination
+        .to_str()
+        .expect("UTF-8 dotted fixture path")
+        .to_owned();
+    assert_ne!(dotted_destination, fixture.display().to_string());
+    let rewrite_config = format!("url.{}.insteadOf", outside_bare.display());
+    run_git(
+        &source,
+        &["config", rewrite_config.as_str(), dotted_destination.as_str()],
+    );
+
+    let reference = "refs/heads/projected-canonical-destination";
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "push",
+            dotted_destination.as_str(),
+            "HEAD:refs/heads/projected-canonical-destination",
+        ])
+        .current_dir(&source)
+        .env("CSA_SESSION_DIR", &session_dir)
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output_with_timeout()
+        .expect("projected canonical fixture push through guard");
+    assert!(
+        output.status.success(),
+        "canonical destination projection failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    for (repository, expected) in [(&fixture, true), (&outside_bare, false)] {
+        let received = std::process::Command::new("git")
+            .args([
+                "-C",
+                repository.to_str().expect("UTF-8 bare repository path"),
+                "show-ref",
+                "--verify",
+                "--quiet",
+                reference,
+            ])
+            .output_with_timeout()
+            .expect("inspect projected destination ref");
+        assert_eq!(
+            received.status.success(),
+            expected,
+            "canonical projection delivered ref to unexpected repository {}",
+            repository.display(),
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_invocation_scoped_url_rewrites_without_touching_outside_sentinel() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+
+    for rewrite_kind in ["-c", "--config-env"] {
+        let temp = tempfile::tempdir().unwrap();
+        let session_dir = temp.path().join("session");
+        let wrapper = session_dir.join("bin/git");
+        std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+        write_executable(&wrapper, git_wrapper_script());
+
+        let source = temp.path().join("source");
+        init_worktree_repo(&source);
+        let fixture_root = session_dir.join("git-fixtures");
+        let fixture = fixture_root.join("transport.git");
+        init_bare_repo(&fixture_root, &fixture);
+        let outside_bare = temp.path().join("outside.git");
+        init_bare_repo(temp.path(), &outside_bare);
+        let reference = format!("refs/heads/should-not-publish-{rewrite_kind}");
+        let rewrite_config = format!(
+            "url.{}.insteadOf={}",
+            outside_bare.display(),
+            fixture.display()
+        );
+
+        let mut command = std::process::Command::new(&wrapper);
+        command.current_dir(&source).env("CSA_SESSION_DIR", &session_dir);
+        match rewrite_kind {
+            "-c" => {
+                command.args(["-c", rewrite_config.as_str()]);
+            }
+            "--config-env" => {
+                let config_env = format!(
+                    "url.{}.insteadOf=CSA_TEST_REWRITE_PREFIX",
+                    outside_bare.display()
+                );
+                command
+                    .args(["--config-env", config_env.as_str()])
+                    .env("CSA_TEST_REWRITE_PREFIX", fixture.as_os_str());
+            }
+            _ => unreachable!("test matrix is closed"),
+        }
+        let refspec = format!("HEAD:{reference}");
+        let output = command
+            .args([
+                "push",
+                fixture.to_str().expect("UTF-8 fixture path"),
+                refspec.as_str(),
+            ])
+            .env_remove("CSA_GIT_PUSH_ALLOWED")
+            .output_with_timeout()
+            .expect("invocation-scoped rewrite push through guard");
+
+        assert_eq!(
+            output.status.code(),
+            Some(128),
+            "{rewrite_kind} rewrite was not blocked:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+
+        let received = std::process::Command::new("git")
+            .args([
+                "-C",
+                outside_bare.to_str().expect("UTF-8 outside bare path"),
+                "show-ref",
+                "--verify",
+                "--quiet",
+                reference.as_str(),
+            ])
+            .output_with_timeout()
+            .expect("inspect blocked invocation-scoped rewrite sentinel");
+        assert_eq!(
+            received.status.code(),
+            Some(1),
+            "{rewrite_kind} rewrite unexpectedly updated outside sentinel",
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_push_instead_of_rewrite_without_touching_outside_sentinel() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    let source = temp.path().join("source");
+    init_worktree_repo(&source);
+    let fixture_root = session_dir.join("git-fixtures");
+    let fixture = fixture_root.join("transport.git");
+    init_bare_repo(&fixture_root, &fixture);
+    let outside_bare = temp.path().join("outside.git");
+    init_bare_repo(temp.path(), &outside_bare);
+    let rewrite_config = format!("url.{}.pushInsteadOf", outside_bare.display());
+    run_git(
+        &source,
+        &[
+            "config",
+            rewrite_config.as_str(),
+            fixture.to_str().expect("UTF-8 fixture path"),
+        ],
+    );
+
+    let reference = "refs/heads/should-not-publish-push-instead-of";
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "push",
+            fixture.to_str().expect("UTF-8 fixture path"),
+            "HEAD:refs/heads/should-not-publish-push-instead-of",
+        ])
+        .current_dir(&source)
+        .env("CSA_SESSION_DIR", &session_dir)
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output_with_timeout()
+        .expect("pushInsteadOf rewrite push through guard");
+
+    assert_eq!(
+        output.status.code(),
+        Some(128),
+        "pushInsteadOf rewrite was not blocked:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let received = std::process::Command::new("git")
+        .args([
+            "-C",
+            outside_bare.to_str().expect("UTF-8 outside bare path"),
+            "show-ref",
+            "--verify",
+            "--quiet",
+            reference,
+        ])
+        .output_with_timeout()
+        .expect("inspect blocked pushInsteadOf rewrite sentinel");
+    assert_eq!(
+        received.status.code(),
+        Some(1),
+        "pushInsteadOf rewrite unexpectedly updated outside sentinel",
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1119"
-weave = "0.1.1119"
+csa = "0.1.1120"
+weave = "0.1.1120"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Closes #2835.

This resolves the original contract: permit only a real Git pack transfer to a session-owned local bare-fixture repository for hermetic regression testing, while keeping every remote/publication-capable Git path fail closed.

### Circuit-breaker redesign

The session Git-push guard now uses a closed authorization grammar rather than trying to recognize a growing denylist of push spellings. The exceptional path accepts only direct local fixture destinations with constrained refspecs, rejects alias/plumbing/named-remote/unknown publication entry points, and projects the validated operation into an isolated transport context.

### Epoch-2 hardening

- Pins the validated fixture root/destination through directory descriptors so the executed destination is bound across pathname replacement races.
- Uses a configless source projection for real pack negotiation and isolates Git config, URL/pushURL rewrite behavior, repository invocation inputs, protocols, and helper routing.
- Clears ambient execution routing and derives trusted Git libexec routing from the real Git binary; an ambient `CSA_REAL_GIT` is not trust authority.
- Keeps failure diagnostics structured and redacted so blocked user-controlled values are not echoed.
- Adds adversarial real-transport coverage for rewrites, injection, aliases/plumbing, helper routing, and TOCTOU cases.

## Verification

- Pre-push quality gate: **PASS** at `834120a56c6cb78cde6a82275b29582a7188e3d5` — `gate_exit_code=0`, receipt identity `6481707032f68b827f02c863aff53bb3c880279497315d2dab678bb738a0ac92`, completed in 1307.75s.
- Fresh exact-HEAD clean-room review of `main...834120a56c6cb78cde6a82275b29582a7188e3d5`: **PASS** — native isolated Hermes review session `20260725_020129_2ab469` found no current bypass across the six required invariants.
- The preferred CSA tier-4-critical/xhigh launch (`01KYC7R4XD0C0P3NPHE971VCEE`) returned `UNAVAILABLE` before a verdict because active-session memory admission was denied; the native review is the substantive fallback evidence, not a synthesized CSA receipt.

## Review scope

The clean-room review must independently verify real pack transfer, fail-closed publication/network behavior, destination validation/execution identity under isolated config, alias/plumbing denial, descriptor pinning/no ambient helper routing, and diagnostic redaction.