### PR TITLE
fix(#2875): expose configured min_timeout in --timeout help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1123"
+version = "0.1.1124"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1123"
+version = "0.1.1124"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cli_commands.rs
+++ b/crates/cli-sub-agent/src/cli_commands.rs
@@ -132,7 +132,9 @@ pub enum Commands {
         #[arg(long, value_parser = clap::value_parser!(u64))]
         initial_response_timeout: Option<u64>,
 
-        /// Absolute wall-clock timeout in seconds (kills execution after N seconds)
+        /// Absolute wall-clock timeout in seconds (kills execution after N seconds).
+        /// Must be at least configured `execution.min_timeout_seconds`; inspect the
+        /// floor with `csa config get execution.min_timeout_seconds`.
         #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
         timeout: Option<u64>,
 

--- a/crates/cli-sub-agent/src/cli_review.rs
+++ b/crates/cli-sub-agent/src/cli_review.rs
@@ -278,7 +278,9 @@ pub struct ReviewArgs {
     )]
     pub consensus: String,
 
-    /// Absolute wall-clock timeout in seconds (kills execution after N seconds when set)
+    /// Absolute wall-clock timeout in seconds (kills execution after N seconds when set).
+    /// Must be at least configured `execution.min_timeout_seconds`; inspect the
+    /// floor with `csa config get execution.min_timeout_seconds`.
     #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
     pub timeout: Option<u64>,
 

--- a/crates/cli-sub-agent/src/review_cmd_tests_cli_flags.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_cli_flags.rs
@@ -16,6 +16,28 @@ fn review_help_discloses_prompt_requires_fix_finding() {
 }
 
 #[test]
+fn review_help_exposes_configured_min_timeout_floor() {
+    let mut command = Cli::command();
+    let review = command
+        .find_subcommand_mut("review")
+        .expect("review subcommand should exist");
+    let help = review.render_long_help().to_string();
+
+    assert!(
+        help.contains("Absolute wall-clock timeout"),
+        "review --timeout help should describe wall-clock timeout: {help}"
+    );
+    assert!(
+        help.contains("execution.min_timeout_seconds"),
+        "review --timeout help should mention configured min_timeout floor: {help}"
+    );
+    assert!(
+        help.contains("csa config get execution.min_timeout_seconds"),
+        "review --timeout help should point at config get for the floor: {help}"
+    );
+}
+
+#[test]
 fn review_cli_parses_hint_difficulty_flag() {
     let args = parse_review_args(&[
         "csa",

--- a/crates/cli-sub-agent/src/run_cmd_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_tests.rs
@@ -180,6 +180,28 @@ fn run_help_explains_tier_policy_for_direct_tool() {
 }
 
 #[test]
+fn run_help_exposes_configured_min_timeout_floor() {
+    let mut command = Cli::command();
+    let run = command
+        .find_subcommand_mut("run")
+        .expect("run subcommand should exist");
+    let help = run.render_long_help().to_string();
+
+    assert!(
+        help.contains("Absolute wall-clock timeout"),
+        "run --timeout help should describe wall-clock timeout: {help}"
+    );
+    assert!(
+        help.contains("execution.min_timeout_seconds"),
+        "run --timeout help should mention configured min_timeout floor: {help}"
+    );
+    assert!(
+        help.contains("csa config get execution.min_timeout_seconds"),
+        "run --timeout help should point at config get for the floor: {help}"
+    );
+}
+
+#[test]
 fn run_cli_parses_require_commit_flag() {
     let cli = try_parse_cli(&["csa", "run", "--require-commit", "--sa-mode", "false", "x"])
         .expect("--require-commit should parse");

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1123"
-weave = "0.1.1123"
+csa = "0.1.1124"
+weave = "0.1.1124"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
`csa run` / `csa review` `--timeout` help now discloses that the absolute wall-clock timeout must be at least configured `execution.min_timeout_seconds`, and points callers to `csa config get execution.min_timeout_seconds`.

## Changes
- Update clap help for run and review `--timeout`
- Add rendered long-help regression tests

## Issues
Closes #2875

## Validation
- just test-f timeout PASS
- pre-push quality gates PASS (7474 tests; isolation suite skipped authorized)
- exact-range Codex review PASS