### PR TITLE
fix(session): defer completion while owned processes are live

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "chrono",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "axum",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "chrono",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "chrono",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "chrono",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1132"
+version = "0.1.1133"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1132"
+version = "0.1.1133"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon.rs
@@ -255,8 +255,7 @@ pub(crate) fn handle_session_attach_with_prompt(
         }
 
         if let Some(completion) = load_daemon_completion_packet(&session_dir)?
-            && (completion.is_legacy_complete_marker()
-                || !session_has_terminal_process(&session_dir))
+            && !session_has_terminal_process(&session_dir)
         {
             // Drain remaining stdout.
             loop {

--- a/crates/cli-sub-agent/src/session_cmds_daemon_2016_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_2016_tests.rs
@@ -77,14 +77,19 @@ fn attach_defers_legacy_complete_marker_while_daemon_pid_is_alive() {
 
     // Attach must keep waiting on the live daemon instead of consuming the
     // legacy marker as terminal success/failure (#2950).
-    let timed_out = rx.recv_timeout(Duration::from_secs(2)).is_err();
-    child.kill().ok();
-    let _ = child.wait();
-    let _ = handle.join();
-    assert!(
-        timed_out,
+    assert_eq!(
+        rx.recv_timeout(Duration::from_secs(2)),
+        Err(mpsc::RecvTimeoutError::Timeout),
         "attach must defer legacy .complete while daemon.pid remains live"
     );
+    child.kill().expect("kill daemon fixture");
+    child.wait().expect("reap daemon fixture");
+    let attach_result = rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("attach worker should finish after daemon exit")
+        .expect("attach should succeed after daemon exit");
+    handle.join().expect("attach worker should not panic");
+    assert_eq!(attach_result, 143);
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_cmds_daemon_2016_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_2016_tests.rs
@@ -29,7 +29,7 @@ fn daemon_pid_record(pid: u32) -> String {
 
 #[cfg(target_os = "linux")]
 #[test]
-fn attach_consumes_legacy_complete_marker_even_with_live_daemon_pid() {
+fn attach_defers_legacy_complete_marker_while_daemon_pid_is_alive() {
     use std::sync::mpsc;
     use std::time::Duration;
 
@@ -75,14 +75,16 @@ fn attach_consumes_legacy_complete_marker_even_with_live_daemon_pid() {
         let _ = tx.send(result);
     });
 
-    let exit_code = rx
-        .recv_timeout(Duration::from_secs(2))
-        .expect("attach should consume legacy .complete without waiting on daemon.pid")
-        .expect("attach result");
+    // Attach must keep waiting on the live daemon instead of consuming the
+    // legacy marker as terminal success/failure (#2950).
+    let timed_out = rx.recv_timeout(Duration::from_secs(2)).is_err();
     child.kill().ok();
     let _ = child.wait();
-    handle.join().expect("attach thread join");
-    assert_eq!(exit_code, 143);
+    let _ = handle.join();
+    assert!(
+        timed_out,
+        "attach must defer legacy .complete while daemon.pid remains live"
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/session_cmds_daemon_attach.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_attach.rs
@@ -253,8 +253,10 @@ pub(super) fn resolve_attach_terminal_exit(
     output_streamed: bool,
     output_log_visible: bool,
 ) -> Result<i32> {
+    // Legacy `.complete` is not terminal while verified owned process liveness
+    // remains; only consume completion after the owned work has exited (#2950).
     if let Some(completion) = load_daemon_completion_packet(session_dir)?
-        && (completion.is_legacy_complete_marker() || !session_has_terminal_process(session_dir))
+        && !session_has_terminal_process(session_dir)
     {
         emit_failure_summary_for_empty_output(session_dir, output_streamed, output_log_visible);
         return Ok(completion.exit_code);

--- a/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_completion.rs
@@ -124,9 +124,13 @@ pub(crate) fn finalize_daemon_completion_if_present(
     let Some(packet) = load_daemon_completion_packet(session_dir)? else {
         return Ok(None);
     };
-    if !packet.is_legacy_complete_marker() && super::session_has_terminal_process(session_dir) {
+    // Owned process/daemon/tool liveness outranks completion packets and legacy
+    // `.complete` markers. Legacy is only an input format, not higher-authority
+    // terminal evidence while verified owned work remains live (#2950).
+    if super::session_has_terminal_process(session_dir) {
         debug!(
             path = %daemon_completion_path(session_dir).display(),
+            legacy = packet.is_legacy_complete_marker(),
             "Ignoring daemon completion packet while session process is still live"
         );
         return Ok(None);

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -505,25 +505,26 @@ fn check_session_stale_before_wait(
     ) {
         Ok(session) => {
             if matches!(session.phase, csa_session::SessionPhase::Active) {
-                // A durable terminal result or completion marker is authoritative.
+                // Verified owned liveness outranks result/completion/legacy markers
+                // for the stale precheck. Only treat durable completion evidence as
+                // authoritative after owned work has exited (#2950).
+                if csa_process::ToolLiveness::is_alive_read_only(session_dir)
+                    || any_session_holds_worktree_write_lock(
+                        worktree_lock_root,
+                        worktree_lock_session_ids,
+                    )
+                    || session_has_terminal_process(session_dir)
+                {
+                    return Ok(());
+                }
                 if super::legacy_complete_marker_is_valid(session_dir)
-                    || (super::daemon_completion_exists(session_dir)
-                        && !session_has_terminal_process(session_dir))
+                    || super::daemon_completion_exists(session_dir)
                 {
                     return Ok(());
                 }
                 match csa_session::load_result(project_root, session_id) {
                     Ok(Some(_)) | Err(_) => return Ok(()),
                     Ok(None) => {}
-                }
-
-                if csa_process::ToolLiveness::is_alive_read_only(session_dir)
-                    || any_session_holds_worktree_write_lock(
-                        worktree_lock_root,
-                        worktree_lock_session_ids,
-                    )
-                {
-                    return Ok(());
                 }
 
                 let elapsed = wait_options

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -15,8 +15,7 @@ use super::completion::{
 };
 use super::liveness::{resume_handoff_blocks_target_reconcile, session_has_live_execution};
 use super::registry_loss::{
-    emit_registry_state_loss_or_missing_result, session_registry_phase_retired,
-    session_registry_state_loss,
+    emit_registry_state_loss_or_missing_result, session_registry_state_loss,
 };
 use super::target::resolve_wait_target;
 pub(crate) use super::types::WaitEmitters;
@@ -199,13 +198,13 @@ pub(crate) fn handle_session_wait_with_emitters(
         let result_registry_state_loss =
             session_registry_state_loss(effective_root, result_session_id, result_session_dir);
         let result_uses_direct_session_dir = is_cross_project || result_registry_state_loss;
-        let result_session_is_retired = !result_registry_state_loss
-            && session_registry_phase_retired(effective_root, result_session_id);
-        let session_live = session_live && !result_session_is_retired;
+        // Stale Retired registry phase is not terminal while verified owned
+        // daemon/tool/worktree-lock liveness remains (#2950).
         let completion_packet = load_daemon_completion_packet(&session_dir)?;
-        if let Some(completion) = completion_packet
-            .filter(|completion| completion.is_legacy_complete_marker() || !session_live)
-        {
+        // Legacy `.complete` is only an input format. While the session still has
+        // verified owned liveness, defer completion instead of treating the
+        // marker as higher-authority terminal evidence (#2950).
+        if let Some(completion) = completion_packet.filter(|_| !session_live) {
             let refreshed_result = refresh_result_for_wait(
                 effective_root,
                 result_session_id,
@@ -525,7 +524,6 @@ pub(crate) fn handle_session_wait_with_emitters(
                 result_session_id,
             ) || csa_process::ToolLiveness::is_alive(result_session_dir)
                 || handoff_blocks_target_reconcile;
-            let session_alive = session_alive && !result_session_is_retired;
             return Ok(emit_wait_cap_outcome(
                 &resolved.session_id,
                 cd.as_deref(),

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -15,7 +15,8 @@ use super::completion::{
 };
 use super::liveness::{resume_handoff_blocks_target_reconcile, session_has_live_execution};
 use super::registry_loss::{
-    emit_registry_state_loss_or_missing_result, session_registry_state_loss,
+    emit_registry_state_loss_or_missing_result, session_registry_phase_retired,
+    session_registry_state_loss,
 };
 use super::target::resolve_wait_target;
 pub(crate) use super::types::WaitEmitters;
@@ -198,6 +199,11 @@ pub(crate) fn handle_session_wait_with_emitters(
         let result_registry_state_loss =
             session_registry_state_loss(effective_root, result_session_id, result_session_dir);
         let result_uses_direct_session_dir = is_cross_project || result_registry_state_loss;
+        let result_session_is_retired = !result_registry_state_loss
+            && session_registry_phase_retired(effective_root, result_session_id);
+        let session_has_passive_liveness = || {
+            !result_session_is_retired && csa_process::ToolLiveness::is_alive(result_session_dir)
+        };
         // Stale Retired registry phase is not terminal while verified owned
         // daemon/tool/worktree-lock liveness remains (#2950).
         let completion_packet = load_daemon_completion_packet(&session_dir)?;
@@ -310,10 +316,7 @@ pub(crate) fn handle_session_wait_with_emitters(
                 return Ok(exit_code);
             }
 
-            if session_live
-                || csa_process::ToolLiveness::is_alive(result_session_dir)
-                || handoff_blocks_target_reconcile
-            {
+            if session_live || session_has_passive_liveness() || handoff_blocks_target_reconcile {
                 tracing::debug!(
                     session_id = %result_session_id,
                     completion_status = %completion.status,
@@ -455,7 +458,7 @@ pub(crate) fn handle_session_wait_with_emitters(
                 );
                 return Ok(exit_code);
             }
-            if csa_process::ToolLiveness::is_alive(result_session_dir) {
+            if session_has_passive_liveness() {
                 // PID detection missed but filesystem liveness signals say alive;
                 // continue polling so the timeout (exit 124) fires instead of exit 1.
                 tracing::debug!(session_id = %result_session_id, "alive; no terminal PID");
@@ -522,7 +525,7 @@ pub(crate) fn handle_session_wait_with_emitters(
                 result_session_dir,
                 &resolved.session_id,
                 result_session_id,
-            ) || csa_process::ToolLiveness::is_alive(result_session_dir)
+            ) || session_has_passive_liveness()
                 || handoff_blocks_target_reconcile;
             return Ok(emit_wait_cap_outcome(
                 &resolved.session_id,

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_registry_loss.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_registry_loss.rs
@@ -8,6 +8,11 @@ pub(super) fn session_registry_state_loss(
     session_dir.is_dir() && csa_session::load_session(project_root, session_id).is_err()
 }
 
+pub(super) fn session_registry_phase_retired(project_root: &Path, session_id: &str) -> bool {
+    csa_session::load_session(project_root, session_id)
+        .is_ok_and(|session| matches!(session.phase, csa_session::SessionPhase::Retired))
+}
+
 pub(super) fn emit_registry_state_loss_or_missing_result(
     project_root: &Path,
     session_id: &str,

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_registry_loss.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_registry_loss.rs
@@ -8,11 +8,6 @@ pub(super) fn session_registry_state_loss(
     session_dir.is_dir() && csa_session::load_session(project_root, session_id).is_err()
 }
 
-pub(super) fn session_registry_phase_retired(project_root: &Path, session_id: &str) -> bool {
-    csa_session::load_session(project_root, session_id)
-        .is_ok_and(|session| matches!(session.phase, csa_session::SessionPhase::Retired))
-}
-
 pub(super) fn emit_registry_state_loss_or_missing_result(
     project_root: &Path,
     session_id: &str,

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -170,8 +170,8 @@ fn dead_active_session_needs_terminal_result(
         return Ok(false);
     }
     let liveness = reconcile_liveness_decision(session_dir);
-    let legacy_done = crate::session_cmds_daemon::legacy_complete_marker_is_valid(session_dir);
-    if liveness.blocks_synthesis && !legacy_done {
+    // Verified owned liveness outranks legacy `.complete` markers (#2950).
+    if liveness.blocks_synthesis {
         debug!(
             session_id = %session_id,
             trigger = %trigger,
@@ -226,8 +226,8 @@ where
         return Ok(DeadActiveSessionReconciliation::NoChange);
     }
     let liveness = reconcile_liveness_decision(session_dir);
-    let legacy_done = crate::session_cmds_daemon::legacy_complete_marker_is_valid(session_dir);
-    if liveness.blocks_synthesis && !legacy_done {
+    // Verified owned liveness outranks legacy `.complete` markers (#2950).
+    if liveness.blocks_synthesis {
         debug!(
             session_id = %session_id,
             trigger = %trigger,
@@ -581,8 +581,8 @@ fn dead_session_with_result_needs_retire(
         return Ok(None);
     }
     let liveness = reconcile_liveness_decision(session_dir);
-    let legacy_done = crate::session_cmds_daemon::legacy_complete_marker_is_valid(session_dir);
-    if liveness.blocks_synthesis && !legacy_done {
+    // Verified owned liveness outranks legacy `.complete` markers (#2950).
+    if liveness.blocks_synthesis {
         debug!(
             session_id = %session_id,
             reason = %liveness.reason,
@@ -608,8 +608,8 @@ fn retire_if_dead_with_result_impl(
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(false);
     }
-    let legacy_done = crate::session_cmds_daemon::legacy_complete_marker_is_valid(session_dir);
-    if liveness.blocks_synthesis && !legacy_done {
+    // Verified owned liveness outranks legacy `.complete` markers (#2950).
+    if liveness.blocks_synthesis {
         debug!(
             session_id = %session_id,
             reason = %liveness.reason,

--- a/crates/cli-sub-agent/src/session_cmds_reconcile.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile.rs
@@ -96,6 +96,17 @@ pub(crate) fn with_reconcile_lock<R>(
 
 fn noop_path(_: &Path) {}
 
+fn liveness_blocks_terminal_reconciliation(
+    liveness: &ReconcileLivenessDecision,
+    session_dir: &Path,
+) -> bool {
+    // Passive progress protects unfinished sessions; verified owned processes
+    // still outrank even a valid legacy completion marker (#2950).
+    liveness.blocks_synthesis
+        && (liveness.owned_process_is_live
+            || !crate::session_cmds_daemon::legacy_complete_marker_is_valid(session_dir))
+}
+
 #[rustfmt::skip]
 fn push_sidecar_rollback_guard(guards: &mut Vec<ArtifactRollbackGuard>, label: &str, result: Result<Option<ArtifactRollbackGuard>>, session_id: &str, trigger: &str) { match result { Ok(Some(rollback_guard)) => guards.push(rollback_guard), Ok(None) => {}, Err(err) => warn!(session_id = %session_id, trigger = %trigger, recovery_sidecar = %label, error = %err, "Failed to persist recovery sidecar"), } }
 
@@ -170,8 +181,7 @@ fn dead_active_session_needs_terminal_result(
         return Ok(false);
     }
     let liveness = reconcile_liveness_decision(session_dir);
-    // Verified owned liveness outranks legacy `.complete` markers (#2950).
-    if liveness.blocks_synthesis {
+    if liveness_blocks_terminal_reconciliation(&liveness, session_dir) {
         debug!(
             session_id = %session_id,
             trigger = %trigger,
@@ -184,7 +194,7 @@ fn dead_active_session_needs_terminal_result(
         session_id = %session_id,
         trigger = %trigger,
         reconciliation_reason = %liveness.reason,
-        "Dead-session reconciliation confirmed no pid/progress blocker before checking result.toml"
+        "Dead-session reconciliation confirmed no terminal blocker before checking result.toml"
     );
     let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
     match load_result(project_root, session_id) {
@@ -226,8 +236,7 @@ where
         return Ok(DeadActiveSessionReconciliation::NoChange);
     }
     let liveness = reconcile_liveness_decision(session_dir);
-    // Verified owned liveness outranks legacy `.complete` markers (#2950).
-    if liveness.blocks_synthesis {
+    if liveness_blocks_terminal_reconciliation(&liveness, session_dir) {
         debug!(
             session_id = %session_id,
             trigger = %trigger,
@@ -240,7 +249,7 @@ where
         session_id = %session_id,
         trigger = %trigger,
         reconciliation_reason = %liveness.reason,
-        "Dead-session reconciliation re-check confirmed no pid/progress blocker before synthesizing fallback"
+        "Dead-session reconciliation re-check confirmed no terminal blocker before synthesizing fallback"
     );
     let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
     match load_result(project_root, session_id) {
@@ -581,8 +590,7 @@ fn dead_session_with_result_needs_retire(
         return Ok(None);
     }
     let liveness = reconcile_liveness_decision(session_dir);
-    // Verified owned liveness outranks legacy `.complete` markers (#2950).
-    if liveness.blocks_synthesis {
+    if liveness_blocks_terminal_reconciliation(&liveness, session_dir) {
         debug!(
             session_id = %session_id,
             reason = %liveness.reason,
@@ -608,8 +616,7 @@ fn retire_if_dead_with_result_impl(
     if !matches!(session.phase, SessionPhase::Active) {
         return Ok(false);
     }
-    // Verified owned liveness outranks legacy `.complete` markers (#2950).
-    if liveness.blocks_synthesis {
+    if liveness_blocks_terminal_reconciliation(&liveness, session_dir) {
         debug!(
             session_id = %session_id,
             reason = %liveness.reason,

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_liveness.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_liveness.rs
@@ -13,6 +13,7 @@ const RECENT_SESSION_WRITE_WINDOW_SECS: u64 = 30;
 
 pub(crate) struct ReconcileLivenessDecision {
     pub(crate) blocks_synthesis: bool,
+    pub(crate) owned_process_is_live: bool,
     pub(crate) reason: &'static str,
 }
 
@@ -45,23 +46,27 @@ pub(crate) fn reconcile_liveness_decision(session_dir: &Path) -> ReconcileLivene
     if ToolLiveness::has_live_process(session_dir) {
         return ReconcileLivenessDecision {
             blocks_synthesis: true,
+            owned_process_is_live: true,
             reason: "live_pid",
         };
     }
     if ToolLiveness::daemon_pid_is_alive(session_dir) {
         return ReconcileLivenessDecision {
             blocks_synthesis: true,
+            owned_process_is_live: true,
             reason: "live_daemon_pid",
         };
     }
     if has_reconcile_progress_signal(session_dir) {
         return ReconcileLivenessDecision {
             blocks_synthesis: true,
+            owned_process_is_live: false,
             reason: "progress_signal",
         };
     }
     ReconcileLivenessDecision {
         blocks_synthesis: false,
+        owned_process_is_live: false,
         reason: "no_pid_no_progress",
     }
 }

--- a/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_reconcile_progress_tests.rs
@@ -414,6 +414,71 @@ fn retirement_with_stale_output_and_existing_result_still_retires() {
     assert_eq!(persisted.termination_reason.as_deref(), Some("completed"));
 }
 
+#[cfg(unix)]
+#[test]
+fn legacy_completion_outranks_passive_stale_snapshot_across_reconcile_guards() {
+    let td = tempdir().expect("tempdir");
+    let _env = SessionTestEnv::new(&td);
+    let project = td.path();
+    fs::create_dir_all(
+        csa_session::get_session_root(project)
+            .expect("session root")
+            .join("sessions/.git"),
+    )
+    .expect("seed isolated sessions repository");
+
+    let session = create_session(project, Some("legacy-complete-stale-snapshot"), None, None)
+        .expect("create session");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+    let output_path = session_dir.join("output.log");
+    fs::write(&output_path, "old output bytes\n").expect("write output");
+    set_file_mtime_seconds_ago(&output_path, 31);
+    write_liveness_snapshot(
+        &session_dir,
+        ["spool_bytes_written=17", "observed_spool_bytes_written=0"],
+    );
+    fs::write(session_dir.join(".complete"), "0\n").expect("write legacy completion");
+
+    let first =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session list")
+            .expect("first reconciliation");
+    let second =
+        ensure_terminal_result_for_dead_active_session(project, &session_id, "session logs")
+            .expect("second reconciliation");
+
+    assert!(first.result_became_available());
+    assert_eq!(second, DeadActiveSessionReconciliation::NoChange);
+    assert!(load_result(project, &session_id).unwrap().is_some());
+    assert_eq!(
+        load_session(project, &session_id).unwrap().phase,
+        csa_session::SessionPhase::Retired
+    );
+
+    let session = create_session(
+        project,
+        Some("legacy-complete-stale-snapshot-existing-result"),
+        None,
+        None,
+    )
+    .expect("create session with result");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir with result");
+    save_result(project, &session_id, &make_result("success", 0)).expect("save result");
+    write_liveness_snapshot(
+        &session_dir,
+        ["spool_bytes_written=17", "observed_spool_bytes_written=0"],
+    );
+    fs::write(session_dir.join(".complete"), "0\n").expect("write legacy completion");
+
+    assert!(retire_with_isolated_state(project, &session_id));
+    assert!(!retire_with_isolated_state(project, &session_id));
+    assert_eq!(
+        load_session(project, &session_id).unwrap().phase,
+        csa_session::SessionPhase::Retired
+    );
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn live_daemon_pid_still_blocks_synthesis() {

--- a/crates/cli-sub-agent/src/session_cmds_result_resume_wrapper_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_resume_wrapper_tests.rs
@@ -143,7 +143,7 @@ fn handle_session_result_on_resume_wrapper_follows_worker_in_legacy_root() {
 
 #[cfg(target_os = "linux")]
 #[test]
-fn handle_session_result_on_resume_wrapper_defers_target_reconcile_while_wrapper_daemon_alive()
+fn handle_session_result_on_resume_wrapper_defers_target_reconcile_for_legacy_completion_while_wrapper_daemon_alive()
 -> anyhow::Result<()> {
     let tmp = tempdir()?;
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
@@ -179,6 +179,7 @@ fn handle_session_result_on_resume_wrapper_defers_target_reconcile_while_wrapper
         csa_process::ToolLiveness::daemon_pid_is_alive(&wrapper_dir),
         "test setup requires a live wrapper daemon.pid"
     );
+    std::fs::write(wrapper_dir.join(".complete"), "143\n")?;
     assert!(
         !target_dir
             .join(csa_session::result::RESULT_FILE_NAME)

--- a/crates/cli-sub-agent/src/session_cmds_result_tests_2016.rs
+++ b/crates/cli-sub-agent/src/session_cmds_result_tests_2016.rs
@@ -2,8 +2,8 @@ use super::*;
 
 #[cfg(target_os = "linux")]
 #[test]
-fn handle_session_result_uses_legacy_complete_marker_143_even_while_daemon_alive()
--> anyhow::Result<()> {
+fn handle_session_result_defers_legacy_complete_marker_143_while_daemon_alive() -> anyhow::Result<()>
+{
     use std::process::Command;
 
     let tmp = tempdir()?;
@@ -38,17 +38,14 @@ fn handle_session_result_uses_legacy_complete_marker_143_even_while_daemon_alive
         StructuredOutputOpts::default(),
     )?;
 
-    let result = load_result(project, &session_id)?
-        .expect("session result should synthesize from legacy .complete");
-    assert_eq!(result.status, "signal");
-    assert_eq!(result.exit_code, 143);
+    assert!(
+        load_result(project, &session_id)?.is_none(),
+        "live daemon must prevent synthesizing a result from legacy .complete"
+    );
 
     let persisted = csa_session::load_session(project, &session_id)?;
-    assert_eq!(persisted.phase, csa_session::SessionPhase::Retired);
-    assert_eq!(
-        persisted.termination_reason.as_deref(),
-        Some("legacy_complete_marker")
-    );
+    assert_eq!(persisted.phase, csa_session::SessionPhase::Active);
+    assert!(persisted.termination_reason.is_none());
 
     child.kill().ok();
     let _ = child.wait();
@@ -57,7 +54,7 @@ fn handle_session_result_uses_legacy_complete_marker_143_even_while_daemon_alive
 
 #[cfg(target_os = "linux")]
 #[test]
-fn handle_session_result_retires_existing_result_after_legacy_complete_marker_with_live_daemon_pid()
+fn handle_session_result_defers_existing_result_after_legacy_complete_marker_with_live_daemon_pid()
 -> anyhow::Result<()> {
     use std::process::Command;
 
@@ -104,14 +101,13 @@ fn handle_session_result_retires_existing_result_after_legacy_complete_marker_wi
         StructuredOutputOpts::default(),
     )?;
 
-    let result =
-        load_result(project, &session_id)?.expect("existing result should remain authoritative");
+    let result = load_result(project, &session_id)?.expect("existing result file remains on disk");
     assert_eq!(result.status, "success");
     assert_eq!(result.exit_code, 0);
 
     let persisted = csa_session::load_session(project, &session_id)?;
-    assert_eq!(persisted.phase, csa_session::SessionPhase::Retired);
-    assert_eq!(persisted.termination_reason.as_deref(), Some("completed"));
+    assert_eq!(persisted.phase, csa_session::SessionPhase::Active);
+    assert!(persisted.termination_reason.is_none());
 
     child.kill().ok();
     let _ = child.wait();

--- a/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
@@ -125,7 +125,7 @@ fn handle_session_wait_kv_warm_exit_when_daemon_alive_at_cap() {
 
 #[cfg(target_os = "linux")]
 #[test]
-fn rewait_after_kv_warm_returns_retired_result_despite_lingering_liveness() {
+fn rewait_after_kv_warm_defers_retired_result_while_lingering_liveness() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
@@ -184,7 +184,6 @@ fn rewait_after_kv_warm_returns_retired_result_despite_lingering_liveness() {
     retired.phase = SessionPhase::Retired;
     save_session(&retired).expect("save retired state");
 
-    let mut completed_signal = None;
     let second_exit = handle_session_wait_with_hooks(
         session_id.clone(),
         Some(project.to_string_lossy().into_owned()),
@@ -197,22 +196,20 @@ fn rewait_after_kv_warm_returns_retired_result_despite_lingering_liveness() {
             },
         },
         |_project_root, _current_session_id, _trigger| {
-            panic!("retired session with result must not be reconciled")
+            panic!("live owned work must not be reconciled")
         },
-        |sid, status, exit_code, synthetic, _mirror_to_stdout| {
-            completed_signal = Some((sid.to_string(), status.to_string(), exit_code, synthetic));
+        |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {
+            panic!("stale Retired + result must not complete while owned liveness remains")
         },
     )
-    .expect("second wait should return retired result");
+    .expect("second wait should return KV-warm while owned work is live");
 
     let _ = child.kill();
     let _ = child.wait();
 
-    assert_eq!(second_exit, 0);
     assert_eq!(
-        completed_signal,
-        Some((session_id, "success".to_string(), 0, false)),
-        "Retired registry phase must make result.toml authoritative over lingering liveness"
+        second_exit, 0,
+        "verified owned liveness must defeat stale Retired + success result (#2950)"
     );
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_kv_warm.rs
@@ -215,6 +215,64 @@ fn rewait_after_kv_warm_defers_retired_result_while_lingering_liveness() {
 
 #[cfg(target_os = "linux")]
 #[test]
+fn retired_session_without_result_rejects_passive_liveness() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+
+    let session = create_session(
+        project,
+        Some("wait-retired-passive-liveness"),
+        None,
+        Some("codex"),
+    )
+    .expect("create");
+    let session_id = session.meta_session_id;
+    let session_dir = get_session_dir(project, &session_id).expect("session dir");
+
+    let mut retired = load_session(project, &session_id).expect("load session");
+    retired.phase = SessionPhase::Retired;
+    save_session(&retired).expect("save retired state");
+    std::fs::write(session_dir.join("stderr.log"), "passive diagnostic\n")
+        .expect("write passive diagnostic");
+    assert!(!session_dir.join("result.toml").exists());
+    assert!(csa_process::ToolLiveness::is_alive(&session_dir));
+
+    let exit_code = handle_session_wait_with_hooks(
+        session_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        },
+        |_project_root, _current_session_id, _trigger| {
+            Ok(WaitReconciliationOutcome {
+                result_became_available: false,
+                synthetic: false,
+            })
+        },
+        |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {
+            panic!("retired passive liveness must not emit a healthy completion")
+        },
+    )
+    .expect("wait should reject passive liveness");
+
+    assert_eq!(
+        exit_code, 1,
+        "Retired registry authority must suppress passive filesystem liveness"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
 fn handle_session_wait_kv_warm_after_registry_state_loss_with_metadata_fallback() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2016.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_2016.rs
@@ -3,8 +3,7 @@ use crate::session_cmds_daemon::{WaitBehavior, WaitLoopTiming, handle_session_wa
 use crate::test_env_lock::ScopedEnvVarRestore;
 
 #[test]
-fn handle_session_wait_retires_active_session_after_legacy_complete_marker_143_even_with_live_daemon_pid()
- {
+fn handle_session_wait_defers_legacy_complete_marker_while_session_is_live() {
     let td = tempdir().unwrap();
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
@@ -43,30 +42,27 @@ fn handle_session_wait_retires_active_session_after_legacy_complete_marker_143_e
         fixed_now,
         Some(true),
         |_project_root, _current_session_id, _trigger| {
-            panic!("legacy complete marker must resolve before dead-session reconciliation")
+            panic!("live session must not reach dead-session reconciliation")
         },
         |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {},
     )
     .unwrap();
 
-    assert_eq!(exit_code, 1);
-
-    let result = load_result(project, &session_id)
-        .unwrap()
-        .expect("wait should synthesize a terminal result from .complete");
-    assert_eq!(result.status, "signal");
-    assert_eq!(result.exit_code, 143);
+    // Live owned work at the wait cap takes the KV-warm path (exit 0), not the
+    // legacy-marker terminal path (#2950 / #1439).
+    assert_eq!(exit_code, 0);
+    assert!(
+        load_result(project, &session_id).unwrap().is_none(),
+        "live session must not synthesize a result from .complete"
+    );
 
     let persisted = load_session(project, &session_id).unwrap();
-    assert_eq!(persisted.phase, SessionPhase::Retired);
-    assert_eq!(
-        persisted.termination_reason.as_deref(),
-        Some("legacy_complete_marker")
-    );
+    assert_eq!(persisted.phase, SessionPhase::Active);
+    assert!(persisted.termination_reason.is_none());
 }
 
 #[test]
-fn handle_session_wait_retires_existing_result_after_legacy_complete_marker_with_live_daemon_pid() {
+fn handle_session_wait_defers_existing_result_after_legacy_complete_marker_with_live_daemon_pid() {
     let td = tempdir().unwrap();
     let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let state_home = td.path().join("xdg-state");
@@ -101,20 +97,23 @@ fn handle_session_wait_retires_existing_result_after_legacy_complete_marker_with
         fixed_now,
         Some(true),
         |_project_root, _current_session_id, _trigger| {
-            panic!("legacy complete marker must resolve before dead-session reconciliation")
+            panic!("live session must not reach dead-session reconciliation")
         },
-        |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {},
+        |_sid, _status, _exit_code, _synthetic, _mirror_to_stdout| {
+            panic!("live owned work must not emit terminal wait completion")
+        },
     )
     .unwrap();
 
+    // Durable success/result is not terminal while verified owned liveness remains.
     assert_eq!(exit_code, 0);
     let result = load_result(project, &session_id)
         .unwrap()
-        .expect("existing result should remain authoritative");
+        .expect("existing result file remains on disk");
     assert_eq!(result.status, "success");
     assert_eq!(result.exit_code, 0);
 
     let persisted = load_session(project, &session_id).unwrap();
-    assert_eq!(persisted.phase, SessionPhase::Retired);
-    assert_eq!(persisted.termination_reason.as_deref(), Some("completed"));
+    assert_eq!(persisted.phase, SessionPhase::Active);
+    assert!(persisted.termination_reason.is_none());
 }

--- a/crates/cli-sub-agent/src/session_resume_handoff.rs
+++ b/crates/cli-sub-agent/src/session_resume_handoff.rs
@@ -36,7 +36,7 @@ fn wrapper_still_owns_handoff(wrapper_session_dir: &Path) -> bool {
 }
 
 fn wrapper_completion_is_terminal(wrapper_session_dir: &Path) -> bool {
-    let Some(packet) =
+    let Some(_packet) =
         crate::session_cmds_daemon::load_daemon_completion_packet(wrapper_session_dir)
             .ok()
             .flatten()
@@ -44,7 +44,9 @@ fn wrapper_completion_is_terminal(wrapper_session_dir: &Path) -> bool {
         return false;
     };
 
-    packet.is_legacy_complete_marker() || !wrapper_has_process_signal(wrapper_session_dir)
+    // Completion packets (including legacy `.complete`) are only terminal after
+    // the wrapper's verified process signal has exited (#2950).
+    !wrapper_has_process_signal(wrapper_session_dir)
 }
 
 fn wrapper_has_process_signal(wrapper_session_dir: &Path) -> bool {

--- a/crates/cli-sub-agent/tests/run_blocked_cargo_target.rs
+++ b/crates/cli-sub-agent/tests/run_blocked_cargo_target.rs
@@ -280,7 +280,7 @@ fn output_reaps_descendants_after_direct_child_exits_and_pipes_drain() {
     let output = output_with_deadline(
         &mut command,
         "direct child exited but descendant survived with closed pipes",
-        Duration::from_millis(100),
+        Duration::from_secs(1),
     );
     let descendant_output = String::from_utf8(output.stdout).expect("descendant pid is utf-8");
     let descendant_identity = descendant_output.split_whitespace().collect::<Vec<_>>();

--- a/crates/cli-sub-agent/tests/run_blocked_cargo_target.rs
+++ b/crates/cli-sub-agent/tests/run_blocked_cargo_target.rs
@@ -280,7 +280,7 @@ fn output_reaps_descendants_after_direct_child_exits_and_pipes_drain() {
     let output = output_with_deadline(
         &mut command,
         "direct child exited but descendant survived with closed pipes",
-        Duration::from_secs(1),
+        Duration::from_secs(5),
     );
     let descendant_output = String::from_utf8(output.stdout).expect("descendant pid is utf-8");
     let descendant_identity = descendant_output.split_whitespace().collect::<Vec<_>>();

--- a/crates/csa-process/src/daemon_cleanup.rs
+++ b/crates/csa-process/src/daemon_cleanup.rs
@@ -340,8 +340,8 @@ mod tests {
 
     #[test]
     fn interrupted_waitid_probe_is_retried() {
-        let mut child = Command::new("sh")
-            .args(["-c", "sleep 5"])
+        let mut child = Command::new("sleep")
+            .arg("5")
             .spawn()
             .expect("spawn waitid fixture");
         let mut calls = 0;

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1132"
-weave = "0.1.1132"
+csa = "0.1.1133"
+weave = "0.1.1133"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- make verified wrapper/process-group liveness authoritative over legacy `.complete` and success-result artifacts
- keep wait, resume, list, attach, and reconciliation paths nonterminal while owned processes are still live
- add regression coverage for legacy completion combined with a verified live wrapper; stabilize lifecycle fixtures without weakening the `<2s` behavior bound
- bump the release version to `0.1.1133`

## Verification

- exact candidate: `1c512c40ef37bf729bc5be723f16b72fb7240037`
- candidate SHA256/provenance and isolated `csa`/`weave` smoke: PASS
- `NEXTEST_TEST_THREADS=1 just pre-push`: 7513 passed, 7 skipped
- hook-enabled push: branch protection, quality gates (7513 passed), review check, and version check all passed
- fresh Tier-4 review session `01KZ2JAKM1K76FC1YYPHF71DX2`: CLEAN, zero findings

Closes #2950
