### PR TITLE
fix(review): relativize absolute paths in UNAVAILABLE reasons (#2911)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1129"
+version = "0.1.1130"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1129"
+version = "0.1.1130"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_parent_unavailable_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_unavailable_tests.rs
@@ -80,3 +80,31 @@ fn issue_2911_all_unavailable_parent_carries_actionable_reason() {
         artifact.failure_reason
     );
 }
+
+#[test]
+fn issue_2911_unavailable_reason_relativizes_absolute_paths() {
+    let absolute = "/home/alice/private-project/config.toml";
+    let reason = format!("provider failed reading {absolute} while launching reviewer");
+    let outcomes = vec![unavailable_outcome(0, &reason)];
+
+    let (primary, failure_reason) = aggregate_unavailable_reviewer_reasons(&outcomes);
+    let primary = primary.expect("primary reason");
+    let failure_reason = failure_reason.expect("failure reason");
+
+    assert!(
+        !primary.contains("/home/alice"),
+        "primary must not leak absolute home path: {primary}"
+    );
+    assert!(
+        !failure_reason.contains("/home/alice"),
+        "failure_reason must not leak absolute home path: {failure_reason}"
+    );
+    assert!(
+        primary.contains("private-project/config.toml"),
+        "primary should keep a relative path for actionability: {primary}"
+    );
+    assert!(
+        primary.contains("provider failed reading"),
+        "primary should keep the actionable diagnostic: {primary}"
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_parent_verdict.rs
+++ b/crates/cli-sub-agent/src/review_cmd_parent_verdict.rs
@@ -76,7 +76,7 @@ pub(in crate::review_cmd) fn unavailable_outcome_reason(
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
         })?;
-    let redacted = csa_session::redact_text_content(raw);
+    let redacted = crate::review_failure_context::sanitize_review_surface_text(raw);
     let compact = redacted.split_whitespace().collect::<Vec<_>>().join(" ");
     if compact.is_empty() {
         return None;

--- a/crates/cli-sub-agent/src/review_failure_context.rs
+++ b/crates/cli-sub-agent/src/review_failure_context.rs
@@ -133,10 +133,15 @@ fn finding_category(finding: &ReviewFinding) -> String {
     "review".to_string()
 }
 
-fn sanitize_finding_text(raw: &str, max_chars: usize) -> String {
+/// Redact credential-shaped secrets and relativize absolute filesystem paths.
+/// Shared by finding titles and UNAVAILABLE reason carriers (#2911 post-merge).
+pub(crate) fn sanitize_review_surface_text(raw: &str) -> String {
     let text = csa_session::redact_text_content(raw);
-    let text = relativize_absolute_paths(&text);
-    clip(text.trim(), max_chars)
+    relativize_absolute_paths(&text)
+}
+
+fn sanitize_finding_text(raw: &str, max_chars: usize) -> String {
+    clip(sanitize_review_surface_text(raw).trim(), max_chars)
 }
 
 fn finding_location(finding: &ReviewFinding) -> String {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_review_label.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_review_label.rs
@@ -43,7 +43,8 @@ pub(super) fn read_review_verdict_label(
             && let Some(primary_failure) = artifact.primary_failure.as_deref()
             && !primary_failure.trim().is_empty()
         {
-            let redacted = csa_session::redact_text_content(primary_failure.trim());
+            let redacted =
+                crate::review_failure_context::sanitize_review_surface_text(primary_failure.trim());
             let compacted = super::compact_wait_summary_text(&redacted);
             let label = compacted.unwrap_or_else(|| redacted.clone());
             return Some(format!("UNAVAILABLE ({label})"));
@@ -221,7 +222,9 @@ fn review_meta_failure_reason_label(meta: &ReviewSessionMeta) -> Option<String> 
 }
 
 fn compact_review_failure_reason(reason: &str) -> Option<String> {
-    super::compact_wait_summary_text(&csa_session::redact_text_content(reason))
+    super::compact_wait_summary_text(
+        &crate::review_failure_context::sanitize_review_surface_text(reason),
+    )
 }
 
 fn summary_looks_clean_without_blockers(summary: &str) -> bool {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -242,7 +242,8 @@ fn format_failover_chain_label(
             && let Some(primary_failure) = artifact.primary_failure.as_deref()
             && !primary_failure.trim().is_empty()
         {
-            let redacted = csa_session::redact_text_content(primary_failure.trim());
+            let redacted =
+                crate::review_failure_context::sanitize_review_surface_text(primary_failure.trim());
             return Some(redacted);
         }
     }

--- a/crates/cli-sub-agent/src/session_unavailable_reason.rs
+++ b/crates/cli-sub-agent/src/session_unavailable_reason.rs
@@ -54,7 +54,7 @@ pub(crate) fn review_unavailable_reason(
         .map(str::trim)
         .find(|text| !text.is_empty())
         .map(|text| {
-            let redacted = csa_session::redact_text_content(text);
+            let redacted = crate::review_failure_context::sanitize_review_surface_text(text);
             let compact = compact_visible_text(&redacted);
             UnavailableReason {
                 kind: actionable_unavailable_kind(&compact),
@@ -104,7 +104,7 @@ struct ReasonCandidate {
 fn provider_limit_candidate(text: &str) -> Option<ReasonCandidate> {
     let score = provider_limit_score(text)?;
     let excerpt = excerpt_around_first_limit_signal(text)?;
-    let redacted = csa_session::redact_text_content(&excerpt);
+    let redacted = crate::review_failure_context::sanitize_review_surface_text(&excerpt);
     let compact = compact_visible_text(&redacted);
     if compact.is_empty() {
         return None;
@@ -325,6 +325,21 @@ mod tests {
         let reason = review_unavailable_reason(&artifact).expect("auth reason");
         assert_eq!(reason.kind, "auth");
         assert!(reason.message.contains("API Key not found") || reason.message.contains("api_key"));
+    }
+
+    #[test]
+    fn review_unavailable_reason_relativizes_absolute_paths() {
+        let artifact = unavailable_artifact(
+            Some("provider_launch"),
+            Some(
+                "provider failed reading /home/alice/private-project/config.toml while launching reviewer",
+            ),
+        );
+
+        let reason = review_unavailable_reason(&artifact).expect("path reason");
+        assert!(!reason.message.contains("/home/alice"));
+        assert!(reason.message.contains("private-project/config.toml"));
+        assert!(reason.message.contains("provider failed reading"));
     }
 
     #[test]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1129"
-weave = "0.1.1129"
+csa = "0.1.1130"
+weave = "0.1.1130"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
Post-merge remediation for #2911 after retrospective clean-room review of PR #2919 found **HIGH**: UNAVAILABLE reason carriers claimed path+secret redaction but only applied credential redaction, so absolute filesystem paths could leak into parent verdict/meta/wait/summary surfaces.

- Reuse existing finding-title path relativization via shared `sanitize_review_surface_text`
- Wire into parent unavailable aggregation, wait labels, failover, and `session_unavailable_reason`
- Add regression tests for absolute-path relativization

## Test plan
- [x] Focused tests: `issue_2911_*`, `review_unavailable_reason_*`, `issue_2512_*`, `issue_2516_*`
- [x] Pre-commit quality gates (hook-enabled commit)
- [x] Pre-push full workspace suite: 7498 passed
- [x] Isolated Codex clean-room review: **VERDICT: PASS** for `df660da7...54f17a1f` / `main...HEAD`

## Review receipt
- Tool: isolated Codex CLI (`CODEX_HOME` auth + empty MCP, `--sandbox read-only`)
- Range: `df660da7193774a16b93624d6005ed1d66a5d0ee...54f17a1f4fbecdb60a8127242bfde8dec47b6d50`
- Final line: `VERDICT: PASS`

Closes post-merge review-gate receipt gap for #2911.