### PR TITLE
fix(#2832): reap daemon fixture process groups before leak-fail

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,7 @@
 [profile.default]
 retries = 2
+# A test that leaves a child holding nextest capture FDs is a failure, not a warning.
+leak-timeout = { period = "500ms", result = "fail" }
 
 [profile.static]
 retries = 0

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -627,7 +627,7 @@ mod session_cmds_daemon_kill_tests;
 mod session_cmds_daemon_routing_proptest;
 #[cfg(test)]
 #[path = "session_cmds_daemon_test_support.rs"]
-mod session_cmds_daemon_test_support;
+pub(crate) mod session_cmds_daemon_test_support;
 #[cfg(test)]
 #[path = "session_cmds_daemon_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/session_cmds_daemon_kill_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_kill_tests.rs
@@ -48,7 +48,8 @@ fn handle_session_kill_accepts_legacy_stderr_pid() {
         "legacy stderr PID fixture must be recognized as a live session process before kill"
     );
 
-    let reaper = std::thread::spawn(move || child.wait().expect("wait child"));
+    let reaper =
+        std::thread::spawn(move || child.wait_for_external_termination().expect("wait child"));
 
     handle_session_kill(
         session_id.clone(),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_test_support.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_test_support.rs
@@ -1,5 +1,108 @@
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-pub(crate) fn spawn_daemon_like_process(session_id: &str) -> std::process::Child {
+use std::process::{Child, ExitStatus};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::time::{Duration, Instant};
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const DAEMON_FIXTURE_TERM_GRACE: Duration = Duration::from_millis(100);
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const DAEMON_FIXTURE_REAP_TIMEOUT: Duration = Duration::from_secs(1);
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const DAEMON_FIXTURE_REAP_POLL: Duration = Duration::from_millis(10);
+
+/// Owns a daemon-like fixture's session/process group until its leader is reaped.
+///
+/// The shell leader is created with `setsid`, so its PID is also the process-group
+/// ID. Cleanup signals the group before reaping the leader; after reaping, a PID
+/// can be reused and a negative-PGID signal would no longer be safe.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) struct DaemonLikeProcess {
+    child: Option<Child>,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl DaemonLikeProcess {
+    fn new(child: Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    pub(crate) fn id(&self) -> u32 {
+        self.child
+            .as_ref()
+            .expect("daemon fixture leader must remain unreaped")
+            .id()
+    }
+
+    /// Reap after an operation that is itself responsible for group termination.
+    ///
+    /// Session-kill fixture tests use this after exercising production's
+    /// group-aware signal path. It deliberately does not issue a post-reap group
+    /// signal because the leader PID may then be reused.
+    pub(crate) fn wait_for_external_termination(&mut self) -> std::io::Result<ExitStatus> {
+        self.child
+            .take()
+            .expect("daemon fixture leader must remain unreaped")
+            .wait()
+    }
+
+    /// Terminate the entire fixture process group and reap its leader within a
+    /// bounded interval. The final group signal occurs while the leader remains
+    /// unreaped, so the negative PGID still belongs to this fixture.
+    pub(crate) fn terminate_and_reap(&mut self) -> std::io::Result<ExitStatus> {
+        let pid = self.id() as libc::pid_t;
+        let pgid = -pid;
+
+        // SAFETY: `pid` is an unreaped leader created by `setsid`; its process
+        // group is therefore this fixture's group, not an unrelated group.
+        let _ = unsafe { libc::kill(pgid, libc::SIGTERM) };
+        std::thread::sleep(DAEMON_FIXTURE_TERM_GRACE);
+        // SAFETY: the leader is still owned and unreaped, so its PID cannot be
+        // reused before this final process-group signal.
+        let kill_rc = unsafe { libc::kill(pgid, libc::SIGKILL) };
+        if kill_rc != 0 && std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH) {
+            // Fall back to the exact leader only if the group signal itself was
+            // rejected for a reason other than the group already being empty.
+            if let Some(child) = self.child.as_mut() {
+                let _ = child.kill();
+            }
+        }
+
+        let deadline = Instant::now() + DAEMON_FIXTURE_REAP_TIMEOUT;
+        loop {
+            let status = self
+                .child
+                .as_mut()
+                .expect("daemon fixture leader must remain unreaped")
+                .try_wait()?;
+            if let Some(status) = status {
+                self.child.take();
+                return Ok(status);
+            }
+            if Instant::now() >= deadline {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "timed out reaping daemon fixture leader after group termination",
+                ));
+            }
+            std::thread::sleep(DAEMON_FIXTURE_REAP_POLL);
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl Drop for DaemonLikeProcess {
+    fn drop(&mut self) {
+        // Arms at spawn and remains armed through assertions/panics. Ignore the
+        // bounded cleanup error here; an unreaped leader retains ownership, so
+        // no unsafe post-reap group signal can occur.
+        if self.child.is_some() {
+            let _ = self.terminate_and_reap();
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn spawn_daemon_like_process(session_id: &str) -> DaemonLikeProcess {
     use std::os::unix::process::CommandExt;
     use std::process::Command;
 
@@ -20,7 +123,7 @@ pub(crate) fn spawn_daemon_like_process(session_id: &str) -> std::process::Child
             Ok(())
         });
     }
-    cmd.spawn().expect("spawn daemon-like child")
+    DaemonLikeProcess::new(cmd.spawn().expect("spawn daemon-like child"))
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_tests.rs
@@ -601,8 +601,9 @@ fn handle_session_attach_waits_for_live_daemon_before_consuming_completion_packe
         "attach must keep tailing while the daemon process is still alive"
     );
 
-    child.kill().ok();
-    child.wait().ok();
+    child
+        .terminate_and_reap()
+        .expect("terminate and reap daemon fixture group");
 
     let exit_code = rx
         .recv_timeout(Duration::from_secs(2))
@@ -716,7 +717,8 @@ fn handle_session_kill_uses_lock_file_for_inline_session() {
     )
     .expect("write lock file");
 
-    let reaper = std::thread::spawn(move || child.wait().expect("wait child"));
+    let reaper =
+        std::thread::spawn(move || child.wait_for_external_termination().expect("wait child"));
 
     handle_session_kill(
         session_id.clone(),

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
@@ -5,6 +5,8 @@ use std::process::Command;
 
 #[path = "session_cmds_tests_tail_daemon_completion.rs"]
 mod daemon_completion;
+#[path = "session_cmds_tests_tail_2832.rs"]
+mod tail_tests_2832;
 
 #[cfg(unix)]
 fn wait_for_spawned_daemon_visibility(
@@ -23,6 +25,7 @@ fn wait_for_spawned_daemon_visibility(
     }
     panic!("daemon child never became visible to ToolLiveness");
 }
+
 
 #[test]
 fn resolve_session_prefix_with_global_fallback_accepts_initializing_exact_session_dir() {
@@ -601,63 +604,6 @@ fn handle_session_wait_prefers_result_toml_over_daemon_completion_exit_code() {
         exit_code, 0,
         "result.toml records the session's actual outcome and must override the daemon process exit code"
     );
-}
-
-#[cfg(unix)]
-#[test]
-fn handle_session_wait_ignores_completion_packet_while_daemon_alive() {
-    use std::os::unix::fs::PermissionsExt;
-    use std::process::Command;
-
-    let td = tempdir().unwrap();
-    let _env_lock = TEST_ENV_LOCK.blocking_lock();
-    let state_home = td.path().join("xdg-state");
-    std::fs::create_dir_all(&state_home).unwrap();
-    let _home_guard = EnvVarGuard::set("HOME", td.path());
-    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
-    let project = td.path();
-
-    let session = create_session(
-        project,
-        Some("wait-live-completion-packet"),
-        None,
-        Some("codex"),
-    )
-    .unwrap();
-    let session_id = session.meta_session_id;
-    let session_dir = get_session_dir(project, &session_id).unwrap();
-    std::fs::write(
-        session_dir.join("daemon-completion.toml"),
-        "exit_code = 1\nstatus = \"failure\"\n",
-    )
-    .unwrap();
-
-    let script_path = td.path().join("live-completion-packet.sh");
-    let script =
-        "#!/bin/sh\nset -eu\nsession_id=\"$1\"\nsleep 2\nprintf '%s' \"$session_id\" >/dev/null\n";
-    std::fs::write(&script_path, script).unwrap();
-    let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(&script_path, perms).unwrap();
-
-    let mut child = Command::new(&script_path).arg(&session_id).spawn().unwrap();
-    std::fs::write(session_dir.join("daemon.pid"), child.id().to_string()).unwrap();
-    wait_for_spawned_daemon_visibility(&session_dir, &mut child);
-
-    let exit_code =
-        handle_session_wait(session_id, Some(project.to_string_lossy().into_owned()), 1).unwrap();
-
-    // Daemon is still alive when the 1s wait cap fires; the completion packet
-    // recorded the daemon process exit, not the session outcome, so the wait
-    // must NOT surface it. Under #1439, alive-at-cap returns the KV-warm code
-    // (0) rather than the legacy 124.
-    assert_eq!(
-        exit_code, 0,
-        "wait should emit the KV-warm exit instead of reporting completion while the daemon is still alive"
-    );
-
-    child.kill().ok();
-    let _ = child.wait();
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail.rs
@@ -3,6 +3,9 @@ use crate::session_cmds::resolve_session_prefix_with_global_fallback;
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use crate::session_cmds_daemon::session_cmds_daemon_test_support::spawn_daemon_like_process;
+
 #[path = "session_cmds_tests_tail_daemon_completion.rs"]
 mod daemon_completion;
 #[path = "session_cmds_tests_tail_2832.rs"]
@@ -134,9 +137,8 @@ fn ensure_terminal_result_for_dead_active_session_is_noop_for_non_active_phase()
     assert!(load_result(project, &session_id).unwrap().is_none());
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
-#[rustfmt::skip]
 fn ensure_terminal_result_for_dead_active_session_is_noop_when_alive() {
     let td = tempdir().unwrap();
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
@@ -152,15 +154,17 @@ fn ensure_terminal_result_for_dead_active_session_is_noop_when_alive() {
     let locks_dir = session_dir.join("locks");
     std::fs::create_dir_all(&locks_dir).unwrap();
 
-    // Use a spawned process with session ID in cmdline to satisfy ToolLiveness context check.
-    let mut child = std::process::Command::new("sh").arg("-c").arg(format!("sleep 60 # {}", session_id)).spawn().unwrap();
+    // Keep the session ID in the fixture leader's cmdline for ToolLiveness.
+    let mut child = spawn_daemon_like_process(&session_id);
     let pid = child.id();
 
     std::fs::write(locks_dir.join("codex.lock"), format!(r#"{{"pid": {}}}"#, pid)).unwrap();
 
     let reconciled = ensure_terminal_result_for_dead_active_session(project, &session_id, "session list").unwrap();
 
-    child.kill().ok(); child.wait().ok();
+    child
+        .terminate_and_reap()
+        .expect("terminate and reap daemon fixture group");
 
     assert_eq!(reconciled, DeadActiveSessionReconciliation::NoChange);
     assert!(load_result(project, &session_id).unwrap().is_none());

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_2832.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_2832.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use crate::session_cmds_daemon::session_cmds_daemon_test_support::{
+    spawn_daemon_like_process, DaemonLikeProcess,
+};
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn wait_for_daemon_fixture_visibility(
+    session_dir: &std::path::Path,
+    fixture: &DaemonLikeProcess,
+) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+    while std::time::Instant::now() < deadline {
+        if csa_process::ToolLiveness::has_live_process(session_dir) {
+            return;
+        }
+        assert!(
+            fixture.id() > 1,
+            "daemon fixture leader must remain owned while waiting for liveness"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    panic!("daemon fixture never became visible to ToolLiveness");
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn handle_session_wait_ignores_completion_packet_while_daemon_alive() {
+    let td = tempdir().unwrap();
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).unwrap();
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-live-completion-packet"),
+        None,
+        Some("codex"),
+    )
+    .unwrap();
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).unwrap();
+    std::fs::write(
+        session_dir.join("daemon-completion.toml"),
+        "exit_code = 1\nstatus = \"failure\"\n",
+    )
+    .unwrap();
+
+    let mut child = spawn_daemon_like_process(&session_id);
+    std::fs::write(session_dir.join("daemon.pid"), child.id().to_string()).unwrap();
+    wait_for_daemon_fixture_visibility(&session_dir, &child);
+
+    let exit_code =
+        handle_session_wait(session_id, Some(project.to_string_lossy().into_owned()), 1).unwrap();
+
+    // Daemon is still alive when the 1s wait cap fires; the completion packet
+    // recorded the daemon process exit, not the session outcome, so the wait
+    // must NOT surface it. Under #1439, alive-at-cap returns the KV-warm code
+    // (0) rather than the legacy 124.
+    assert_eq!(
+        exit_code, 0,
+        "wait should emit the KV-warm exit instead of reporting completion while the daemon is still alive"
+    );
+
+    child
+        .terminate_and_reap()
+        .expect("terminate and reap daemon fixture group");
+}

--- a/crates/csa-process/src/tool_liveness_tests.rs
+++ b/crates/csa-process/src/tool_liveness_tests.rs
@@ -18,6 +18,10 @@ fn wait_for_process_command_line_contains(pid: u32, expected: &str) -> bool {
     read_process_command_line(pid).is_some_and(|cmdline| cmdline.contains(expected))
 }
 
+#[cfg(test)]
+#[path = "tool_liveness_tests_daemon_fixture.rs"]
+mod daemon_fixture;
+
 #[test]
 fn lock_file_is_recent_false_when_stale() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -118,39 +122,6 @@ fn daemon_pid_is_alive_detects_live_pid_without_context_match() {
 
     child.kill().ok();
     child.wait().ok();
-}
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-#[test]
-fn daemon_pid_is_alive_accepts_legacy_pid_with_session_id_context() {
-    use std::os::unix::fs::PermissionsExt;
-
-    const SESSION_ID: &str = "01TESTSESSIONCONTEXT0000000001";
-
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let session_dir = tmp.path().join(SESSION_ID);
-    fs::create_dir_all(&session_dir).expect("create session dir");
-    let daemon_fixture = session_dir.join("daemon-sleep");
-    fs::write(&daemon_fixture, "#!/bin/sh\nsleep 60\n").expect("write daemon fixture");
-    let mut perms = fs::metadata(&daemon_fixture)
-        .expect("daemon fixture metadata")
-        .permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(&daemon_fixture, perms).expect("mark daemon fixture executable");
-    let mut child = std::process::Command::new(&daemon_fixture).spawn().unwrap();
-    let pid = child.id();
-    let cmdline_ready = wait_for_process_command_line_contains(pid, SESSION_ID);
-    fs::write(session_dir.join(DAEMON_PID_FILE), format!("{pid}\n")).expect("write daemon pid");
-    let daemon_pid_alive = ToolLiveness::daemon_pid_is_alive(&session_dir);
-
-    child.kill().ok();
-    child.wait().ok();
-
-    assert!(
-        cmdline_ready,
-        "spawned daemon command line should expose session context"
-    );
-    assert!(daemon_pid_alive, "legacy bare daemon.pid should stay alive");
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/csa-process/src/tool_liveness_tests_daemon_fixture.rs
+++ b/crates/csa-process/src/tool_liveness_tests_daemon_fixture.rs
@@ -1,0 +1,93 @@
+use super::super::*;
+use super::wait_for_process_command_line_contains;
+
+/// Own a daemon-style test fixture and clean up every process in its group.
+///
+/// The fixture command is its own session leader, so a shell script that starts
+/// a child cannot leave that child holding inherited test-harness file
+/// descriptors after the script leader is terminated.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+struct DaemonFixtureProcess {
+    child: Option<std::process::Child>,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl DaemonFixtureProcess {
+    fn spawn(program: &std::path::Path) -> Self {
+        use std::os::unix::process::CommandExt;
+
+        let mut command = std::process::Command::new(program);
+        // SAFETY: test fixture only; gives the fixture a private process group.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        Self {
+            child: Some(command.spawn().expect("spawn daemon fixture")),
+        }
+    }
+
+    fn id(&self) -> u32 {
+        self.child
+            .as_ref()
+            .expect("daemon fixture leader must remain unreaped")
+            .id()
+    }
+
+    fn terminate_and_reap(&mut self) {
+        let pid = self.id() as libc::pid_t;
+        // SAFETY: the unreaped setsid leader owns this fixture's process group.
+        let _ = unsafe { libc::kill(-pid, libc::SIGTERM) };
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        // SAFETY: the leader remains unreaped, so its PID cannot have been reused.
+        let _ = unsafe { libc::kill(-pid, libc::SIGKILL) };
+        let _ = self
+            .child
+            .take()
+            .expect("daemon fixture leader must remain unreaped")
+            .wait();
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl Drop for DaemonFixtureProcess {
+    fn drop(&mut self) {
+        if self.child.is_some() {
+            self.terminate_and_reap();
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn daemon_pid_is_alive_accepts_legacy_pid_with_session_id_context() {
+    use std::os::unix::fs::PermissionsExt;
+
+    const SESSION_ID: &str = "01TESTSESSIONCONTEXT0000000001";
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let session_dir = tmp.path().join(SESSION_ID);
+    fs::create_dir_all(&session_dir).expect("create session dir");
+    let daemon_fixture = session_dir.join("daemon-sleep");
+    fs::write(&daemon_fixture, "#!/bin/sh\nsleep 60\n").expect("write daemon fixture");
+    let mut perms = fs::metadata(&daemon_fixture)
+        .expect("daemon fixture metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&daemon_fixture, perms).expect("mark daemon fixture executable");
+    let child = DaemonFixtureProcess::spawn(&daemon_fixture);
+    let pid = child.id();
+    let cmdline_ready = wait_for_process_command_line_contains(pid, SESSION_ID);
+    fs::write(session_dir.join(DAEMON_PID_FILE), format!("{pid}\n")).expect("write daemon pid");
+    let daemon_pid_alive = ToolLiveness::daemon_pid_is_alive(&session_dir);
+
+    assert!(
+        cmdline_ready,
+        "spawned daemon command line should expose session context"
+    );
+    assert!(daemon_pid_alive, "legacy bare daemon.pid should stay alive");
+}


### PR DESCRIPTION
## Summary
- reap all daemon-style test fixture process groups before releasing captured test-harness FDs
- enable Nextest FD-leak failures and cover live-daemon completion behavior

## Verification
- focused daemon/liveness tests
- `just pre-commit-fast`
- hook-enabled pre-push full suite (7,485 all-feature tests passed)
- isolated Codex range review: PASS

Closes #2832