### PR TITLE
fix(#2880,#2886): inherited memory_max_mb must not require cgroup enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1121"
+version = "0.1.1122"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1121"
+version = "0.1.1122"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -194,7 +194,8 @@ fn resolve_sandbox_options_with_capability_source(
         extra_readable,
         execution_env,
     } = input;
-    let has_run_memory_override = resource_overrides.has_memory_max_override();
+    let has_memory_max_override = resource_overrides.has_memory_max_override();
+    let has_explicit_cli_memory_max = resource_overrides.has_explicit_cli_memory_max();
 
     let default_resources = csa_config::ResourcesConfig::default();
     let stdin_write_timeout_seconds = config
@@ -225,7 +226,7 @@ fn resolve_sandbox_options_with_capability_source(
 
         if memory_override::default_off_allows_unsandboxed(
             defaults.enforcement,
-            has_run_memory_override,
+            has_memory_max_override,
         ) {
             return SandboxResolution::Ok(Box::new(execute_options));
         }
@@ -242,7 +243,7 @@ fn resolve_sandbox_options_with_capability_source(
         };
         if let Some(message) = memory_override::capability_error_if_unenforced(
             tool_name,
-            has_run_memory_override,
+            has_explicit_cli_memory_max,
             resource_cap,
         ) {
             return SandboxResolution::RequiredButUnavailable(message);
@@ -324,7 +325,7 @@ fn resolve_sandbox_options_with_capability_source(
             .build()
             .expect("BestEffort IsolationPlan should never fail");
         if let Some(message) =
-            memory_override::plan_error_if_unenforced(tool_name, has_run_memory_override, &plan)
+            memory_override::plan_error_if_unenforced(tool_name, has_explicit_cli_memory_max, &plan)
         {
             return SandboxResolution::RequiredButUnavailable(message);
         }
@@ -350,7 +351,8 @@ fn resolve_sandbox_options_with_capability_source(
     let enforcement = match memory_override::resolve_config_enforcement(
         cfg,
         tool_name,
-        has_run_memory_override,
+        has_memory_max_override,
+        has_explicit_cli_memory_max,
     ) {
         Ok(Some(enforcement)) => enforcement,
         Ok(None) => {
@@ -378,7 +380,7 @@ fn resolve_sandbox_options_with_capability_source(
     let resource_cap = resource_capability();
     if let Some(message) = memory_override::capability_error_if_unenforced(
         tool_name,
-        has_run_memory_override,
+        has_explicit_cli_memory_max,
         resource_cap,
     ) {
         return SandboxResolution::RequiredButUnavailable(message);
@@ -573,7 +575,7 @@ fn resolve_sandbox_options_with_capability_source(
         }
     };
     if let Some(message) =
-        memory_override::plan_error_if_unenforced(tool_name, has_run_memory_override, &plan)
+        memory_override::plan_error_if_unenforced(tool_name, has_explicit_cli_memory_max, &plan)
     {
         return SandboxResolution::RequiredButUnavailable(message);
     }

--- a/crates/cli-sub-agent/src/pipeline_sandbox_memory_override.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_memory_override.rs
@@ -12,16 +12,19 @@ pub(crate) fn default_off_allows_unsandboxed(
 pub(crate) fn resolve_config_enforcement(
     cfg: &ProjectConfig,
     tool_name: &str,
-    has_run_memory_override: bool,
+    has_memory_max_override: bool,
+    has_explicit_cli_memory_max: bool,
 ) -> Result<Option<EnforcementMode>, String> {
     let enforcement = cfg.tool_enforcement_mode(tool_name);
     if !matches!(enforcement, EnforcementMode::Off) {
         return Ok(Some(enforcement));
     }
-    if !has_run_memory_override {
+    if !has_memory_max_override {
         return Ok(None);
     }
-    if explicit_resource_enforcement_mode(cfg, tool_name) == Some(EnforcementMode::Off) {
+    if has_explicit_cli_memory_max
+        && explicit_resource_enforcement_mode(cfg, tool_name) == Some(EnforcementMode::Off)
+    {
         return Err(format!(
             "--memory-max-mb cannot be used for tool '{tool_name}' because resource \
              sandbox enforcement_mode is explicitly \"off\". Set enforcement_mode = \
@@ -31,7 +34,7 @@ pub(crate) fn resolve_config_enforcement(
 
     warn!(
         tool = %tool_name,
-        "Auto-promoting resource enforcement_mode Off to BestEffort for per-run --memory-max-mb"
+        "Auto-promoting resource enforcement_mode Off to BestEffort for inherited or per-run memory_max_mb"
     );
     Ok(Some(EnforcementMode::BestEffort))
 }

--- a/crates/cli-sub-agent/src/pipeline_sandbox_memory_override_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_memory_override_tests.rs
@@ -67,6 +67,48 @@ fn resolve_with_memory_override(
     )
 }
 
+fn resolve_with_resource_overrides_on_capability(
+    config: &csa_config::ProjectConfig,
+    resource_overrides: crate::run_resource_overrides::RunResourceOverrides,
+    resource_capability: csa_resource::ResourceCapability,
+) -> SandboxResolution {
+    resolve_with_resource_overrides_on_capability_for_tool(
+        config,
+        "codex",
+        resource_overrides,
+        resource_capability,
+    )
+}
+
+fn resolve_with_resource_overrides_on_capability_for_tool(
+    config: &csa_config::ProjectConfig,
+    tool_name: &str,
+    resource_overrides: crate::run_resource_overrides::RunResourceOverrides,
+    resource_capability: csa_resource::ResourceCapability,
+) -> SandboxResolution {
+    resolve_sandbox_options_with_capabilities(
+        SandboxResolveInput {
+            config: Some(config),
+            tool_name,
+            session_id: "test-session",
+            project_root: &current_project_root(),
+            stream_mode: StreamMode::BufferOnly,
+            idle_timeout_seconds: 120,
+            liveness_dead_seconds: 600,
+            initial_response_timeout_seconds: Some(120),
+            no_fs_sandbox: false,
+            allow_user_daemon_ipc: false,
+            readonly_project_root: false,
+            extra_writable: &[],
+            extra_readable: &[],
+            execution_env: None,
+        },
+        resource_overrides,
+        resource_capability,
+        csa_resource::FilesystemCapability::Bwrap,
+    )
+}
+
 #[test]
 fn run_memory_override_promotes_no_config_lightweight_default_off() {
     let result = resolve_with_memory_override(None, "opencode", 6144);
@@ -122,4 +164,87 @@ memory_max_mb = 16384
     let result = resolve_with_memory_override(Some(&cfg), "codex", 6144);
 
     assert_run_memory_override_enforced_or_rejected(result, 6144);
+}
+
+#[test]
+fn inherited_memory_override_promotes_config_lightweight_default_off() {
+    let cfg = parse_project_config(
+        r#"
+[tools.opencode]
+enabled = true
+"#,
+    );
+    let inherited =
+        crate::run_resource_overrides::RunResourceOverrides::from_cli(Some(6144), None).for_child();
+
+    let result = resolve_with_resource_overrides_on_capability_for_tool(
+        &cfg,
+        "opencode",
+        inherited,
+        csa_resource::ResourceCapability::Setrlimit,
+    );
+
+    let SandboxResolution::Ok(opts) = result else {
+        panic!("inherited memory_max_mb must promote a default-off child sandbox");
+    };
+    let sandbox = opts
+        .sandbox
+        .expect("inherited memory_max_mb should still build an isolation plan");
+    assert_eq!(sandbox.isolation_plan.memory_max_mb, Some(6144));
+    assert_eq!(
+        sandbox.isolation_plan.resource,
+        csa_resource::ResourceCapability::Setrlimit
+    );
+}
+
+#[test]
+fn inherited_memory_override_allows_setrlimit_and_keeps_memory_limit() {
+    let cfg = parse_project_config(
+        r#"
+[resources]
+enforcement_mode = "best-effort"
+"#,
+    );
+    let inherited =
+        crate::run_resource_overrides::RunResourceOverrides::from_cli(Some(6144), None).for_child();
+
+    let result = resolve_with_resource_overrides_on_capability(
+        &cfg,
+        inherited,
+        csa_resource::ResourceCapability::Setrlimit,
+    );
+
+    let SandboxResolution::Ok(opts) = result else {
+        panic!("inherited memory_max_mb must not require cgroup v2 enforcement");
+    };
+    let sandbox = opts
+        .sandbox
+        .expect("inherited memory_max_mb should still build an isolation plan");
+    assert_eq!(sandbox.isolation_plan.memory_max_mb, Some(6144));
+    assert_eq!(
+        sandbox.isolation_plan.resource,
+        csa_resource::ResourceCapability::Setrlimit
+    );
+}
+
+#[test]
+fn explicit_cli_memory_override_requires_cgroup_v2_on_setrlimit() {
+    let cfg = parse_project_config(
+        r#"
+[resources]
+enforcement_mode = "best-effort"
+"#,
+    );
+
+    let result = resolve_with_resource_overrides_on_capability(
+        &cfg,
+        crate::run_resource_overrides::RunResourceOverrides::from_cli(Some(6144), None),
+        csa_resource::ResourceCapability::Setrlimit,
+    );
+
+    let SandboxResolution::RequiredButUnavailable(message) = result else {
+        panic!("explicit --memory-max-mb must require cgroup v2 enforcement");
+    };
+    assert!(message.contains("--memory-max-mb"));
+    assert!(message.contains("cgroup v2"));
 }

--- a/crates/cli-sub-agent/src/resource_admission.rs
+++ b/crates/cli-sub-agent/src/resource_admission.rs
@@ -437,6 +437,23 @@ memory_max_mb = 16384
     }
 
     #[test]
+    fn spawn_projection_uses_inherited_memory_override_before_tool_config() {
+        let cfg: ProjectConfig = toml::from_str(
+            r#"
+[tools.codex]
+memory_max_mb = 16384
+"#,
+        )
+        .expect("config should parse");
+        let inherited = RunResourceOverrides::from_cli(Some(6144), None).for_child();
+
+        assert_eq!(
+            spawn_memory_projection_mb_with_overrides(Some(&cfg), "codex", inherited),
+            6144
+        );
+    }
+
+    #[test]
     fn default_projection_is_bounded_by_physical_memory_after_reserve() {
         assert_eq!(
             bound_default_spawn_projection_mb(14_000, 12_000, 1024),

--- a/crates/cli-sub-agent/src/run_resource_overrides.rs
+++ b/crates/cli-sub-agent/src/run_resource_overrides.rs
@@ -212,6 +212,10 @@ impl RunResourceOverrides {
         self.memory_max_mb.is_some()
     }
 
+    pub(crate) fn has_explicit_cli_memory_max(self) -> bool {
+        self.memory_max_mb_source == Some(ResourceValueSource::ExplicitCli)
+    }
+
     pub(crate) fn resolve_memory_max_mb(
         self,
         config: Option<&ProjectConfig>,
@@ -306,6 +310,7 @@ mod tests {
         let info = overrides.resolution_info(None, "codex");
 
         assert_eq!(overrides.resolve_memory_max_mb(None, "codex"), Some(12_000));
+        assert!(overrides.has_explicit_cli_memory_max());
         assert_eq!(
             info.inherited_memory_max_mb,
             Some(SourcedResourceValue {
@@ -344,6 +349,8 @@ mod tests {
             })
         );
         assert_eq!(info.effective_memory_max_mb, info.inherited_memory_max_mb);
+        assert!(overrides.has_memory_max_override());
+        assert!(!overrides.has_explicit_cli_memory_max());
     }
 
     #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1121"
-weave = "0.1.1121"
+csa = "0.1.1122"
+weave = "0.1.1122"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Preserve an inherited parent `memory_max_mb` in the child sandbox resource plan when the child tool defaults to Off enforcement.
- Keep the cgroup-v2 requirement and explicit Off conflict scoped to direct CLI memory-cap requests.
- Add a default-Off inherited-memory regression test alongside provenance/admission coverage.

## Validation
- `just fmt`
- `just test-f memory_override`
- `just test-f resource_admission`
- `just test-f sandbox`
- `just test-f pipeline_sandbox`
- `just pre-commit-fast`
- `scripts/monolith/check.sh --scope staged --baseline scripts/monolith/baseline.toml --report-all`
- guarded push quality gate: 7,468 tests passed

## Review
Native read-only Codex review of `main...c63f511996a62231c10c6572e3efa0bc151ab222`: **VERDICT: PASS**. This is the exact remote head; it is the approved fallback while CSA resource admission is tracked in #2883.

Fixes #2880
Fixes #2886