### PR TITLE
fix(review): actionable UNAVAILABLE reasons + force-ignore default tier (#2911)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1128"
+version = "0.1.1129"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1128"
+version = "0.1.1129"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -334,16 +334,23 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
         agreement * 100.0,
     );
     for outcome in &outcomes {
+        let reason_suffix = outcome
+            .diagnostic
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|reason| format!("; reason: {reason}"))
+            .unwrap_or_default();
         if excluded_from_consensus.contains(&outcome.reviewer_index) {
             println!(
-                "- reviewer {} ({}) => {} (excluded_from_consensus: permanent quota unavailable)",
+                "- reviewer {} ({}) => {} (excluded_from_consensus: permanent quota unavailable){reason_suffix}",
                 outcome.reviewer_index + 1,
                 outcome.tool,
                 outcome.verdict
             );
         } else {
             println!(
-                "- reviewer {} ({}) => {}",
+                "- reviewer {} ({}) => {}{reason_suffix}",
                 outcome.reviewer_index + 1,
                 outcome.tool,
                 outcome.verdict

--- a/crates/cli-sub-agent/src/review_cmd_multi.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi.rs
@@ -334,11 +334,7 @@ pub(super) async fn run_multi_reviewer_review(ctx: MultiReviewerReviewContext<'_
         agreement * 100.0,
     );
     for outcome in &outcomes {
-        let reason_suffix = outcome
-            .diagnostic
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
+        let reason_suffix = super::parent_artifacts::unavailable_outcome_reason(outcome)
             .map(|reason| format!("; reason: {reason}"))
             .unwrap_or_default();
         if excluded_from_consensus.contains(&outcome.reviewer_index) {

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -28,7 +28,10 @@ use super::output::ReviewerOutcome;
 
 #[path = "review_cmd_parent_verdict.rs"]
 mod parent_verdict;
-use parent_verdict::write_parent_review_verdict;
+use parent_verdict::{
+    aggregate_unavailable_reviewer_reasons, patch_parent_review_verdict_unavailable_reasons,
+    write_parent_review_details, write_parent_review_summary, write_parent_review_verdict,
+};
 
 pub(super) struct MultiReviewerConsensusArtifacts<'a> {
     pub(super) project_root: &'a Path,
@@ -243,6 +246,7 @@ fn write_multi_reviewer_parent_artifacts_with_diff_size(
     let parent_artifact = parent_artifact_for_decision(&consolidated, parent_decision);
     write_consolidated_artifact(&parent_artifact, &session_dir)?;
     write_parent_findings_toml(&session_dir, &parent_artifact)?;
+    let (primary_failure, failure_reason) = aggregate_unavailable_reviewer_reasons(outcomes);
     write_parent_review_verdict(
         &session_dir,
         &session_id,
@@ -256,11 +260,20 @@ fn write_multi_reviewer_parent_artifacts_with_diff_size(
         // Authoritative run mode, not reviewer-derived `parent_artifact.review_mode` (#1817).
         run_review_mode,
     )?;
+    if primary_failure.is_some() || failure_reason.is_some() {
+        patch_parent_review_verdict_unavailable_reasons(
+            &session_dir,
+            primary_failure.as_deref(),
+            failure_reason.as_deref(),
+        )?;
+    }
     if let Some(meta) = parent_review_meta {
         let mut meta = meta.clone();
         meta.decision = parent_decision.as_str().to_string();
         meta.verdict = parent_verdict.clone();
         meta.review_mode = run_review_mode.map(str::to_string);
+        meta.primary_failure = primary_failure.clone();
+        meta.failure_reason = failure_reason.clone();
         meta.exit_code = if parent_decision.is_clean() { 0 } else { 1 };
         write_review_meta_with_diff_report(&session_dir, &meta, diff_size, large_diff_warning)
             .context("failed to write parent review_meta.json")?;
@@ -330,6 +343,7 @@ pub(super) fn write_standalone_consensus_review_artifacts(
     let artifact = parent_artifact_for_decision(&consolidated, decision);
     write_consolidated_artifact(&artifact, &session_dir)?;
     write_parent_findings_toml(&session_dir, &artifact)?;
+    let (primary_failure, failure_reason) = aggregate_unavailable_reviewer_reasons(ctx.outcomes);
     let meta = ReviewSessionMeta {
         session_id: target.session_id.clone(),
         head_sha: ctx.head_sha.to_string(),
@@ -339,8 +353,8 @@ pub(super) fn write_standalone_consensus_review_artifacts(
         review_mode: ctx.run_review_mode.map(str::to_string),
         status_reason: None,
         routed_to: None,
-        primary_failure: None,
-        failure_reason: None,
+        primary_failure: primary_failure.clone(),
+        failure_reason: failure_reason.clone(),
         tool: "consensus".to_string(),
         scope: ctx.scope.to_string(),
         exit_code: if decision.is_clean() { 0 } else { 1 },
@@ -361,6 +375,8 @@ pub(super) fn write_standalone_consensus_review_artifacts(
         Vec::new(),
     );
     verdict_artifact.review_mode = ctx.run_review_mode.map(str::to_string);
+    verdict_artifact.primary_failure = primary_failure;
+    verdict_artifact.failure_reason = failure_reason;
     verdict_artifact.diff_size = ctx.diff_size.cloned();
     apply_large_diff_warning(&mut verdict_artifact, ctx.large_diff_warning);
     write_review_verdict(&session_dir, &verdict_artifact)
@@ -590,73 +606,6 @@ fn parent_legacy_verdict(decision: ReviewDecision, fallback: &str) -> String {
             fallback.to_string()
         }
     }
-}
-
-fn write_parent_review_summary(
-    session_dir: &Path,
-    outcomes: &[ReviewerOutcome],
-    final_verdict: &str,
-    diff_size: Option<&ReviewDiffSize>,
-) -> Result<()> {
-    let output_dir = session_dir.join("output");
-    fs::create_dir_all(&output_dir)
-        .with_context(|| format!("failed to create {}", output_dir.display()))?;
-    let mut summary = format!("Final verdict: {final_verdict}\n\nReviewer outcomes:\n");
-    if let Some(diff_size) = diff_size {
-        summary = format!(
-            "{}\n{summary}",
-            super::diff_size::format_review_diff_size_line(diff_size)
-        );
-    }
-    for outcome in outcomes {
-        summary.push_str(&format!(
-            "- reviewer {} ({}) => {}",
-            outcome.reviewer_index + 1,
-            outcome.tool,
-            outcome.verdict
-        ));
-        if let Some(diagnostic) = &outcome.diagnostic {
-            summary.push_str(&format!("; diagnostic: {diagnostic}"));
-        }
-        summary.push('\n');
-    }
-    fs::write(output_dir.join("summary.md"), summary)
-        .context("failed to write parent output/summary.md")
-}
-
-fn write_parent_review_details(
-    session_dir: &Path,
-    outcomes: &[ReviewerOutcome],
-    diff_size: Option<&ReviewDiffSize>,
-) -> Result<()> {
-    let output_dir = session_dir.join("output");
-    fs::create_dir_all(&output_dir)
-        .with_context(|| format!("failed to create {}", output_dir.display()))?;
-    let mut details = String::new();
-    if let Some(diff_size) = diff_size {
-        details.push_str(&super::diff_size::format_review_diff_size_line(diff_size));
-        details.push_str("\n\n");
-    }
-    for outcome in outcomes {
-        details.push_str(&format!(
-            "## Reviewer {} ({})\n\nVerdict: {}\nExit code: {}\n",
-            outcome.reviewer_index + 1,
-            outcome.tool,
-            outcome.verdict,
-            outcome.exit_code
-        ));
-        if let Some(diagnostic) = &outcome.diagnostic {
-            details.push_str(&format!("Diagnostic: {diagnostic}\n"));
-        }
-        details.push('\n');
-        details.push_str(&outcome.output);
-        if !details.ends_with('\n') {
-            details.push('\n');
-        }
-        details.push('\n');
-    }
-    fs::write(output_dir.join("details.md"), details)
-        .context("failed to write parent output/details.md")
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -248,7 +248,11 @@ fn write_multi_reviewer_parent_artifacts_with_diff_size(
     let parent_artifact = parent_artifact_for_decision(&consolidated, parent_decision);
     write_consolidated_artifact(&parent_artifact, &session_dir)?;
     write_parent_findings_toml(&session_dir, &parent_artifact)?;
-    let (primary_failure, failure_reason) = aggregate_unavailable_reviewer_reasons(outcomes);
+    let (primary_failure, failure_reason) = if parent_decision == ReviewDecision::Unavailable {
+        aggregate_unavailable_reviewer_reasons(outcomes)
+    } else {
+        (None, None)
+    };
     write_parent_review_verdict(
         &session_dir,
         &session_id,
@@ -345,7 +349,11 @@ pub(super) fn write_standalone_consensus_review_artifacts(
     let artifact = parent_artifact_for_decision(&consolidated, decision);
     write_consolidated_artifact(&artifact, &session_dir)?;
     write_parent_findings_toml(&session_dir, &artifact)?;
-    let (primary_failure, failure_reason) = aggregate_unavailable_reviewer_reasons(ctx.outcomes);
+    let (primary_failure, failure_reason) = if decision == ReviewDecision::Unavailable {
+        aggregate_unavailable_reviewer_reasons(ctx.outcomes)
+    } else {
+        (None, None)
+    };
     let meta = ReviewSessionMeta {
         session_id: target.session_id.clone(),
         head_sha: ctx.head_sha.to_string(),

--- a/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_artifacts.rs
@@ -33,6 +33,8 @@ use parent_verdict::{
     write_parent_review_details, write_parent_review_summary, write_parent_review_verdict,
 };
 
+pub(super) use parent_verdict::unavailable_outcome_reason;
+
 pub(super) struct MultiReviewerConsensusArtifacts<'a> {
     pub(super) project_root: &'a Path,
     pub(super) reviewers: usize,

--- a/crates/cli-sub-agent/src/review_cmd_parent_unavailable_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_unavailable_tests.rs
@@ -1,0 +1,82 @@
+use super::{
+    aggregate_unavailable_reviewer_reasons, patch_parent_review_verdict_unavailable_reasons,
+    write_parent_review_verdict,
+};
+use crate::review_cmd::diff_size::ReviewDiffReport;
+use crate::review_cmd::output::ReviewerOutcome;
+use crate::review_consensus::UNAVAILABLE;
+use csa_core::types::{ReviewDecision, ToolName};
+use csa_session::ReviewVerdictArtifact;
+use std::fs;
+use tempfile::tempdir;
+
+fn unavailable_outcome(index: usize, reason: &str) -> ReviewerOutcome {
+    ReviewerOutcome {
+        reviewer_index: index,
+        tool: ToolName::Codex,
+        session_id: format!("01TESTREVIEWER{index:012}"),
+        output: format!("Review unavailable: {reason}\n"),
+        exit_code: 1,
+        verdict: UNAVAILABLE,
+        diagnostic: Some(reason.to_string()),
+    }
+}
+
+#[test]
+fn issue_2911_all_unavailable_parent_carries_actionable_reason() {
+    let reason = "host_memory_admission: reviewer provider did not launch; no alternate configured reviewer candidate was available";
+    let outcomes = vec![
+        unavailable_outcome(0, reason),
+        unavailable_outcome(1, reason),
+        unavailable_outcome(2, reason),
+        unavailable_outcome(3, reason),
+    ];
+
+    let (primary, failure_reason) = aggregate_unavailable_reviewer_reasons(&outcomes);
+    assert_eq!(primary.as_deref(), Some(reason));
+    assert_eq!(
+        failure_reason.as_deref(),
+        Some(
+            "codex=host_memory_admission: reviewer provider did not launch; no alternate configured reviewer candidate was available"
+        ),
+        "identical reviewer reasons must de-dupe rather than repeat four opaque labels"
+    );
+
+    let temp = tempdir().expect("tempdir");
+    write_parent_review_verdict(
+        temp.path(),
+        "01PARENTSESSION000000000000",
+        &[],
+        ReviewDecision::Unavailable,
+        UNAVAILABLE,
+        ReviewDiffReport {
+            diff_size: None,
+            large_diff_warning: None,
+        },
+        None,
+    )
+    .expect("write parent verdict");
+    patch_parent_review_verdict_unavailable_reasons(
+        temp.path(),
+        primary.as_deref(),
+        failure_reason.as_deref(),
+    )
+    .expect("patch unavailable reasons");
+
+    let artifact: ReviewVerdictArtifact = serde_json::from_str(
+        &fs::read_to_string(temp.path().join("output").join("review-verdict.json"))
+            .expect("read verdict"),
+    )
+    .expect("parse verdict");
+    assert_eq!(artifact.decision, ReviewDecision::Unavailable);
+    assert_eq!(artifact.verdict_legacy, UNAVAILABLE);
+    assert_eq!(artifact.primary_failure.as_deref(), Some(reason));
+    assert!(
+        artifact
+            .failure_reason
+            .as_deref()
+            .is_some_and(|text| text.contains("host_memory_admission")),
+        "parent verdict must carry actionable unavailable reason: {:?}",
+        artifact.failure_reason
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_parent_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_verdict.rs
@@ -6,6 +6,8 @@ use csa_session::review_artifact::Finding;
 use csa_session::{ReviewVerdictArtifact, write_review_verdict};
 
 use super::super::diff_size::{ReviewDiffReport, apply_large_diff_warning};
+use super::super::output::ReviewerOutcome;
+use crate::review_consensus::UNAVAILABLE;
 
 pub(super) fn write_parent_review_verdict(
     session_dir: &Path,
@@ -29,3 +31,162 @@ pub(super) fn write_parent_review_verdict(
     write_review_verdict(session_dir, &verdict)
         .context("failed to write parent output/review-verdict.json")
 }
+
+/// Aggregate distinct UNAVAILABLE reviewer reasons for parent meta/verdict (#2911).
+/// Bounded + redacted; secrets/paths stay out of the compact carrier.
+pub(super) fn aggregate_unavailable_reviewer_reasons(
+    outcomes: &[ReviewerOutcome],
+) -> (Option<String>, Option<String>) {
+    let mut unique: Vec<String> = Vec::new();
+    for outcome in outcomes {
+        if outcome.verdict != UNAVAILABLE {
+            continue;
+        }
+        let Some(reason) = unavailable_outcome_reason(outcome) else {
+            continue;
+        };
+        let entry = format!("{}={reason}", outcome.tool);
+        if !unique.iter().any(|existing| existing == &entry) {
+            unique.push(entry);
+        }
+    }
+    if unique.is_empty() {
+        return (None, None);
+    }
+    let primary = unique
+        .first()
+        .and_then(|entry| entry.split_once('='))
+        .map(|(_, reason)| reason.to_string());
+    (primary, Some(unique.join("; ")))
+}
+
+pub(super) fn unavailable_outcome_reason(outcome: &ReviewerOutcome) -> Option<String> {
+    let raw = outcome
+        .diagnostic
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            outcome
+                .output
+                .lines()
+                .find_map(|line| line.strip_prefix("Review unavailable: "))
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+        })?;
+    let redacted = csa_session::redact_text_content(raw);
+    let compact = redacted.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.is_empty() {
+        return None;
+    }
+    const MAX_CHARS: usize = 360;
+    if compact.chars().count() <= MAX_CHARS {
+        return Some(compact);
+    }
+    let mut out = String::new();
+    for ch in compact.chars().take(MAX_CHARS.saturating_sub(1)) {
+        out.push(ch);
+    }
+    out.push('…');
+    Some(out)
+}
+
+pub(super) fn patch_parent_review_verdict_unavailable_reasons(
+    session_dir: &Path,
+    primary_failure: Option<&str>,
+    failure_reason: Option<&str>,
+) -> Result<()> {
+    if primary_failure.is_none() && failure_reason.is_none() {
+        return Ok(());
+    }
+    let verdict_path = session_dir.join("output").join("review-verdict.json");
+    if !verdict_path.is_file() {
+        return Ok(());
+    }
+    let raw = std::fs::read_to_string(&verdict_path)
+        .with_context(|| format!("failed to read {}", verdict_path.display()))?;
+    let mut verdict: ReviewVerdictArtifact = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse {}", verdict_path.display()))?;
+    verdict.primary_failure = primary_failure.map(str::to_string);
+    verdict.failure_reason = failure_reason.map(str::to_string);
+    write_review_verdict(session_dir, &verdict)
+        .context("failed to rewrite parent output/review-verdict.json with unavailable reasons")
+}
+
+pub(super) fn write_parent_review_summary(
+    session_dir: &Path,
+    outcomes: &[ReviewerOutcome],
+    final_verdict: &str,
+    diff_size: Option<&csa_session::ReviewDiffSize>,
+) -> Result<()> {
+    let output_dir = session_dir.join("output");
+    std::fs::create_dir_all(&output_dir)
+        .with_context(|| format!("failed to create {}", output_dir.display()))?;
+    let mut summary = format!("Final verdict: {final_verdict}\n\nReviewer outcomes:\n");
+    if let Some(diff_size) = diff_size {
+        summary = format!(
+            "{}\n{summary}",
+            super::super::diff_size::format_review_diff_size_line(diff_size)
+        );
+    }
+    for outcome in outcomes {
+        summary.push_str(&format!(
+            "- reviewer {} ({}) => {}",
+            outcome.reviewer_index + 1,
+            outcome.tool,
+            outcome.verdict
+        ));
+        if let Some(reason) = unavailable_outcome_reason(outcome) {
+            summary.push_str(&format!("; reason: {reason}"));
+        } else if let Some(diagnostic) = &outcome.diagnostic {
+            summary.push_str(&format!("; diagnostic: {diagnostic}"));
+        }
+        summary.push('\n');
+    }
+    if let (_, Some(reason)) = aggregate_unavailable_reviewer_reasons(outcomes) {
+        summary.push_str(&format!("\nUnavailable reasons: {reason}\n"));
+    }
+    std::fs::write(output_dir.join("summary.md"), summary)
+        .context("failed to write parent output/summary.md")
+}
+
+pub(super) fn write_parent_review_details(
+    session_dir: &Path,
+    outcomes: &[ReviewerOutcome],
+    diff_size: Option<&csa_session::ReviewDiffSize>,
+) -> Result<()> {
+    let output_dir = session_dir.join("output");
+    std::fs::create_dir_all(&output_dir)
+        .with_context(|| format!("failed to create {}", output_dir.display()))?;
+    let mut details = String::new();
+    if let Some(diff_size) = diff_size {
+        details.push_str(&super::super::diff_size::format_review_diff_size_line(
+            diff_size,
+        ));
+        details.push_str("\n\n");
+    }
+    for outcome in outcomes {
+        details.push_str(&format!(
+            "## Reviewer {} ({})\n\nVerdict: {}\nExit code: {}\n",
+            outcome.reviewer_index + 1,
+            outcome.tool,
+            outcome.verdict,
+            outcome.exit_code
+        ));
+        if let Some(diagnostic) = &outcome.diagnostic {
+            details.push_str(&format!("Diagnostic: {diagnostic}\n"));
+        }
+        details.push('\n');
+        details.push_str(&outcome.output);
+        if !details.ends_with('\n') {
+            details.push('\n');
+        }
+        details.push('\n');
+    }
+    std::fs::write(output_dir.join("details.md"), details)
+        .context("failed to write parent output/details.md")
+}
+
+#[cfg(test)]
+#[path = "review_cmd_parent_unavailable_tests.rs"]
+mod tests;

--- a/crates/cli-sub-agent/src/review_cmd_parent_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_verdict.rs
@@ -60,7 +60,9 @@ pub(super) fn aggregate_unavailable_reviewer_reasons(
     (primary, Some(unique.join("; ")))
 }
 
-pub(super) fn unavailable_outcome_reason(outcome: &ReviewerOutcome) -> Option<String> {
+pub(in crate::review_cmd) fn unavailable_outcome_reason(
+    outcome: &ReviewerOutcome,
+) -> Option<String> {
     let raw = outcome
         .diagnostic
         .as_deref()

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -124,6 +124,13 @@ pub(crate) fn resolve_review_tier_name(
         return Ok(Some(cli.to_string()));
     }
 
+    // #2911: --force-ignore-tier-setting must bypass default review.tier too.
+    // Otherwise a bare `--tool` recovery still fails candidate checks against the
+    // configured default tier even though no explicit --tier was passed.
+    if force_ignore_tier_setting {
+        return Ok(None);
+    }
+
     Ok(project_config
         .and_then(|cfg| cfg.review.as_ref())
         .and_then(|r| r.tier.as_deref())

--- a/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tier_tests.rs
@@ -380,6 +380,50 @@ fn test_review_force_ignore_tier_allows_direct_tool() {
 }
 
 #[test]
+fn issue_2911_force_ignore_bypasses_default_review_tier_candidate_check() {
+    // Recovery path from opaque multi-reviewer UNAVAILABLE: alternate tool without
+    // explicit --tier must not still be rejected against configured review.tier.
+    let global = GlobalConfig {
+        review: csa_config::ReviewConfig {
+            tier: Some("tier-4-critical".to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut cfg = review_config_with_tier(
+        "tier-4-critical",
+        vec!["codex/openai/gpt-5.4/high"],
+        &["codex", "opencode"],
+    );
+    cfg.review = Some(csa_config::ReviewConfig {
+        tier: Some("tier-4-critical".to_string()),
+        ..Default::default()
+    });
+
+    let tier = resolve_review_tier_name(Some(&cfg), &global, None, false, true)
+        .expect("force-ignore must resolve");
+    assert_eq!(
+        tier, None,
+        "default review.tier must be suppressed under --force-ignore-tier-setting"
+    );
+
+    let selection = resolve_review_selection(
+        Some(ToolName::Opencode),
+        None,
+        Some(&cfg),
+        &global,
+        Some("claude-code"),
+        std::path::Path::new("/tmp/test-project"),
+        false,
+        None, // no explicit --tier (the failing recovery command)
+        true, // --force-ignore-tier-setting
+        true,
+    )
+    .expect("force-ignore + non-candidate tool must not fail on default tier");
+    assert_eq!(selection.tool, ToolName::Opencode);
+}
+
+#[test]
 fn test_review_tool_plus_tier_and_force_ignore_errors_on_conflict() {
     let global = GlobalConfig::default();
     let cfg = review_config_with_tier(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_unavailable_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary_unavailable_tests.rs
@@ -53,7 +53,9 @@ fn compact_summary_includes_redacted_provider_usage_limit_reason() {
 }
 
 #[test]
-fn compact_summary_omits_provider_usage_reason_for_auth_only_unavailable() {
+fn compact_summary_surfaces_actionable_auth_unavailable_reason() {
+    // #2911: auth/admission failures must remain actionable (not opaque UNAVAILABLE).
+    // Secrets still redacted; only the "omit entirely" behavior is retired.
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let api_field = concat!("api", "_", "key");
     let fake_value = concat!("sk", "-", "sec", "...", "6789");
@@ -82,8 +84,10 @@ fn compact_summary_omits_provider_usage_reason_for_auth_only_unavailable() {
 
     let summary = render_wait_result_summary(temp.path(), "01TESTWAITAUTHA", &result);
 
-    assert!(!summary.contains("Unavailable reason:"));
+    assert!(summary.contains("Unavailable reason: auth:"));
+    assert!(summary.contains("API Key not found") || summary.contains("api_key_invalid"));
     assert!(!summary.contains(fake_value));
+    assert!(summary.contains("[REDACTED]"));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_unavailable_reason.rs
+++ b/crates/cli-sub-agent/src/session_unavailable_reason.rs
@@ -34,15 +34,56 @@ pub(crate) fn review_unavailable_reason(
         artifact.failure_reason.as_deref(),
         artifact.primary_failure.as_deref(),
     ];
-    candidates
+    if let Some(candidate) = candidates
         .into_iter()
         .flatten()
         .filter_map(provider_limit_candidate)
         .max_by_key(|candidate| candidate.score)
-        .map(|candidate| UnavailableReason {
+    {
+        return Some(UnavailableReason {
             kind: UNAVAILABLE_REASON_KIND,
             message: candidate.message,
+        });
+    }
+
+    // #2911: admission/provider launch failures must remain actionable even when
+    // they are not usage-limit shaped (opaque UNAVAILABLE is not enough).
+    candidates
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|text| !text.is_empty())
+        .map(|text| {
+            let redacted = csa_session::redact_text_content(text);
+            let compact = compact_visible_text(&redacted);
+            UnavailableReason {
+                kind: actionable_unavailable_kind(&compact),
+                message: clip_chars(&compact, UNAVAILABLE_REASON_MAX_CHARS),
+            }
         })
+        .filter(|reason| !reason.message.is_empty())
+}
+
+fn actionable_unavailable_kind(text: &str) -> &'static str {
+    let lower = text.to_ascii_lowercase();
+    if lower.contains("host_memory_admission")
+        || lower.contains("memory admission")
+        || lower.contains("active-session memory")
+    {
+        "host_memory_admission"
+    } else if lower.contains("admission") {
+        "admission"
+    } else if lower.contains("api key")
+        || lower.contains("api_key")
+        || lower.contains("auth")
+        || lower.contains("unauthorized")
+    {
+        "auth"
+    } else if lower.contains("did not launch") || lower.contains("provider") {
+        "provider_launch"
+    } else {
+        "unavailable"
+    }
 }
 
 fn read_review_verdict_artifact(session_dir: &Path) -> Option<ReviewVerdictArtifact> {
@@ -260,13 +301,30 @@ mod tests {
     }
 
     #[test]
-    fn review_unavailable_reason_ignores_auth_only_unavailable() {
+    fn review_unavailable_reason_surfaces_admission_reason() {
+        let artifact = unavailable_artifact(
+            Some(
+                "host_memory_admission: reviewer provider did not launch; no alternate configured reviewer candidate was available",
+            ),
+            Some("codex=host_memory_admission: reviewer provider did not launch"),
+        );
+
+        let reason = review_unavailable_reason(&artifact).expect("admission reason");
+        assert_eq!(reason.kind, "host_memory_admission");
+        assert!(reason.message.contains("host_memory_admission"));
+        assert!(reason.message.contains("did not launch"));
+    }
+
+    #[test]
+    fn review_unavailable_reason_surfaces_auth_failure() {
         let artifact = unavailable_artifact(
             Some("api_key_invalid"),
             Some("gemini-cli tool failure: API Key not found"),
         );
 
-        assert_eq!(review_unavailable_reason(&artifact), None);
+        let reason = review_unavailable_reason(&artifact).expect("auth reason");
+        assert_eq!(reason.kind, "auth");
+        assert!(reason.message.contains("API Key not found") || reason.message.contains("api_key"));
     }
 
     #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1128"
-weave = "0.1.1128"
+csa = "0.1.1129"
+weave = "0.1.1129"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Persist/report redacted actionable root reasons for multi-reviewer/chunked `UNAVAILABLE` outcomes (admission/provider/auth), not four opaque labels.
- Make `--force-ignore-tier-setting` suppress configured default `review.tier` when no explicit `--tier` is passed, so alternate-tool recovery can start.
- Preserve #2910 single-spawn semantics (already on main via 6934cbbb) and fail-closed parent unavailable verdicts.

## Classification
- **Covered by #2910 / 6934cbbb**: large-diff auto-chunk multi-spawn under explicit `--single` (4 concurrent admission attempts). Proved by existing `forced_single_reviewer_blocks_auto_chunk_multi_spawn` and related single-reviewer tests on main.
- **Residual fixed here**:
  1. actionable UNAVAILABLE reason aggregation/rendering into parent meta/verdict/summary/wait output
  2. force-ignore default-tier candidate bypass

## Test plan
- [x] `just test-f issue_2911`
- [x] `just test-f single_reviewer` / chunking single-spawn regressions
- [x] `just pre-commit-fast` + hook-enabled push (full workspace nextest 7496 passed)
- [x] isolated Codex CLI `review --base origin/main` — no blocking findings

Closes #2911