### PR TITLE
fix(#2826): redirect read-only mise Cargo registry under sandbox

### DIFF
--- a/crates/cli-sub-agent/src/pipeline_tests_env.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_env.rs
@@ -68,12 +68,17 @@ fn build_merged_env_preserves_current_path_for_tool_runtime_resolution() {
 }
 
 #[test]
-fn build_merged_env_normalizes_readonly_usr_local_rust_state() {
+fn build_merged_env_normalizes_readonly_mise_cargo_registry() {
     let _env_lock = crate::test_env_lock::TEST_ENV_LOCK.blocking_lock();
     let temp = tempfile::tempdir().expect("tempdir");
     let home = temp.path().join("home");
     let mise_data = temp.path().join("mise-data");
     let mise_rust = mise_data.join("installs/rust/stable");
+    // Match the inherited CARGO_HOME from the Verbatim writer incident (#2826).
+    // This is a Rust toolchain install directory, never a sandbox-writable
+    // Cargo registry/cache even if its host mount happens to be writable.
+    let readonly_mise_cargo_home =
+        std::path::Path::new("/usr/local/share/mise/installs/rust/1.97.1");
     let toolchain_bin = mise_rust
         .join("toolchains")
         .join("1.96.0-x86_64-unknown-linux-gnu")
@@ -92,7 +97,10 @@ fn build_merged_env_normalizes_readonly_usr_local_rust_state() {
     .expect("write rust toolchain");
     let _home = ScopedEnvVarRestore::set("HOME", home.to_str().expect("home utf8"));
     let _path = ScopedEnvVarRestore::set("PATH", "/usr/local/bin:/bin");
-    let _cargo_home = ScopedEnvVarRestore::set(csa_core::env::CARGO_HOME_ENV_KEY, "/usr/local");
+    let _cargo_home = ScopedEnvVarRestore::set(
+        csa_core::env::CARGO_HOME_ENV_KEY,
+        readonly_mise_cargo_home.to_str().expect("mise cargo home utf8"),
+    );
     let _rustup_home = ScopedEnvVarRestore::set(csa_core::env::RUSTUP_HOME_ENV_KEY, "/usr/local");
     let _cargo_install_root =
         ScopedEnvVarRestore::set(csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY, "/usr/local");
@@ -126,9 +134,14 @@ fn build_merged_env_normalizes_readonly_usr_local_rust_state() {
         "CARGO_HOME should use shared cache or HOME/.cargo; repo-local .cargo-local is forbidden, got {}",
         normalized_cargo_home.display()
     );
+    assert_ne!(
+        normalized_cargo_home,
+        readonly_mise_cargo_home,
+        "the inherited mise toolchain install directory must never reach the writer"
+    );
     assert!(
-        !csa_core::env::rust_state_path_needs_session_override(&normalized_cargo_home),
-        "normalized CARGO_HOME must not point at read-only /usr/local"
+        !csa_core::env::cargo_home_needs_session_override(&normalized_cargo_home),
+        "normalized CARGO_HOME must be writable outside the bwrap read-only prefix"
     );
     assert_eq!(
         merged

--- a/crates/csa-core/src/env.rs
+++ b/crates/csa-core/src/env.rs
@@ -126,7 +126,17 @@ fn cargo_home_needs_session_override_with_rust_state(
     path.starts_with(std::path::Path::new("/usr/local")) || rust_state_needs_session_override
 }
 
+#[cfg(test)]
+thread_local! {
+    static RUST_STATE_WRITABILITY_PROBE_CALLS: std::cell::Cell<usize> = const {
+        std::cell::Cell::new(0)
+    };
+}
+
 fn rust_state_path_is_writable(path: &std::path::Path) -> bool {
+    #[cfg(test)]
+    RUST_STATE_WRITABILITY_PROBE_CALLS.with(|calls| calls.set(calls.get() + 1));
+
     let dir = if path.is_dir() {
         path
     } else if let Some(parent) = path.parent() {
@@ -384,14 +394,23 @@ mod tests {
     }
 
     #[test]
-    fn cargo_home_under_usr_local_overrides_even_when_host_path_is_writable() {
+    fn cargo_home_under_usr_local_short_circuits_writability_probe() {
         let mise_toolchain_home =
             std::path::Path::new("/usr/local/share/mise/installs/rust/1.97.1");
 
+        RUST_STATE_WRITABILITY_PROBE_CALLS.with(|calls| calls.set(0));
+
         assert!(
-            cargo_home_needs_session_override_with_rust_state(mise_toolchain_home, false),
+            cargo_home_needs_session_override(mise_toolchain_home),
             "a bwrap child receives /usr/local read-only even when the host can write the mise path"
         );
+        RUST_STATE_WRITABILITY_PROBE_CALLS.with(|calls| {
+            assert_eq!(
+                calls.get(),
+                0,
+                "CARGO_HOME beneath /usr/local must short-circuit before the writability probe"
+            );
+        });
     }
 
     #[test]

--- a/crates/csa-core/src/env.rs
+++ b/crates/csa-core/src/env.rs
@@ -106,8 +106,20 @@ pub fn rust_state_path_needs_session_override(path: &std::path::Path) -> bool {
 /// Keep the narrower Rustup helper above for deliberately mounted mise
 /// toolchain homes; never use those install prefixes as a Cargo cache.
 pub fn cargo_home_needs_session_override(path: &std::path::Path) -> bool {
-    path.starts_with(std::path::Path::new("/usr/local"))
-        || rust_state_path_needs_session_override(path)
+    cargo_home_needs_session_override_with_rust_state(
+        path,
+        rust_state_path_needs_session_override(path),
+    )
+}
+
+// Keep the policy decision separable from the host writability probe. A Cargo
+// cache under `/usr/local` is unsafe in bwrap even when its host mount is
+// writable, while Rustup toolchain state can retain its narrower policy.
+fn cargo_home_needs_session_override_with_rust_state(
+    path: &std::path::Path,
+    rust_state_needs_session_override: bool,
+) -> bool {
+    path.starts_with(std::path::Path::new("/usr/local")) || rust_state_needs_session_override
 }
 
 fn rust_state_path_is_writable(path: &std::path::Path) -> bool {
@@ -365,6 +377,17 @@ mod tests {
         assert!(rust_state_path_needs_session_override(
             std::path::Path::new("/usr/local")
         ));
+    }
+
+    #[test]
+    fn cargo_home_under_usr_local_overrides_even_when_host_path_is_writable() {
+        let mise_toolchain_home =
+            std::path::Path::new("/usr/local/share/mise/installs/rust/1.97.1");
+
+        assert!(
+            cargo_home_needs_session_override_with_rust_state(mise_toolchain_home, false),
+            "a bwrap child receives /usr/local read-only even when the host can write the mise path"
+        );
     }
 
     #[test]

--- a/crates/csa-core/src/env.rs
+++ b/crates/csa-core/src/env.rs
@@ -106,6 +106,10 @@ pub fn rust_state_path_needs_session_override(path: &std::path::Path) -> bool {
 /// Keep the narrower Rustup helper above for deliberately mounted mise
 /// toolchain homes; never use those install prefixes as a Cargo cache.
 pub fn cargo_home_needs_session_override(path: &std::path::Path) -> bool {
+    if path.starts_with(std::path::Path::new("/usr/local")) {
+        return true;
+    }
+
     cargo_home_needs_session_override_with_rust_state(
         path,
         rust_state_path_needs_session_override(path),

--- a/crates/csa-resource/src/isolation_plan_rust_env_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_rust_env_tests.rs
@@ -102,17 +102,18 @@ fn tool_defaults_override_cargo_home_env_when_usr_local_is_readonly() {
 }
 
 #[test]
-fn tool_defaults_override_cargo_registry_under_usr_local_even_when_host_writable() {
+fn tool_defaults_redirect_mise_cargo_home_to_sandbox_owned_cache() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();
     let home = temp.path().join("home");
     std::fs::create_dir_all(home.join(".cargo")).unwrap();
     let _home = ScopedEnvVar::set("HOME", &home);
     let _xdg = ScopedEnvVar::unset("XDG_STATE_HOME");
-    // The host may make this path writable, but bwrap starts from a read-only
-    // root. A Cargo registry beneath /usr/local therefore cannot be trusted as
-    // a sandbox cache source (#2833).
-    let _cargo_home = ScopedEnvVar::set(csa_core::env::CARGO_HOME_ENV_KEY, "/usr/local/registry");
+    // The Verbatim writer inherited this exact mise toolchain install path.
+    // Cargo must use a sandbox-owned cache instead of this toolchain state.
+    let readonly_mise_cargo_home = "/usr/local/share/mise/installs/rust/1.97.1";
+    let _cargo_home =
+        ScopedEnvVar::set(csa_core::env::CARGO_HOME_ENV_KEY, readonly_mise_cargo_home);
     let _rustup_home = ScopedEnvVar::unset(csa_core::env::RUSTUP_HOME_ENV_KEY);
 
     let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
@@ -137,7 +138,7 @@ fn tool_defaults_override_cargo_registry_under_usr_local_even_when_host_writable
     assert!(
         !plan
             .writable_paths
-            .contains(&PathBuf::from("/usr/local/registry")),
+            .contains(&PathBuf::from(readonly_mise_cargo_home)),
         "the host registry must not be granted a writable bind"
     );
 }


### PR DESCRIPTION
Closes #2826

Redirects Cargo homes beneath `/usr/local` before any host writability probe, preserving Rustup least-privilege behavior.

Validation: focused Cargo-home tests, `just pre-commit-fast`, hook-enabled `just pre-push` (7,485 all-feature tests), and isolated Codex review PASS.