### PR TITLE
fix(#2882): parse markdown prose findings into structured artifacts

### DIFF
--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_2017_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_2017_tests.rs
@@ -135,6 +135,68 @@ Review result: FAIL. One medium severity finding blocks the change.
 }
 
 #[test]
+fn issue_2882_markdown_heading_findings_with_locations_backfill_structured_artifacts() {
+    let session_id = "01TEST2882HEADINGFIND";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-2882-markdown-heading-findings", session_id);
+
+    write_extracted_empty_findings(&session_dir);
+    csa_session::persist_structured_output(
+        &session_dir,
+        r#"<!-- CSA:SECTION:summary -->
+Review result: FAIL. Two blocking findings remain.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+### 1. [HIGH][correctness] A committed mutation can be reported as a retryable lock failure.
+Location: `src/core/sqlite_retry.rs:65`
+Trigger: a retry wakes after the configured deadline.
+
+### 2. [MEDIUM][regression] Self-healing connection open is outside the deadline.
+Location: `src/core/async_db.rs:620`
+Impact: a future retry change can reintroduce the deadline overrun.
+
+## Recommended Actions
+
+1. Enforce the deadline before scheduling another retry.
+<!-- CSA:SECTION:details:END -->
+"#,
+    )
+    .expect("persist structured output");
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 2, "findings: {findings:#?}");
+    assert_eq!(findings.findings[0].severity, Severity::High);
+    assert_eq!(
+        findings.findings[0].file_ranges[0].path,
+        "src/core/sqlite_retry.rs"
+    );
+    assert_eq!(findings.findings[0].file_ranges[0].start, 65);
+    assert_eq!(findings.findings[1].severity, Severity::Medium);
+    assert_eq!(
+        findings.findings[1].file_ranges[0].path,
+        "src/core/async_db.rs"
+    );
+    assert_eq!(findings.findings[1].file_ranges[0].start, 620);
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+    assert_ne!(
+        verdict.failure_reason.as_deref(),
+        Some("prose_findings_present_but_unparsed")
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn issue_2017_fail_verdict_with_unparseable_details_writes_explicit_artifact_error() {
     let session_id = "01TEST2017ARTIFACTERR";
     let (_env_lock, project_root, session_dir) =

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -61,7 +61,8 @@ pub(in crate::review_cmd) fn extract_review_findings_from_prose_with_default(
             in_findings_section = true;
             continue;
         }
-        if in_findings_section && trimmed.starts_with('#') {
+        if in_findings_section && trimmed.starts_with('#') && !is_markdown_finding_heading(trimmed)
+        {
             in_findings_section = false;
             continue;
         }
@@ -159,7 +160,7 @@ pub(in crate::review_cmd) fn findings_section_bodies(text: &str) -> Vec<Findings
         let Some((body, _)) = current.as_mut() else {
             continue;
         };
-        if !in_code_fence && trimmed.starts_with('#') {
+        if !in_code_fence && trimmed.starts_with('#') && !is_markdown_finding_heading(trimmed) {
             if let Some((body, is_markdown_heading)) = current.take() {
                 bodies.push(FindingsSectionBody {
                     body,
@@ -273,7 +274,17 @@ fn bracketed_finding_severity(body: &str) -> Option<Severity> {
 }
 
 fn structured_finding_body(line: &str) -> Option<&str> {
+    let line = line.trim_start();
+    let line = line
+        .strip_prefix('#')
+        .map_or(line, |line| line.trim_start_matches('#').trim_start());
     strip_numbered_prefix(line).or_else(|| strip_unordered_finding_prefix(line))
+}
+
+fn is_markdown_finding_heading(line: &str) -> bool {
+    line.trim_start()
+        .strip_prefix('#')
+        .is_some_and(|line| structured_finding_body(line).is_some())
 }
 
 fn strip_numbered_prefix(line: &str) -> Option<&str> {
@@ -372,7 +383,8 @@ fn parse_path_prefixed_finding(body: &str, severity: Severity) -> Option<ParsedP
 fn parse_file_reference_line(line: &str) -> Option<ReviewFindingFileRange> {
     let line = strip_unordered_list_prefix(line);
     let (label, rest) = line.split_once(':')?;
-    if !label.trim().eq_ignore_ascii_case("file") {
+    if !(label.trim().eq_ignore_ascii_case("file") || label.trim().eq_ignore_ascii_case("location"))
+    {
         return None;
     }
     parse_leading_file_range(rest.trim()).map(|(range, _)| range)


### PR DESCRIPTION
Closes #2882

## Summary
- Keep numbered Markdown finding headings (for example `### 1. [HIGH] ...`) inside the Findings section.
- Treat `Location:` as a valid finding file reference.
- Add a regression fixture covering the empty-artifact → prose-backfill → severity/verdict lifecycle.

## Root cause
The prose parser treated every heading as a Findings-section boundary, so numbered finding headings terminated parsing before structured artifacts could be reconstructed.

## Validation
- `pre-commit-fast` passed before publication.
- Pre-push test suite passed.
- Clean-room, read-only Codex review of `origin/main...HEAD`: `VERDICT: PASS`.
