### PR TITLE
fix(#2833): redirect Cargo caches from /usr/local under sandbox

### DIFF
--- a/crates/cli-sub-agent/src/pipeline_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_env.rs
@@ -207,7 +207,7 @@ fn apply_rust_session_env_contract_inner(
     let home = env_path(env, "HOME");
     let cargo_home = preferred_cargo_home(home.as_deref(), project_root);
     if let Some(cargo_home) = cargo_home.as_deref() {
-        ensure_rust_env_path(env, csa_core::env::CARGO_HOME_ENV_KEY, cargo_home);
+        ensure_cargo_home_env_path(env, cargo_home);
     }
 
     if materialize_cargo_install_root {
@@ -257,7 +257,7 @@ fn preferred_cargo_home_with_shared(
     project_root: Option<&Path>,
     shared: &Path,
 ) -> Option<PathBuf> {
-    if shared.is_dir() && !csa_core::env::rust_state_path_needs_session_override(shared) {
+    if shared.is_dir() && !csa_core::env::cargo_home_needs_session_override(shared) {
         return Some(shared.to_path_buf());
     }
 
@@ -274,6 +274,16 @@ fn ensure_rust_env_path(env: &mut HashMap<String, String>, key: &str, fallback: 
         .filter(|current| !csa_core::env::rust_state_path_needs_session_override(current))
         .unwrap_or_else(|| fallback.to_path_buf());
     env.insert(key.to_string(), effective.to_string_lossy().into_owned());
+}
+
+fn ensure_cargo_home_env_path(env: &mut HashMap<String, String>, fallback: &Path) {
+    let effective = env_path(env, csa_core::env::CARGO_HOME_ENV_KEY)
+        .filter(|current| !csa_core::env::cargo_home_needs_session_override(current))
+        .unwrap_or_else(|| fallback.to_path_buf());
+    env.insert(
+        csa_core::env::CARGO_HOME_ENV_KEY.to_string(),
+        effective.to_string_lossy().into_owned(),
+    );
 }
 
 fn force_project_env_path(env: &mut HashMap<String, String>, key: &str, fallback: &Path) {

--- a/crates/csa-core/src/env.rs
+++ b/crates/csa-core/src/env.rs
@@ -97,6 +97,19 @@ pub fn rust_state_path_needs_session_override(path: &std::path::Path) -> bool {
     path.starts_with(usr_local) && !rust_state_path_is_writable(path)
 }
 
+/// Return true when `CARGO_HOME` must be redirected to a sandbox-owned cache.
+///
+/// Unlike `RUSTUP_HOME`, Cargo's registry and git state are mutable during
+/// normal quality gates. A bwrap child starts with `/usr/local` read-only, so a
+/// host writability probe for a descendant (for example `/usr/local/registry`)
+/// is not evidence that Cargo can populate it in the child namespace (#2833).
+/// Keep the narrower Rustup helper above for deliberately mounted mise
+/// toolchain homes; never use those install prefixes as a Cargo cache.
+pub fn cargo_home_needs_session_override(path: &std::path::Path) -> bool {
+    path.starts_with(std::path::Path::new("/usr/local"))
+        || rust_state_path_needs_session_override(path)
+}
+
 fn rust_state_path_is_writable(path: &std::path::Path) -> bool {
     let dir = if path.is_dir() {
         path

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -338,16 +338,15 @@ impl IsolationPlanBuilder {
             let default_cargo_home = home.join(".cargo");
             if let Ok(cargo_home_env) = std::env::var(csa_core::env::CARGO_HOME_ENV_KEY) {
                 let cargo_home =
-                    rust_env::resolve_rust_state_path(&cargo_home_env, &default_cargo_home);
+                    rust_env::resolve_cargo_home_path(&cargo_home_env, &default_cargo_home);
                 if cargo_home == default_cargo_home {
                     // CARGO_HOME points to the default — treat as if unset.
                     add_dir_or_creatable_parent(&mut self.writable_paths, &default_cargo_home);
                     // Override the env var when the original pointed at a
                     // read-only system prefix (e.g. /usr/local) so the child
                     // process uses the writable default instead (#2607).
-                    rust_env::insert_env_override_if_needed(
+                    rust_env::insert_cargo_home_override_if_needed(
                         &mut self.env_overrides,
-                        csa_core::env::CARGO_HOME_ENV_KEY,
                         &cargo_home_env,
                         &default_cargo_home,
                     );

--- a/crates/csa-resource/src/isolation_plan_rust_env.rs
+++ b/crates/csa-resource/src/isolation_plan_rust_env.rs
@@ -20,6 +20,17 @@ pub(crate) fn resolve_rust_state_path(value: &str, default: &Path) -> PathBuf {
     }
 }
 
+/// Resolve `CARGO_HOME`, which must never use `/usr/local` descendants as a
+/// mutable cache in a bwrap child (#2833).
+pub(crate) fn resolve_cargo_home_path(value: &str, default: &Path) -> PathBuf {
+    let path = PathBuf::from(value);
+    if value.trim().is_empty() || csa_core::env::cargo_home_needs_session_override(&path) {
+        default.to_path_buf()
+    } else {
+        path
+    }
+}
+
 /// If the original env value pointed at a read-only system prefix, insert an
 /// override mapping it to the writable default. Returns `true` when an
 /// override was inserted.
@@ -32,6 +43,24 @@ pub(crate) fn insert_env_override_if_needed(
     if csa_core::env::rust_state_path_needs_session_override(&PathBuf::from(original_value)) {
         env_overrides.insert(
             env_key.to_string(),
+            default_path.to_string_lossy().into_owned(),
+        );
+        true
+    } else {
+        false
+    }
+}
+
+/// Insert a `CARGO_HOME` override when its original value cannot be used as a
+/// mutable Cargo cache from the bwrap namespace.
+pub(crate) fn insert_cargo_home_override_if_needed(
+    env_overrides: &mut HashMap<String, String>,
+    original_value: &str,
+    default_path: &Path,
+) -> bool {
+    if csa_core::env::cargo_home_needs_session_override(&PathBuf::from(original_value)) {
+        env_overrides.insert(
+            csa_core::env::CARGO_HOME_ENV_KEY.to_string(),
             default_path.to_string_lossy().into_owned(),
         );
         true

--- a/crates/csa-resource/src/isolation_plan_rust_env_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_rust_env_tests.rs
@@ -100,3 +100,44 @@ fn tool_defaults_override_cargo_home_env_when_usr_local_is_readonly() {
         "RUSTUP_HOME must be overridden to writable ~/.rustup when original is /usr/local"
     );
 }
+
+#[test]
+fn tool_defaults_override_cargo_registry_under_usr_local_even_when_host_writable() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(home.join(".cargo")).unwrap();
+    let _home = ScopedEnvVar::set("HOME", &home);
+    let _xdg = ScopedEnvVar::unset("XDG_STATE_HOME");
+    // The host may make this path writable, but bwrap starts from a read-only
+    // root. A Cargo registry beneath /usr/local therefore cannot be trusted as
+    // a sandbox cache source (#2833).
+    let _cargo_home = ScopedEnvVar::set(csa_core::env::CARGO_HOME_ENV_KEY, "/usr/local/registry");
+    let _rustup_home = ScopedEnvVar::unset(csa_core::env::RUSTUP_HOME_ENV_KEY);
+
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_tool_defaults(
+            "codex",
+            &PathBuf::from("/tmp/project"),
+            &PathBuf::from("/tmp/session"),
+        )
+        .build()
+        .expect("should succeed");
+
+    assert_eq!(
+        plan.env_overrides.get(csa_core::env::CARGO_HOME_ENV_KEY),
+        Some(&home.join(".cargo").to_string_lossy().to_string()),
+        "CARGO_HOME beneath /usr/local must be redirected to the sandbox-owned cache"
+    );
+    assert!(
+        plan.writable_paths.contains(&home.join(".cargo")),
+        "the redirected Cargo home must be writable in the bwrap sandbox"
+    );
+    assert!(
+        !plan
+            .writable_paths
+            .contains(&PathBuf::from("/usr/local/registry")),
+        "the host registry must not be granted a writable bind"
+    );
+}


### PR DESCRIPTION
## Summary
- Redirect Cargo state rooted under `/usr/local` to the session-local writable Cargo home in bwrap plans.
- Keep `/usr/local` read-only and add regression coverage for registry/cache redirection.

## Validation
- `just pre-commit-fast`
- `just pre-push` (7,484 passed)
- Isolated exact-head Codex review: PASS

Closes #2833