### PR TITLE
fix(#2824): expose role-specific memory floor before session creation

### DIFF
--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -84,7 +84,7 @@ async fn ri(request: RunLoopRequest<'_>, g: &mut Cg) -> Result<RunLoopCompletion
             request.run_timeout_seconds,
             tool_name_str,
         );
-        if (session_arg.is_none() || is_fork)
+        if (effective_session_arg.is_none() || is_fork)
             && executed_session_id.is_none()
             && pre_created_fork_session_id.is_none()
         {

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -1,5 +1,8 @@
 include!("run_cmd_attempt_prelude.rs");
 
+#[path = "run_cmd_attempt_admission.rs"]
+mod admission;
+
 pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunLoopCompletion> {
     let mut g = capture_cg(request.project_root, request.skill)?;
     let o = ri(request, &mut g).await;
@@ -11,6 +14,7 @@ pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunL
 
 async fn ri(request: RunLoopRequest<'_>, g: &mut Cg) -> Result<RunLoopCompletion> {
     let config_refs = request.config_refs();
+    let memory_admission = admission::RunMemoryAdmission::from_request(&request);
     let max_failover_attempts =
         max_failovers(request.no_failover, request.config, request.global_config);
 
@@ -80,6 +84,12 @@ async fn ri(request: RunLoopRequest<'_>, g: &mut Cg) -> Result<RunLoopCompletion
             request.run_timeout_seconds,
             tool_name_str,
         );
+        if (session_arg.is_none() || is_fork)
+            && executed_session_id.is_none()
+            && pre_created_fork_session_id.is_none()
+        {
+            memory_admission.validate(tool_name_str, initial_response_timeout_seconds)?;
+        }
         let max_concurrent = request.global_config.max_concurrent(tool_name_str);
         let mut _slot_guard = match acquire_attempt_slot(
             AttemptSlotRequest {

--- a/crates/cli-sub-agent/src/run_cmd_attempt_admission.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_admission.rs
@@ -1,0 +1,68 @@
+use anyhow::Result;
+use csa_config::{GlobalConfig, ProjectConfig};
+use csa_process::StreamMode;
+use std::path::{Path, PathBuf};
+
+use super::RunLoopRequest;
+
+/// Resolved writer admission inputs retained independently of the run request,
+/// whose owned routing fields are moved into the attempt loop.
+pub(super) struct RunMemoryAdmission<'a> {
+    project_root: &'a Path,
+    project_config: Option<&'a ProjectConfig>,
+    global_config: &'a GlobalConfig,
+    resource_overrides: crate::run_resource_overrides::RunResourceOverrides,
+    stream_mode: StreamMode,
+    idle_timeout_seconds: u64,
+    build_jobs: Option<u32>,
+    no_fs_sandbox: bool,
+    extra_writable: Vec<PathBuf>,
+    extra_readable: Vec<PathBuf>,
+}
+
+impl<'a> RunMemoryAdmission<'a> {
+    pub(super) fn from_request(request: &RunLoopRequest<'a>) -> Self {
+        Self {
+            project_root: request.project_root,
+            project_config: request.config,
+            global_config: request.global_config,
+            resource_overrides: request.resource_overrides,
+            stream_mode: request.stream_mode,
+            idle_timeout_seconds: crate::pipeline::resolve_effective_idle_timeout_seconds(
+                request.config,
+                request.cli_idle_timeout,
+                request.run_timeout_seconds,
+            ),
+            build_jobs: request.build_jobs,
+            no_fs_sandbox: request.no_fs_sandbox,
+            extra_writable: request.extra_writable.clone(),
+            extra_readable: request.extra_readable.clone(),
+        }
+    }
+
+    /// Applies the writer role's resolved soft-memory floor before any fresh
+    /// run attempt can allocate a session, including native fork children.
+    pub(super) fn validate(
+        &self,
+        tool_name: &str,
+        initial_response_timeout_seconds: Option<u64>,
+    ) -> Result<()> {
+        crate::run_cmd_preflight::validate_run_memory_soft_limit_before_session(
+            crate::run_cmd_preflight::RunMemorySoftLimitPreflight {
+                project_root: self.project_root,
+                project_config: self.project_config,
+                global_config: self.global_config,
+                tool_name,
+                resource_overrides: self.resource_overrides,
+                stream_mode: self.stream_mode,
+                idle_timeout_seconds: self.idle_timeout_seconds,
+                initial_response_timeout_seconds,
+                build_jobs: self.build_jobs,
+                no_fs_sandbox: self.no_fs_sandbox,
+                allow_user_daemon_ipc: false,
+                extra_writable: &self.extra_writable,
+                extra_readable: &self.extra_readable,
+            },
+        )
+    }
+}

--- a/crates/cli-sub-agent/src/run_cmd_attempt_outcome_catalog_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_outcome_catalog_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-fn cross_model_retry_clears_non_fork_effective_session() {
+fn cross_model_resume_retry_clears_non_fork_effective_session_for_fresh_admission() {
     let mut failover_context = None;
     let mut tool = ToolName::Codex;
     let mut model_spec = Some("codex/test-provider/model-a/high".to_string());

--- a/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_pre_exec_tests.rs
@@ -314,7 +314,10 @@ async fn handle_run_fails_fast_when_worktree_write_lock_is_held() {
     unsafe {
         std::env::set_var("PATH", format!("{}:{inherited_path}", bin_dir.display()));
     }
-    let config = run_config_with_tier("default", vec!["codex/openai/gpt-5.5/high"], &["codex"]);
+    let mut config = run_config_with_tier("default", vec!["codex/openai/gpt-5.5/high"], &["codex"]);
+    config.resources.memory_max_mb = Some(10_000);
+    config.resources.soft_limit_percent = Some(90);
+    config.tools.get_mut("codex").unwrap().memory_max_mb = Some(10_000);
     write_project_config(project_dir.path(), &config);
     let holder =
         csa_session::create_session(project_dir.path(), Some("holder"), None, Some("codex"))
@@ -386,7 +389,7 @@ async fn handle_run_fails_fast_when_worktree_write_lock_is_held() {
     )
     .await
     .expect_err("run writer should fail before tool execution when worktree lock is held");
-    let err = err.to_string();
+    let err = format!("{err:#}");
 
     assert!(
         !execution_marker.exists(),
@@ -408,6 +411,92 @@ async fn handle_run_fails_fast_when_worktree_write_lock_is_held() {
     assert!(
         err.contains("sequentially"),
         "missing serialize guidance: {err}"
+    );
+}
+
+#[tokio::test]
+async fn handle_run_writer_memory_floor_with_user_daemon_ipc_creates_no_preflight_artifact() {
+    let project_dir = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    let mut config = run_config_with_tier("default", vec!["codex/openai/gpt-5.5/high"], &["codex"]);
+    config.resources.memory_max_mb = Some(9_103);
+    config.resources.min_free_memory_mb = 1;
+    config.resources.soft_limit_percent = Some(90);
+    config.tools.get_mut("codex").unwrap().memory_max_mb = Some(9_103);
+    write_project_config(project_dir.path(), &config);
+
+    let error = handle_run(
+        Some(ToolArg::Specific(ToolName::Codex)),
+        None,
+        None,
+        None,
+        Some("fix the repository".to_string()),
+        None,
+        None,
+        None,
+        None,
+        false,
+        None,
+        false,
+        false,
+        Some("writer memory floor admission".to_string()),
+        false,
+        None,
+        None,
+        false,
+        true,
+        Some(project_dir.path().display().to_string()),
+        None,
+        None,
+        None,
+        false,
+        false,
+        false,
+        false,
+        false,
+        None,
+        crate::run_resource_overrides::RunResourceOverrides::absent(),
+        false,
+        None,
+        None,
+        None,
+        false,
+        false,
+        None,
+        0,
+        OutputFormat::Text,
+        csa_process::StreamMode::BufferOnly,
+        Some("default".to_string()),
+        false,
+        false,
+        true,
+        None, // error_marker_scan_override: defer to marker/config (#1745/#1847)
+        false,
+        false,
+        false,
+        false,
+        false,
+        Vec::new(),
+        Vec::new(),
+        crate::startup_env::StartupSubtreeEnv::default(),
+    )
+    .await
+    .expect_err("writer cap below its role-specific floor must fail before session creation");
+
+    let message = format!("{error:#}");
+    assert!(message.contains("memory_soft_limit_admission"), "{message}");
+    let sessions = csa_session::list_sessions(project_dir.path(), None).expect("list sessions");
+    assert!(
+        sessions.is_empty(),
+        "memory floor preflight must not create a writer session"
+    );
+    let preflight_dir = csa_session::get_session_root(project_dir.path())
+        .expect("get session root")
+        .join("run-pre-session-preflight");
+    assert!(
+        !preflight_dir.exists(),
+        "--allow-user-daemon-ipc must not write a synthetic preflight directory: {}",
+        preflight_dir.display()
     );
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/run_cmd_preflight.rs
@@ -1,19 +1,112 @@
 //! Preflight helpers for `csa run`.
 
-use anyhow::Result;
-use std::path::Path;
+use anyhow::{Context, Result};
+use csa_config::{ExecutionEnvOptions, GlobalConfig, ProjectConfig};
+use csa_process::StreamMode;
+use std::path::{Path, PathBuf};
 
-use csa_config::{GlobalConfig, ProjectConfig};
 use csa_core::types::ToolArg;
 
 use crate::run_cmd_model_pin::{self, inherited_model_pin_from_startup};
 use crate::run_helpers_branch_guard;
 use crate::startup_env::StartupSubtreeEnv;
 
+const RUN_PREFLIGHT_SESSION_ID: &str = "run-pre-session-preflight";
+
+/// The final resolved inputs needed to reject an unsafe writer memory envelope
+/// before allocating a session directory.
+pub(crate) struct RunMemorySoftLimitPreflight<'a> {
+    pub project_root: &'a Path,
+    pub project_config: Option<&'a ProjectConfig>,
+    pub global_config: &'a GlobalConfig,
+    pub tool_name: &'a str,
+    pub resource_overrides: crate::run_resource_overrides::RunResourceOverrides,
+    pub stream_mode: StreamMode,
+    pub idle_timeout_seconds: u64,
+    pub initial_response_timeout_seconds: Option<u64>,
+    pub build_jobs: Option<u32>,
+    pub no_fs_sandbox: bool,
+    pub allow_user_daemon_ipc: bool,
+    pub extra_writable: &'a [PathBuf],
+    pub extra_readable: &'a [PathBuf],
+}
+
 /// Validate `--prompt-file` with filesystem semantics before any Git pathspec
 /// handling, preflight probes, or session creation (#2834).
 pub(crate) fn validate_run_prompt_file(path: Option<&Path>) -> Result<()> {
     crate::run_helpers::validate_prompt_file_path(path)
+}
+
+/// Resolve the writer's actual sandbox plan before creating a fresh session.
+///
+/// This deliberately uses the same resolved limits and soft-limit admission
+/// gate as session execution. A cap that is adequate for a reviewer may still
+/// be below the writer's role-specific floor; returning that error here keeps
+/// the caller from receiving a new, guaranteed-to-fail session.
+pub(crate) fn validate_run_memory_soft_limit_before_session(
+    input: RunMemorySoftLimitPreflight<'_>,
+) -> Result<()> {
+    let mut execution_env = input.global_config.build_execution_env(
+        input.tool_name,
+        ExecutionEnvOptions::with_no_flash_fallback(),
+    );
+    crate::build_jobs_env::apply_build_jobs_env(&mut execution_env, input.build_jobs);
+    let sandbox_input = crate::pipeline_sandbox::SandboxResolveInput {
+        config: input.project_config,
+        tool_name: input.tool_name,
+        session_id: RUN_PREFLIGHT_SESSION_ID,
+        project_root: input.project_root,
+        stream_mode: input.stream_mode,
+        idle_timeout_seconds: input.idle_timeout_seconds,
+        liveness_dead_seconds: crate::pipeline::resolve_liveness_dead_seconds(input.project_config),
+        initial_response_timeout_seconds: input.initial_response_timeout_seconds,
+        no_fs_sandbox: input.no_fs_sandbox,
+        allow_user_daemon_ipc: input.allow_user_daemon_ipc,
+        readonly_project_root: false,
+        extra_writable: input.extra_writable,
+        extra_readable: input.extra_readable,
+        execution_env: execution_env.as_ref(),
+    };
+    let execute_options = match crate::pipeline_sandbox::resolve_sandbox_options_with_overrides(
+        sandbox_input,
+        input.resource_overrides,
+    ) {
+        crate::pipeline_sandbox::SandboxResolution::Ok(options) => *options,
+        crate::pipeline_sandbox::SandboxResolution::RequiredButUnavailable(message) => {
+            anyhow::bail!(message)
+        }
+    };
+    crate::resource_admission_soft_limit::ensure_memory_soft_limit_admission(
+        Some("run"),
+        input.tool_name,
+        execute_options
+            .sandbox
+            .as_ref()
+            .map(|sandbox| &sandbox.isolation_plan),
+    )
+    .map_err(|err| {
+        let err = anyhow::Error::new(err);
+        let argv: Vec<String> = std::env::args().collect();
+        let guidance =
+            crate::no_provider_launch::soft_limit_admission_guidance_from_error_with_argv(
+                input.project_root,
+                RUN_PREFLIGHT_SESSION_ID,
+                input.tool_name,
+                input.project_config,
+                input.resource_overrides,
+                &err,
+                &argv,
+            );
+        if let Some(guidance) = guidance {
+            err.context(format!(
+                "writer soft-limit memory retry guidance before session creation:\n- {}",
+                guidance.join("\n- ")
+            ))
+        } else {
+            err
+        }
+    })
+    .with_context(|| format!("run preflight for writer tool '{}'", input.tool_name))
 }
 
 #[derive(Clone, Copy)]
@@ -159,3 +252,7 @@ fn disable_ai_config_preflight(
         global_config.preflight.ai_config_symlink_check.enabled = false;
     }
 }
+
+#[cfg(test)]
+#[path = "run_cmd_preflight_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/run_cmd_preflight_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_preflight_tests.rs
@@ -1,0 +1,47 @@
+use super::{RunMemorySoftLimitPreflight, validate_run_memory_soft_limit_before_session};
+use crate::run_resource_overrides::RunResourceOverrides;
+use crate::test_env_lock::ScopedEnvVarRestore;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_config::GlobalConfig;
+
+#[test]
+fn writer_soft_limit_floor_is_rejected_before_session_creation() {
+    let project_dir = tempfile::tempdir().expect("temp project");
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _tools_available =
+        ScopedEnvVarRestore::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let mut config = crate::review_cmd::tests::project_config_with_enabled_tools(&["codex"]);
+    config.resources.memory_max_mb = Some(9_103);
+    config.resources.min_free_memory_mb = 1;
+    config.resources.soft_limit_percent = Some(90);
+    let global_config = GlobalConfig::default();
+
+    let error = validate_run_memory_soft_limit_before_session(RunMemorySoftLimitPreflight {
+        project_root: project_dir.path(),
+        project_config: Some(&config),
+        global_config: &global_config,
+        tool_name: "codex",
+        resource_overrides: RunResourceOverrides::from_cli(Some(9_103), None),
+        stream_mode: csa_process::StreamMode::BufferOnly,
+        idle_timeout_seconds: 120,
+        initial_response_timeout_seconds: Some(120),
+        build_jobs: Some(1),
+        no_fs_sandbox: false,
+        allow_user_daemon_ipc: false,
+        extra_writable: &[],
+        extra_readable: &[],
+    })
+    .expect_err("writer cap below its role-specific floor must fail before session creation");
+
+    let message = format!("{error:#}");
+    assert!(message.contains("memory_soft_limit_admission"), "{message}");
+    assert!(message.contains("codex writer soft memory threshold is 8192MB"));
+    assert!(message.contains("below required=9000MB"));
+    assert!(message.contains("writer soft-limit memory retry guidance before session creation"));
+    assert!(message.contains("run preflight for writer tool 'codex'"));
+    let sessions = csa_session::list_sessions(project_dir.path(), None).expect("list sessions");
+    assert!(
+        sessions.is_empty(),
+        "memory floor preflight must not create a writer session"
+    );
+}


### PR DESCRIPTION
Reject writer configurations below their role-specific soft-memory floor before a new session is created.

Also prevents synthetic preflight audit artifacts when `--allow-user-daemon-ipc` is requested and preserves admission for fresh children produced by identity-changing resumed failover.

Closes #2824