### PR TITLE
fix(session): dedupe state roots for active-session admission (#2920)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1130"
+version = "0.1.1131"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1130"
+version = "0.1.1131"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/no_provider_launch.rs
+++ b/crates/cli-sub-agent/src/no_provider_launch.rs
@@ -136,6 +136,17 @@ fn soft_limit_admission_diagnostic_memory(
         current_session_id,
         error.memory_max_mb(),
     );
+    let Ok(admission) = admission else {
+        return NoProviderLaunchMemoryDiagnostic {
+            effective_memory_max_mb: Some(error.memory_max_mb()),
+            soft_limit_percent: Some(error.soft_limit_percent()),
+            soft_threshold_mb: Some(error.threshold_mb()),
+            required_floor_mb: Some(error.required_threshold_mb()),
+            required_memory_max_mb: Some(error.required_memory_max_mb()),
+            projected_spawn_mb: Some(error.memory_max_mb()),
+            ..Default::default()
+        };
+    };
     let mut resource_guard = ResourceGuard::new(ResourceLimits {
         min_free_memory_mb: resource_overrides.resolve_min_free_memory_mb(config),
     });

--- a/crates/cli-sub-agent/src/pipeline_sandbox_memory_balloon.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_memory_balloon.rs
@@ -19,8 +19,16 @@ pub(crate) fn maybe_inflate_balloon(tool_name: &str, project_root: &Path, sessio
     let available_memory = sys.available_memory();
     let available_swap = sys.free_swap();
     let available_memory_mb = available_memory / 1024 / 1024;
-    let active_session_count =
-        crate::resource_admission::active_session_count_for_balloon(project_root, session_id);
+    let active_session_count = match crate::resource_admission::active_session_count_for_balloon(
+        project_root,
+        session_id,
+    ) {
+        Ok(count) => count,
+        Err(err) => {
+            warn!(error = %err, "Skipping MemoryBalloon prewarm: active-session admission is unavailable");
+            return;
+        }
+    };
 
     if should_skip_balloon_prewarm(available_memory_mb, active_session_count) {
         warn!(

--- a/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
@@ -81,8 +81,28 @@ pub(super) fn check_resources_before_spawn(
             },
         ));
     }
-    let admission =
-        build_spawn_memory_admission(project_root, &session.meta_session_id, projected_spawn_mb);
+    let admission = match build_spawn_memory_admission(
+        project_root,
+        &session.meta_session_id,
+        projected_spawn_mb,
+    ) {
+        Ok(admission) => admission,
+        Err(err) => {
+            return Err(persist_pipeline_pre_exec_failure(
+                project_root,
+                session,
+                executor.tool_name(),
+                err.context("Failed to build host-memory admission"),
+                cleanup_guard,
+                None,
+                PipelinePreExecFailureDetails {
+                    config,
+                    task_type,
+                    resource_overrides,
+                },
+            ));
+        }
+    };
 
     if !skip_host_memory_admission_for_test()
         && let Err(err) =

--- a/crates/cli-sub-agent/src/resource_admission.rs
+++ b/crates/cli-sub-agent/src/resource_admission.rs
@@ -1,11 +1,10 @@
 use std::{io, path::Path};
 
-use anyhow::Context;
+use anyhow::{Context, Result};
 use chrono::{DateTime, TimeDelta, Utc};
 use csa_config::ProjectConfig;
 use csa_resource::{ResourceGuard, ResourceLimits, SpawnMemoryAdmission};
 use csa_session::{MetaSessionState, SandboxInfo, SessionPhase, SessionTreeMemorySampler};
-use tracing::warn;
 
 use crate::run_resource_overrides::RunResourceOverrides;
 
@@ -173,31 +172,27 @@ pub(crate) fn build_spawn_memory_admission(
     project_root: &Path,
     current_session_id: &str,
     projected_spawn_mb: u64,
-) -> SpawnMemoryAdmission {
-    let active = match csa_session::list_all_sessions_all_projects() {
-        Ok(sessions) => aggregate_active_session_memory(
-            &sessions,
-            current_session_id,
-            Utc::now(),
-            sample_session_memory,
-        ),
-        Err(err) => {
-            warn!(
-                error = %err,
-                project_root = %project_root.display(),
-                "Failed to list active CSA sessions for host-memory admission"
-            );
-            ActiveSessionMemory::default()
-        }
-    };
+) -> Result<SpawnMemoryAdmission> {
+    let sessions = csa_session::list_all_sessions_all_projects().with_context(|| {
+        format!(
+            "Failed to list active CSA sessions for host-memory admission in {}",
+            project_root.display()
+        )
+    })?;
+    let active = aggregate_active_session_memory(
+        &sessions,
+        current_session_id,
+        Utc::now(),
+        sample_session_memory,
+    );
 
-    SpawnMemoryAdmission {
+    Ok(SpawnMemoryAdmission {
         projected_spawn_mb,
         active_session_rss_mb: active.sampled_rss_mb,
         active_session_projected_mb: active.projected_mb,
         active_session_count: active.active_count,
         sampled_session_count: active.sampled_count,
-    }
+    })
 }
 
 fn sample_session_memory(session: &MetaSessionState) -> SessionMemorySample {
@@ -327,23 +322,19 @@ fn recent_pending_projection_mb(
 pub(crate) fn active_session_count_for_balloon(
     project_root: &Path,
     current_session_id: &str,
-) -> u64 {
-    match csa_session::list_all_sessions_all_projects() {
-        Ok(sessions) => count_observable_active_sessions(
-            &sessions,
-            current_session_id,
-            Utc::now(),
-            sample_session_memory,
-        ),
-        Err(err) => {
-            warn!(
-                error = %err,
-                project_root = %project_root.display(),
-                "Failed to count active CSA sessions for memory-balloon admission"
-            );
-            0
-        }
-    }
+) -> Result<u64> {
+    let sessions = csa_session::list_all_sessions_all_projects().with_context(|| {
+        format!(
+            "Failed to count active CSA sessions for memory-balloon admission in {}",
+            project_root.display()
+        )
+    })?;
+    Ok(count_observable_active_sessions(
+        &sessions,
+        current_session_id,
+        Utc::now(),
+        sample_session_memory,
+    ))
 }
 
 fn count_observable_active_sessions(
@@ -365,6 +356,10 @@ fn count_observable_active_sessions(
 #[cfg(test)]
 #[path = "resource_admission_terminal_session_tests.rs"]
 mod terminal_session_tests;
+
+#[cfg(test)]
+#[path = "resource_admission_state_root_tests.rs"]
+mod state_root_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/cli-sub-agent/src/resource_admission_state_root_tests.rs
+++ b/crates/cli-sub-agent/src/resource_admission_state_root_tests.rs
@@ -1,0 +1,59 @@
+use super::*;
+
+#[cfg(unix)]
+fn inaccessible_legacy_state_root() -> (
+    tempfile::TempDir,
+    crate::test_env_lock::ScopedTestEnvVar,
+    std::path::PathBuf,
+) {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let state_home = temp.path().join("state");
+    let state_home_guard =
+        crate::test_env_lock::ScopedTestEnvVar::set("XDG_STATE_HOME", &state_home);
+    let legacy = state_home.join("csa");
+    fs::create_dir_all(&legacy).expect("legacy state root");
+    let mut permissions = fs::metadata(&legacy)
+        .expect("legacy metadata")
+        .permissions();
+    permissions.set_mode(0o000);
+    fs::set_permissions(&legacy, permissions).expect("block legacy state root");
+    (temp, state_home_guard, legacy)
+}
+
+#[cfg(unix)]
+fn restore_state_root_permissions(path: &Path) {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+        .expect("restore legacy state-root permissions");
+}
+
+#[cfg(unix)]
+#[test]
+fn spawn_memory_admission_fails_closed_when_legacy_state_root_is_inaccessible() {
+    let (_temp, _state_home, legacy) = inaccessible_legacy_state_root();
+    let admission = build_spawn_memory_admission(Path::new("/project"), "current", 1024);
+    restore_state_root_permissions(&legacy);
+
+    assert!(
+        admission.is_err(),
+        "inaccessible state inventory must block spawn-memory admission, not yield zero active memory"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn balloon_admission_fails_closed_when_legacy_state_root_is_inaccessible() {
+    let (_temp, _state_home, legacy) = inaccessible_legacy_state_root();
+    let count = active_session_count_for_balloon(Path::new("/project"), "current");
+    restore_state_root_permissions(&legacy);
+
+    assert!(
+        count.is_err(),
+        "inaccessible state inventory must block balloon admission, not yield zero active sessions"
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_preflight.rs
@@ -290,7 +290,8 @@ fn validate_host_memory_before_session(
         project_root,
         REVIEW_PREFLIGHT_SESSION_ID,
         projected_spawn_mb,
-    );
+    )
+    .context("Failed to build host-memory admission")?;
     resource_guard
         .check_availability_with_admission(tool.as_str(), Some(admission))
         .map_err(|err| {

--- a/crates/csa-session/src/manager_paths.rs
+++ b/crates/csa-session/src/manager_paths.rs
@@ -349,20 +349,26 @@ fn extract_project_path_from_state(content: &str) -> Option<String> {
     None
 }
 
-/// List all project session roots across all state directories.
+/// List all project session roots across all state epochs.
 ///
 /// Returns `Vec<(session_root, project_key)>` for each project that has sessions.
+///
+/// Uses [`paths::state_dir_all_roots`] so symlink-equivalent primary/legacy
+/// state dirs (e.g. `~/.local/state/csa` → `cli-sub-agent`) are visited once.
+/// Without that de-dupe, every active session is listed twice and host-memory
+/// admission projects double the real active-session charge (#2920).
 pub fn list_all_project_session_roots() -> Result<Vec<(PathBuf, String)>> {
-    let mut roots = Vec::new();
-
-    let primary_state_dir =
-        paths::state_dir_write().context("Failed to determine project directories")?;
-    collect_project_roots_under(&primary_state_dir, &mut roots)?;
-
-    if let Some(legacy_state_dir) = paths::legacy_state_dir() {
-        collect_project_roots_under(&legacy_state_dir, &mut roots)?;
+    let state_roots = paths::state_dir_all_roots();
+    if state_roots.is_empty() {
+        // Preserve the previous hard failure when no writable state dir exists.
+        let _ = paths::state_dir_write().context("Failed to determine project directories")?;
+        return Ok(Vec::new());
     }
 
+    let mut roots = Vec::new();
+    for state_dir in state_roots {
+        collect_project_roots_under(&state_dir, &mut roots)?;
+    }
     Ok(roots)
 }
 
@@ -399,6 +405,32 @@ fn collect_project_roots_under(state_dir: &Path, roots: &mut Vec<(PathBuf, Strin
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod project_root_list_tests {
+    use csa_config::paths;
+    use std::collections::HashSet;
+
+    #[test]
+    fn state_dir_all_roots_dedupes_symlink_equivalent_primary_and_legacy() {
+        // Host layout on this repo's CI/dev machines often has
+        // ~/.local/state/csa -> cli-sub-agent. Admission used to walk both.
+        let state_roots = paths::state_dir_all_roots();
+        let mut unique = HashSet::new();
+        for root in &state_roots {
+            let key = root
+                .canonicalize()
+                .unwrap_or_else(|_| root.clone())
+                .to_string_lossy()
+                .into_owned();
+            assert!(
+                unique.insert(key),
+                "state_dir_all_roots returned duplicate equivalent path: {}",
+                root.display()
+            );
+        }
+    }
 }
 
 /// Internal function for testing: get session directory with explicit base

--- a/crates/csa-session/src/manager_paths.rs
+++ b/crates/csa-session/src/manager_paths.rs
@@ -353,23 +353,45 @@ fn extract_project_path_from_state(content: &str) -> Option<String> {
 ///
 /// Returns `Vec<(session_root, project_key)>` for each project that has sessions.
 ///
-/// Uses [`paths::state_dir_all_roots`] so symlink-equivalent primary/legacy
-/// state dirs (e.g. `~/.local/state/csa` → `cli-sub-agent`) are visited once.
-/// Without that de-dupe, every active session is listed twice and host-memory
-/// admission projects double the real active-session charge (#2920).
+/// Always walks the writable state dir first so inaccessible roots still
+/// surface as errors (unlike `Path::exists()` filtering). Additional roots from
+/// [`paths::state_dir_all_roots`] are visited only when not path-equivalent to
+/// a root already walked — so a `~/.local/state/csa` → `cli-sub-agent` symlink
+/// cannot double-list every session for host-memory admission (#2920).
 pub fn list_all_project_session_roots() -> Result<Vec<(PathBuf, String)>> {
-    let state_roots = paths::state_dir_all_roots();
-    if state_roots.is_empty() {
-        // Preserve the previous hard failure when no writable state dir exists.
-        let _ = paths::state_dir_write().context("Failed to determine project directories")?;
-        return Ok(Vec::new());
-    }
+    let primary = paths::state_dir_write().context("Failed to determine project directories")?;
+    let mut state_dirs = vec![primary];
+    state_dirs.extend(paths::state_dir_all_roots());
+    collect_project_roots_across_state_dirs(state_dirs)
+}
 
+/// Walk each state dir once (symlink-equivalent spellings collapsed).
+fn collect_project_roots_across_state_dirs(
+    state_dirs: impl IntoIterator<Item = PathBuf>,
+) -> Result<Vec<(PathBuf, String)>> {
     let mut roots = Vec::new();
-    for state_dir in state_roots {
+    let mut visited: Vec<PathBuf> = Vec::new();
+    for state_dir in state_dirs {
+        if visited
+            .iter()
+            .any(|seen| state_dirs_equivalent(seen, &state_dir))
+        {
+            continue;
+        }
+        visited.push(state_dir.clone());
         collect_project_roots_under(&state_dir, &mut roots)?;
     }
     Ok(roots)
+}
+
+fn state_dirs_equivalent(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
 }
 
 /// Recursively find project directories that contain a `sessions/` subdirectory.
@@ -409,27 +431,46 @@ fn collect_project_roots_under(state_dir: &Path, roots: &mut Vec<(PathBuf, Strin
 
 #[cfg(test)]
 mod project_root_list_tests {
-    use csa_config::paths;
-    use std::collections::HashSet;
+    use super::{collect_project_roots_across_state_dirs, state_dirs_equivalent};
+    use std::fs;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+    use tempfile::tempdir;
 
     #[test]
-    fn state_dir_all_roots_dedupes_symlink_equivalent_primary_and_legacy() {
-        // Host layout on this repo's CI/dev machines often has
-        // ~/.local/state/csa -> cli-sub-agent. Admission used to walk both.
-        let state_roots = paths::state_dir_all_roots();
-        let mut unique = HashSet::new();
-        for root in &state_roots {
-            let key = root
-                .canonicalize()
-                .unwrap_or_else(|_| root.clone())
-                .to_string_lossy()
-                .into_owned();
-            assert!(
-                unique.insert(key),
-                "state_dir_all_roots returned duplicate equivalent path: {}",
-                root.display()
-            );
-        }
+    fn symlink_equivalent_state_dirs_yield_one_project_root() {
+        let td = tempdir().expect("tempdir");
+        let primary = td.path().join("primary");
+        let project = primary.join("proj");
+        fs::create_dir_all(project.join("sessions")).expect("sessions");
+        let legacy = td.path().join("legacy");
+        symlink(&primary, &legacy).expect("legacy -> primary");
+
+        assert!(state_dirs_equivalent(&primary, &legacy));
+
+        let roots =
+            collect_project_roots_across_state_dirs([primary.clone(), legacy]).expect("list roots");
+        assert_eq!(
+            roots.len(),
+            1,
+            "symlink-equivalent state roots must not double-list projects: {roots:?}"
+        );
+        assert_eq!(roots[0].0, primary.join("proj"));
+    }
+
+    #[test]
+    fn inaccessible_state_root_propagates_read_error() {
+        let td = tempdir().expect("tempdir");
+        let blocked = td.path().join("blocked");
+        fs::create_dir_all(&blocked).expect("blocked");
+        // Remove search permission so read_dir fails (not NotFound).
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o000)).expect("chmod");
+        let result = collect_project_roots_across_state_dirs([blocked.clone()]);
+        // Restore so tempdir cleanup can remove the tree.
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o755)).expect("chmod restore");
+        assert!(
+            result.is_err(),
+            "inaccessible state root must not collapse to empty Ok: {result:?}"
+        );
     }
 }
 

--- a/crates/csa-session/src/manager_paths.rs
+++ b/crates/csa-session/src/manager_paths.rs
@@ -353,16 +353,30 @@ fn extract_project_path_from_state(content: &str) -> Option<String> {
 ///
 /// Returns `Vec<(session_root, project_key)>` for each project that has sessions.
 ///
-/// Always walks the writable state dir first so inaccessible roots still
-/// surface as errors (unlike `Path::exists()` filtering). Additional roots from
-/// [`paths::state_dir_all_roots`] are visited only when not path-equivalent to
-/// a root already walked — so a `~/.local/state/csa` → `cli-sub-agent` symlink
-/// cannot double-list every session for host-memory admission (#2920).
+/// Walks the writable state dir and the legacy state dir (when present) once
+/// each. Symlink-equivalent spellings are collapsed so a
+/// `~/.local/state/csa` → `cli-sub-agent` layout cannot double-list every
+/// session for host-memory admission (#2920). Roots are walked even when
+/// `Path::exists()` would fail, so inaccessible directories still surface as
+/// read errors instead of silent empty inventory.
 pub fn list_all_project_session_roots() -> Result<Vec<(PathBuf, String)>> {
     let primary = paths::state_dir_write().context("Failed to determine project directories")?;
-    let mut state_dirs = vec![primary];
-    state_dirs.extend(paths::state_dir_all_roots());
-    collect_project_roots_across_state_dirs(state_dirs)
+    collect_project_roots_across_state_dirs(candidate_state_dirs_for_listing(
+        primary,
+        paths::legacy_state_dir(),
+    ))
+}
+
+/// Candidate state dirs for global session inventory (primary then optional legacy).
+///
+/// Intentionally does **not** pre-filter with `Path::exists()` — that would
+/// hide permission errors and skip dangling-but-configured legacy roots.
+fn candidate_state_dirs_for_listing(primary: PathBuf, legacy: Option<PathBuf>) -> Vec<PathBuf> {
+    let mut dirs = vec![primary];
+    if let Some(legacy) = legacy {
+        dirs.push(legacy);
+    }
+    dirs
 }
 
 /// Walk each state dir once (symlink-equivalent spellings collapsed).
@@ -431,10 +445,29 @@ fn collect_project_roots_under(state_dir: &Path, roots: &mut Vec<(PathBuf, Strin
 
 #[cfg(test)]
 mod project_root_list_tests {
-    use super::{collect_project_roots_across_state_dirs, state_dirs_equivalent};
+    use super::{
+        candidate_state_dirs_for_listing, collect_project_roots_across_state_dirs,
+        state_dirs_equivalent,
+    };
     use std::fs;
     use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::path::PathBuf;
     use tempfile::tempdir;
+
+    #[test]
+    fn candidate_state_dirs_always_include_configured_legacy_without_exists_filter() {
+        let primary = PathBuf::from("/primary-state");
+        let legacy = PathBuf::from("/legacy-state-that-may-not-exist");
+        let dirs = candidate_state_dirs_for_listing(primary.clone(), Some(legacy.clone()));
+        assert_eq!(dirs, vec![primary, legacy]);
+    }
+
+    #[test]
+    fn candidate_state_dirs_omit_legacy_when_unset() {
+        let primary = PathBuf::from("/primary-state");
+        let dirs = candidate_state_dirs_for_listing(primary.clone(), None);
+        assert_eq!(dirs, vec![primary]);
+    }
 
     #[test]
     fn symlink_equivalent_state_dirs_yield_one_project_root() {
@@ -446,13 +479,15 @@ mod project_root_list_tests {
         symlink(&primary, &legacy).expect("legacy -> primary");
 
         assert!(state_dirs_equivalent(&primary, &legacy));
-
-        let roots =
-            collect_project_roots_across_state_dirs([primary.clone(), legacy]).expect("list roots");
+        let roots = collect_project_roots_across_state_dirs(candidate_state_dirs_for_listing(
+            primary.clone(),
+            Some(legacy),
+        ))
+        .expect("list");
         assert_eq!(
             roots.len(),
             1,
-            "symlink-equivalent state roots must not double-list projects: {roots:?}"
+            "symlink-equivalent primary/legacy must not double-list: {roots:?}"
         );
         assert_eq!(roots[0].0, primary.join("proj"));
     }
@@ -460,13 +495,20 @@ mod project_root_list_tests {
     #[test]
     fn inaccessible_state_root_propagates_read_error() {
         let td = tempdir().expect("tempdir");
+        let primary = td.path().join("primary");
+        fs::create_dir_all(primary.join("proj").join("sessions")).expect("primary sessions");
         let blocked = td.path().join("blocked");
         fs::create_dir_all(&blocked).expect("blocked");
-        // Remove search permission so read_dir fails (not NotFound).
-        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o000)).expect("chmod");
-        let result = collect_project_roots_across_state_dirs([blocked.clone()]);
-        // Restore so tempdir cleanup can remove the tree.
-        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o755)).expect("chmod restore");
+        let mut perms = fs::metadata(&blocked).expect("meta").permissions();
+        perms.set_mode(0o000);
+        fs::set_permissions(&blocked, perms).expect("chmod");
+
+        let result = collect_project_roots_across_state_dirs(candidate_state_dirs_for_listing(
+            primary,
+            Some(blocked.clone()),
+        ));
+
+        let _ = fs::set_permissions(&blocked, fs::Permissions::from_mode(0o755));
         assert!(
             result.is_err(),
             "inaccessible state root must not collapse to empty Ok: {result:?}"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1130"
-weave = "0.1.1130"
+csa = "0.1.1131"
+weave = "0.1.1131"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- `list_all_project_session_roots` walked primary + legacy state dirs separately
- when `~/.local/state/csa` → `cli-sub-agent`, every session was listed twice
- host-memory admission projected 2× active charge → `active-session upper=0MB` despite one live session
- switch to `paths::state_dir_all_roots` (symlink-equivalent de-dupe)

Closes #2920

## Live revalidation
HEAD under test: `d52bde8b` (post-#2909 main + this fix)

**Before (main only, #2909 present):**
```
projected_active=36000MB > host_safe_limit=23844MB
active_sessions=2 sampled_sessions=2
active_session_projected_mb=24000 projected_spawn_mb=12000
```
(one live 12GB session double-counted)

**After this fix:** same host/load, `--memory-max-mb 12000` → `CSA:SESSION_STARTED` (`01KYVACY7T1VQ923DCPQDRPTRQ`) — admission admits; no active-session denial.

#2909 terminal-session exclusion remains correct and necessary; residual overcharge was inventory double-list.

## Validation
- `cargo test -p csa-session --lib project_root_list_tests` PASS
- `cargo test -p cli-sub-agent --bin csa resource_admission::` 23 PASS
- pre-push quality gates: 7499 passed, 7 skipped