### PR TITLE
fix(#2884): disclose --prompt fix-finding restriction in review help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1122"
+version = "0.1.1123"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1122"
+version = "0.1.1123"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -354,7 +354,7 @@ pub struct ReviewArgs {
     #[arg(long, value_delimiter = ',', value_name = "PATH")]
     pub extra_readable: Vec<PathBuf>,
 
-    /// Caller-confirmed fix prompt text for --fix-finding.
+    /// Fix-finding prompt text (requires --fix-finding).
     ///
     /// Optional when the source review has exactly one structured finding in
     /// `output/findings.toml` (derived automatically). Otherwise required via

--- a/crates/cli-sub-agent/src/review_cmd_tests_cli_flags.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_cli_flags.rs
@@ -1,4 +1,19 @@
 use super::*;
+use clap::CommandFactory;
+
+#[test]
+fn review_help_discloses_prompt_requires_fix_finding() {
+    let mut command = Cli::command();
+    let review = command
+        .find_subcommand_mut("review")
+        .expect("review subcommand should exist");
+    let help = review.render_long_help().to_string();
+
+    assert!(
+        help.contains("Fix-finding prompt text (requires --fix-finding)."),
+        "{help}"
+    );
+}
 
 #[test]
 fn review_cli_parses_hint_difficulty_flag() {

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1122"
-weave = "0.1.1122"
+csa = "0.1.1123"
+weave = "0.1.1123"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Clarify that `csa review --prompt` requires `--fix-finding`.
- Add a Clap long-help regression test for the restriction.
- Bump the workspace version required by the repository gate.

## Validation
- `just fmt`
- `just test-f review_cli`
- `just test-f cli_flags`
- `just pre-commit-fast`
- Pre-push hook with `NEXTEST_TEST_THREADS=8`
- Foreground Codex review of `main...HEAD` (no actionable regressions)

Fixes #2884