### PR TITLE
fix(#2830): preserve require-commit gate failure evidence

### DIFF
--- a/crates/cli-sub-agent/src/run_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute.rs
@@ -95,3 +95,7 @@ mod pre_exec_tests;
 #[cfg(test)]
 #[path = "run_cmd_execute_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "run_cmd_execute_handle_tests.rs"]
+mod handle_tests;

--- a/crates/cli-sub-agent/src/run_cmd_execute_handle.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_handle.rs
@@ -1,4 +1,47 @@
 use super::*;
+use std::path::Path;
+
+/// Enforce the commit contract without losing the writer-success signal used to
+/// decide whether a post-exec gate must run. A missing commit changes the
+/// caller-facing result to fatal, but the configured gate is still diagnostic
+/// evidence for a writer that completed successfully.
+pub(super) async fn record_run_dirty_then_apply_post_exec_gate(
+    project_root: &Path,
+    prompt_text: &str,
+    session_id: Option<&str>,
+    config: Option<&csa_config::ProjectConfig>,
+    result: &mut csa_process::ExecutionResult,
+    changed_paths: Option<&[String]>,
+    commit_created: Option<bool>,
+    require_commit: bool,
+    post_exec_options: PostExecGateApplyOptions<'_>,
+) -> Result<Option<csa_session::LargeDiffWarningReport>> {
+    // Preserve the writer's outcome before `record_run_dirty` may convert a
+    // missing required commit into a fatal result. Gate failure details are the
+    // actionable diagnostic for this exact case (#2830).
+    let post_exec_gate_eligible = result.exit_code == 0;
+    let warning = crate::run_cmd::uncommitted::record_run_dirty(
+        project_root,
+        session_id,
+        result,
+        changed_paths,
+        commit_created,
+        require_commit,
+        config,
+    );
+    if post_exec_gate_eligible {
+        apply_post_exec_gate_after_success_with_runner(
+            project_root,
+            prompt_text,
+            session_id,
+            config,
+            post_exec_options,
+            execute_post_exec_gate_command,
+        )
+        .await?;
+    }
+    Ok(warning)
+}
 
 pub(crate) async fn handle_run(
     tool: Option<ToolArg>,
@@ -545,41 +588,26 @@ pub(crate) async fn handle_run(
     let executed_session_id = loop_outcome.executed_session_id;
     let session_id = executed_session_id.as_deref();
     let fork_resolution = loop_outcome.fork_resolution;
-    // Preserve whether the writer itself completed successfully before enforcing
-    // the commit contract. `record_run_dirty` intentionally turns a missing
-    // commit into a fatal result, but that must not suppress the configured
-    // post-exec gate: its structured failure report is the actionable evidence
-    // a require-commit caller needs to diagnose dirty work that did not commit.
-    let post_exec_gate_eligible = result.exit_code == 0;
-    let warning = crate::run_cmd::uncommitted::record_run_dirty(
+    let post_exec_gate_env = crate::build_jobs_env::build_jobs_env(build_jobs);
+    let warning = record_run_dirty_then_apply_post_exec_gate(
         &project_root,
+        &gate_prompt_text,
         session_id,
+        config.as_ref(),
         &mut result,
         loop_outcome.changed_paths.as_deref(),
         loop_outcome.commit_created,
         require_commit,
-        config.as_ref(),
-    );
+        PostExecGateApplyOptions {
+            changed_paths: loop_outcome.changed_paths.as_deref(),
+            extra_env: post_exec_gate_env,
+            no_post_exec_gate,
+            planning_only: skill.as_deref() == Some("mktd"),
+        },
+    )
+    .await?;
     if ephemeral && executed_session_id.is_none() {
         run_output::enrich_ephemeral_signal_diagnostics(&mut result);
-    }
-
-    if post_exec_gate_eligible {
-        let post_exec_gate_env = crate::build_jobs_env::build_jobs_env(build_jobs);
-        apply_post_exec_gate_after_success_with_runner(
-            &project_root,
-            &gate_prompt_text,
-            session_id,
-            config.as_ref(),
-            PostExecGateApplyOptions {
-                changed_paths: loop_outcome.changed_paths.as_deref(),
-                extra_env: post_exec_gate_env,
-                no_post_exec_gate,
-                planning_only: skill.as_deref() == Some("mktd"),
-            },
-            execute_post_exec_gate_command,
-        )
-        .await?;
     }
 
     if fork_call {

--- a/crates/cli-sub-agent/src/run_cmd_execute_handle.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_handle.rs
@@ -545,6 +545,12 @@ pub(crate) async fn handle_run(
     let executed_session_id = loop_outcome.executed_session_id;
     let session_id = executed_session_id.as_deref();
     let fork_resolution = loop_outcome.fork_resolution;
+    // Preserve whether the writer itself completed successfully before enforcing
+    // the commit contract. `record_run_dirty` intentionally turns a missing
+    // commit into a fatal result, but that must not suppress the configured
+    // post-exec gate: its structured failure report is the actionable evidence
+    // a require-commit caller needs to diagnose dirty work that did not commit.
+    let post_exec_gate_eligible = result.exit_code == 0;
     let warning = crate::run_cmd::uncommitted::record_run_dirty(
         &project_root,
         session_id,
@@ -558,7 +564,7 @@ pub(crate) async fn handle_run(
         run_output::enrich_ephemeral_signal_diagnostics(&mut result);
     }
 
-    if result.exit_code == 0 {
+    if post_exec_gate_eligible {
         let post_exec_gate_env = crate::build_jobs_env::build_jobs_env(build_jobs);
         apply_post_exec_gate_after_success_with_runner(
             &project_root,

--- a/crates/cli-sub-agent/src/run_cmd_execute_handle_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_handle_tests.rs
@@ -1,0 +1,156 @@
+use super::PostExecGateApplyOptions;
+use super::handle::record_run_dirty_then_apply_post_exec_gate;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_config::{PostExecGateConfig, ProjectConfig, ProjectMeta, ResourcesConfig, RunConfig};
+use csa_session::{SessionResult, create_session_fresh, load_result, save_result};
+use std::collections::HashMap;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn project_config_with_gate(gate: PostExecGateConfig) -> ProjectConfig {
+    ProjectConfig {
+        schema_version: csa_config::config::CURRENT_SCHEMA_VERSION,
+        project: ProjectMeta {
+            name: "test".to_string(),
+            created_at: chrono::Utc::now(),
+            max_recursion_depth: 5,
+        },
+        resources: ResourcesConfig::default(),
+        acp: Default::default(),
+        github: None,
+        session: Default::default(),
+        memory: Default::default(),
+        tools: HashMap::new(),
+        review: None,
+        debate: None,
+        tiers: HashMap::new(),
+        tier_mapping: HashMap::new(),
+        aliases: HashMap::new(),
+        tool_aliases: HashMap::new(),
+        preferences: None,
+        hooks: Default::default(),
+        run: RunConfig {
+            allow_base_branch_working: false,
+            writer_must_commit: false,
+            large_diff_warning: Default::default(),
+            post_exec_gate: gate,
+        },
+        execution: Default::default(),
+        session_wait: None,
+        preflight: Default::default(),
+        vcs: Default::default(),
+        tool_state_dirs: HashMap::new(),
+        filesystem_sandbox: Default::default(),
+    }
+}
+
+fn init_clean_git_repo(project_root: &Path) {
+    let run = |args: &[&str]| {
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(args)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git command failed: {args:?}");
+    };
+    run(&["init", "--initial-branch", "main"]);
+    run(&["config", "user.name", "CSA Test"]);
+    run(&["config", "user.email", "csa-test@example.com"]);
+    std::fs::write(project_root.join("tracked.txt"), "initial\n").expect("write tracked file");
+    run(&["add", "tracked.txt"]);
+    run(&["commit", "-m", "initial"]);
+}
+
+fn write_success_result_for(project_root: &Path, session_id: &str) {
+    let now = chrono::Utc::now();
+    save_result(
+        project_root,
+        session_id,
+        &SessionResult {
+            post_exec_gate: None,
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: "writer completed".to_string(),
+            tool: "codex".to_string(),
+            original_tool: None,
+            fallback_tool: None,
+            fallback_reason: None,
+            started_at: now,
+            completed_at: now,
+            events_count: 0,
+            artifacts: Vec::new(),
+            ..Default::default()
+        },
+    )
+    .expect("write success result");
+}
+
+#[tokio::test]
+async fn handle_run_sequencing_runs_failing_gate_after_require_commit_fatal() {
+    let project_dir = tempdir().expect("temp project");
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    init_clean_git_repo(project_dir.path());
+    let session_id = create_session_fresh(
+        project_dir.path(),
+        Some("handle-run gate eligibility"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session")
+    .meta_session_id;
+    write_success_result_for(project_dir.path(), &session_id);
+    std::fs::write(project_dir.path().join("tracked.txt"), "dirty\n").expect("dirty tracked file");
+
+    let mut gate = PostExecGateConfig::default();
+    gate.command = "printf 'simulated gate failure\\n' >&2; exit 37".to_string();
+    let config = project_config_with_gate(gate);
+    let changed_paths = vec!["tracked.txt".to_string()];
+    let mut execution = csa_process::ExecutionResult {
+        summary: "writer completed".to_string(),
+        exit_code: 0,
+        model_completed: Some(true),
+        terminal_reason: Some("end_turn".to_string()),
+        ..Default::default()
+    };
+
+    let err = record_run_dirty_then_apply_post_exec_gate(
+        project_dir.path(),
+        "modify tracked.txt",
+        Some(&session_id),
+        Some(&config),
+        &mut execution,
+        Some(&changed_paths),
+        Some(false),
+        true,
+        PostExecGateApplyOptions {
+            changed_paths: Some(&changed_paths),
+            extra_env: None,
+            no_post_exec_gate: false,
+            planning_only: false,
+        },
+    )
+    .await
+    .expect_err("failing gate must remain fatal after require-commit failure");
+
+    assert!(err.to_string().contains("post-exec gate failed"));
+    assert_eq!(
+        execution.exit_code, 1,
+        "require-commit made the writer result fatal"
+    );
+    let persisted = load_result(project_dir.path(), &session_id)
+        .expect("load result")
+        .expect("persisted result");
+    assert_eq!(persisted.status, "failure");
+    assert!(persisted.summary.starts_with("POST-EXEC GATE FAILED"));
+    let report = persisted
+        .post_exec_gate
+        .as_ref()
+        .expect("[post_exec_gate] evidence must be persisted");
+    assert_eq!(report.exit_code, 37);
+    assert!(report.output_tail.contains("simulated gate failure"));
+    assert!(
+        persisted.require_commit_recovery.is_some(),
+        "gate evidence must retain require-commit recovery"
+    );
+}

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_tests.rs
@@ -532,13 +532,39 @@ async fn post_exec_gate_nonzero_committed_clean_is_fatal() {
 }
 
 #[tokio::test]
-async fn post_exec_gate_nonzero_dirty_is_fatal() {
+async fn require_commit_gate_failure_preserves_structured_evidence() {
     let project_dir = tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
     init_clean_git_repo(project_dir.path());
     let session_id = create_session_at_current_head(project_dir.path());
     std::fs::write(project_dir.path().join("tracked.txt"), "dirty\n").unwrap();
     write_success_result_for(project_dir.path(), &session_id);
+    // `--require-commit` marks the caller-facing execution result fatal before
+    // the post-exec gate runs. The gate must still execute from the writer's
+    // original success and replace the generic contract result with structured
+    // gate evidence (#2830).
+    let changed_paths = vec!["tracked.txt".to_string()];
+    let mut execution = csa_process::ExecutionResult {
+        summary: "writer completed".to_string(),
+        exit_code: 0,
+        model_completed: Some(true),
+        terminal_reason: Some("end_turn".to_string()),
+        ..Default::default()
+    };
+    crate::run_cmd::uncommitted::record_run_dirty(
+        project_dir.path(),
+        Some(&session_id),
+        &mut execution,
+        Some(&changed_paths),
+        Some(false),
+        true,
+        None,
+    );
+    assert_eq!(execution.exit_code, 1);
+    assert_eq!(
+        persisted_result(project_dir.path(), &session_id).summary,
+        "require-commit contract failed: no qualifying commit or tracked dirty work remains"
+    );
     // No employee sections seeded: exercises the branch that CREATES summary.md
     // with the banner when the employee emitted none.
 
@@ -563,6 +589,10 @@ async fn post_exec_gate_nonzero_dirty_is_fatal() {
 
     let result = persisted_result(project_dir.path(), &session_id);
     assert_gate_failure_surfaced(project_dir.path(), &session_id, &result);
+    assert!(
+        result.require_commit_recovery.is_some(),
+        "post-exec evidence must not discard require-commit recovery context"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- preserve pre-require-commit post-exec gate eligibility so a failing gate still executes and writes structured evidence
- add a handle_run-level sequencing regression for require-commit fatal recovery and a failing gate

## Verification
- Lefthook pre-push quality gates passed (authorized isolation skip; not claimed as literal full-isolation PASS)
- isolated, read-only Codex review of origin/main...e796dae8 passed

Closes #2830