### PR TITLE
fix(#2900): ignore reclaimable cgroup page cache at soft limit

### DIFF
--- a/crates/csa-resource/src/lib.rs
+++ b/crates/csa-resource/src/lib.rs
@@ -12,6 +12,7 @@ pub mod landlock;
 pub mod landlock;
 pub mod memory_balloon;
 pub mod memory_monitor;
+mod memory_monitor_cgroup;
 pub mod memory_policy;
 pub mod rlimit;
 pub mod sandbox;

--- a/crates/csa-resource/src/memory_monitor.rs
+++ b/crates/csa-resource/src/memory_monitor.rs
@@ -1,14 +1,17 @@
 //! Background memory monitor for cgroup scopes.
 //!
-//! Polls `MemoryCurrent` at a configurable interval and sends SIGTERM to the
-//! process group when usage exceeds `soft_limit_percent` of `MemoryMax`.
-//! After a grace period, escalates to SIGKILL.
+//! Polls cgroup memory usage at a configurable interval and sends SIGTERM to
+//! the process group when its non-reclaimable working set exceeds
+//! `soft_limit_percent` of `MemoryMax`. After a grace period, escalates to
+//! SIGKILL.
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, SystemTime};
+
+use crate::memory_monitor_cgroup::query_soft_limit_usage_bytes;
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
@@ -191,17 +194,19 @@ async fn monitor_loop(
             }
         };
 
-        if current < threshold_bytes {
+        let usage = query_soft_limit_usage_bytes(&config.scope_name, current).await;
+        if usage < threshold_bytes {
             continue;
         }
 
         // Soft limit exceeded — record concrete evidence before sending SIGTERM.
         let diagnostic =
-            MemorySoftLimitKillDiagnostic::from_config(&config, current, threshold_bytes);
+            MemorySoftLimitKillDiagnostic::from_config(&config, usage, threshold_bytes);
         let current_mb = diagnostic.current_mb;
         let threshold_mb = diagnostic.threshold_mb;
         warn!(
             scope = %config.scope_name,
+            cgroup_current_mb = bytes_to_mb(current),
             current_mb,
             threshold_mb,
             "memory soft limit exceeded, sending SIGTERM to process group"
@@ -220,16 +225,19 @@ async fn monitor_loop(
             }
         }
 
-        // Re-check: if still over threshold, escalate to SIGKILL.
-        if let Some(still_current) = query_memory_current(&config.scope_name).await
-            && still_current >= threshold_bytes
-        {
-            warn!(
-                scope = %config.scope_name,
-                current_mb = still_current / 1024 / 1024,
-                "still over soft limit after grace period, sending SIGKILL"
-            );
-            send_signal(config.pgid, libc::SIGKILL);
+        // Re-check: if the non-reclaimable working set remains over threshold,
+        // escalate to SIGKILL.
+        if let Some(still_current) = query_memory_current(&config.scope_name).await {
+            let still_usage = query_soft_limit_usage_bytes(&config.scope_name, still_current).await;
+            if still_usage >= threshold_bytes {
+                warn!(
+                    scope = %config.scope_name,
+                    cgroup_current_mb = bytes_to_mb(still_current),
+                    current_mb = bytes_to_mb(still_usage),
+                    "still over soft limit after grace period, sending SIGKILL"
+                );
+                send_signal(config.pgid, libc::SIGKILL);
+            }
         }
         return;
     }
@@ -392,273 +400,5 @@ fn bytes_to_mb(bytes: u64) -> u64 {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn test_soft_limit_diagnostic() -> MemorySoftLimitKillDiagnostic {
-        MemorySoftLimitKillDiagnostic {
-            kill_hint: MEMORY_SOFT_LIMIT_KILL_HINT.to_string(),
-            signal: libc::SIGTERM,
-            current_mb: 900,
-            threshold_mb: 700,
-            memory_max_mb: 1000,
-            soft_limit_percent: 70,
-            scope_name: "csa-codex-01J.scope".to_string(),
-        }
-    }
-
-    #[test]
-    fn test_start_returns_none_for_zero_max() {
-        let config = MemoryMonitorConfig {
-            scope_name: "test.scope".to_string(),
-            pgid: 1234,
-            memory_max_bytes: 0,
-            soft_limit_percent: 80,
-            interval: Duration::from_secs(5),
-            grace_period: Duration::from_secs(5),
-            diagnostic_path: None,
-        };
-        assert!(start(config).is_none());
-    }
-
-    #[test]
-    fn test_start_returns_none_for_zero_percent() {
-        let config = MemoryMonitorConfig {
-            scope_name: "test.scope".to_string(),
-            pgid: 1234,
-            memory_max_bytes: 1024 * 1024 * 1024,
-            soft_limit_percent: 0,
-            interval: Duration::from_secs(5),
-            grace_period: Duration::from_secs(5),
-            diagnostic_path: None,
-        };
-        assert!(start(config).is_none());
-    }
-
-    #[test]
-    fn test_start_returns_none_for_over_100_percent() {
-        let config = MemoryMonitorConfig {
-            scope_name: "test.scope".to_string(),
-            pgid: 1234,
-            memory_max_bytes: 1024 * 1024 * 1024,
-            soft_limit_percent: 101,
-            interval: Duration::from_secs(5),
-            grace_period: Duration::from_secs(5),
-            diagnostic_path: None,
-        };
-        assert!(start(config).is_none());
-    }
-
-    #[test]
-    fn soft_limit_diagnostic_from_config_records_actionable_fields() {
-        let config = MemoryMonitorConfig {
-            scope_name: "csa-codex-01J.scope".to_string(),
-            pgid: 1234,
-            memory_max_bytes: 10 * 1024 * 1024,
-            soft_limit_percent: 70,
-            interval: Duration::from_secs(5),
-            grace_period: Duration::from_secs(5),
-            diagnostic_path: None,
-        };
-
-        let diagnostic =
-            MemorySoftLimitKillDiagnostic::from_config(&config, 8 * 1024 * 1024, 7 * 1024 * 1024);
-
-        assert_eq!(diagnostic.kill_hint, MEMORY_SOFT_LIMIT_KILL_HINT);
-        assert_eq!(diagnostic.signal, libc::SIGTERM);
-        assert_eq!(diagnostic.current_mb, 8);
-        assert_eq!(diagnostic.threshold_mb, 7);
-        assert_eq!(diagnostic.memory_max_mb, 10);
-        assert_eq!(diagnostic.soft_limit_percent, 70);
-        assert_eq!(diagnostic.scope_name, "csa-codex-01J.scope");
-    }
-
-    #[test]
-    fn records_soft_limit_diagnostic_without_writing_artifact() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
-        let diagnostic = MemorySoftLimitKillDiagnostic {
-            kill_hint: MEMORY_SOFT_LIMIT_KILL_HINT.to_string(),
-            signal: libc::SIGTERM,
-            current_mb: 900,
-            threshold_mb: 700,
-            memory_max_mb: 1000,
-            soft_limit_percent: 70,
-            scope_name: "csa-codex-01J.scope".to_string(),
-        };
-
-        record_soft_limit_diagnostic(Some(&path), &diagnostic);
-
-        let loaded = read_soft_limit_diagnostic(&path).expect("diagnostic should parse");
-        assert_eq!(loaded, diagnostic);
-        assert!(
-            !path.exists(),
-            "memory soft-limit registry evidence must not create a disk artifact"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn records_soft_limit_diagnostic_without_following_existing_symlink() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
-        let symlink_target = temp.path().join("would-be-clobbered.txt");
-        let sentinel = "do not overwrite me";
-        std::fs::write(&symlink_target, sentinel).expect("write symlink target");
-        std::os::unix::fs::symlink(&symlink_target, &path).expect("create symlink");
-        let diagnostic = test_soft_limit_diagnostic();
-
-        record_soft_limit_diagnostic(Some(&path), &diagnostic);
-
-        assert_eq!(
-            read_soft_limit_diagnostic(&path),
-            Some(diagnostic),
-            "registry evidence should still be available for the current run"
-        );
-        assert_eq!(
-            std::fs::read_to_string(&symlink_target).expect("read symlink target"),
-            sentinel,
-            "memory soft-limit recording must not follow or clobber a symlink path"
-        );
-    }
-
-    #[test]
-    fn ignores_unregistered_soft_limit_diagnostic_artifact_file() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
-        let diagnostic = MemorySoftLimitKillDiagnostic {
-            kill_hint: MEMORY_SOFT_LIMIT_KILL_HINT.to_string(),
-            signal: libc::SIGTERM,
-            current_mb: 900,
-            threshold_mb: 700,
-            memory_max_mb: 1000,
-            soft_limit_percent: 70,
-            scope_name: "csa-codex-01J.scope".to_string(),
-        };
-        std::fs::write(
-            &path,
-            toml::to_string_pretty(&diagnostic).expect("serialize"),
-        )
-        .expect("write forged artifact");
-
-        assert!(
-            read_soft_limit_diagnostic(&path).is_none(),
-            "a TOML file alone is not authoritative CSA monitor evidence"
-        );
-    }
-
-    #[test]
-    fn ignores_soft_limit_diagnostic_with_unexpected_hint() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
-        let diagnostic = MemorySoftLimitKillDiagnostic {
-            kill_hint: "unknown_signal".to_string(),
-            signal: libc::SIGTERM,
-            current_mb: 900,
-            threshold_mb: 700,
-            memory_max_mb: 1000,
-            soft_limit_percent: 70,
-            scope_name: "csa-codex-01J.scope".to_string(),
-        };
-        record_soft_limit_diagnostic_evidence(&path, &diagnostic);
-
-        assert!(read_soft_limit_diagnostic(&path).is_none());
-    }
-
-    #[test]
-    fn rejects_soft_limit_diagnostic_recorded_before_not_before_without_grace_window() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
-        let run_start = SystemTime::now();
-        let diagnostic = test_soft_limit_diagnostic();
-
-        record_soft_limit_diagnostic_evidence(&path, &diagnostic);
-
-        assert_eq!(
-            read_soft_limit_diagnostic_recorded_at_or_after(&path, Some(run_start)),
-            Some(diagnostic.clone()),
-            "evidence recorded after this run's start should remain authoritative"
-        );
-        let later_run_start = SystemTime::now()
-            .checked_add(Duration::from_millis(500))
-            .expect("later run start");
-        assert!(
-            read_soft_limit_diagnostic_recorded_at_or_after(&path, Some(later_run_start)).is_none(),
-            "evidence recorded before a later run start must not be accepted by a grace window"
-        );
-    }
-
-    #[test]
-    fn start_clears_stale_soft_limit_registry_when_monitor_disabled_without_touching_artifact() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
-        let diagnostic = test_soft_limit_diagnostic();
-        record_soft_limit_diagnostic_evidence(&path, &diagnostic);
-        let stale_contents = "kill_hint = \"memory_soft_limit\"\n";
-        std::fs::write(&path, stale_contents).expect("write stale artifact");
-
-        assert!(
-            start(MemoryMonitorConfig {
-                scope_name: "test.scope".to_string(),
-                pgid: 1234,
-                memory_max_bytes: 0,
-                soft_limit_percent: 70,
-                interval: Duration::from_secs(5),
-                grace_period: Duration::from_secs(5),
-                diagnostic_path: Some(path.clone()),
-            })
-            .is_none(),
-            "zero memory limit should skip monitor setup"
-        );
-
-        assert_eq!(
-            std::fs::read_to_string(&path).expect("stale artifact should be untouched"),
-            stale_contents,
-            "disabled monitor setup must not mutate disk artifacts"
-        );
-        assert!(
-            read_soft_limit_diagnostic(&path).is_none(),
-            "disabled monitor setup should still clear stale in-process evidence"
-        );
-    }
-
-    #[tokio::test]
-    async fn start_clears_stale_soft_limit_registry_without_touching_artifact() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
-        let diagnostic = MemorySoftLimitKillDiagnostic {
-            kill_hint: MEMORY_SOFT_LIMIT_KILL_HINT.to_string(),
-            signal: libc::SIGTERM,
-            current_mb: 900,
-            threshold_mb: 700,
-            memory_max_mb: 1000,
-            soft_limit_percent: 70,
-            scope_name: "csa-codex-01J.scope".to_string(),
-        };
-        record_soft_limit_diagnostic_evidence(&path, &diagnostic);
-        let stale_contents = "kill_hint = \"memory_soft_limit\"\n";
-        std::fs::write(&path, stale_contents).expect("write stale artifact");
-
-        let handle = start(MemoryMonitorConfig {
-            scope_name: "test.scope".to_string(),
-            pgid: 1234,
-            memory_max_bytes: 1024 * 1024 * 1024,
-            soft_limit_percent: 70,
-            interval: Duration::from_secs(3600),
-            grace_period: Duration::from_secs(5),
-            diagnostic_path: Some(path.clone()),
-        })
-        .expect("monitor should start");
-
-        assert_eq!(
-            std::fs::read_to_string(&path).expect("stale artifact should be untouched"),
-            stale_contents,
-            "start should clear stale registry evidence without mutating disk artifacts"
-        );
-        assert!(
-            read_soft_limit_diagnostic(&path).is_none(),
-            "start should clear stale in-process diagnostic evidence"
-        );
-        handle.stop().await;
-    }
-}
+#[path = "memory_monitor_tests.rs"]
+mod tests;

--- a/crates/csa-resource/src/memory_monitor_cgroup.rs
+++ b/crates/csa-resource/src/memory_monitor_cgroup.rs
@@ -1,0 +1,89 @@
+//! Cgroup v2 working-set sampling for the soft memory monitor.
+
+use std::path::PathBuf;
+
+/// Return the cgroup usage that should count toward the soft limit.
+///
+/// `memory.current` includes page cache charged to the scope. The cgroup v2
+/// `inactive_file` counter is reclaimable file cache, so exclude it when the
+/// kernel provides a coherent value. If the stat cannot be read or is malformed,
+/// retain the full charge so an unavailable diagnostic source never weakens the
+/// memory limit.
+pub(crate) fn soft_limit_usage_bytes(memory_current_bytes: u64, memory_stat: Option<&str>) -> u64 {
+    let Some(inactive_file_bytes) = memory_stat
+        .and_then(parse_inactive_file_bytes)
+        .filter(|inactive_file_bytes| *inactive_file_bytes <= memory_current_bytes)
+    else {
+        return memory_current_bytes;
+    };
+
+    memory_current_bytes - inactive_file_bytes
+}
+
+fn parse_inactive_file_bytes(memory_stat: &str) -> Option<u64> {
+    memory_stat.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        match (fields.next(), fields.next(), fields.next()) {
+            (Some("inactive_file"), Some(value), None) => value.parse().ok(),
+            _ => None,
+        }
+    })
+}
+
+pub(crate) async fn query_soft_limit_usage_bytes(
+    scope_name: &str,
+    memory_current_bytes: u64,
+) -> u64 {
+    let memory_stat = query_cgroup_memory_stat(scope_name).await;
+    soft_limit_usage_bytes(memory_current_bytes, memory_stat.as_deref())
+}
+
+async fn query_cgroup_memory_stat(scope_name: &str) -> Option<String> {
+    let control_group = query_systemd_control_group(scope_name).await?;
+    let path = cgroup_memory_stat_path(&control_group)?;
+    tokio::fs::read_to_string(path).await.ok()
+}
+
+async fn query_systemd_control_group(scope_name: &str) -> Option<String> {
+    let output = tokio::process::Command::new("systemctl")
+        .args([
+            "--user",
+            "show",
+            scope_name,
+            "--property=ControlGroup",
+            "--value",
+        ])
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .await
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let control_group = String::from_utf8(output.stdout).ok()?;
+    cgroup_memory_stat_path(&control_group)?;
+    Some(control_group)
+}
+
+fn cgroup_memory_stat_path(control_group: &str) -> Option<PathBuf> {
+    let relative = control_group.trim().trim_start_matches('/');
+    if relative.is_empty() {
+        return None;
+    }
+
+    let mut path = PathBuf::from("/sys/fs/cgroup");
+    for segment in relative.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return None;
+        }
+        path.push(segment);
+    }
+    Some(path.join("memory.stat"))
+}
+
+#[cfg(test)]
+#[path = "memory_monitor_cgroup_tests.rs"]
+mod tests;

--- a/crates/csa-resource/src/memory_monitor_cgroup_tests.rs
+++ b/crates/csa-resource/src/memory_monitor_cgroup_tests.rs
@@ -1,0 +1,29 @@
+use super::soft_limit_usage_bytes;
+
+#[test]
+fn cgroup_page_cache_does_not_consume_soft_limit_working_set() {
+    let memory_current = 10 * 1024 * 1024;
+    let memory_stat = "anon 1048576\nfile 9437184\ninactive_file 8388608\n";
+
+    assert_eq!(
+        soft_limit_usage_bytes(memory_current, Some(memory_stat)),
+        2 * 1024 * 1024,
+        "reclaimable inactive file cache must not trigger a scope soft kill"
+    );
+}
+
+#[test]
+fn malformed_or_incoherent_cgroup_stat_keeps_the_full_soft_limit_charge() {
+    let memory_current = 10 * 1024 * 1024;
+
+    assert_eq!(soft_limit_usage_bytes(memory_current, None), memory_current);
+    assert_eq!(
+        soft_limit_usage_bytes(memory_current, Some("inactive_file not-a-number\n")),
+        memory_current
+    );
+    assert_eq!(
+        soft_limit_usage_bytes(memory_current, Some("inactive_file 11534336\n")),
+        memory_current,
+        "a raced or incoherent counter must not weaken the soft limit"
+    );
+}

--- a/crates/csa-resource/src/memory_monitor_tests.rs
+++ b/crates/csa-resource/src/memory_monitor_tests.rs
@@ -1,0 +1,268 @@
+use super::*;
+
+fn test_soft_limit_diagnostic() -> MemorySoftLimitKillDiagnostic {
+    MemorySoftLimitKillDiagnostic {
+        kill_hint: MEMORY_SOFT_LIMIT_KILL_HINT.to_string(),
+        signal: libc::SIGTERM,
+        current_mb: 900,
+        threshold_mb: 700,
+        memory_max_mb: 1000,
+        soft_limit_percent: 70,
+        scope_name: "csa-codex-01J.scope".to_string(),
+    }
+}
+
+#[test]
+fn test_start_returns_none_for_zero_max() {
+    let config = MemoryMonitorConfig {
+        scope_name: "test.scope".to_string(),
+        pgid: 1234,
+        memory_max_bytes: 0,
+        soft_limit_percent: 80,
+        interval: Duration::from_secs(5),
+        grace_period: Duration::from_secs(5),
+        diagnostic_path: None,
+    };
+    assert!(start(config).is_none());
+}
+
+#[test]
+fn test_start_returns_none_for_zero_percent() {
+    let config = MemoryMonitorConfig {
+        scope_name: "test.scope".to_string(),
+        pgid: 1234,
+        memory_max_bytes: 1024 * 1024 * 1024,
+        soft_limit_percent: 0,
+        interval: Duration::from_secs(5),
+        grace_period: Duration::from_secs(5),
+        diagnostic_path: None,
+    };
+    assert!(start(config).is_none());
+}
+
+#[test]
+fn test_start_returns_none_for_over_100_percent() {
+    let config = MemoryMonitorConfig {
+        scope_name: "test.scope".to_string(),
+        pgid: 1234,
+        memory_max_bytes: 1024 * 1024 * 1024,
+        soft_limit_percent: 101,
+        interval: Duration::from_secs(5),
+        grace_period: Duration::from_secs(5),
+        diagnostic_path: None,
+    };
+    assert!(start(config).is_none());
+}
+
+#[test]
+fn soft_limit_diagnostic_from_config_records_actionable_fields() {
+    let config = MemoryMonitorConfig {
+        scope_name: "csa-codex-01J.scope".to_string(),
+        pgid: 1234,
+        memory_max_bytes: 10 * 1024 * 1024,
+        soft_limit_percent: 70,
+        interval: Duration::from_secs(5),
+        grace_period: Duration::from_secs(5),
+        diagnostic_path: None,
+    };
+
+    let diagnostic =
+        MemorySoftLimitKillDiagnostic::from_config(&config, 8 * 1024 * 1024, 7 * 1024 * 1024);
+
+    assert_eq!(diagnostic.kill_hint, MEMORY_SOFT_LIMIT_KILL_HINT);
+    assert_eq!(diagnostic.signal, libc::SIGTERM);
+    assert_eq!(diagnostic.current_mb, 8);
+    assert_eq!(diagnostic.threshold_mb, 7);
+    assert_eq!(diagnostic.memory_max_mb, 10);
+    assert_eq!(diagnostic.soft_limit_percent, 70);
+    assert_eq!(diagnostic.scope_name, "csa-codex-01J.scope");
+}
+
+#[test]
+fn records_soft_limit_diagnostic_without_writing_artifact() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
+    let diagnostic = MemorySoftLimitKillDiagnostic {
+        kill_hint: MEMORY_SOFT_LIMIT_KILL_HINT.to_string(),
+        signal: libc::SIGTERM,
+        current_mb: 900,
+        threshold_mb: 700,
+        memory_max_mb: 1000,
+        soft_limit_percent: 70,
+        scope_name: "csa-codex-01J.scope".to_string(),
+    };
+
+    record_soft_limit_diagnostic(Some(&path), &diagnostic);
+
+    let loaded = read_soft_limit_diagnostic(&path).expect("diagnostic should parse");
+    assert_eq!(loaded, diagnostic);
+    assert!(
+        !path.exists(),
+        "memory soft-limit registry evidence must not create a disk artifact"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn records_soft_limit_diagnostic_without_following_existing_symlink() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
+    let symlink_target = temp.path().join("would-be-clobbered.txt");
+    let sentinel = "do not overwrite me";
+    std::fs::write(&symlink_target, sentinel).expect("write symlink target");
+    std::os::unix::fs::symlink(&symlink_target, &path).expect("create symlink");
+    let diagnostic = test_soft_limit_diagnostic();
+
+    record_soft_limit_diagnostic(Some(&path), &diagnostic);
+
+    assert_eq!(
+        read_soft_limit_diagnostic(&path),
+        Some(diagnostic),
+        "registry evidence should still be available for the current run"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&symlink_target).expect("read symlink target"),
+        sentinel,
+        "memory soft-limit recording must not follow or clobber a symlink path"
+    );
+}
+
+#[test]
+fn ignores_unregistered_soft_limit_diagnostic_artifact_file() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
+    let diagnostic = MemorySoftLimitKillDiagnostic {
+        kill_hint: MEMORY_SOFT_LIMIT_KILL_HINT.to_string(),
+        signal: libc::SIGTERM,
+        current_mb: 900,
+        threshold_mb: 700,
+        memory_max_mb: 1000,
+        soft_limit_percent: 70,
+        scope_name: "csa-codex-01J.scope".to_string(),
+    };
+    std::fs::write(
+        &path,
+        toml::to_string_pretty(&diagnostic).expect("serialize"),
+    )
+    .expect("write forged artifact");
+
+    assert!(
+        read_soft_limit_diagnostic(&path).is_none(),
+        "a TOML file alone is not authoritative CSA monitor evidence"
+    );
+}
+
+#[test]
+fn ignores_soft_limit_diagnostic_with_unexpected_hint() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
+    let diagnostic = MemorySoftLimitKillDiagnostic {
+        kill_hint: "unknown_signal".to_string(),
+        signal: libc::SIGTERM,
+        current_mb: 900,
+        threshold_mb: 700,
+        memory_max_mb: 1000,
+        soft_limit_percent: 70,
+        scope_name: "csa-codex-01J.scope".to_string(),
+    };
+    record_soft_limit_diagnostic_evidence(&path, &diagnostic);
+
+    assert!(read_soft_limit_diagnostic(&path).is_none());
+}
+
+#[test]
+fn rejects_soft_limit_diagnostic_recorded_before_not_before_without_grace_window() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
+    let run_start = SystemTime::now();
+    let diagnostic = test_soft_limit_diagnostic();
+
+    record_soft_limit_diagnostic_evidence(&path, &diagnostic);
+
+    assert_eq!(
+        read_soft_limit_diagnostic_recorded_at_or_after(&path, Some(run_start)),
+        Some(diagnostic.clone()),
+        "evidence recorded after this run's start should remain authoritative"
+    );
+    let later_run_start = SystemTime::now()
+        .checked_add(Duration::from_millis(500))
+        .expect("later run start");
+    assert!(
+        read_soft_limit_diagnostic_recorded_at_or_after(&path, Some(later_run_start)).is_none(),
+        "evidence recorded before a later run start must not be accepted by a grace window"
+    );
+}
+
+#[test]
+fn start_clears_stale_soft_limit_registry_when_monitor_disabled_without_touching_artifact() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
+    let diagnostic = test_soft_limit_diagnostic();
+    record_soft_limit_diagnostic_evidence(&path, &diagnostic);
+    let stale_contents = "kill_hint = \"memory_soft_limit\"\n";
+    std::fs::write(&path, stale_contents).expect("write stale artifact");
+
+    assert!(
+        start(MemoryMonitorConfig {
+            scope_name: "test.scope".to_string(),
+            pgid: 1234,
+            memory_max_bytes: 0,
+            soft_limit_percent: 70,
+            interval: Duration::from_secs(5),
+            grace_period: Duration::from_secs(5),
+            diagnostic_path: Some(path.clone()),
+        })
+        .is_none(),
+        "zero memory limit should skip monitor setup"
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("stale artifact should be untouched"),
+        stale_contents,
+        "disabled monitor setup must not mutate disk artifacts"
+    );
+    assert!(
+        read_soft_limit_diagnostic(&path).is_none(),
+        "disabled monitor setup should still clear stale in-process evidence"
+    );
+}
+
+#[tokio::test]
+async fn start_clears_stale_soft_limit_registry_without_touching_artifact() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join(MEMORY_SOFT_LIMIT_KILL_FILE_NAME);
+    let diagnostic = MemorySoftLimitKillDiagnostic {
+        kill_hint: MEMORY_SOFT_LIMIT_KILL_HINT.to_string(),
+        signal: libc::SIGTERM,
+        current_mb: 900,
+        threshold_mb: 700,
+        memory_max_mb: 1000,
+        soft_limit_percent: 70,
+        scope_name: "csa-codex-01J.scope".to_string(),
+    };
+    record_soft_limit_diagnostic_evidence(&path, &diagnostic);
+    let stale_contents = "kill_hint = \"memory_soft_limit\"\n";
+    std::fs::write(&path, stale_contents).expect("write stale artifact");
+
+    let handle = start(MemoryMonitorConfig {
+        scope_name: "test.scope".to_string(),
+        pgid: 1234,
+        memory_max_bytes: 1024 * 1024 * 1024,
+        soft_limit_percent: 70,
+        interval: Duration::from_secs(3600),
+        grace_period: Duration::from_secs(5),
+        diagnostic_path: Some(path.clone()),
+    })
+    .expect("monitor should start");
+
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("stale artifact should be untouched"),
+        stale_contents,
+        "start should clear stale registry evidence without mutating disk artifacts"
+    );
+    assert!(
+        read_soft_limit_diagnostic(&path).is_none(),
+        "start should clear stale in-process diagnostic evidence"
+    );
+    handle.stop().await;
+}


### PR DESCRIPTION
## Summary
- exclude coherent reclaimable cgroup `inactive_file` page cache from soft-limit usage
- fail closed to full cgroup charge when cgroup stats are unavailable or incoherent

## Validation
- pre-push quality gates / `NEXTEST_PROFILE=static just test`
- isolated Codex exact-range review: PASS

Closes #2900