### PR TITLE
fix(#2908): preserve productive sessions past liveness deadline

### DIFF
--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -482,10 +482,12 @@ fn emit_wait_completion_signal(
     }
 }
 
-/// Check whether the session's last event remains within its configured
-/// liveness deadline while waiting. A live PID or diagnostic lock does not
-/// override a stale event: callers need a liveness failure instead of repeated
-/// `status=alive` outcomes for a stuck worker.
+/// Check whether a session has gone stale while waiting.
+///
+/// A stale event stream alone is not a death signal: a read-only liveness
+/// probe or a live worktree write lock shows that the session is still making
+/// progress. In their absence, the configured event deadline remains
+/// fail-closed for genuinely dead sessions.
 fn check_session_stale_before_wait(
     project_root: &Path,
     session_id: &str,
@@ -504,8 +506,6 @@ fn check_session_stale_before_wait(
         Ok(session) => {
             if matches!(session.phase, csa_session::SessionPhase::Active) {
                 // A durable terminal result or completion marker is authoritative.
-                // Otherwise, verify the event age before accepting a live PID or
-                // worktree lock as proof that the session is still healthy.
                 if super::legacy_complete_marker_is_valid(session_dir)
                     || (super::daemon_completion_exists(session_dir)
                         && !session_has_terminal_process(session_dir))
@@ -517,6 +517,15 @@ fn check_session_stale_before_wait(
                     Ok(None) => {}
                 }
 
+                if csa_process::ToolLiveness::is_alive_read_only(session_dir)
+                    || any_session_holds_worktree_write_lock(
+                        worktree_lock_root,
+                        worktree_lock_session_ids,
+                    )
+                {
+                    return Ok(());
+                }
+
                 let elapsed = wait_options
                     .current_time()
                     .signed_duration_since(session.last_accessed);
@@ -526,15 +535,6 @@ fn check_session_stale_before_wait(
                         elapsed.num_seconds(),
                         liveness_dead_seconds
                     ));
-                }
-
-                if csa_process::ToolLiveness::is_alive(session_dir)
-                    || any_session_holds_worktree_write_lock(
-                        worktree_lock_root,
-                        worktree_lock_session_ids,
-                    )
-                {
-                    return Ok(());
                 }
             }
         }
@@ -560,7 +560,7 @@ fn state_loss_has_waitable_evidence(session_dir: &Path) -> bool {
         .is_file()
         || super::daemon_completion_exists(session_dir)
         || session_has_terminal_process(session_dir)
-        || csa_process::ToolLiveness::is_alive(session_dir)
+        || csa_process::ToolLiveness::is_alive_read_only(session_dir)
 }
 
 fn any_session_holds_worktree_write_lock(

--- a/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
@@ -386,7 +386,7 @@ fn exact_id_wait_and_result_survive_repeated_kv_warm_after_registry_state_loss()
 
 #[cfg(target_os = "linux")]
 #[test]
-fn stale_precheck_fails_live_daemon_after_liveness_deadline() {
+fn stale_precheck_preserves_live_daemon_after_liveness_deadline() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
@@ -434,11 +434,11 @@ fn stale_precheck_fails_live_daemon_after_liveness_deadline() {
             panic!("stale precheck must not emit a synthetic completion for a live daemon");
         },
     )
-    .expect("wait should reject the stale event before accepting liveness");
+    .expect("wait should preserve liveness before the event deadline");
 
     assert_eq!(
-        exit_code, 1,
-        "a live daemon must not override the configured liveness deadline"
+        exit_code, 0,
+        "a live daemon must override the configured liveness deadline"
     );
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_liveness.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_liveness.rs
@@ -95,8 +95,8 @@ fn handle_session_wait_continues_polling_when_pid_missing_but_liveness_signals_p
         "test requires session_has_terminal_process=false: no daemon pid"
     );
     assert!(
-        csa_process::ToolLiveness::is_alive(&session_dir),
-        "recent session writes must make is_alive return true"
+        csa_process::ToolLiveness::is_alive_read_only(&session_dir),
+        "recent session writes must make the read-only liveness probe return true"
     );
 
     let exit_code = handle_session_wait_with_hooks(
@@ -128,7 +128,7 @@ fn handle_session_wait_continues_polling_when_pid_missing_but_liveness_signals_p
 
 #[cfg(target_os = "linux")]
 #[test]
-fn handle_session_wait_fails_when_live_daemon_event_exceeds_configured_liveness_deadline() {
+fn handle_session_wait_continues_when_read_only_liveness_outlives_event_deadline() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
@@ -158,6 +158,7 @@ fn handle_session_wait_fails_when_live_daemon_event_exceeds_configured_liveness_
     session.last_accessed = fixed_now - chrono::Duration::seconds(2);
     save_session(&session).expect("persist stale event at fixed time");
     let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
 
     let wait_result = handle_session_wait_with_hooks_at(
         session_id,
@@ -173,17 +174,21 @@ fn handle_session_wait_fails_when_live_daemon_event_exceeds_configured_liveness_
         fixed_now,
         Some(true),
         |_project_root, _current_session_id, _trigger| {
-            panic!("stale live session must fail liveness before reconciliation")
+            panic!("live session must not reconcile after its event deadline")
         },
         |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {
-            panic!("stale live session must not emit a terminal completion")
+            panic!("live session must not emit a terminal completion")
         },
     );
 
     assert_eq!(
-        wait_result.expect("wait should classify stale liveness"),
-        1,
-        "a live PID with no new session event past liveness_dead_seconds must not return alive"
+        wait_result.expect("wait should preserve productive liveness"),
+        0,
+        "read-only liveness must override an event deadline while productive evidence remains"
+    );
+    assert!(
+        !session_dir.join(".liveness.snapshot").exists(),
+        "stale precheck must not persist a liveness snapshot"
     );
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
@@ -321,7 +321,7 @@ fn handle_session_wait_rejects_duplicate_wait_before_entering_loop() {
 }
 
 #[test]
-fn handle_session_wait_fails_stale_session_despite_live_worktree_lock() {
+fn handle_session_wait_continues_stale_session_with_live_worktree_lock() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
@@ -365,18 +365,18 @@ fn handle_session_wait_fails_stale_session_despite_live_worktree_lock() {
         fixed_now,
         None,
         |_project_root, _current_session_id, _trigger| {
-            panic!("stale liveness failure must happen before reconciliation")
+            panic!("live worktree lock must prevent stale-session reconciliation")
         },
         |sid: &str, status: &str, exit_code, synthetic, _mirror_to_stdout| {
             emitted_completion = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
         },
     )
-    .expect("wait should fail the stale session despite its live lock");
+    .expect("wait should preserve the stale session while its lock is live");
 
-    assert_eq!(exit_code, 1);
+    assert_eq!(exit_code, 0);
     assert_eq!(
         emitted_completion, None,
-        "live lock must not override the configured liveness deadline"
+        "live lock must override the configured liveness deadline"
     );
 }
 

--- a/crates/cli-sub-agent/tests/run_wait_memory_admission.rs
+++ b/crates/cli-sub-agent/tests/run_wait_memory_admission.rs
@@ -78,6 +78,7 @@ fn run_wait_host_memory_denial_fails_before_session_started_marker() {
             "run",
             "--sa-mode",
             "false",
+            "--allow-base-branch-working",
             "--wait",
             "--tool",
             "codex",

--- a/crates/cli-sub-agent/tests/session_wait_liveness_exit.rs
+++ b/crates/cli-sub-agent/tests/session_wait_liveness_exit.rs
@@ -55,26 +55,42 @@ fn output_text(output: &Output) -> String {
 }
 
 #[cfg(target_os = "linux")]
-fn read_process_start_time_ticks(pid: u32) -> u64 {
-    let content = std::fs::read_to_string(format!("/proc/{pid}/stat")).expect("read /proc stat");
-    let close_paren = content.rfind(')').expect("stat comm terminator");
-    let mut parts = content[close_paren + 1..].split_whitespace();
-    parts.next().expect("state");
-    parts.next().expect("ppid");
-    parts.next().expect("pgrp");
-    for _ in 0..16 {
-        parts.next().expect("intermediate stat field");
+fn backdate_tree(path: &Path, seconds_ago: u64) {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    if path.is_dir() {
+        for entry in std::fs::read_dir(path).expect("read session tree") {
+            backdate_tree(&entry.expect("session tree entry").path(), seconds_ago);
+        }
     }
-    parts
-        .next()
-        .expect("starttime")
-        .parse::<u64>()
-        .expect("starttime parse")
+    let target = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock after unix epoch")
+        .saturating_sub(Duration::from_secs(seconds_ago));
+    let times = [
+        libc::timespec {
+            tv_sec: target.as_secs() as libc::time_t,
+            tv_nsec: target.subsec_nanos() as libc::c_long,
+        },
+        libc::timespec {
+            tv_sec: target.as_secs() as libc::time_t,
+            tv_nsec: target.subsec_nanos() as libc::c_long,
+        },
+    ];
+    let path = CString::new(path.as_os_str().as_bytes()).expect("path contains no NUL");
+    // SAFETY: `path` is NUL-terminated and `times` lives for the system call.
+    assert_eq!(
+        unsafe { libc::utimensat(libc::AT_FDCWD, path.as_ptr(), times.as_ptr(), 0) },
+        0,
+        "backdate {}",
+        path.to_string_lossy()
+    );
 }
 
 #[cfg(target_os = "linux")]
 #[test]
-fn session_wait_liveness_failure_exits_nonzero_even_with_live_daemon() {
+fn session_wait_liveness_failure_exits_nonzero_without_live_signal() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let project = tmp.path().join("project");
     std::fs::create_dir_all(project.join(".csa")).expect("create project config dir");
@@ -112,20 +128,7 @@ fn session_wait_liveness_failure_exits_nonzero_even_with_live_daemon() {
     std::fs::create_dir_all(session_dir.join("input")).expect("create session input dir");
     std::fs::create_dir_all(session_dir.join("output")).expect("create session output dir");
     csa_session::save_session_in(&session_root, &session).expect("save stale active session");
-
-    let mut daemon = Command::new("sleep")
-        .arg("30")
-        .spawn()
-        .expect("spawn live daemon stand-in");
-    std::fs::write(
-        session_dir.join("daemon.pid"),
-        format!(
-            "{} {}\n",
-            daemon.id(),
-            read_process_start_time_ticks(daemon.id())
-        ),
-    )
-    .expect("write live daemon pid");
+    backdate_tree(&session_dir, 31);
 
     let mut wait = csa_cmd(tmp.path())
         .current_dir(&project)
@@ -152,8 +155,6 @@ fn session_wait_liveness_failure_exits_nonzero_even_with_live_daemon() {
             None => {
                 wait.kill().ok();
                 wait.wait().ok();
-                daemon.kill().ok();
-                daemon.wait().ok();
                 panic!("session wait did not fail before the test watchdog expired");
             }
         }
@@ -161,15 +162,6 @@ fn session_wait_liveness_failure_exits_nonzero_even_with_live_daemon() {
     let output = wait
         .wait_with_output()
         .expect("collect csa session wait output");
-
-    assert!(
-        daemon.try_wait().expect("poll live daemon").is_none(),
-        "session wait must report stale liveness while the daemon is still live: {}",
-        output_text(&output)
-    );
-
-    daemon.kill().ok();
-    daemon.wait().ok();
 
     assert_eq!(
         output.status.code(),


### PR DESCRIPTION
## Summary
- Preserve active waits past the event-liveness deadline when read-only tool liveness or a live worktree write lock proves productive work.
- Retain fail-closed liveness failure when no productive signal exists.

## Validation
- Isolated read-only Codex review of `origin/main...b61c893fe1baaf854d116764e24d9eabcb313691`: `VERDICT: PASS`.
- Pre-push suite passed for this exact SHA.

Closes #2908