### PR TITLE
fix(review): honor --single over large-diff auto-chunk multi-spawn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1127"
+version = "0.1.1128"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1127"
+version = "0.1.1128"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_chunking.rs
+++ b/crates/cli-sub-agent/src/review_cmd_chunking.rs
@@ -194,8 +194,30 @@ pub(super) fn should_bypass_chunking(
     mode: ReviewChunkingMode,
     fix: bool,
     session_present: bool,
+    force_single_reviewer: bool,
 ) -> bool {
-    mode == ReviewChunkingMode::Off || fix || session_present
+    // Explicit single-reviewer intent must win over large-diff auto-chunk multi-spawn
+    // (which otherwise writes tool=consensus and issues N admission attempts).
+    mode == ReviewChunkingMode::Off || fix || session_present || force_single_reviewer
+}
+
+/// Whether the large-diff auto-chunk multi-spawn path may activate.
+///
+/// Explicit multi-reviewer requests keep the non-chunked multi-reviewer path.
+/// `--single` / explicit `--reviewers 1` force the single-reviewer path (#2910).
+pub(super) fn should_attempt_auto_chunking(args: &ReviewArgs) -> bool {
+    let explicit_multi_reviewer = args.reviewers.is_some() && args.requested_reviewers() > 1;
+    if explicit_multi_reviewer {
+        return false;
+    }
+    let force_single_reviewer =
+        args.single || (args.reviewers.is_some() && args.requested_reviewers() == 1);
+    !should_bypass_chunking(
+        args.chunked_review,
+        args.fix,
+        args.session.is_some(),
+        force_single_reviewer,
+    )
 }
 
 pub(super) fn plan_review_chunks(

--- a/crates/cli-sub-agent/src/review_cmd_chunking_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_chunking_tests.rs
@@ -151,23 +151,90 @@ fn config_helpers_and_bypass_predicate_match_cli_semantics() {
     assert!(should_bypass_chunking(
         ReviewChunkingMode::Off,
         false,
+        false,
         false
     ));
     assert!(should_bypass_chunking(
         ReviewChunkingMode::Auto,
         true,
+        false,
         false
     ));
     assert!(should_bypass_chunking(
         ReviewChunkingMode::Auto,
         false,
-        true
+        true,
+        false
     ));
     assert!(!should_bypass_chunking(
         ReviewChunkingMode::Auto,
         false,
+        false,
         false
     ));
+    // #2910: forced single-reviewer intent wins over large-diff auto-chunk multi-spawn.
+    assert!(should_bypass_chunking(
+        ReviewChunkingMode::Auto,
+        false,
+        false,
+        true
+    ));
+    assert!(should_bypass_chunking(
+        ReviewChunkingMode::Always,
+        false,
+        false,
+        true
+    ));
+}
+
+#[test]
+fn forced_single_reviewer_blocks_auto_chunk_multi_spawn() {
+    use clap::Parser;
+
+    fn parse(argv: &[&str]) -> ReviewArgs {
+        let cli = crate::cli::Cli::try_parse_from(argv).expect("review CLI args should parse");
+        match cli.command {
+            crate::cli::Commands::Review(args) => args,
+            _ => panic!("expected review subcommand"),
+        }
+    }
+
+    // Default large-range path may still attempt auto-chunking.
+    assert!(should_attempt_auto_chunking(&parse(&[
+        "csa",
+        "review",
+        "--range",
+        "main...HEAD"
+    ])));
+
+    // --single always wins.
+    assert!(!should_attempt_auto_chunking(&parse(&[
+        "csa",
+        "review",
+        "--range",
+        "main...HEAD",
+        "--single"
+    ])));
+
+    // Explicit --reviewers 1 wins (same class as --single).
+    assert!(!should_attempt_auto_chunking(&parse(&[
+        "csa",
+        "review",
+        "--range",
+        "main...HEAD",
+        "--reviewers",
+        "1"
+    ])));
+
+    // Explicit multi-reviewer keeps the non-chunk multi-reviewer path.
+    assert!(!should_attempt_auto_chunking(&parse(&[
+        "csa",
+        "review",
+        "--range",
+        "main...HEAD",
+        "--reviewers",
+        "3"
+    ])));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_handle.rs
+++ b/crates/cli-sub-agent/src/review_cmd_handle.rs
@@ -257,10 +257,7 @@ async fn handle_review_inner(
     let explicit_tool_with_failover =
         (selection.direct_tool_requested && tier_active && !execution_no_failover).then_some(tool);
 
-    let explicit_multi_reviewer = args.reviewers.is_some() && args.requested_reviewers() > 1;
-    if !explicit_multi_reviewer
-        && !chunking::should_bypass_chunking(args.chunked_review, args.fix, args.session.is_some())
-    {
+    if chunking::should_attempt_auto_chunking(&args) {
         let chunking_config = chunking::ReviewChunkingConfig::for_args(args.chunked_review);
         match chunking::plan_review_chunks(&project_root, &scope, diff.as_ref(), &chunking_config) {
             Ok(Some(chunk_plan)) => {

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1127"
-weave = "0.1.1127"
+csa = "0.1.1128"
+weave = "0.1.1128"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
Closes #2910.

Large-range reviews with explicit `--single` / `--reviewers 1` still multi-spawned via auto-chunking and wrote `tool: consensus`, even though heterogeneous auto-selection already respected those overrides.

## Root cause
- Auto-heterogeneous reviewer selection already suppressed multi-select for `--single`, explicit reviewers count, `--tool`, and `--model-spec`.
- Residual path: `--chunked-review auto` still activated multi-chunk spawn and consensus metadata for large multi-file diffs, ignoring forced single-reviewer intent.

## Fix
- `should_bypass_chunking(..., force_single_reviewer)`
- `should_attempt_auto_chunking(&ReviewArgs)` centralizes: skip auto-chunk for explicit multi-reviewer requests and for forced single (`--single` or explicit `--reviewers 1`)
- Handle path uses the shared predicate (keeps `review_cmd_handle.rs` under monolith budget)

## Tests
- `config_helpers_and_bypass_predicate_match_cli_semantics` covers force-single bypass for Auto/Always
- `forced_single_reviewer_blocks_auto_chunk_multi_spawn` covers CLI default / `--single` / `--reviewers 1` / `--reviewers 3`
- Existing auto-selection single/explicit-reviewers regressions remain green

## Review evidence
- Exact range: `origin/main...HEAD` = `51be4fe52c81db5d38ec558ad835bdf28d747b1c...6934cbbb1f614131040a6df1de747d78db58cfe5`
- Isolated Codex CLI (`CODEX_HOME` auth-only, ignore-user-config): **VERDICT: PASS**
- Formal CSA review marker unavailable on installed `csa 0.1.1118` due multi-admission / memory accounting (the bug this PR fixes + #2909 class); authorized pre-push bypass logged with reason.

## Checklist
- [x] focused tests
- [x] `just pre-commit-fast`
- [x] intentional atomic commit
- [x] hook-enabled push (full suite green on successful push)
- [x] Closes #2910