### PR TITLE
fix(#2898): clarify session wait --model-provider is caller KV TTL provider

### DIFF
--- a/crates/cli-sub-agent/src/cli_session.rs
+++ b/crates/cli-sub-agent/src/cli_session.rs
@@ -293,6 +293,8 @@ pub enum SessionCommands {
     },
 
     /// Wait for a daemon session to report a terminal result.
+    /// `--model-provider` selects the calling parent agent's provider for KV-cache
+    /// wait TTL, not the review tool's provider.
     /// Every wait requires an explicit normalized `--model-provider` whose configured
     /// `[kv_cache.provider_ttls]` entry is > 0. Its TTL is resolved exactly from that
     /// entry; missing, unconfigured, or zero values fail closed.
@@ -319,7 +321,8 @@ pub enum SessionCommands {
         #[arg(long)]
         memory_warn_mb: Option<u64>,
 
-        /// Caller provider for wait TTL selection. Derive this dynamically on every wait.
+        /// Calling parent agent provider for KV-cache wait TTL, not the review tool provider.
+        /// Derive this dynamically on every wait.
         /// Accepted values: any configured [kv_cache.provider_ttls] key with TTL > 0.
         #[arg(long, value_parser = csa_config::parse_model_provider)]
         model_provider: Option<csa_config::ModelProvider>,

--- a/crates/cli-sub-agent/src/daemon_caller_hints.rs
+++ b/crates/cli-sub-agent/src/daemon_caller_hints.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use csa_config::{GlobalConfig, ModelProvider, provider_ttl};
+use csa_config::{GlobalConfig, ModelProvider};
 
 const MAX_CALLER_HINT_BODY_BYTES: usize = 300;
 const SESSION_WAIT_CALLER_HINT_FORBID: &str =
@@ -31,23 +31,30 @@ impl SessionWaitCommand {
             self.legal_provider_keys.join(",")
         };
         let legal_keys = escape_structured_comment_attr(&legal_keys);
-        format!(
+        let marker = format!(
             "<!-- CSA:CALLER_HINT action=\"select_wait_provider\" legal_keys=\"{legal_keys}\" \
-             rule=\"Do not issue a bare session wait. Derive the caller provider and pass --model-provider with one legal configured key.\" -->"
-        )
+             rule=\"Do not issue a bare session wait. Choose the calling parent provider for KV-cache wait TTL, not the review tool, then pass --model-provider with one legal configured key.\" -->"
+        );
+        if marker.len() <= MAX_CALLER_HINT_BODY_BYTES {
+            return marker;
+        }
+
+        "<!-- CSA:CALLER_HINT action=\"select_wait_provider\" legal_keys=\"truncated\" \
+         rule=\"Choose the calling parent provider for KV-cache wait TTL, not the review tool; inspect [kv_cache.provider_ttls].\" -->"
+            .to_string()
     }
 }
 
 /// Resolve a provider-qualified `csa session wait` command for caller hints.
 ///
-/// A command is emitted only for the explicit launch or wait provider when it
-/// has a positive TTL in the active user configuration. Otherwise the caller
-/// must choose from the legal keys carried by
-/// [`SessionWaitCommand::provider_selection_hint`].
+/// Launch routing identifies the child/reviewer model, not the parent that
+/// owns the KV cache. Until a trusted caller-provider field is available, this
+/// deliberately emits no runnable command and directs the caller to choose
+/// from [`SessionWaitCommand::provider_selection_hint`].
 pub(crate) fn resolve_session_wait_command(
-    session_id: &str,
-    project_root: &Path,
-    preferred_provider: Option<&ModelProvider>,
+    _session_id: &str,
+    _project_root: &Path,
+    _launch_provider: Option<&ModelProvider>,
 ) -> SessionWaitCommand {
     let config = GlobalConfig::load().ok();
     let legal_provider_keys = config
@@ -63,20 +70,9 @@ pub(crate) fn resolve_session_wait_command(
                 .collect()
         })
         .unwrap_or_default();
-    let provider = preferred_provider
-        .filter(|provider| {
-            config
-                .as_ref()
-                .and_then(|config| provider_ttl(provider, &config.kv_cache))
-                .is_some()
-        })
-        .map(|provider| provider.as_str().to_string());
-
     SessionWaitCommand {
-        command: provider
-            .as_deref()
-            .map(|provider| format_session_wait_command(session_id, project_root, provider)),
-        provider,
+        command: None,
+        provider: None,
         legal_provider_keys,
     }
 }
@@ -129,6 +125,7 @@ pub(crate) fn explicit_wait_provider_from_launch_routing(
 }
 
 /// Format every emitted shell wait command in one provider-aware form.
+#[cfg(test)]
 pub(crate) fn format_session_wait_command(
     session_id: &str,
     project_root: &Path,
@@ -174,7 +171,7 @@ fn shell_escape_for_command(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_session_wait_command;
+    use super::{MAX_CALLER_HINT_BODY_BYTES, resolve_session_wait_command};
     use crate::test_env_lock::TEST_ENV_LOCK;
     use std::path::Path;
 
@@ -238,7 +235,7 @@ mod tests {
     }
 
     #[test]
-    fn retry_command_reloads_provider_ttl_config_and_preserves_explicit_provider() {
+    fn launch_provider_never_makes_a_parent_wait_command_runnable() {
         let _env_lock = TEST_ENV_LOCK.blocking_lock();
         let dir = tempfile::tempdir().expect("tempdir");
         let config_root = dir.path().join("xdg-config");
@@ -259,18 +256,15 @@ mod tests {
             Path::new("/tmp/repo"),
             Some(&provider),
         );
-        assert_eq!(
-            command.command(),
-            Some(
-                "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --model-provider xai --cd '/tmp/repo'"
-            )
+        assert!(
+            command.command().is_none(),
+            "a child launch provider must not be reused as the caller's wait provider"
         );
         assert!(
             command
-                .caller_hint("retry_wait")
-                .expect("validated provider must be retained for the caller hint")
-                .contains("provider=\"xai\""),
-            "caller hint must retain the validated normalized provider"
+                .provider_selection_hint()
+                .contains("legal_keys=\"xai\""),
+            "the caller must select its own provider from configured keys"
         );
 
         std::fs::write(&config_path, "[kv_cache.provider_ttls]\nxai = 0\n")
@@ -289,6 +283,36 @@ mod tests {
                 .provider_selection_hint()
                 .contains("legal_keys=\"none\""),
             "an invalidated explicit provider must fail closed"
+        );
+    }
+
+    #[test]
+    fn provider_selection_hint_stays_within_budget_for_long_legal_keys() {
+        let _env_lock = TEST_ENV_LOCK.blocking_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_root = dir.path().join("xdg-config");
+        std::fs::create_dir_all(&config_root).expect("create config root");
+        let _home_guard = EnvVarGuard::set("HOME", dir.path());
+        let _xdg_guard = EnvVarGuard::set("XDG_CONFIG_HOME", &config_root);
+        let provider = "x".repeat(80);
+        let config_path =
+            csa_config::ProjectConfig::user_config_path().expect("resolve user config path");
+        std::fs::create_dir_all(config_path.parent().expect("config parent"))
+            .expect("create config parent");
+        std::fs::write(
+            config_path,
+            format!("[kv_cache.provider_ttls]\n\"{provider}\" = 17\n"),
+        )
+        .expect("write provider config");
+
+        let command = resolve_session_wait_command("session", Path::new("/tmp/repo"), None);
+        let hint = command.provider_selection_hint();
+
+        assert!(hint.len() <= MAX_CALLER_HINT_BODY_BYTES, "{hint}");
+        assert!(hint.contains("legal_keys=\"truncated\""), "{hint}");
+        assert!(
+            hint.contains("calling parent provider for KV-cache wait TTL, not the review tool"),
+            "{hint}"
         );
     }
 }

--- a/crates/cli-sub-agent/src/daemon_caller_hints.rs
+++ b/crates/cli-sub-agent/src/daemon_caller_hints.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use csa_config::{GlobalConfig, ModelProvider};
+use csa_config::{GlobalConfig, ModelProvider, provider_ttl};
 
 const MAX_CALLER_HINT_BODY_BYTES: usize = 300;
 const SESSION_WAIT_CALLER_HINT_FORBID: &str =
@@ -45,20 +45,46 @@ impl SessionWaitCommand {
     }
 }
 
-/// Resolve a provider-qualified `csa session wait` command for caller hints.
+/// Resolve an initial `csa session wait` command for caller hints.
 ///
 /// Launch routing identifies the child/reviewer model, not the parent that
-/// owns the KV cache. Until a trusted caller-provider field is available, this
-/// deliberately emits no runnable command and directs the caller to choose
-/// from [`SessionWaitCommand::provider_selection_hint`].
+/// owns the KV cache. An initial hint therefore deliberately emits no runnable
+/// command and directs the caller to choose from
+/// [`SessionWaitCommand::provider_selection_hint`].
 pub(crate) fn resolve_session_wait_command(
     _session_id: &str,
     _project_root: &Path,
-    _launch_provider: Option<&ModelProvider>,
 ) -> SessionWaitCommand {
     let config = GlobalConfig::load().ok();
-    let legal_provider_keys = config
+    SessionWaitCommand {
+        command: None,
+        provider: None,
+        legal_provider_keys: configured_wait_provider_keys(config.as_ref()),
+    }
+}
+
+/// Resolve a provider-qualified retry from the caller provider already
+/// validated by `csa session wait`.
+pub(crate) fn resolve_session_wait_retry_command(
+    session_id: &str,
+    project_root: &Path,
+    caller_provider: &ModelProvider,
+) -> SessionWaitCommand {
+    let config = GlobalConfig::load().ok();
+    let valid_provider = config
         .as_ref()
+        .is_some_and(|config| provider_ttl(caller_provider, &config.kv_cache).is_some());
+    let provider = caller_provider.as_str().to_string();
+    SessionWaitCommand {
+        command: valid_provider
+            .then(|| format_session_wait_command(session_id, project_root, &provider)),
+        provider: valid_provider.then_some(provider),
+        legal_provider_keys: configured_wait_provider_keys(config.as_ref()),
+    }
+}
+
+fn configured_wait_provider_keys(config: Option<&GlobalConfig>) -> Vec<String> {
+    config
         .map(|config| {
             config
                 .kv_cache
@@ -69,12 +95,7 @@ pub(crate) fn resolve_session_wait_command(
                 .map(|(provider, _)| provider.clone())
                 .collect()
         })
-        .unwrap_or_default();
-    SessionWaitCommand {
-        command: None,
-        provider: None,
-        legal_provider_keys,
-    }
+        .unwrap_or_default()
 }
 
 /// Render the compact structured contract required to wait for a CSA session.
@@ -125,7 +146,6 @@ pub(crate) fn explicit_wait_provider_from_launch_routing(
 }
 
 /// Format every emitted shell wait command in one provider-aware form.
-#[cfg(test)]
 pub(crate) fn format_session_wait_command(
     session_id: &str,
     project_root: &Path,
@@ -171,7 +191,10 @@ fn shell_escape_for_command(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{MAX_CALLER_HINT_BODY_BYTES, resolve_session_wait_command};
+    use super::{
+        MAX_CALLER_HINT_BODY_BYTES, resolve_session_wait_command,
+        resolve_session_wait_retry_command,
+    };
     use crate::test_env_lock::TEST_ENV_LOCK;
     use std::path::Path;
 
@@ -217,11 +240,8 @@ mod tests {
         std::fs::write(config_path, "[kv_cache.provider_ttls]\nopenai = 17\n")
             .expect("write provider config");
 
-        let command = resolve_session_wait_command(
-            "01KAS6M5XG7V4M4M6YDRS7P8R9",
-            Path::new("/tmp/repo"),
-            None,
-        );
+        let command =
+            resolve_session_wait_command("01KAS6M5XG7V4M4M6YDRS7P8R9", Path::new("/tmp/repo"));
         assert!(
             command.command().is_none(),
             "an initial or retry hint must not infer its provider from HERMES_MODEL_PROVIDER"
@@ -251,11 +271,8 @@ mod tests {
             .expect("write provider config");
 
         let provider = csa_config::ModelProvider::new(" XAI ");
-        let command = resolve_session_wait_command(
-            "01KAS6M5XG7V4M4M6YDRS7P8R9",
-            Path::new("/tmp/repo"),
-            Some(&provider),
-        );
+        let command =
+            resolve_session_wait_command("01KAS6M5XG7V4M4M6YDRS7P8R9", Path::new("/tmp/repo"));
         assert!(
             command.command().is_none(),
             "a child launch provider must not be reused as the caller's wait provider"
@@ -267,12 +284,24 @@ mod tests {
             "the caller must select its own provider from configured keys"
         );
 
-        std::fs::write(&config_path, "[kv_cache.provider_ttls]\nxai = 0\n")
-            .expect("invalidate provider config");
-        let reloaded = resolve_session_wait_command(
+        let retry = resolve_session_wait_retry_command(
             "01KAS6M5XG7V4M4M6YDRS7P8R9",
             Path::new("/tmp/repo"),
-            Some(&provider),
+            &provider,
+        );
+        assert!(
+            retry
+                .command()
+                .is_some_and(|command| command.contains("--model-provider xai")),
+            "a validated caller provider must be retained for retry"
+        );
+
+        std::fs::write(&config_path, "[kv_cache.provider_ttls]\nxai = 0\n")
+            .expect("invalidate provider config");
+        let reloaded = resolve_session_wait_retry_command(
+            "01KAS6M5XG7V4M4M6YDRS7P8R9",
+            Path::new("/tmp/repo"),
+            &provider,
         );
         assert!(
             reloaded.command().is_none(),
@@ -305,7 +334,7 @@ mod tests {
         )
         .expect("write provider config");
 
-        let command = resolve_session_wait_command("session", Path::new("/tmp/repo"), None);
+        let command = resolve_session_wait_command("session", Path::new("/tmp/repo"));
         let hint = command.provider_selection_hint();
 
         assert!(hint.len() <= MAX_CALLER_HINT_BODY_BYTES, "{hint}");

--- a/crates/cli-sub-agent/src/daemon_started_output.rs
+++ b/crates/cli-sub-agent/src/daemon_started_output.rs
@@ -15,12 +15,8 @@ pub(crate) fn prepare(
     _wait_provider: Option<&csa_config::ModelProvider>,
 ) -> Result<DaemonStartedOutput> {
     crate::run_cmd_daemon::verify_daemon_session_waitable(project_root, &result.session_id)?;
-    let wait_command = crate::daemon_caller_hints::resolve_session_wait_command(
-        &result.session_id,
-        project_root,
-        // Launch routing selects the child/reviewer, not the caller KV-cache provider.
-        None,
-    );
+    let wait_command =
+        crate::daemon_caller_hints::resolve_session_wait_command(&result.session_id, project_root);
     let wait_cmd_attr = wait_command
         .command()
         .map(crate::daemon_caller_hints::escape_structured_comment_attr)

--- a/crates/cli-sub-agent/src/daemon_started_output.rs
+++ b/crates/cli-sub-agent/src/daemon_started_output.rs
@@ -12,13 +12,14 @@ pub(crate) struct DaemonStartedOutput {
 pub(crate) fn prepare(
     result: &csa_process::daemon::DaemonSpawnResult,
     project_root: &Path,
-    wait_provider: Option<&csa_config::ModelProvider>,
+    _wait_provider: Option<&csa_config::ModelProvider>,
 ) -> Result<DaemonStartedOutput> {
     crate::run_cmd_daemon::verify_daemon_session_waitable(project_root, &result.session_id)?;
     let wait_command = crate::daemon_caller_hints::resolve_session_wait_command(
         &result.session_id,
         project_root,
-        wait_provider,
+        // Launch routing selects the child/reviewer, not the caller KV-cache provider.
+        None,
     );
     let wait_cmd_attr = wait_command
         .command()
@@ -172,7 +173,7 @@ mod tests {
     }
 
     #[test]
-    fn root_initial_wait_hint_propagates_normalized_explicit_provider() {
+    fn root_initial_wait_hint_requires_the_parent_to_select_its_provider() {
         let _lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
         let temp = tempfile::tempdir().expect("tempdir");
         let project_root = temp.path().join("project");
@@ -208,18 +209,15 @@ mod tests {
         let output =
             prepare(&result, &project_root, Some(&provider)).expect("render root started marker");
 
-        let expected_wait_command = format!(
-            "wait_cmd=\"csa session wait --session {session_id} --model-provider xai --cd '{}'\"",
-            project_root.display(),
-        );
         assert!(
-            output.stderr.contains(&expected_wait_command),
-            "root initial wait hint must preserve its normalized launch provider: {:#?}",
+            output.stderr.contains("wait_cmd=\"\""),
+            "root initial wait hint must not reuse the launched provider: {:#?}",
             output.stderr
         );
         assert!(
-            !output.stderr.contains("--model-provider custom"),
-            "root initial wait hint must not use the ambient provider: {:#?}",
+            output.stderr.contains("action=\"select_wait_provider\"")
+                && output.stderr.contains("legal_keys=\"xai\""),
+            "root initial wait hint must make the parent select its provider: {:#?}",
             output.stderr
         );
         let _ = std::fs::remove_dir_all(session_root);
@@ -321,6 +319,13 @@ mod tests {
         );
         assert!(
             output.stderr.contains("legal_keys=\"custom\""),
+            "{:#?}",
+            output.stderr
+        );
+        assert!(
+            output.stderr.contains(
+                "Choose the calling parent provider for KV-cache wait TTL, not the review tool"
+            ),
             "{:#?}",
             output.stderr
         );

--- a/crates/cli-sub-agent/src/run_cmd_daemon_wait_hint_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_wait_hint_tests.rs
@@ -1,5 +1,5 @@
 #[test]
-fn subagent_initial_wait_hint_preserves_trusted_normalized_provider() {
+fn subagent_initial_wait_hint_requires_the_parent_to_select_its_provider() {
     let _lock = crate::test_env_lock::TEST_ENV_LOCK
         .clone()
         .blocking_lock_owned();
@@ -30,15 +30,14 @@ fn subagent_initial_wait_hint_preserves_trusted_normalized_provider() {
         spawn_options.wait_hint_provider.as_ref(),
     );
 
-    assert_eq!(
-        command.command(),
-        Some(
-            format!(
-                "csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --model-provider xai --cd '{}'",
-                project.path().display(),
-            )
-            .as_str()
-        ),
-        "subagent initial wait hint must preserve its trusted normalized launch provider"
+    assert!(
+        command.command().is_none(),
+        "the subagent launch provider is not the caller's KV-cache provider"
+    );
+    assert!(
+        command
+            .provider_selection_hint()
+            .contains("legal_keys=\"xai\""),
+        "the caller must select its own configured provider"
     );
 }

--- a/crates/cli-sub-agent/src/run_cmd_daemon_wait_hint_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon_wait_hint_tests.rs
@@ -21,13 +21,12 @@ fn subagent_initial_wait_hint_requires_the_parent_to_select_its_provider() {
     let provider =
         crate::daemon_caller_hints::explicit_wait_provider_from_launch_routing(None, &startup_env)
             .expect("trusted subagent model pin must carry a provider");
-    let spawn_options = DaemonSpawnOptions::for_run(None, None, None, None, false, &[], false)
+    let _spawn_options = DaemonSpawnOptions::for_run(None, None, None, None, false, &[], false)
         .with_wait_hint_provider(Some(provider));
 
     let command = crate::daemon_caller_hints::resolve_session_wait_command(
         "01KAS6M5XG7V4M4M6YDRS7P8R9",
         project.path(),
-        spawn_options.wait_hint_provider.as_ref(),
     );
 
     assert!(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_completion.rs
@@ -267,7 +267,7 @@ mod tests {
     use chrono::TimeZone;
 
     #[test]
-    fn wait_cap_and_retry_hint_preserve_exact_configured_xai_ttl() {
+    fn wait_cap_preserves_exact_configured_xai_ttl_without_reusing_reviewer_provider() {
         let _lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
         let temp = tempfile::tempdir().expect("tempdir");
         let config_home = temp.path().join("xdg-config");
@@ -281,13 +281,13 @@ mod tests {
         std::fs::write(config_path, "[kv_cache.provider_ttls]\nxai = 3300\n")
             .expect("write config");
 
-        let provider = csa_config::ModelProvider::new(" XAI ");
+        let reviewer_provider = csa_config::ModelProvider::new(" XAI ");
         let outcome = render_wait_cap_outcome(
             "01KAS6M5XG7V4M4M6YDRS7P8R9",
             None,
             WaitCapContext {
                 project_root: temp.path(),
-                preferred_provider: Some(&provider),
+                preferred_provider: Some(&reviewer_provider),
             },
             3300,
             3300,
@@ -302,17 +302,25 @@ mod tests {
             outcome.text
         );
         assert!(
-            outcome.text.contains(
-                "cmd=\"csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --model-provider xai"
-            ),
+            outcome.text.contains("action=select_wait_provider"),
+            "{}",
+            outcome.text
+        );
+        assert!(
+            outcome.text.contains("legal_keys=\"xai\""),
             "{}",
             outcome.text
         );
         assert!(
             outcome
                 .text
-                .contains("CSA:CALLER_HINT action=\"retry_wait\""),
+                .contains("calling parent provider for KV-cache wait TTL, not the review tool"),
             "{}",
+            outcome.text
+        );
+        assert!(
+            !outcome.text.contains("--model-provider xai"),
+            "a reviewer provider must not produce a runnable caller wait command: {}",
             outcome.text
         );
         assert!(!outcome.text.contains("240"), "{}", outcome.text);

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_completion.rs
@@ -145,10 +145,20 @@ fn render_wait_cap_outcome(
         .map(|path| crate::daemon_caller_hints::format_cd_arg(Path::new(path)))
         .unwrap_or_default();
     if session_alive {
-        let wait_command = crate::daemon_caller_hints::resolve_session_wait_command(
-            session_id,
-            context.project_root,
-            context.preferred_provider,
+        let wait_command = context.preferred_provider.map_or_else(
+            || {
+                crate::daemon_caller_hints::resolve_session_wait_command(
+                    session_id,
+                    context.project_root,
+                )
+            },
+            |caller_provider| {
+                crate::daemon_caller_hints::resolve_session_wait_retry_command(
+                    session_id,
+                    context.project_root,
+                    caller_provider,
+                )
+            },
         );
         let _ = writeln!(
             text,
@@ -267,7 +277,7 @@ mod tests {
     use chrono::TimeZone;
 
     #[test]
-    fn wait_cap_preserves_exact_configured_xai_ttl_without_reusing_reviewer_provider() {
+    fn wait_cap_and_retry_hint_preserve_exact_configured_xai_ttl() {
         let _lock = TEST_ENV_LOCK.clone().blocking_lock_owned();
         let temp = tempfile::tempdir().expect("tempdir");
         let config_home = temp.path().join("xdg-config");
@@ -281,13 +291,13 @@ mod tests {
         std::fs::write(config_path, "[kv_cache.provider_ttls]\nxai = 3300\n")
             .expect("write config");
 
-        let reviewer_provider = csa_config::ModelProvider::new(" XAI ");
+        let caller_provider = csa_config::ModelProvider::new(" XAI ");
         let outcome = render_wait_cap_outcome(
             "01KAS6M5XG7V4M4M6YDRS7P8R9",
             None,
             WaitCapContext {
                 project_root: temp.path(),
-                preferred_provider: Some(&reviewer_provider),
+                preferred_provider: Some(&caller_provider),
             },
             3300,
             3300,
@@ -302,25 +312,17 @@ mod tests {
             outcome.text
         );
         assert!(
-            outcome.text.contains("action=select_wait_provider"),
-            "{}",
-            outcome.text
-        );
-        assert!(
-            outcome.text.contains("legal_keys=\"xai\""),
+            outcome.text.contains(
+                "cmd=\"csa session wait --session 01KAS6M5XG7V4M4M6YDRS7P8R9 --model-provider xai"
+            ),
             "{}",
             outcome.text
         );
         assert!(
             outcome
                 .text
-                .contains("calling parent provider for KV-cache wait TTL, not the review tool"),
+                .contains("CSA:CALLER_HINT action=\"retry_wait\" provider=\"xai\""),
             "{}",
-            outcome.text
-        );
-        assert!(
-            !outcome.text.contains("--model-provider xai"),
-            "a reviewer provider must not produce a runnable caller wait command: {}",
             outcome.text
         );
         assert!(!outcome.text.contains("240"), "{}", outcome.text);

--- a/crates/cli-sub-agent/src/session_dispatch.rs
+++ b/crates/cli-sub-agent/src/session_dispatch.rs
@@ -315,7 +315,7 @@ fn wait_provider_error(
         let _ = writeln!(message, "Config load error: {error:#}");
     }
     message.push_str(
-        "Action: re-run with --model-provider <one configured key> matching the caller model provider.\n\
+        "Action: re-run with --model-provider <one configured key> matching the calling parent agent's KV-cache TTL policy, not the review tool.\n\
          Do not omit this flag; provider can change mid-session when the user switches models.\n\
          <!-- CSA:CALLER_HINT action=\"select_wait_provider\" rule=\"Derive the caller model provider dynamically on every wait; pass --model-provider with a configured provider_ttls key.\" -->",
     );
@@ -432,6 +432,9 @@ custom = 1666
         );
         assert!(message.contains("CSA:CALLER_HINT"));
         assert!(message.contains("dynamically on every wait"));
+        assert!(
+            message.contains("calling parent agent's KV-cache TTL policy, not the review tool")
+        );
         assert!(!message.contains("default_ttl_seconds = 555"));
     }
 

--- a/crates/cli-sub-agent/src/session_tier_failover.rs
+++ b/crates/cli-sub-agent/src/session_tier_failover.rs
@@ -49,7 +49,7 @@ pub(crate) fn emit_pending_tier_failover_handoff(
 
 fn render_pending_tier_failover_handoff(session_id: &str, project_root: &Path) -> String {
     let wait_command =
-        crate::daemon_caller_hints::resolve_session_wait_command(session_id, project_root, None);
+        crate::daemon_caller_hints::resolve_session_wait_command(session_id, project_root);
     debug_assert!(
         wait_command.command().is_none(),
         "tier fallback has no trusted provider and must not emit a runnable wait command"

--- a/crates/cli-sub-agent/tests/session_wait_provider_ttl.rs
+++ b/crates/cli-sub-agent/tests/session_wait_provider_ttl.rs
@@ -245,6 +245,12 @@ fn session_wait_help_requires_an_explicit_configured_provider_ttl() {
         "{stdout}"
     );
     assert!(
+        stdout.contains(
+            "calling parent agent's provider for KV-cache wait TTL, not the review tool's provider"
+        ),
+        "{stdout}"
+    );
+    assert!(
         stdout.contains("configured `[kv_cache.provider_ttls]` entry is > 0"),
         "{stdout}"
     );


### PR DESCRIPTION
Clarify that `csa session wait --model-provider` selects the calling parent agent provider for KV-cache wait TTL, preserve the validated provider across retry, and cover the 300-byte caller-hint budget.

Closes #2898