### PR TITLE
fix(#2883,#2885): unified feasibility interval for soft-limit admission denial

### DIFF
--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -546,31 +546,97 @@ fn timeout_validation_message(given: u64, min_timeout: u64) -> String {
 
 fn build_suggested_command(given: u64, min_timeout: u64) -> String {
     let args: Vec<String> = std::env::args().collect();
-    let given_str = given.to_string();
-    let min_str = min_timeout.to_string();
-
-    let mut result = args.clone();
-    let mut replaced = false;
-    let mut i = 0;
-
-    while i < result.len() {
-        if result[i] == "--timeout" && i + 1 < result.len() && result[i + 1] == given_str {
-            result[i + 1] = min_str.clone();
-            replaced = true;
+    let given = given.to_string();
+    let given_equals = format!("--timeout={given}");
+    let mut found = false;
+    let mut index = 0;
+    while index < args.len() {
+        if args[index] == "--" {
             break;
         }
-        if result[i] == format!("--timeout={given_str}") {
-            result[i] = format!("--timeout={min_str}");
-            replaced = true;
+        if (args[index] == "--timeout" && args.get(index + 1) == Some(&given))
+            || args[index] == given_equals
+        {
+            found = true;
             break;
         }
-        i += 1;
+        index += 1;
     }
 
-    if replaced {
-        result.join(" ")
+    if found {
+        rewrite_cli_command_options(&args, &[("--timeout", min_timeout.to_string())])
+            .unwrap_or_else(|| format!("csa ... --timeout {min_timeout}"))
     } else {
-        format!("csa ... --timeout {min_str}")
+        format!("csa ... --timeout {min_timeout}")
+    }
+}
+
+/// Rebuild a shell-copyable command after replacing or adding CLI options.
+pub(crate) fn rewrite_cli_command_options(
+    argv: &[String],
+    replacements: &[(&str, String)],
+) -> Option<String> {
+    if argv.is_empty() {
+        return None;
+    }
+
+    let mut result = argv.to_vec();
+    for (option, value) in replacements {
+        let mut replaced = false;
+        let mut index = 0;
+        while index < result.len() {
+            if result[index] == "--" {
+                break;
+            }
+            if result[index] == *option {
+                if index + 1 < result.len() && result[index + 1] != "--" {
+                    result[index + 1] = value.clone();
+                    replaced = true;
+                    index += 2;
+                    continue;
+                }
+            } else if result[index]
+                .strip_prefix(option)
+                .is_some_and(|suffix| suffix.starts_with('='))
+            {
+                result[index] = format!("{option}={value}");
+                replaced = true;
+            }
+            index += 1;
+        }
+
+        if !replaced {
+            let insertion_index = result
+                .iter()
+                .position(|argument| argument == "--")
+                .unwrap_or(result.len());
+            result.insert(insertion_index, (*option).to_string());
+            result.insert(insertion_index + 1, value.clone());
+        }
+    }
+
+    Some(
+        result
+            .iter()
+            .map(|argument| shell_escape_suggested_argument(argument))
+            .collect::<Vec<_>>()
+            .join(" "),
+    )
+}
+
+fn shell_escape_suggested_argument(argument: &str) -> String {
+    let is_shell_safe = !argument.is_empty()
+        && argument.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'_' | b'@' | b'%' | b'+' | b'=' | b':' | b',' | b'.' | b'/' | b'-'
+                )
+        });
+    if is_shell_safe {
+        argument.to_string()
+    } else {
+        format!("'{}'", argument.replace('\'', "'\\''"))
     }
 }
 

--- a/crates/cli-sub-agent/src/no_provider_launch.rs
+++ b/crates/cli-sub-agent/src/no_provider_launch.rs
@@ -1,6 +1,8 @@
+use std::path::Path;
+
 use anyhow::Error;
 use csa_config::ProjectConfig;
-use csa_resource::{MemoryAdmissionError, memory_policy};
+use csa_resource::{MemoryAdmissionError, ResourceGuard, ResourceLimits, memory_policy};
 use csa_session::{
     MetaSessionState, NO_PROVIDER_LAUNCH_SCHEMA_VERSION, NoProviderLaunchDiagnostic,
     NoProviderLaunchMemoryDiagnostic,
@@ -38,19 +40,22 @@ fn from_soft_limit_admission(
     ctx: NoProviderLaunchContext<'_>,
     error: &MemorySoftLimitAdmissionError,
 ) -> NoProviderLaunchDiagnostic {
+    let memory = soft_limit_admission_diagnostic_memory(
+        Path::new(&ctx.session.project_path),
+        &ctx.session.meta_session_id,
+        ctx.config,
+        ctx.resource_overrides,
+        error,
+    );
+    let mut guidance = error.guidance();
+    guidance.extend(soft_limit_admission_guidance(ctx.tool_name, &memory));
+
     base_diagnostic(
         &ctx,
         error.role(),
         MemorySoftLimitAdmissionError::TERMINATION_REASON,
-        NoProviderLaunchMemoryDiagnostic {
-            effective_memory_max_mb: Some(error.memory_max_mb()),
-            soft_limit_percent: Some(error.soft_limit_percent()),
-            soft_threshold_mb: Some(error.threshold_mb()),
-            required_floor_mb: Some(error.required_threshold_mb()),
-            required_memory_max_mb: Some(error.required_memory_max_mb()),
-            ..Default::default()
-        },
-        error.guidance(),
+        memory,
+        guidance,
     )
 }
 
@@ -92,6 +97,83 @@ pub(crate) fn host_memory_guidance_from_error(
         host_memory,
     );
     Some(host_memory_guidance(task_type, tool_name, &memory))
+}
+
+pub(crate) fn soft_limit_admission_guidance_from_error(
+    project_root: &Path,
+    current_session_id: &str,
+    tool_name: &str,
+    config: Option<&ProjectConfig>,
+    resource_overrides: RunResourceOverrides,
+    error: &Error,
+) -> Option<Vec<String>> {
+    let soft_limit = error.downcast_ref::<MemorySoftLimitAdmissionError>()?;
+    let memory = soft_limit_admission_diagnostic_memory(
+        project_root,
+        current_session_id,
+        config,
+        resource_overrides,
+        soft_limit,
+    );
+    let mut guidance = soft_limit.guidance();
+    guidance.extend(soft_limit_admission_guidance(tool_name, &memory));
+    Some(guidance)
+}
+
+fn soft_limit_admission_diagnostic_memory(
+    project_root: &Path,
+    current_session_id: &str,
+    config: Option<&ProjectConfig>,
+    resource_overrides: RunResourceOverrides,
+    error: &MemorySoftLimitAdmissionError,
+) -> NoProviderLaunchMemoryDiagnostic {
+    let admission = crate::resource_admission::build_spawn_memory_admission(
+        project_root,
+        current_session_id,
+        error.memory_max_mb(),
+    );
+    let mut resource_guard = ResourceGuard::new(ResourceLimits {
+        min_free_memory_mb: resource_overrides.resolve_min_free_memory_mb(config),
+    });
+    let snapshot = resource_guard.memory_admission_retry_snapshot(admission);
+    let retry_lower_bound_mb = Some(host_memory_retry_lower_bound_mb(Some(
+        error.required_memory_max_mb(),
+    )));
+    let retry_feasible = retry_lower_bound_mb.map(|lower_bound_mb| {
+        lower_bound_mb <= snapshot.retry_bounds.combined_upper_mb
+            || reserve_delta_retry_from_bounds(
+                snapshot.available_phys_mb,
+                snapshot.reserve_mb,
+                snapshot
+                    .retry_bounds
+                    .active_session_upper_mb
+                    .unwrap_or(u64::MAX),
+                lower_bound_mb,
+            )
+            .is_some_and(|retry| lower_bound_mb <= retry.adjusted_upper_mb)
+    });
+
+    NoProviderLaunchMemoryDiagnostic {
+        effective_memory_max_mb: Some(error.memory_max_mb()),
+        soft_limit_percent: Some(error.soft_limit_percent()),
+        soft_threshold_mb: Some(error.threshold_mb()),
+        required_floor_mb: Some(error.required_threshold_mb()),
+        required_memory_max_mb: Some(error.required_memory_max_mb()),
+        reserve_mb: Some(snapshot.reserve_mb),
+        available_memory_mb: Some(snapshot.available_phys_mb),
+        required_available_mb: retry_lower_bound_mb
+            .map(|lower_bound_mb| lower_bound_mb.saturating_add(snapshot.reserve_mb)),
+        projected_spawn_mb: Some(snapshot.admission.projected_spawn_mb),
+        active_session_rss_mb: Some(snapshot.admission.active_session_rss_mb),
+        active_session_projected_mb: Some(snapshot.admission.active_session_projected_mb),
+        active_session_count: Some(snapshot.admission.active_session_count),
+        sampled_session_count: Some(snapshot.admission.sampled_session_count),
+        retry_physical_upper_mb: Some(snapshot.retry_bounds.physical_upper_mb),
+        retry_active_session_upper_mb: snapshot.retry_bounds.active_session_upper_mb,
+        retry_combined_upper_mb: Some(snapshot.retry_bounds.combined_upper_mb),
+        retry_lower_bound_mb,
+        retry_feasible,
+    }
 }
 
 fn host_memory_diagnostic_memory(
@@ -184,6 +266,19 @@ pub(crate) fn role_from_task_type(task_type: Option<&str>) -> &'static str {
         Some("run") | None => "writer",
         Some(_) => "session",
     }
+}
+
+fn soft_limit_admission_guidance(
+    tool_name: &str,
+    memory: &NoProviderLaunchMemoryDiagnostic,
+) -> Vec<String> {
+    vec![
+        "CSA: soft-limit admission rejected before provider launch; this is an \
+         infrastructure/session-unavailable pre-exec denial and did not launch the provider or \
+         mutate the worktree."
+            .to_string(),
+        host_memory_retry_feasibility(tool_name, memory),
+    ]
 }
 
 fn host_memory_guidance(
@@ -412,96 +507,5 @@ pub(crate) fn enrich_review_diagnostic(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn host_memory_reviewer_guidance_suggests_soft_limit_safe_retry_pair() {
-        let memory = NoProviderLaunchMemoryDiagnostic {
-            effective_memory_max_mb: Some(10_000),
-            soft_limit_percent: Some(90),
-            soft_threshold_mb: Some(9_000),
-            required_floor_mb: Some(8_192),
-            required_memory_max_mb: Some(9_103),
-            reserve_mb: Some(9_000),
-            available_memory_mb: Some(17_033),
-            required_available_mb: Some(19_000),
-            projected_spawn_mb: Some(10_000),
-            retry_physical_upper_mb: Some(8_033),
-            retry_active_session_upper_mb: Some(16_000),
-            retry_combined_upper_mb: Some(8_033),
-            retry_lower_bound_mb: Some(9_103),
-            retry_feasible: Some(true),
-            ..Default::default()
-        };
-
-        let guidance = host_memory_guidance(Some("reviewer_sub_session"), "codex", &memory);
-        let joined = guidance.join("\n");
-
-        assert!(joined.contains("physical MemAvailable only"));
-        assert!(joined.contains("swap/combined memory is diagnostic"));
-        assert!(joined.contains("Retry feasibility: feasible with reserve delta"));
-        assert!(joined.contains("--memory-max-mb 9103 --min-free-memory-mb 6000"));
-        assert!(joined.contains("lower_bound=9103MB > current_upper=8033MB"));
-        assert!(joined.contains("lowering reserve opens retry_window=9103..=11033MB"));
-        assert!(joined.contains("host_required=15103MB <= physical_available=17033MB"));
-        assert!(joined.contains("csa plan run"));
-    }
-
-    #[test]
-    fn host_memory_reviewer_guidance_preserves_tight_retry_window() {
-        let memory = NoProviderLaunchMemoryDiagnostic {
-            effective_memory_max_mb: Some(10_000),
-            soft_limit_percent: Some(90),
-            soft_threshold_mb: Some(9_000),
-            required_floor_mb: Some(8_192),
-            required_memory_max_mb: Some(9_103),
-            reserve_mb: Some(256),
-            available_memory_mb: Some(9_296),
-            required_available_mb: Some(10_256),
-            projected_spawn_mb: Some(10_000),
-            retry_physical_upper_mb: Some(9_040),
-            retry_active_session_upper_mb: Some(12_000),
-            retry_combined_upper_mb: Some(9_040),
-            retry_lower_bound_mb: Some(9_103),
-            retry_feasible: Some(true),
-            ..Default::default()
-        };
-
-        let guidance = host_memory_guidance(Some("reviewer_sub_session"), "codex", &memory);
-        let joined = guidance.join("\n");
-
-        assert!(joined.contains("--memory-max-mb 9103 --min-free-memory-mb 193"));
-        assert!(joined.contains("lower_bound=9103MB > current_upper=9040MB"));
-        assert!(joined.contains("lowering reserve opens retry_window=9103..=9103MB"));
-        assert!(joined.contains("host_required=9296MB <= physical_available=9296MB"));
-    }
-
-    #[test]
-    fn host_memory_reviewer_guidance_reports_active_pressure_infeasible() {
-        let memory = NoProviderLaunchMemoryDiagnostic {
-            effective_memory_max_mb: Some(10_000),
-            soft_limit_percent: Some(90),
-            soft_threshold_mb: Some(9_000),
-            required_floor_mb: Some(8_192),
-            required_memory_max_mb: Some(9_103),
-            reserve_mb: Some(1_000),
-            available_memory_mb: Some(20_000),
-            required_available_mb: Some(11_000),
-            projected_spawn_mb: Some(10_000),
-            retry_physical_upper_mb: Some(19_000),
-            retry_active_session_upper_mb: Some(8_000),
-            retry_combined_upper_mb: Some(8_000),
-            retry_lower_bound_mb: Some(9_103),
-            retry_feasible: Some(false),
-            ..Default::default()
-        };
-
-        let guidance = host_memory_guidance(Some("reviewer_sub_session"), "codex", &memory);
-        let joined = guidance.join("\n");
-
-        assert!(joined.contains("Retry feasibility: infeasible"));
-        assert!(joined.contains("active-session upper 8000MB is below lower_bound=9103MB"));
-        assert!(joined.contains("Do not retry with another memory_max_mb"));
-    }
-}
+#[path = "no_provider_launch_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/no_provider_launch.rs
+++ b/crates/cli-sub-agent/src/no_provider_launch.rs
@@ -8,6 +8,7 @@ use csa_session::{
     NoProviderLaunchMemoryDiagnostic,
 };
 
+use crate::cli::rewrite_cli_command_options;
 use crate::resource_admission_soft_limit::MemorySoftLimitAdmissionError;
 use crate::run_resource_overrides::RunResourceOverrides;
 
@@ -99,13 +100,14 @@ pub(crate) fn host_memory_guidance_from_error(
     Some(host_memory_guidance(task_type, tool_name, &memory))
 }
 
-pub(crate) fn soft_limit_admission_guidance_from_error(
+pub(crate) fn soft_limit_admission_guidance_from_error_with_argv(
     project_root: &Path,
     current_session_id: &str,
     tool_name: &str,
     config: Option<&ProjectConfig>,
     resource_overrides: RunResourceOverrides,
     error: &Error,
+    argv: &[String],
 ) -> Option<Vec<String>> {
     let soft_limit = error.downcast_ref::<MemorySoftLimitAdmissionError>()?;
     let memory = soft_limit_admission_diagnostic_memory(
@@ -116,7 +118,9 @@ pub(crate) fn soft_limit_admission_guidance_from_error(
         soft_limit,
     );
     let mut guidance = soft_limit.guidance();
-    guidance.extend(soft_limit_admission_guidance(tool_name, &memory));
+    guidance.extend(soft_limit_admission_guidance_with_argv(
+        tool_name, &memory, argv,
+    ));
     Some(guidance)
 }
 
@@ -260,7 +264,24 @@ fn base_diagnostic(
     }
 }
 
-pub(crate) fn role_from_task_type(task_type: Option<&str>) -> &'static str {
+fn suggested_retry_command(
+    argv: &[String],
+    memory_max_mb: u64,
+    min_free_memory_mb: Option<u64>,
+) -> String {
+    let mut replacements = vec![("--memory-max-mb", memory_max_mb.to_string())];
+    if let Some(min_free_memory_mb) = min_free_memory_mb {
+        replacements.push(("--min-free-memory-mb", min_free_memory_mb.to_string()));
+    }
+    rewrite_cli_command_options(argv, &replacements).unwrap_or_else(|| {
+        let min_free_memory = min_free_memory_mb
+            .map(|value| format!(" --min-free-memory-mb {value}"))
+            .unwrap_or_default();
+        format!("csa --memory-max-mb {memory_max_mb}{min_free_memory}")
+    })
+}
+
+fn role_from_task_type(task_type: Option<&str>) -> &'static str {
     match task_type {
         Some("reviewer_sub_session" | "review_fix_finding" | "review") => "reviewer",
         Some("run") | None => "writer",
@@ -272,12 +293,21 @@ fn soft_limit_admission_guidance(
     tool_name: &str,
     memory: &NoProviderLaunchMemoryDiagnostic,
 ) -> Vec<String> {
+    let argv: Vec<String> = std::env::args().collect();
+    soft_limit_admission_guidance_with_argv(tool_name, memory, &argv)
+}
+
+fn soft_limit_admission_guidance_with_argv(
+    tool_name: &str,
+    memory: &NoProviderLaunchMemoryDiagnostic,
+    argv: &[String],
+) -> Vec<String> {
     vec![
         "CSA: soft-limit admission rejected before provider launch; this is an \
          infrastructure/session-unavailable pre-exec denial and did not launch the provider or \
          mutate the worktree."
             .to_string(),
-        host_memory_retry_feasibility(tool_name, memory),
+        host_memory_retry_feasibility(tool_name, memory, argv),
     ]
 }
 
@@ -286,7 +316,17 @@ fn host_memory_guidance(
     tool_name: &str,
     memory: &NoProviderLaunchMemoryDiagnostic,
 ) -> Vec<String> {
-    let feasibility = host_memory_retry_feasibility(tool_name, memory);
+    let argv: Vec<String> = std::env::args().collect();
+    host_memory_guidance_with_argv(task_type, tool_name, memory, &argv)
+}
+
+fn host_memory_guidance_with_argv(
+    task_type: Option<&str>,
+    tool_name: &str,
+    memory: &NoProviderLaunchMemoryDiagnostic,
+    argv: &[String],
+) -> Vec<String> {
+    let feasibility = host_memory_retry_feasibility(tool_name, memory, argv);
     match role_from_task_type(task_type) {
         "reviewer" => {
             let mut guidance = vec![
@@ -366,6 +406,7 @@ fn reserve_delta_retry_from_bounds(
 fn host_memory_retry_feasibility(
     tool_name: &str,
     memory: &NoProviderLaunchMemoryDiagnostic,
+    argv: &[String],
 ) -> String {
     let lower_bound_mb = memory
         .retry_lower_bound_mb
@@ -410,13 +451,13 @@ fn host_memory_retry_feasibility(
     );
     if lower_bound_mb <= current_upper_mb {
         let host_required_mb = lower_bound_mb.saturating_add(current_reserve_mb);
+        let retry_command = suggested_retry_command(argv, lower_bound_mb, None);
         return format!(
-            "Retry feasibility: feasible now. {bounds} Retry command delta: add \
-             --memory-max-mb {lower_bound_mb} to the same CSA invocation; for \
-             dev2merge/mktd child steps, add the same flag to csa plan run or the \
-             workflow's child csa run/review step. Config delta: set \
-             tools.{tool_name}.memory_max_mb = {lower_bound_mb} or \
-             resources.memory_max_mb = {lower_bound_mb}. host_required={host_required_mb}MB."
+            "Retry feasibility: feasible now. {bounds} Suggested retry command: {retry_command}. \
+             For dev2merge/mktd child steps, add the same flag to csa plan run or the workflow's \
+             child csa run/review step. Config delta: set tools.{tool_name}.memory_max_mb = \
+             {lower_bound_mb} or resources.memory_max_mb = {lower_bound_mb}. \
+             host_required={host_required_mb}MB."
         );
     }
 
@@ -429,15 +470,15 @@ fn host_memory_retry_feasibility(
         lower_bound_mb,
     ) {
         let host_required_mb = lower_bound_mb.saturating_add(retry.reserve_mb);
+        let retry_command = suggested_retry_command(argv, lower_bound_mb, Some(retry.reserve_mb));
         return format!(
             "Retry feasibility: feasible with reserve delta. {bounds} Current reserve has no \
              valid window because lower_bound={lower_bound_mb}MB > current_upper={current_upper_mb}MB; \
              lowering reserve opens retry_window={lower_bound_mb}..={adjusted_upper}MB. \
-             Retry command delta: add --memory-max-mb {lower_bound_mb} \
-             --min-free-memory-mb {reserve_mb} to the same CSA invocation; for dev2merge/mktd \
-             child steps, add the same flags to csa plan run or the workflow's child csa \
-             run/review step. Config delta: set tools.{tool_name}.memory_max_mb = \
-             {lower_bound_mb} and resources.min_free_memory_mb = {reserve_mb}. \
+             Suggested retry command: {retry_command}. For dev2merge/mktd child steps, add the \
+             same flags to csa plan run or the workflow's child csa run/review step. Config delta: \
+             set tools.{tool_name}.memory_max_mb = {lower_bound_mb} and \
+             resources.min_free_memory_mb = {reserve_mb}. \
              host_required={host_required_mb}MB <= physical_available={available_mb}MB.",
             adjusted_upper = retry.adjusted_upper_mb,
             reserve_mb = retry.reserve_mb,

--- a/crates/cli-sub-agent/src/no_provider_launch_tests.rs
+++ b/crates/cli-sub-agent/src/no_provider_launch_tests.rs
@@ -1,0 +1,205 @@
+use super::*;
+
+#[test]
+fn host_memory_reviewer_guidance_suggests_soft_limit_safe_retry_pair() {
+    let memory = NoProviderLaunchMemoryDiagnostic {
+        effective_memory_max_mb: Some(10_000),
+        soft_limit_percent: Some(90),
+        soft_threshold_mb: Some(9_000),
+        required_floor_mb: Some(8_192),
+        required_memory_max_mb: Some(9_103),
+        reserve_mb: Some(9_000),
+        available_memory_mb: Some(17_033),
+        required_available_mb: Some(19_000),
+        projected_spawn_mb: Some(10_000),
+        retry_physical_upper_mb: Some(8_033),
+        retry_active_session_upper_mb: Some(16_000),
+        retry_combined_upper_mb: Some(8_033),
+        retry_lower_bound_mb: Some(9_103),
+        retry_feasible: Some(true),
+        ..Default::default()
+    };
+
+    let guidance = host_memory_guidance(Some("reviewer_sub_session"), "codex", &memory);
+    let joined = guidance.join("\n");
+
+    assert!(joined.contains("physical MemAvailable only"));
+    assert!(joined.contains("swap/combined memory is diagnostic"));
+    assert!(joined.contains("Retry feasibility: feasible with reserve delta"));
+    assert!(joined.contains("--memory-max-mb 9103 --min-free-memory-mb 6000"));
+    assert!(joined.contains("lower_bound=9103MB > current_upper=8033MB"));
+    assert!(joined.contains("lowering reserve opens retry_window=9103..=11033MB"));
+    assert!(joined.contains("host_required=15103MB <= physical_available=17033MB"));
+    assert!(joined.contains("csa plan run"));
+}
+
+#[test]
+fn host_memory_reviewer_guidance_preserves_tight_retry_window() {
+    let memory = NoProviderLaunchMemoryDiagnostic {
+        effective_memory_max_mb: Some(10_000),
+        soft_limit_percent: Some(90),
+        soft_threshold_mb: Some(9_000),
+        required_floor_mb: Some(8_192),
+        required_memory_max_mb: Some(9_103),
+        reserve_mb: Some(256),
+        available_memory_mb: Some(9_296),
+        required_available_mb: Some(10_256),
+        projected_spawn_mb: Some(10_000),
+        retry_physical_upper_mb: Some(9_040),
+        retry_active_session_upper_mb: Some(12_000),
+        retry_combined_upper_mb: Some(9_040),
+        retry_lower_bound_mb: Some(9_103),
+        retry_feasible: Some(true),
+        ..Default::default()
+    };
+
+    let guidance = host_memory_guidance(Some("reviewer_sub_session"), "codex", &memory);
+    let joined = guidance.join("\n");
+
+    assert!(joined.contains("--memory-max-mb 9103 --min-free-memory-mb 193"));
+    assert!(joined.contains("lower_bound=9103MB > current_upper=9040MB"));
+    assert!(joined.contains("lowering reserve opens retry_window=9103..=9103MB"));
+    assert!(joined.contains("host_required=9296MB <= physical_available=9296MB"));
+}
+
+#[test]
+fn soft_limit_writer_guidance_reports_feasible_unified_interval_and_retry_command() {
+    let memory = NoProviderLaunchMemoryDiagnostic {
+        effective_memory_max_mb: Some(9_103),
+        soft_limit_percent: Some(90),
+        soft_threshold_mb: Some(8_192),
+        required_floor_mb: Some(9_000),
+        required_memory_max_mb: Some(10_000),
+        reserve_mb: Some(1_024),
+        available_memory_mb: Some(11_191),
+        projected_spawn_mb: Some(9_103),
+        retry_physical_upper_mb: Some(10_167),
+        retry_active_session_upper_mb: Some(20_000),
+        retry_combined_upper_mb: Some(10_167),
+        retry_lower_bound_mb: Some(10_000),
+        retry_feasible: Some(true),
+        ..Default::default()
+    };
+
+    let guidance = soft_limit_admission_guidance("codex", &memory);
+    let joined = guidance.join("\n");
+
+    assert!(joined.contains("soft-limit admission rejected before provider launch"));
+    assert!(joined.contains("Retry feasibility: feasible now"));
+    assert!(joined.contains(
+        "lower_bound=10000MB (role/tool soft-limit floor); current_upper=10167MB \
+         (physical/reserve upper=10167MB, active-session upper=20000MB)"
+    ));
+    assert!(
+        joined
+            .contains("Retry command delta: add --memory-max-mb 10000 to the same CSA invocation")
+    );
+}
+
+#[test]
+fn soft_limit_diagnostic_reports_live_retry_interval_without_provider_side_effects() {
+    use csa_resource::{FilesystemCapability, IsolationPlan, ResourceCapability};
+
+    let project_dir = tempfile::tempdir().expect("temporary project");
+    let _sandbox = crate::test_session_sandbox::ScopedSessionSandbox::new_blocking(&project_dir);
+    let session = csa_session::create_session(
+        project_dir.path(),
+        Some("soft-limit feasibility diagnostic"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let plan = IsolationPlan {
+        resource: ResourceCapability::CgroupV2,
+        filesystem: FilesystemCapability::Bwrap,
+        writable_paths: Vec::new(),
+        readable_paths: Vec::new(),
+        env_overrides: std::collections::HashMap::new(),
+        degraded_reasons: Vec::new(),
+        memory_max_mb: Some(9_103),
+        memory_swap_max_mb: None,
+        pids_max: None,
+        readonly_project_root: true,
+        project_root: None,
+        soft_limit_percent: Some(90),
+        memory_monitor_interval_seconds: None,
+        user_daemon_ipc: false,
+    };
+    let error = anyhow::Error::new(
+        crate::resource_admission_soft_limit::ensure_memory_soft_limit_admission(
+            Some("run"),
+            "codex",
+            Some(&plan),
+        )
+        .expect_err("writer soft limit should be denied"),
+    );
+
+    let diagnostic = diagnostic_from_error(
+        NoProviderLaunchContext {
+            session: &session,
+            tool_name: "codex",
+            task_type: Some("run"),
+            config: None,
+            resource_overrides: RunResourceOverrides::absent(),
+        },
+        &error,
+    )
+    .expect("soft-limit admission should retain a no-provider diagnostic");
+    let memory = &diagnostic.memory;
+    let available_mb = memory
+        .available_memory_mb
+        .expect("live physical availability is captured");
+    let reserve_mb = memory.reserve_mb.expect("configured reserve is captured");
+    let physical_upper_mb = memory
+        .retry_physical_upper_mb
+        .expect("physical/reserve upper bound is captured");
+    let combined_upper_mb = memory
+        .retry_combined_upper_mb
+        .expect("unified retry upper bound is captured");
+
+    assert!(diagnostic.no_provider_launch);
+    assert!(!diagnostic.provider_side_effects);
+    assert_eq!(
+        diagnostic.denial_class,
+        crate::resource_admission_soft_limit::MEMORY_SOFT_LIMIT_ADMISSION_REASON
+    );
+    assert_eq!(memory.retry_lower_bound_mb, Some(10_000));
+    assert_eq!(physical_upper_mb, available_mb.saturating_sub(reserve_mb));
+    assert_eq!(
+        combined_upper_mb,
+        physical_upper_mb.min(memory.retry_active_session_upper_mb.unwrap_or(u64::MAX))
+    );
+    let guidance = diagnostic.guidance.join("\n");
+    assert!(guidance.contains("soft-limit admission rejected before provider launch"));
+    assert!(guidance.contains("lower_bound=10000MB (role/tool soft-limit floor)"));
+    assert!(guidance.contains("physical/reserve upper="));
+    assert!(guidance.contains("Retry feasibility:"));
+}
+
+#[test]
+fn host_memory_reviewer_guidance_reports_active_pressure_infeasible() {
+    let memory = NoProviderLaunchMemoryDiagnostic {
+        effective_memory_max_mb: Some(10_000),
+        soft_limit_percent: Some(90),
+        soft_threshold_mb: Some(9_000),
+        required_floor_mb: Some(8_192),
+        required_memory_max_mb: Some(9_103),
+        reserve_mb: Some(1_000),
+        available_memory_mb: Some(20_000),
+        required_available_mb: Some(11_000),
+        projected_spawn_mb: Some(10_000),
+        retry_physical_upper_mb: Some(19_000),
+        retry_active_session_upper_mb: Some(8_000),
+        retry_combined_upper_mb: Some(8_000),
+        retry_lower_bound_mb: Some(9_103),
+        retry_feasible: Some(false),
+        ..Default::default()
+    };
+
+    let guidance = host_memory_guidance(Some("reviewer_sub_session"), "codex", &memory);
+    let joined = guidance.join("\n");
+
+    assert!(joined.contains("Retry feasibility: infeasible"));
+    assert!(joined.contains("active-session upper 8000MB is below lower_bound=9103MB"));
+    assert!(joined.contains("Do not retry with another memory_max_mb"));
+}

--- a/crates/cli-sub-agent/src/no_provider_launch_tests.rs
+++ b/crates/cli-sub-agent/src/no_provider_launch_tests.rs
@@ -20,13 +20,27 @@ fn host_memory_reviewer_guidance_suggests_soft_limit_safe_retry_pair() {
         ..Default::default()
     };
 
-    let guidance = host_memory_guidance(Some("reviewer_sub_session"), "codex", &memory);
+    let original_argv = vec![
+        "csa".to_string(),
+        "review".to_string(),
+        "--memory-max-mb".to_string(),
+        "10000".to_string(),
+        "--diff".to_string(),
+    ];
+    let guidance = host_memory_guidance_with_argv(
+        Some("reviewer_sub_session"),
+        "codex",
+        &memory,
+        &original_argv,
+    );
     let joined = guidance.join("\n");
 
     assert!(joined.contains("physical MemAvailable only"));
     assert!(joined.contains("swap/combined memory is diagnostic"));
     assert!(joined.contains("Retry feasibility: feasible with reserve delta"));
-    assert!(joined.contains("--memory-max-mb 9103 --min-free-memory-mb 6000"));
+    assert!(joined.contains(
+        "Suggested retry command: csa review --memory-max-mb 9103 --diff --min-free-memory-mb 6000"
+    ));
     assert!(joined.contains("lower_bound=9103MB > current_upper=8033MB"));
     assert!(joined.contains("lowering reserve opens retry_window=9103..=11033MB"));
     assert!(joined.contains("host_required=15103MB <= physical_available=17033MB"));
@@ -81,7 +95,14 @@ fn soft_limit_writer_guidance_reports_feasible_unified_interval_and_retry_comman
         ..Default::default()
     };
 
-    let guidance = soft_limit_admission_guidance("codex", &memory);
+    let original_argv = vec![
+        "csa".to_string(),
+        "run".to_string(),
+        "--memory-max-mb".to_string(),
+        "9103".to_string(),
+        "fix the retry guidance".to_string(),
+    ];
+    let guidance = soft_limit_admission_guidance_with_argv("codex", &memory, &original_argv);
     let joined = guidance.join("\n");
 
     assert!(joined.contains("soft-limit admission rejected before provider launch"));
@@ -90,10 +111,9 @@ fn soft_limit_writer_guidance_reports_feasible_unified_interval_and_retry_comman
         "lower_bound=10000MB (role/tool soft-limit floor); current_upper=10167MB \
          (physical/reserve upper=10167MB, active-session upper=20000MB)"
     ));
-    assert!(
-        joined
-            .contains("Retry command delta: add --memory-max-mb 10000 to the same CSA invocation")
-    );
+    assert!(joined.contains(
+        "Suggested retry command: csa run --memory-max-mb 10000 'fix the retry guidance'"
+    ));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_preflight.rs
@@ -14,6 +14,15 @@ pub(crate) fn validate_before_session(
     args: &ReviewArgs,
     startup_env: &StartupSubtreeEnv,
 ) -> Result<()> {
+    let argv: Vec<String> = std::env::args().collect();
+    validate_before_session_with_argv(args, startup_env, &argv)
+}
+
+fn validate_before_session_with_argv(
+    args: &ReviewArgs,
+    startup_env: &StartupSubtreeEnv,
+    argv: &[String],
+) -> Result<()> {
     if args.check_verdict {
         return Ok(());
     }
@@ -21,13 +30,13 @@ pub(crate) fn validate_before_session(
     super::session_fix::validate_session_fix_before_daemon(args)?;
     super::fix_finding::validate_fix_finding_before_daemon(args)?;
     if args.fix_finding {
-        return validate_fix_finding_resources_before_session(args);
+        return validate_fix_finding_resources_before_session(args, argv);
     }
     super::validate_review_prompt_file(args.prompt_file.as_deref())?;
-    validate_review_routing_before_session(args, startup_env)
+    validate_review_routing_before_session(args, startup_env, argv)
 }
 
-fn validate_fix_finding_resources_before_session(args: &ReviewArgs) -> Result<()> {
+fn validate_fix_finding_resources_before_session(args: &ReviewArgs, argv: &[String]) -> Result<()> {
     let project_root = crate::pipeline::determine_project_root(args.cd.as_deref())?;
     let effective_config = csa_config::EffectiveConfig::load(&project_root)?;
     let project_config = effective_config.project;
@@ -44,12 +53,14 @@ fn validate_fix_finding_resources_before_session(args: &ReviewArgs) -> Result<()
         &global_config,
         route.tool,
         false,
+        argv,
     )
 }
 
 fn validate_review_routing_before_session(
     args: &ReviewArgs,
     startup_env: &StartupSubtreeEnv,
+    argv: &[String],
 ) -> Result<()> {
     let project_root = crate::pipeline::determine_project_root(args.cd.as_deref())?;
     let effective_config = csa_config::EffectiveConfig::load(&project_root)?;
@@ -155,6 +166,7 @@ fn validate_review_routing_before_session(
             &global_config,
             candidate_tool,
             readonly_project_root,
+            argv,
         )?;
     }
 
@@ -180,6 +192,7 @@ fn validate_review_candidate_resources_before_session(
     global_config: &GlobalConfig,
     tool: ToolName,
     readonly_project_root: bool,
+    argv: &[String],
 ) -> Result<()> {
     let resource_overrides = args.resource_overrides();
     let stream_mode =
@@ -236,14 +249,16 @@ fn validate_review_candidate_resources_before_session(
     )
     .map_err(|err| {
         let err = anyhow::Error::new(err);
-        let guidance = crate::no_provider_launch::soft_limit_admission_guidance_from_error(
-            project_root,
-            REVIEW_PREFLIGHT_SESSION_ID,
-            tool.as_str(),
-            project_config,
-            resource_overrides,
-            &err,
-        );
+        let guidance =
+            crate::no_provider_launch::soft_limit_admission_guidance_from_error_with_argv(
+                project_root,
+                REVIEW_PREFLIGHT_SESSION_ID,
+                tool.as_str(),
+                project_config,
+                resource_overrides,
+                &err,
+                argv,
+            );
         if let Some(guidance) = guidance {
             err.context(format!(
                 "soft-limit memory retry guidance:\n- {}",

--- a/crates/cli-sub-agent/src/review_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_preflight.rs
@@ -233,7 +233,26 @@ fn validate_review_candidate_resources_before_session(
             .sandbox
             .as_ref()
             .map(|sandbox| &sandbox.isolation_plan),
-    )?;
+    )
+    .map_err(|err| {
+        let err = anyhow::Error::new(err);
+        let guidance = crate::no_provider_launch::soft_limit_admission_guidance_from_error(
+            project_root,
+            REVIEW_PREFLIGHT_SESSION_ID,
+            tool.as_str(),
+            project_config,
+            resource_overrides,
+            &err,
+        );
+        if let Some(guidance) = guidance {
+            err.context(format!(
+                "soft-limit memory retry guidance:\n- {}",
+                guidance.join("\n- ")
+            ))
+        } else {
+            err
+        }
+    })?;
     validate_host_memory_before_session(project_root, project_config, tool, resource_overrides)
         .with_context(|| format!("review preflight for tool '{tool}'"))
 }

--- a/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
@@ -148,6 +148,43 @@ fn review_host_memory_admission_is_rejected_before_session_creation() {
 }
 
 #[test]
+fn review_soft_limit_resource_admission_reports_unified_retry_guidance_before_session_creation() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    let _tools_available =
+        ScopedEnvVarRestore::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let mut config = project_config_with_quality_tier();
+    config.resources.memory_max_mb = Some(8_192);
+    config.resources.soft_limit_percent = Some(70);
+    write_project_config(project_dir.path(), &config);
+    let args = parse_review_args(
+        project_dir.path(),
+        &["--tier", "quality", "--tool", "codex"],
+    );
+
+    let err = super::validate_before_session(&args, &StartupSubtreeEnv::default())
+        .expect_err("reviewer soft-limit admission must fail before session creation");
+
+    let msg = format!("{err:#}");
+    assert!(msg.contains("memory_soft_limit_admission"), "{msg}");
+    assert!(msg.contains("soft-limit memory retry guidance"), "{msg}");
+    assert!(msg.contains("Retry feasibility:"), "{msg}");
+    assert!(msg.contains("lower_bound=11703MB (role/tool soft-limit floor)"));
+    assert!(msg.contains("physical/reserve upper="), "{msg}");
+    assert!(
+        msg.contains("soft-limit admission rejected before provider launch"),
+        "{msg}"
+    );
+    let sessions = csa_session::list_sessions(project_dir.path(), None).unwrap();
+    assert!(
+        sessions.is_empty(),
+        "soft-limit preflight validation must not create a review session"
+    );
+}
+
+#[test]
 fn fix_finding_prompt_file_dash_reaches_fix_finding_validation() {
     let project_dir = tempfile::tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);

--- a/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
@@ -161,11 +161,35 @@ fn review_soft_limit_resource_admission_reports_unified_retry_guidance_before_se
     write_project_config(project_dir.path(), &config);
     let args = parse_review_args(
         project_dir.path(),
-        &["--tier", "quality", "--tool", "codex"],
+        &[
+            "--tier",
+            "quality",
+            "--tool",
+            "codex",
+            "--memory-max-mb",
+            "8192",
+        ],
     );
+    let original_argv = vec![
+        "csa".to_string(),
+        "review".to_string(),
+        "--cd".to_string(),
+        project_dir.path().display().to_string(),
+        "--diff".to_string(),
+        "--tier".to_string(),
+        "quality".to_string(),
+        "--tool".to_string(),
+        "codex".to_string(),
+        "--memory-max-mb".to_string(),
+        "8192".to_string(),
+    ];
 
-    let err = super::validate_before_session(&args, &StartupSubtreeEnv::default())
-        .expect_err("reviewer soft-limit admission must fail before session creation");
+    let err = super::validate_before_session_with_argv(
+        &args,
+        &StartupSubtreeEnv::default(),
+        &original_argv,
+    )
+    .expect_err("reviewer soft-limit admission must fail before session creation");
 
     let msg = format!("{err:#}");
     assert!(msg.contains("memory_soft_limit_admission"), "{msg}");
@@ -173,6 +197,10 @@ fn review_soft_limit_resource_admission_reports_unified_retry_guidance_before_se
     assert!(msg.contains("Retry feasibility:"), "{msg}");
     assert!(msg.contains("lower_bound=11703MB (role/tool soft-limit floor)"));
     assert!(msg.contains("physical/reserve upper="), "{msg}");
+    assert!(msg.contains("Suggested retry command: csa review"), "{msg}");
+    assert!(msg.contains("--memory-max-mb 11703"), "{msg}");
+    assert!(!msg.contains("Retry command delta:"), "{msg}");
+    assert!(msg.contains("host_required="), "{msg}");
     assert!(
         msg.contains("soft-limit admission rejected before provider launch"),
         "{msg}"

--- a/crates/csa-resource/src/guard.rs
+++ b/crates/csa-resource/src/guard.rs
@@ -49,6 +49,11 @@ pub struct MemoryAdmissionRetryBounds {
     pub combined_upper_mb: u64,
 }
 
+#[path = "guard_retry_snapshot.rs"]
+mod guard_retry_snapshot;
+
+pub use guard_retry_snapshot::MemoryAdmissionRetrySnapshot;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryAdmissionKind {
     Reserve,

--- a/crates/csa-resource/src/guard_retry_snapshot.rs
+++ b/crates/csa-resource/src/guard_retry_snapshot.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+/// Fresh host-memory inputs used to render a retry-feasibility interval.
+///
+/// The snapshot reuses the same physical/reserve and active-session bound rules
+/// as pre-spawn host-memory admission, but it is available when another
+/// pre-exec admission (such as a soft-limit floor) failed first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryAdmissionRetrySnapshot {
+    /// Effective physical MemAvailable after enclosing cgroup limits are applied.
+    pub available_phys_mb: u64,
+    /// Configured physical-memory reserve retained by a retry.
+    pub reserve_mb: u64,
+    /// Active-session projection used for the retry calculation.
+    pub admission: SpawnMemoryAdmission,
+    /// Unified physical/reserve and active-session retry bounds.
+    pub retry_bounds: MemoryAdmissionRetryBounds,
+}
+
+impl ResourceGuard {
+    /// Sample the unified retry bounds for a prospective spawn without denying it.
+    ///
+    /// This is intended for a different pre-exec guard that has already rejected
+    /// the spawn but still needs to render an honest lower/upper retry interval.
+    pub fn memory_admission_retry_snapshot(
+        &mut self,
+        admission: SpawnMemoryAdmission,
+    ) -> MemoryAdmissionRetrySnapshot {
+        self.sys.refresh_memory();
+
+        let available_phys_mb =
+            effective_available_memory_bytes(self.sys.available_memory()) / 1024 / 1024;
+        let total_ram_mb = self.sys.total_memory() / 1024 / 1024;
+        let reserve_mb = self.limits.min_free_memory_mb;
+        let retry_bounds = retry_bounds_for(available_phys_mb, total_ram_mb, reserve_mb, admission);
+
+        MemoryAdmissionRetrySnapshot {
+            available_phys_mb,
+            reserve_mb,
+            admission,
+            retry_bounds,
+        }
+    }
+}

--- a/crates/csa-resource/src/lib.rs
+++ b/crates/csa-resource/src/lib.rs
@@ -23,8 +23,8 @@ pub use cgroup::{
 };
 pub use filesystem_sandbox::{FilesystemCapability, detect_filesystem_capability};
 pub use guard::{
-    MemoryAdmissionError, MemoryAdmissionKind, MemoryAdmissionRetryBounds, ResourceGuard,
-    ResourceLimits, SpawnMemoryAdmission,
+    MemoryAdmissionError, MemoryAdmissionKind, MemoryAdmissionRetryBounds,
+    MemoryAdmissionRetrySnapshot, ResourceGuard, ResourceLimits, SpawnMemoryAdmission,
 };
 pub use isolation_plan::{EnforcementMode, IsolationPlan, IsolationPlanBuilder};
 pub use landlock::apply_landlock_rules;

--- a/scripts/tests/build-exact-head-binaries-tests.sh
+++ b/scripts/tests/build-exact-head-binaries-tests.sh
@@ -3,6 +3,18 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 builder="${repo_root}/scripts/build-exact-head-binaries.sh"
+
+# Git hooks export their checkout's local Git environment. This test creates
+# and commits a separate fixture repository, so discard that inherited context
+# before any fixture Git command can resolve back to the checkout.
+clear_inherited_git_environment() {
+  local variable
+  while IFS= read -r variable; do
+    unset "$variable"
+  done < <(git rev-parse --local-env-vars)
+}
+clear_inherited_git_environment
+
 tmp="$(mktemp -d)"
 race_builder_pid=""
 cleanup() {


### PR DESCRIPTION
## Summary
Soft-limit admission denials now include a unified lower/upper feasibility interval and a reproducible retry command reconstructed from the original CSA argv.

## Changes
- Enrich soft-limit admission denial with live physical/reserve/active-session bounds and feasibility status
- Rebuild shell-copyable retry command from original argv (rewrites/adds --memory-max-mb and --min-free-memory-mb when needed)
- Extract monolith-gated tests/helpers: no_provider_launch_tests.rs, guard_retry_snapshot.rs
- Route review preflight soft-limit errors through the enriched guidance path
- Preserve no_provider_launch == true / provider_side_effects == false

## Issues
Closes #2883
Closes #2885

## Validation
- just test-f no_provider / soft_limit / resource_admission / preflight PASS
- pre-push quality gates PASS (7471 tests; isolation suite skipped authorized)
- exact-range Codex review PASS