### PR TITLE
fix: #3004/#3006 process lifecycle and gemini cache gate flakes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1134"
+version = "0.1.1135"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1134"
+version = "0.1.1135"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-executor/src/transport_tests_gemini_fixture.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_fixture.rs
@@ -1,0 +1,11 @@
+fn configure_fake_gemini_cache(
+    temp: &tempfile::TempDir,
+    env: &mut HashMap<String, String>,
+) {
+    let cache_home = temp.path().join("xdg-cache");
+    std::fs::create_dir(&cache_home).expect("create fake Gemini cache home");
+    env.insert(
+        "XDG_CACHE_HOME".to_string(),
+        cache_home.to_string_lossy().into_owned(),
+    );
+}

--- a/crates/csa-executor/src/transport_tests_tail.rs
+++ b/crates/csa-executor/src/transport_tests_tail.rs
@@ -546,6 +546,7 @@ fn build_test_meta_session(project_path: &str) -> MetaSessionState {
     }
 }
 
+include!("transport_tests_gemini_fixture.rs");
 fn setup_fake_gemini_environment(
     success_on: u32,
 ) -> (
@@ -590,7 +591,6 @@ while [ "$#" -gt 0 ]; do
 done
 printf '%s\n' "${model}" >>"${MODEL_LOG_FILE}"
 
-# Log auth mode: if GEMINI_API_KEY is set, auth is api_key; otherwise oauth
 if [ -n "${GEMINI_API_KEY:-}" ]; then
   printf 'api_key\n' >>"${AUTH_LOG_FILE}"
 else
@@ -618,6 +618,7 @@ printf 'ok attempt=%s model=%s\n' "${count}" "${model}"
         "PATH".to_string(),
         format!("{}:{old_path}", temp.path().display()),
     );
+    configure_fake_gemini_cache(&temp, &mut env);
     env.insert(
         "CSA_TEST_DISABLE_GEMINI_DIRECT_LAUNCH".to_string(),
         "1".to_string(),

--- a/crates/csa-process/src/lib.rs
+++ b/crates/csa-process/src/lib.rs
@@ -39,6 +39,8 @@ mod output_helpers;
 mod signal_exit;
 #[path = "lib_subprocess_helpers.rs"]
 mod subprocess_helpers;
+#[cfg(all(test, unix))]
+mod test_process_group;
 mod tool_liveness;
 mod workspace_boundary;
 #[cfg(unix)]

--- a/crates/csa-process/src/lib_subprocess_helpers.rs
+++ b/crates/csa-process/src/lib_subprocess_helpers.rs
@@ -87,17 +87,22 @@ pub(crate) fn waitid_without_reaping(
 
 #[cfg(unix)]
 fn signal_process_group(process_group: i32, signal: libc::c_int) -> Result<()> {
-    // SAFETY: the negative PID targets the still-owned child's process group.
-    let rc = unsafe { libc::kill(-process_group, signal) };
-    if rc == 0 {
-        return Ok(());
-    }
+    loop {
+        // SAFETY: the negative PID targets the still-owned child's process group.
+        let rc = unsafe { libc::kill(-process_group, signal) };
+        if rc == 0 {
+            return Ok(());
+        }
 
-    let error = std::io::Error::last_os_error();
-    if error.raw_os_error() == Some(libc::ESRCH) {
-        return Ok(());
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ESRCH) {
+            return Ok(());
+        }
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error)
+                .with_context(|| format!("failed to signal process group {process_group}"));
+        }
     }
-    Err(error).with_context(|| format!("failed to signal process group {process_group}"))
 }
 
 async fn wait_for_child_exit(child: &mut tokio::process::Child) -> Result<ExitStatus> {
@@ -105,6 +110,23 @@ async fn wait_for_child_exit(child: &mut tokio::process::Child) -> Result<ExitSt
         .await
         .context("timed out waiting for child process to exit")?
         .context("failed to wait for child process")
+}
+
+#[cfg(target_os = "linux")]
+async fn wait_for_process_group_termination(process_group: i32) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + CHILD_REAP_TIMEOUT;
+    loop {
+        match crate::process_activity::process_group_has_live_members(process_group) {
+            Ok(false) => return Ok(()),
+            Ok(true) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error).context("failed to inspect child process group"),
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!("timed out waiting for child process group to terminate");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 }
 
 pub async fn terminate_child_process_group(
@@ -122,6 +144,8 @@ pub async fn terminate_child_process_group(
             // Do not reap the leader before the final group signal: its unreaped
             // PID anchors the PGID even when it exited on SIGTERM.
             signal_process_group(process_group, libc::SIGKILL)?;
+            #[cfg(target_os = "linux")]
+            wait_for_process_group_termination(process_group).await?;
             return wait_for_child_exit(child).await;
         }
     }

--- a/crates/csa-process/src/lib_tests.rs
+++ b/crates/csa-process/src/lib_tests.rs
@@ -337,13 +337,13 @@ fn test_tool_liveness_true_for_live_pid_and_output_growth() {
 #[test]
 fn test_tool_liveness_matches_daemon_pid_by_session_dir_path() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let mut child = std::process::Command::new("sh")
+    let mut command = std::process::Command::new("sh");
+    command
         .arg("-c")
         .arg("while true; do sleep 1; done")
         .arg("session-runner")
-        .arg(tmp.path())
-        .spawn()
-        .expect("spawn sleeper");
+        .arg(tmp.path());
+    let child = crate::test_process_group::ProcessGroupFixture::spawn(command);
     std::fs::write(tmp.path().join("daemon.pid"), child.id().to_string()).expect("write pid");
 
     let expected_pid = child.id();
@@ -355,9 +355,6 @@ fn test_tool_liveness_matches_daemon_pid_by_session_dir_path() {
         }
         std::thread::sleep(Duration::from_millis(10));
     }
-
-    let _ = child.kill();
-    let _ = child.wait();
 
     assert_eq!(observed_pid, Some(expected_pid));
 }

--- a/crates/csa-process/src/lib_tests_tail.rs
+++ b/crates/csa-process/src/lib_tests_tail.rs
@@ -521,18 +521,14 @@ fn test_is_working_reads_proc_stat() {
     let locks_dir = tmp.path().join("locks");
     std::fs::create_dir_all(&locks_dir).expect("create locks dir");
     // Use a spawned process with 'tool' in cmdline to satisfy context check.
-    let mut child = std::process::Command::new("sh")
-        .arg("-c")
-        .arg("sleep 60 # tool")
-        .spawn()
-        .unwrap();
+    let mut command = std::process::Command::new("sh");
+    command.arg("-c").arg("sleep 60 # tool");
+    let child = crate::test_process_group::ProcessGroupFixture::spawn(command);
     let pid = child.id();
     std::fs::write(locks_dir.join("tool.lock"), format!("{{\"pid\": {}}}", pid))
         .expect("write lock");
 
     let working = ToolLiveness::is_working(tmp.path());
-    child.kill().ok();
-    child.wait().ok();
     assert!(
         working,
         "is_working should return true for a running process with correct context"

--- a/crates/csa-process/src/process_activity.rs
+++ b/crates/csa-process/src/process_activity.rs
@@ -62,7 +62,7 @@ struct ProcStat {
 
 #[cfg(target_os = "linux")]
 fn platform_process_tree_cpu_ticks(root_pid: u32) -> Option<u64> {
-    let stats = read_all_proc_stats();
+    let stats = read_all_proc_stats().ok()?;
     let root = stats.iter().find(|stat| stat.pid == root_pid).copied();
     let root_pgrp = root.and_then(|stat| (stat.pgrp == root_pid as i32).then_some(stat.pgrp));
     let parents: HashMap<u32, u32> = stats.iter().map(|stat| (stat.pid, stat.ppid)).collect();
@@ -108,18 +108,27 @@ fn is_descendant_of(pid: u32, root_pid: u32, parents: &HashMap<u32, u32>) -> boo
 }
 
 #[cfg(target_os = "linux")]
-fn read_all_proc_stats() -> Vec<ProcStat> {
-    let Ok(entries) = std::fs::read_dir("/proc") else {
-        return Vec::new();
-    };
-
-    entries
+fn read_all_proc_stats() -> std::io::Result<Vec<ProcStat>> {
+    Ok(std::fs::read_dir("/proc")?
         .flatten()
         .filter_map(|entry| {
             let pid = entry.file_name().to_str()?.parse::<u32>().ok()?;
             read_proc_stat(pid)
         })
-        .collect()
+        .collect())
+}
+
+#[cfg(target_os = "linux")]
+/// Report whether an anchored process group still has a non-terminal member.
+pub(crate) fn process_group_has_live_members(process_group: i32) -> std::io::Result<bool> {
+    Ok(read_all_proc_stats()?
+        .into_iter()
+        .any(|stat| stat.pgrp == process_group && !matches!(stat.state, 'Z' | 'X')))
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+pub(crate) fn process_group_has_live_members(_process_group: i32) -> std::io::Result<bool> {
+    Ok(false)
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/csa-process/src/test_process_group.rs
+++ b/crates/csa-process/src/test_process_group.rs
@@ -1,0 +1,52 @@
+use std::os::unix::process::CommandExt;
+
+/// Own a test fixture and clean up every process in its private group.
+pub(crate) struct ProcessGroupFixture {
+    child: Option<std::process::Child>,
+}
+
+impl ProcessGroupFixture {
+    pub(crate) fn spawn(mut command: std::process::Command) -> Self {
+        // SAFETY: test fixture only; gives the fixture a private process group.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        Self {
+            child: Some(command.spawn().expect("spawn process-group fixture")),
+        }
+    }
+
+    pub(crate) fn id(&self) -> u32 {
+        self.child
+            .as_ref()
+            .expect("fixture leader must remain unreaped")
+            .id()
+    }
+
+    fn terminate_and_reap(&mut self) {
+        let pid = self.id() as libc::pid_t;
+        // SAFETY: the unreaped setsid leader owns this fixture's process group.
+        let _ = unsafe { libc::kill(-pid, libc::SIGTERM) };
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        // SAFETY: the leader remains unreaped, so its PID cannot have been reused.
+        let _ = unsafe { libc::kill(-pid, libc::SIGKILL) };
+        let _ = self
+            .child
+            .take()
+            .expect("fixture leader must remain unreaped")
+            .wait();
+    }
+}
+
+impl Drop for ProcessGroupFixture {
+    fn drop(&mut self) {
+        if self.child.is_some() {
+            self.terminate_and_reap();
+        }
+    }
+}

--- a/crates/csa-process/src/tool_liveness.rs
+++ b/crates/csa-process/src/tool_liveness.rs
@@ -33,7 +33,6 @@ struct DaemonPidRecord {
 #[derive(Debug, Clone, Copy)]
 struct ProcessMetadata {
     state: char,
-    pgrp: i32,
     start_time_ticks: u64,
 }
 
@@ -327,41 +326,22 @@ fn read_process_metadata(pid: u32) -> Option<ProcessMetadata> {
     let mut parts = after_comm.split_whitespace();
     let state = parts.next()?.chars().next()?;
     let _ppid = parts.next()?;
-    let pgrp = parts.next()?.parse::<i32>().ok()?;
+    parts.next()?;
     for _ in 0..16 {
         parts.next()?;
     }
     let start_time_ticks = parts.next()?.parse::<u64>().ok()?;
     Some(ProcessMetadata {
         state,
-        pgrp,
         start_time_ticks,
     })
 }
 
 #[cfg(unix)]
 fn has_live_process_group_member(leader_pid: u32) -> bool {
-    let Ok(entries) = fs::read_dir("/proc") else {
-        return false;
-    };
-    let target_pgrp = leader_pid as i32;
-
-    for entry in entries.flatten() {
-        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
-            continue;
-        };
-        let Ok(pid) = name.parse::<u32>() else {
-            continue;
-        };
-        let Some(ProcessMetadata { state, pgrp, .. }) = read_process_metadata(pid) else {
-            continue;
-        };
-        if pgrp == target_pgrp && !matches!(state, 'Z' | 'X') {
-            return true;
-        }
-    }
-
-    false
+    i32::try_from(leader_pid).is_ok_and(|process_group| {
+        crate::process_activity::process_group_has_live_members(process_group).unwrap_or(false)
+    })
 }
 
 fn has_live_pid_signal(session_dir: &Path) -> bool {

--- a/crates/csa-process/src/tool_liveness_tests.rs
+++ b/crates/csa-process/src/tool_liveness_tests.rs
@@ -47,11 +47,9 @@ fn is_working_returns_true_for_own_process() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let locks_dir = tmp.path().join("locks");
     fs::create_dir_all(&locks_dir).expect("create locks dir");
-    let mut child = std::process::Command::new("sh")
-        .arg("-c")
-        .arg("sleep 60 # codex")
-        .spawn()
-        .unwrap();
+    let mut command = std::process::Command::new("sh");
+    command.arg("-c").arg("sleep 60 # codex");
+    let child = crate::test_process_group::ProcessGroupFixture::spawn(command);
     let pid = child.id();
     fs::write(
         locks_dir.join("codex.lock"),
@@ -60,8 +58,6 @@ fn is_working_returns_true_for_own_process() {
     .expect("write lock");
 
     let working = ToolLiveness::is_working(tmp.path());
-    child.kill().ok();
-    child.wait().ok();
     assert!(working);
 }
 
@@ -82,17 +78,13 @@ fn find_session_pid_returns_own_pid() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let locks_dir = tmp.path().join("locks");
     fs::create_dir_all(&locks_dir).expect("create locks dir");
-    let mut child = std::process::Command::new("sh")
-        .arg("-c")
-        .arg("sleep 60 # tool")
-        .spawn()
-        .unwrap();
+    let mut command = std::process::Command::new("sh");
+    command.arg("-c").arg("sleep 60 # tool");
+    let child = crate::test_process_group::ProcessGroupFixture::spawn(command);
     let pid = child.id();
     fs::write(locks_dir.join("tool.lock"), format!("{{\"pid\": {pid}}}")).expect("write lock");
 
     let found_pid = find_session_pid(tmp.path());
-    child.kill().ok();
-    child.wait().ok();
     assert_eq!(found_pid, Some(pid));
 }
 
@@ -688,17 +680,12 @@ fn find_session_pid_ignores_reconcile_lock_in_parent_dir() {
     let reconcile_lock = tmp.path().join(".reconcile.lock");
     fs::write(&reconcile_lock, "{\"pid\": 12345}").expect("write lock");
 
-    let mut child = std::process::Command::new("sh")
-        .arg("-c")
-        .arg("sleep 60 # tool")
-        .spawn()
-        .unwrap();
+    let mut command = std::process::Command::new("sh");
+    command.arg("-c").arg("sleep 60 # tool");
+    let child = crate::test_process_group::ProcessGroupFixture::spawn(command);
     let pid = child.id();
     fs::write(locks_dir.join("tool.lock"), format!("{{\"pid\": {pid}}}")).expect("write lock");
 
     let found_pid = find_session_pid(tmp.path());
-    child.kill().ok();
-    child.wait().ok();
-
     assert_eq!(found_pid, Some(pid));
 }

--- a/crates/csa-process/src/tool_liveness_tests_daemon_fixture.rs
+++ b/crates/csa-process/src/tool_liveness_tests_daemon_fixture.rs
@@ -1,66 +1,6 @@
 use super::super::*;
 use super::wait_for_process_command_line_contains;
-
-/// Own a daemon-style test fixture and clean up every process in its group.
-///
-/// The fixture command is its own session leader, so a shell script that starts
-/// a child cannot leave that child holding inherited test-harness file
-/// descriptors after the script leader is terminated.
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-struct DaemonFixtureProcess {
-    child: Option<std::process::Child>,
-}
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-impl DaemonFixtureProcess {
-    fn spawn(program: &std::path::Path) -> Self {
-        use std::os::unix::process::CommandExt;
-
-        let mut command = std::process::Command::new(program);
-        // SAFETY: test fixture only; gives the fixture a private process group.
-        unsafe {
-            command.pre_exec(|| {
-                if libc::setsid() == -1 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                Ok(())
-            });
-        }
-        Self {
-            child: Some(command.spawn().expect("spawn daemon fixture")),
-        }
-    }
-
-    fn id(&self) -> u32 {
-        self.child
-            .as_ref()
-            .expect("daemon fixture leader must remain unreaped")
-            .id()
-    }
-
-    fn terminate_and_reap(&mut self) {
-        let pid = self.id() as libc::pid_t;
-        // SAFETY: the unreaped setsid leader owns this fixture's process group.
-        let _ = unsafe { libc::kill(-pid, libc::SIGTERM) };
-        std::thread::sleep(std::time::Duration::from_millis(100));
-        // SAFETY: the leader remains unreaped, so its PID cannot have been reused.
-        let _ = unsafe { libc::kill(-pid, libc::SIGKILL) };
-        let _ = self
-            .child
-            .take()
-            .expect("daemon fixture leader must remain unreaped")
-            .wait();
-    }
-}
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-impl Drop for DaemonFixtureProcess {
-    fn drop(&mut self) {
-        if self.child.is_some() {
-            self.terminate_and_reap();
-        }
-    }
-}
+use crate::test_process_group::ProcessGroupFixture;
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
@@ -79,7 +19,7 @@ fn daemon_pid_is_alive_accepts_legacy_pid_with_session_id_context() {
         .permissions();
     perms.set_mode(0o755);
     fs::set_permissions(&daemon_fixture, perms).expect("mark daemon fixture executable");
-    let child = DaemonFixtureProcess::spawn(&daemon_fixture);
+    let child = ProcessGroupFixture::spawn(std::process::Command::new(&daemon_fixture));
     let pid = child.id();
     let cmdline_ready = wait_for_process_command_line_contains(pid, SESSION_ID);
     fs::write(session_dir.join(DAEMON_PID_FILE), format!("{pid}\n")).expect("write daemon pid");

--- a/scripts/tests/quality-gate-receipt-integrity-tests.sh
+++ b/scripts/tests/quality-gate-receipt-integrity-tests.sh
@@ -41,24 +41,61 @@ assert_single_json() {
     '/tmp/|example\.invalid|credential|secret-token' "$record"
 }
 
-wait_for_pid_bounded() {
-  local pid="$1"
-  if ! timeout 10 tail --pid="$pid" -f /dev/null; then
-    kill "$pid" 2>/dev/null || true
-    wait "$pid" 2>/dev/null || true
-    unregister_child "$pid"
-    _receipt_test_fail fixture-process-timeout completed-within-10s timed-out
-    return 1
-  fi
-  local code
-  if wait "$pid"; then
-    unregister_child "$pid"
-    return 0
-  else
-    code=$?
-  fi
-  unregister_child "$pid"
-  _receipt_test_fail fixture-process-exit 0 "$code"
+wait_for_pids_bounded() {
+  local -a pending=("$@") remaining
+  local completed pid code
+  while [ "${#pending[@]}" -gt 0 ]; do
+    # Lock acquisition order is nondeterministic, so reap whichever exact child
+    # exits next instead of imposing launch order on serialized fixture writers.
+    if ! completed="$(python3 - "${pending[@]}" <<'PY'
+import os
+import select
+import sys
+
+pidfds = {}
+try:
+    poller = select.poll()
+    for value in sys.argv[1:]:
+        try:
+            descriptor = os.pidfd_open(int(value))
+        except ProcessLookupError:
+            print(value)
+            raise SystemExit
+        pidfds[descriptor] = value
+        poller.register(descriptor, select.POLLIN)
+    ready = poller.poll(10_000)
+    if not ready:
+        raise SystemExit(124)
+    print(pidfds[ready[0][0]])
+finally:
+    for descriptor in pidfds:
+        os.close(descriptor)
+PY
+    )"; then
+      for pid in "${pending[@]}"; do
+        kill "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+        unregister_child "$pid"
+      done
+      _receipt_test_fail fixture-process-timeout completed-within-10s timed-out
+      return 1
+    fi
+    if wait "$completed"; then
+      code=0
+    else
+      code=$?
+    fi
+    unregister_child "$completed"
+    if [ "$code" -ne 0 ]; then
+      _receipt_test_fail fixture-process-exit 0 "$code"
+      return 1
+    fi
+    remaining=()
+    for pid in "${pending[@]}"; do
+      [ "$pid" = "$completed" ] || remaining+=("$pid")
+    done
+    pending=("${remaining[@]}")
+  done
 }
 
 run_integrity_concurrency() {
@@ -179,8 +216,7 @@ PY'
   local writer_two=$!
   register_child "$writer_two"
   touch "$fixture/target/quality-gate-test-state/release"
-  wait_for_pid_bounded "$writer_one"
-  wait_for_pid_bounded "$writer_two"
+  wait_for_pids_bounded "$writer_one" "$writer_two"
   assert_eq integrity-concurrency-initial-gate-runs 1 "$(wc -c <"$counter")"
   assert_eq integrity-concurrency-receipt-count 1 \
     "$(find "$receipt_dir" -maxdepth 1 -type f -name '*.json' | wc -l)"
@@ -197,10 +233,7 @@ PY'
     writers+=("$!")
     register_child "$!"
   done
-  local writer
-  for writer in "${writers[@]}"; do
-    wait_for_pid_bounded "$writer"
-  done
+  wait_for_pids_bounded "${writers[@]}"
   assert_eq integrity-concurrency-final-gate-runs 1 "$(wc -c <"$counter")"
   echo "PASS integrity-concurrency"
 

--- a/scripts/tests/quality-gate-receipt-tests.sh
+++ b/scripts/tests/quality-gate-receipt-tests.sh
@@ -438,7 +438,7 @@ run_invalidation_matrix() {
   fi
   printf 'drift\n' >>"$fixture/Cargo.toml"
   touch "$fixture/target/quality-gate-test-state/drift-release"
-  wait_for_pid_bounded "$drift_writer"
+  wait_for_pids_bounded "$drift_writer"
   after="$(<"$fixture/target/quality-gate-test-state/drift-output.json")"
   local after_identity
   after_identity="$(printf '%s' "$after" | json_field receipt_identity)"

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1134"
-weave = "0.1.1134"
+csa = "0.1.1135"
+weave = "0.1.1135"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
Closes #3004 and #3006.

Root-cause fixes for full pre-push process-lifecycle flakes and quality-gate HOME-dependent Gemini npm-cache fixture setup, plus a residual one-line repair after the concurrent-writer reaper rename.

### Commits
1. `f8888e47` fix(process): await process-group termination
2. `3d5000a4` test(process): own shell fixture process groups
3. `ba6fe5b7` test(gates): reap concurrent writers by completion
4. `81173d90` test(executor): isolate fake Gemini npm cache
5. `525571e2` test(gates): restore singular wait helper for input-drift case

### Residual note (`525571e2`)
`ba6fe5b7` renamed `wait_for_pid_bounded` → `wait_for_pids_bounded` and updated concurrency callers, but left the singular call site in `scripts/tests/quality-gate-receipt-tests.sh` used by `invalidation-input-drift`. That produced host full-gate exit 127 (`command not found`). The one-line call-site fix restores the plural helper.

## Test plan
- Focused:
  - process-group / tool-liveness contracts (branch commits)
  - `bash scripts/tests/quality-gate-receipt-tests.sh invalidation-matrix` → PASS incl. `invalidation-input-drift`
  - `PATH="/usr/bin:$PATH" bash scripts/tests/quality-gate-receipt-tests.sh integrity-concurrency` → PASS
  - isolation `process-tree` focused 3/3 PASS (push-time timeout under foreign mempal load classified non-regression)
- Authoritative host gate: `just pre-push` exit 0 at `525571e2` / tree `f350fa53`
  - log `/home/obj/tmp/3004-3006-host-prepush-525571e2.log`
  - sha256 `dae131c5960490dea4e1068f5220b7c9fb4e548809e5ee9665750264070fbace`
  - Summary: 7536 tests run: 7536 passed, 7 skipped

## Review evidence
- CSA Tier-4 unavailable (infrastructure): #3036 phantom active-session memory admission denied twice while `csa session list --all-projects --status active` was empty. Comment: https://github.com/RyderFreeman4Logos/cli-sub-agent/issues/3036#issuecomment-5240518158
- Native clean-room exact-HEAD review: **VERDICT: PASS**
  - report `/home/obj/tmp/3004-3006-native-tier4-525571e2.md`
  - sha256 `932d2c74d2f49e0b595af4b4ade162fe3ad6cb38d7cbf5f0c905a89ba05a900c`
- Structured native bypass artifact validated: `.csa/native-review-bypass/525571e2abbf52c7b6b373a6723f398477f5256a.toml`
- Pre-push used audited `CSA_SKIP_REVIEW_CHECK=1` with the above reason after CSA marker was unavailable; quality-gates/version/branch-protection still ran.

## Out of scope / filed separately
- #3038 CSA run cannot reach user systemd scope preflight
- #3037 WD resolver path not installed
- #3040 CSA git guard blocks quality-gate receipt harness via `git -C`
