### PR TITLE
fix(#2913): tolerate existing cargo-install-root directory

### DIFF
--- a/crates/cli-sub-agent/src/pipeline_sandbox_cargo_install_root_writable_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_cargo_install_root_writable_tests.rs
@@ -1,0 +1,91 @@
+use super::*;
+
+#[test]
+fn test_rust_env_writable_cargo_install_root_accepts_existing_directory() {
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let cargo_install_root = project_root.path().join("target/cargo-install-root");
+    std::fs::create_dir_all(&cargo_install_root).expect("create existing cargo install root");
+    let execution_env = HashMap::from([(
+        csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY.to_string(),
+        cargo_install_root.to_string_lossy().into_owned(),
+    )]);
+
+    let plan = add_execution_env_writable_paths(
+        csa_resource::isolation_plan::IsolationPlanBuilder::new(
+            csa_resource::isolation_plan::EnforcementMode::BestEffort,
+        ),
+        Some(&execution_env),
+        project_root.path(),
+    )
+    .expect("existing cargo install-root directory should remain usable")
+    .build()
+    .expect("build isolation plan");
+
+    assert!(
+        plan.writable_paths.contains(
+            &cargo_install_root
+                .canonicalize()
+                .expect("canonical install root")
+        )
+    );
+}
+
+#[test]
+fn test_rust_env_writable_cargo_install_root_rejects_existing_file_clearly() {
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let cargo_install_root = project_root.path().join("target/cargo-install-root");
+    std::fs::create_dir_all(cargo_install_root.parent().expect("install root parent"))
+        .expect("create install root parent");
+    std::fs::write(&cargo_install_root, "not a directory").expect("create install root file");
+    let execution_env = HashMap::from([(
+        csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY.to_string(),
+        cargo_install_root.to_string_lossy().into_owned(),
+    )]);
+
+    let error = add_execution_env_writable_paths(
+        csa_resource::isolation_plan::IsolationPlanBuilder::new(
+            csa_resource::isolation_plan::EnforcementMode::BestEffort,
+        ),
+        Some(&execution_env),
+        project_root.path(),
+    )
+    .expect_err("file at cargo install-root must fail closed");
+
+    assert!(
+        error.contains("exists as a file"),
+        "unexpected error: {error}"
+    );
+    assert!(error.contains(&cargo_install_root.display().to_string()));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_rust_env_writable_cargo_install_root_reports_broken_parent_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let project_root = tempfile::tempdir().expect("project root tempdir");
+    let broken_target = project_root.path().join("missing-target");
+    let target = project_root.path().join("target");
+    symlink(&broken_target, &target).expect("create broken target symlink");
+    let cargo_install_root = target.join("cargo-install-root");
+    let execution_env = HashMap::from([(
+        csa_core::env::CARGO_INSTALL_ROOT_ENV_KEY.to_string(),
+        cargo_install_root.to_string_lossy().into_owned(),
+    )]);
+
+    let error = add_execution_env_writable_paths(
+        csa_resource::isolation_plan::IsolationPlanBuilder::new(
+            csa_resource::isolation_plan::EnforcementMode::BestEffort,
+        ),
+        Some(&execution_env),
+        project_root.path(),
+    )
+    .expect_err("broken target symlink must fail closed");
+
+    assert!(
+        error.contains("exists as a symlink"),
+        "unexpected error: {error}"
+    );
+    assert!(error.contains(&target.display().to_string()));
+    assert!(!error.contains("File exists (os error 17)"));
+}

--- a/crates/cli-sub-agent/src/pipeline_sandbox_extra_writable_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_extra_writable_tests.rs
@@ -4,6 +4,9 @@ use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 
 use super::*;
 
+#[path = "pipeline_sandbox_cargo_install_root_writable_tests.rs"]
+mod cargo_install_root_writable_tests;
+
 fn parse_project_config(toml_str: &str) -> csa_config::ProjectConfig {
     toml::from_str(toml_str).expect("test TOML should parse")
 }

--- a/crates/cli-sub-agent/src/pipeline_sandbox_writable.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_writable.rs
@@ -125,10 +125,11 @@ fn resolve_and_prepare_required_writable_sources(
             Ok(true) if candidate.is_dir() => prepared.push(candidate.clone()),
             Ok(true) => {
                 return Err(format!(
-                    "{source_label} path '{}' resolved to '{}' is not a directory before session launch. \
+                    "{source_label} path '{}' resolved to '{}' {} before session launch. \
                      Rust state env values must point to writable directories.",
                     path.display(),
-                    candidate.display()
+                    candidate.display(),
+                    non_directory_path_detail(candidate)
                 ));
             }
             Ok(false) => {
@@ -215,16 +216,92 @@ fn prepare_missing_required_source_directory(
         path = %candidate.display(),
         "Creating missing required writable directory before sandbox launch"
     );
-    std::fs::create_dir_all(candidate).map_err(|error| {
-        format!(
-            "{source_label} path '{}' resolved to '{}' could not be created before session launch: {error}. \
-             Set Cargo/Rustup env to writable paths or grant the exact cache directory with --extra-writable.",
-            original.display(),
-            candidate.display()
-        )
-    })?;
-    prepared.push(candidate.to_path_buf());
+    match std::fs::create_dir_all(candidate) {
+        Ok(()) => prepared.push(candidate.to_path_buf()),
+        // A concurrent creator may win after the preceding existence check.
+        // Treat the resulting directory as success, but never mask a file,
+        // broken symlink, or other non-directory that reports EEXIST.
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists && candidate.is_dir() => {
+            prepared.push(candidate.to_path_buf());
+        }
+        Err(error) => {
+            let reason =
+                non_directory_component_detail(candidate).unwrap_or_else(|| error.to_string());
+            return Err(format!(
+                "{source_label} path '{}' resolved to '{}' could not be created before session launch: {reason}. \
+                 Set Cargo/Rustup env to writable paths or grant the exact cache directory with --extra-writable.",
+                original.display(),
+                candidate.display()
+            ));
+        }
+    }
     Ok(())
+}
+
+fn non_directory_path_detail(path: &Path) -> &'static str {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            "exists as a symlink to a non-directory (not a directory)"
+        }
+        Ok(_) => "exists as a file or other non-directory (not a directory)",
+        Err(_) => "is not a directory",
+    }
+}
+
+/// Return a precise type diagnostic for the first existing path component that
+/// prevents `create_dir_all` from creating a required Rust state directory.
+///
+/// `Path::try_exists` follows symlinks, so a broken intermediate symlink looks
+/// absent and otherwise surfaces only as an opaque EEXIST from `create_dir_all`.
+/// Keep a directory symlink valid, but call out a broken or non-directory
+/// symlink without relaxing the required-directory check.
+fn non_directory_component_detail(path: &Path) -> Option<String> {
+    let mut component = path.to_path_buf();
+    loop {
+        match std::fs::symlink_metadata(&component) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                match std::fs::metadata(&component) {
+                    Ok(target) if target.is_dir() => {}
+                    Ok(_) => {
+                        return Some(format!(
+                            "path component '{}' exists as a symlink to a non-directory (not a directory)",
+                            component.display()
+                        ));
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        return Some(format!(
+                            "path component '{}' exists as a symlink with an unavailable target",
+                            component.display()
+                        ));
+                    }
+                    Err(error) => {
+                        return Some(format!(
+                            "path component '{}' exists as a symlink that could not be inspected: {error}",
+                            component.display()
+                        ));
+                    }
+                }
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                return Some(format!(
+                    "path component '{}' exists as a file or other non-directory (not a directory)",
+                    component.display()
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Some(format!(
+                    "path component '{}' could not be inspected: {error}",
+                    component.display()
+                ));
+            }
+        }
+
+        if !component.pop() {
+            return None;
+        }
+    }
 }
 
 fn path_looks_like_file(path: &Path) -> bool {


### PR DESCRIPTION
## Summary
- tolerate an already-existing `CARGO_INSTALL_ROOT` directory and the create race that returns `EEXIST`
- retain fail-closed errors for files, broken/non-directory symlinks, and uncreatable paths
- add focused cargo-install-root writable-path coverage

## Review
- Codex clean-room read-only review: `VERDICT: PASS` for `origin/main...d157664e3b549aa89349e2ff5ddd46ac6d3fd7a0`

Closes #2913