### PR TITLE
fix(admission): memory soft-limit empty interval and cgroup floor (#3044/#3043)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1136"
+version = "0.1.1137"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1136"
+version = "0.1.1137"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/no_provider_launch.rs
+++ b/crates/cli-sub-agent/src/no_provider_launch.rs
@@ -48,7 +48,7 @@ fn from_soft_limit_admission(
         ctx.resource_overrides,
         error,
     );
-    let mut guidance = error.guidance();
+    let mut guidance = soft_limit_admission_initial_guidance(error.guidance(), &memory);
     guidance.extend(soft_limit_admission_guidance(
         ctx.tool_name,
         &memory,
@@ -121,7 +121,7 @@ pub(crate) fn soft_limit_admission_guidance_from_error_with_argv(
         resource_overrides,
         soft_limit,
     );
-    let mut guidance = soft_limit.guidance();
+    let mut guidance = soft_limit_admission_initial_guidance(soft_limit.guidance(), &memory);
     guidance.extend(soft_limit_admission_guidance_with_argv(
         tool_name,
         &memory,
@@ -141,7 +141,7 @@ fn soft_limit_admission_diagnostic_memory(
     let admission = crate::resource_admission::build_spawn_memory_admission(
         project_root,
         current_session_id,
-        error.memory_max_mb(),
+        error.memory_max_mb().max(error.required_memory_max_mb()),
     );
     let admission = match admission {
         Ok(admission) => admission,
@@ -314,6 +314,20 @@ fn role_from_task_type(task_type: Option<&str>) -> &'static str {
         Some("run") | None => "writer",
         Some(_) => "session",
     }
+}
+
+fn soft_limit_admission_initial_guidance(
+    admission_guidance: Vec<String>,
+    memory: &NoProviderLaunchMemoryDiagnostic,
+) -> Vec<String> {
+    if memory.retry_feasible == Some(false) {
+        return vec![
+            "No floor-compliant retry envelope exists for the current host snapshot; do not \
+             raise or lower memory_max_mb until host capacity or active-session pressure changes."
+                .to_string(),
+        ];
+    }
+    admission_guidance
 }
 
 fn soft_limit_admission_guidance(

--- a/crates/cli-sub-agent/src/no_provider_launch_tests.rs
+++ b/crates/cli-sub-agent/src/no_provider_launch_tests.rs
@@ -117,6 +117,60 @@ fn soft_limit_writer_guidance_reports_feasible_unified_interval_and_retry_comman
 }
 
 #[test]
+fn soft_limit_writer_guidance_reports_one_infeasible_interval_without_raise_hint() {
+    let memory = NoProviderLaunchMemoryDiagnostic {
+        effective_memory_max_mb: Some(8_000),
+        soft_limit_percent: Some(90),
+        soft_threshold_mb: Some(7_200),
+        required_floor_mb: Some(9_000),
+        required_memory_max_mb: Some(10_000),
+        reserve_mb: Some(1_000),
+        available_memory_mb: Some(9_277),
+        projected_spawn_mb: Some(10_000),
+        retry_physical_upper_mb: Some(8_277),
+        retry_active_session_upper_mb: Some(20_000),
+        retry_combined_upper_mb: Some(8_277),
+        retry_lower_bound_mb: Some(10_000),
+        retry_feasible: Some(false),
+        ..Default::default()
+    };
+    let guidance = soft_limit_admission_initial_guidance(
+        vec!["Raise --memory-max-mb to at least 10000MB".to_string()],
+        &memory,
+    );
+    let joined = guidance.join("\n");
+
+    assert!(
+        joined.contains("No floor-compliant retry envelope exists"),
+        "{joined}"
+    );
+    assert!(!joined.contains("Raise --memory-max-mb"), "{joined}");
+
+    let argv = vec![
+        "csa".to_string(),
+        "run".to_string(),
+        "--memory-max-mb".to_string(),
+        "8000".to_string(),
+        "fix the retry interval".to_string(),
+    ];
+    let retry_guidance = soft_limit_admission_guidance_with_argv("codex", &memory, None, &argv);
+    let retry_joined = retry_guidance.join("\n");
+
+    assert!(
+        retry_joined.contains("Retry feasibility: infeasible"),
+        "{retry_joined}"
+    );
+    assert!(
+        retry_joined
+            .contains("lower_bound=10000MB (role/tool soft-limit floor); current_upper=8277MB")
+    );
+    assert!(
+        !retry_joined.contains("Suggested retry command:"),
+        "{retry_joined}"
+    );
+}
+
+#[test]
 fn soft_limit_diagnostic_reports_live_retry_interval_without_provider_side_effects() {
     use csa_resource::{FilesystemCapability, IsolationPlan, ResourceCapability};
 

--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -28,13 +28,19 @@ use crate::pipeline::{
 mod memory_balloon;
 #[path = "pipeline_sandbox_memory_override.rs"]
 mod memory_override;
+#[path = "pipeline_sandbox_session_dir.rs"]
+mod session_dir;
+#[path = "pipeline_sandbox_spawn_admission.rs"]
+mod spawn_admission;
 #[path = "pipeline_sandbox_writable.rs"]
 mod writable_sources;
+use session_dir::resolve_session_dir_for_sandbox;
 use writable_sources::add_execution_env_writable_paths;
 
 pub(crate) use memory_balloon::maybe_inflate_balloon;
 #[cfg(test)]
 pub(crate) use memory_balloon::should_skip_balloon_prewarm;
+pub(crate) use spawn_admission::resource_capability_for_spawn_admission;
 
 /// Outcome of sandbox resolution — either enriched options or a fatal error string
 /// (for `Required` mode with no capability).
@@ -61,15 +67,6 @@ pub(crate) struct SandboxResolveInput<'a> {
     pub(crate) extra_writable: &'a [PathBuf],
     pub(crate) extra_readable: &'a [PathBuf],
     pub(crate) execution_env: Option<&'a HashMap<String, String>>,
-}
-
-fn resolve_session_dir_for_sandbox(project_root: &Path, session_id: &str) -> PathBuf {
-    csa_session::manager::get_session_dir(project_root, session_id).unwrap_or_else(|_| {
-        std::env::temp_dir()
-            .join("cli-sub-agent")
-            .join("sessions")
-            .join(session_id)
-    })
 }
 
 pub(crate) fn validate_run_extra_writable_sources_exist(

--- a/crates/cli-sub-agent/src/pipeline_sandbox_session_dir.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_session_dir.rs
@@ -1,0 +1,12 @@
+//! Session directory resolution for sandbox plan construction.
+
+use std::path::{Path, PathBuf};
+
+pub(super) fn resolve_session_dir_for_sandbox(project_root: &Path, session_id: &str) -> PathBuf {
+    csa_session::manager::get_session_dir(project_root, session_id).unwrap_or_else(|_| {
+        std::env::temp_dir()
+            .join("cli-sub-agent")
+            .join("sessions")
+            .join(session_id)
+    })
+}

--- a/crates/cli-sub-agent/src/pipeline_sandbox_spawn_admission.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_spawn_admission.rs
@@ -1,0 +1,16 @@
+//! Spawn-admission helpers derived from a resolved sandbox plan.
+
+use csa_executor::ExecuteOptions;
+use csa_resource::ResourceCapability;
+
+/// Resource capability from the resolved sandbox plan used for spawn admission.
+pub(crate) fn resource_capability_for_spawn_admission(
+    options: &ExecuteOptions,
+) -> ResourceCapability {
+    options
+        .sandbox
+        .as_ref()
+        .map_or(ResourceCapability::None, |sandbox| {
+            sandbox.isolation_plan.resource
+        })
+}

--- a/crates/cli-sub-agent/src/pipeline_session_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec.rs
@@ -54,8 +54,8 @@ mod session_exec_write_lock;
 #[path = "pipeline_session_exec_state_preflight.rs"]
 mod state_preflight;
 use self::session_exec_pre_exec::{
-    PipelinePreExecFailureDetails, check_resources_before_spawn, persist_pipeline_pre_exec_failure,
-    write_fatal_error_marker_sidecar,
+    PipelinePreExecFailureDetails, SpawnResourceCheckInput, check_resources_before_spawn,
+    persist_pipeline_pre_exec_failure, write_fatal_error_marker_sidecar,
 };
 use clean_room::execute_clean_room_session_core;
 #[cfg(test)]
@@ -232,14 +232,56 @@ pub(crate) async fn execute_with_session_and_meta_with_parent_source<
         executor.tool_name(),
         &mut cleanup_guard,
     )?;
+    let resource_capability =
+        match crate::pipeline_sandbox::resolve_pre_session_sandbox_options_with_overrides(
+            crate::pipeline_sandbox::SandboxResolveInput {
+                config,
+                tool_name: executor.tool_name(),
+                session_id: &session.meta_session_id,
+                project_root,
+                stream_mode,
+                idle_timeout_seconds,
+                liveness_dead_seconds: crate::pipeline::resolve_liveness_dead_seconds(config),
+                initial_response_timeout_seconds,
+                no_fs_sandbox,
+                allow_user_daemon_ipc,
+                readonly_project_root,
+                extra_writable,
+                extra_readable,
+                execution_env: None,
+            },
+            resource_overrides,
+        ) {
+            crate::pipeline_sandbox::SandboxResolution::Ok(options) => {
+                crate::pipeline_sandbox::resource_capability_for_spawn_admission(&options)
+            }
+            crate::pipeline_sandbox::SandboxResolution::RequiredButUnavailable(message) => {
+                return Err(persist_pipeline_pre_exec_failure(
+                    project_root,
+                    &mut session,
+                    executor.tool_name(),
+                    anyhow::anyhow!(message).context("resolve final pre-spawn sandbox plan"),
+                    &mut cleanup_guard,
+                    None,
+                    PipelinePreExecFailureDetails {
+                        config,
+                        task_type,
+                        resource_overrides,
+                    },
+                ));
+            }
+        };
     check_resources_before_spawn(
-        config,
+        SpawnResourceCheckInput {
+            config,
+            resource_overrides,
+            task_type,
+            resource_capability,
+        },
         executor,
         project_root,
         &mut session,
         &mut cleanup_guard,
-        resource_overrides,
-        task_type,
     )?;
     if let Some(ref budget) = session.token_budget {
         if budget.is_hard_exceeded() {

--- a/crates/cli-sub-agent/src/pipeline_session_exec_clean_room.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_clean_room.rs
@@ -16,7 +16,7 @@ use super::clean_room_completion::{
 };
 use super::session_exec_api::{CleanRoomExecutionLimits, SessionExecutionPolicy};
 use super::session_exec_bootstrap::bootstrap_clean_room_session;
-use super::session_exec_pre_exec::check_resources_before_spawn;
+use super::session_exec_pre_exec::{SpawnResourceCheckInput, check_resources_before_spawn};
 use crate::pipeline::admitted_executor::DispatchExecutor;
 use crate::pipeline::{AdmittedExecutor, SessionExecutionResult};
 use crate::run_resource_overrides::RunResourceOverrides;
@@ -339,14 +339,42 @@ pub(super) async fn execute_clean_room_session_core(
             &mut cleanup_guard,
         );
     }
+    let resource_capability = match resolve_clean_room_sandbox_options(
+        CleanRoomSandboxInput {
+            config,
+            tool_name: executor.tool_name(),
+            session_id: &session.meta_session_id,
+            project_root: &project_root,
+            evidence_bundle: &evidence_bundle,
+            session_dir: &session_dir,
+            idle_timeout_seconds: limits.idle_timeout_seconds(),
+            initial_response_timeout_seconds: limits.initial_response_timeout_seconds(),
+        },
+        limits.resource_overrides(),
+    ) {
+        Ok(options) => crate::pipeline_sandbox::resource_capability_for_spawn_admission(&options),
+        Err(error) => {
+            return fail_clean_room_pre_transport(
+                &project_root,
+                &mut session,
+                executor.tool_name(),
+                execution_start_time,
+                error.context("resolve final clean-room pre-spawn sandbox plan"),
+                &mut cleanup_guard,
+            );
+        }
+    };
     check_resources_before_spawn(
-        config,
+        SpawnResourceCheckInput {
+            config,
+            resource_overrides: limits.resource_overrides(),
+            task_type: None,
+            resource_capability,
+        },
         executor,
         &project_root,
         &mut session,
         &mut cleanup_guard,
-        limits.resource_overrides(),
-        None,
     )?;
     let default_global;
     let global = match global_config {

--- a/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
@@ -61,8 +61,12 @@ pub(super) fn check_resources_before_spawn(
     let mut resource_guard = ResourceGuard::new(ResourceLimits {
         min_free_memory_mb: resource_overrides.resolve_min_free_memory_mb(config),
     });
-    let projected_spawn_mb =
-        spawn_memory_projection_mb_with_overrides(config, executor.tool_name(), resource_overrides);
+    let projected_spawn_mb = spawn_memory_projection_mb_with_overrides(
+        task_type,
+        config,
+        executor.tool_name(),
+        resource_overrides,
+    );
     if let Err(err) = crate::resource_admission::persist_spawn_memory_projection(
         session,
         projected_spawn_mb,

--- a/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
@@ -66,6 +66,7 @@ pub(super) fn check_resources_before_spawn(
         config,
         executor.tool_name(),
         resource_overrides,
+        csa_resource::detect_resource_capability(),
     );
     if let Err(err) = crate::resource_admission::persist_spawn_memory_projection(
         session,

--- a/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_pre_exec.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use csa_config::ProjectConfig;
 use csa_executor::Executor;
-use csa_resource::{ResourceGuard, ResourceLimits};
+use csa_resource::{ResourceCapability, ResourceGuard, ResourceLimits};
 use csa_session::{MetaSessionState, save_session};
 use tracing::warn;
 
@@ -49,15 +49,28 @@ impl PipelinePreExecFailureDetails<'_> {
     }
 }
 
+/// Resource-policy inputs for the final pre-spawn host-memory check.
+#[derive(Clone, Copy)]
+pub(super) struct SpawnResourceCheckInput<'a> {
+    pub(super) config: Option<&'a ProjectConfig>,
+    pub(super) resource_overrides: RunResourceOverrides,
+    pub(super) task_type: Option<&'a str>,
+    pub(super) resource_capability: ResourceCapability,
+}
+
 pub(super) fn check_resources_before_spawn(
-    config: Option<&ProjectConfig>,
+    input: SpawnResourceCheckInput<'_>,
     executor: &Executor,
     project_root: &Path,
     session: &mut MetaSessionState,
     cleanup_guard: &mut Option<SessionCleanupGuard>,
-    resource_overrides: RunResourceOverrides,
-    task_type: Option<&str>,
 ) -> anyhow::Result<()> {
+    let SpawnResourceCheckInput {
+        config,
+        resource_overrides,
+        task_type,
+        resource_capability,
+    } = input;
     let mut resource_guard = ResourceGuard::new(ResourceLimits {
         min_free_memory_mb: resource_overrides.resolve_min_free_memory_mb(config),
     });
@@ -66,7 +79,7 @@ pub(super) fn check_resources_before_spawn(
         config,
         executor.tool_name(),
         resource_overrides,
-        csa_resource::detect_resource_capability(),
+        resource_capability,
     );
     if let Err(err) = crate::resource_admission::persist_spawn_memory_projection(
         session,

--- a/crates/cli-sub-agent/src/resource_admission.rs
+++ b/crates/cli-sub-agent/src/resource_admission.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use chrono::{DateTime, TimeDelta, Utc};
 use csa_config::ProjectConfig;
-use csa_resource::{ResourceGuard, ResourceLimits, SpawnMemoryAdmission, memory_policy};
+use csa_resource::{
+    ResourceCapability, ResourceGuard, ResourceLimits, SpawnMemoryAdmission, memory_policy,
+};
 use csa_session::{MetaSessionState, SandboxInfo, SessionPhase};
 
 use crate::run_resource_overrides::RunResourceOverrides;
@@ -40,6 +42,7 @@ fn spawn_memory_projection_mb_for_physical_available(
     config: Option<&ProjectConfig>,
     tool_name: &str,
     resource_overrides: RunResourceOverrides,
+    resource_capability: ResourceCapability,
     physical_available_mb: u64,
 ) -> u64 {
     let configured_projection_mb = resource_overrides
@@ -58,6 +61,9 @@ fn spawn_memory_projection_mb_for_physical_available(
         physical_available_mb,
         resource_overrides.resolve_min_free_memory_mb(config),
     );
+    if resource_capability != ResourceCapability::CgroupV2 {
+        return bounded_projection_mb;
+    }
     required_default_memory_max_mb(task_type, config, tool_name)
         .map_or(bounded_projection_mb, |required| {
             bounded_projection_mb.max(required)
@@ -69,6 +75,7 @@ pub(crate) fn spawn_memory_projection_mb_with_overrides(
     config: Option<&ProjectConfig>,
     tool_name: &str,
     resource_overrides: RunResourceOverrides,
+    resource_capability: ResourceCapability,
 ) -> u64 {
     if resource_overrides.has_memory_max_override()
         || config_has_explicit_memory_max_mb(config, tool_name)
@@ -84,6 +91,7 @@ pub(crate) fn spawn_memory_projection_mb_with_overrides(
         config,
         tool_name,
         resource_overrides,
+        resource_capability,
         resource_guard.available_physical_memory_mb(),
     )
 }
@@ -398,88 +406,6 @@ mod tests {
             }),
             ..Default::default()
         }
-    }
-
-    #[test]
-    fn spawn_projection_uses_configured_tool_limit() {
-        let cfg: ProjectConfig =
-            toml::from_str("[resources]\nmemory_max_mb = 8192\n").expect("config should parse");
-
-        assert_eq!(
-            spawn_memory_projection_mb_for_physical_available(
-                None,
-                Some(&cfg),
-                "codex",
-                RunResourceOverrides::absent(),
-                1,
-            ),
-            8192
-        );
-    }
-
-    #[test]
-    fn spawn_projection_uses_run_override_before_tool_config() {
-        let cfg: ProjectConfig = toml::from_str(
-            r#"
-[tools.codex]
-memory_max_mb = 16384
-"#,
-        )
-        .expect("config should parse");
-        let overrides = RunResourceOverrides::from_cli(Some(6144), None);
-
-        assert_eq!(
-            spawn_memory_projection_mb_with_overrides(None, Some(&cfg), "codex", overrides),
-            6144
-        );
-    }
-
-    #[test]
-    fn spawn_projection_uses_inherited_memory_override_before_tool_config() {
-        let cfg: ProjectConfig = toml::from_str(
-            r#"
-[tools.codex]
-memory_max_mb = 16384
-"#,
-        )
-        .expect("config should parse");
-        let inherited = RunResourceOverrides::from_cli(Some(6144), None).for_child();
-
-        assert_eq!(
-            spawn_memory_projection_mb_with_overrides(None, Some(&cfg), "codex", inherited),
-            6144
-        );
-    }
-
-    #[test]
-    fn default_projection_is_bounded_by_physical_memory_after_reserve() {
-        assert_eq!(
-            bound_default_spawn_projection_mb(14_000, 12_000, 1024),
-            10_976
-        );
-        assert_eq!(
-            bound_default_spawn_projection_mb(14_000, 32_000, 1024),
-            14_000
-        );
-    }
-
-    #[test]
-    fn default_projection_uses_a_minimum_when_host_headroom_is_exhausted() {
-        assert_eq!(bound_default_spawn_projection_mb(14_000, 1024, 2048), 256);
-    }
-
-    #[test]
-    fn spawn_projection_uses_tool_default_without_config() {
-        assert_eq!(
-            spawn_memory_projection_mb_for_physical_available(
-                None,
-                None,
-                "codex",
-                RunResourceOverrides::absent(),
-                12_000,
-            ),
-            7904
-        );
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/resource_admission.rs
+++ b/crates/cli-sub-agent/src/resource_admission.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use chrono::{DateTime, TimeDelta, Utc};
 use csa_config::ProjectConfig;
-use csa_resource::{ResourceGuard, ResourceLimits, SpawnMemoryAdmission};
+use csa_resource::{ResourceGuard, ResourceLimits, SpawnMemoryAdmission, memory_policy};
 use csa_session::{MetaSessionState, SandboxInfo, SessionPhase};
 
 use crate::run_resource_overrides::RunResourceOverrides;
@@ -36,6 +36,7 @@ struct ActiveSessionObservation {
 }
 
 fn spawn_memory_projection_mb_for_physical_available(
+    task_type: Option<&str>,
     config: Option<&ProjectConfig>,
     tool_name: &str,
     resource_overrides: RunResourceOverrides,
@@ -52,14 +53,19 @@ fn spawn_memory_projection_mb_for_physical_available(
         return configured_projection_mb;
     }
 
-    bound_default_spawn_projection_mb(
+    let bounded_projection_mb = bound_default_spawn_projection_mb(
         configured_projection_mb,
         physical_available_mb,
         resource_overrides.resolve_min_free_memory_mb(config),
-    )
+    );
+    required_default_memory_max_mb(task_type, config, tool_name)
+        .map_or(bounded_projection_mb, |required| {
+            bounded_projection_mb.max(required)
+        })
 }
 
 pub(crate) fn spawn_memory_projection_mb_with_overrides(
+    task_type: Option<&str>,
     config: Option<&ProjectConfig>,
     tool_name: &str,
     resource_overrides: RunResourceOverrides,
@@ -74,6 +80,7 @@ pub(crate) fn spawn_memory_projection_mb_with_overrides(
 
     let mut resource_guard = ResourceGuard::new(ResourceLimits::default());
     spawn_memory_projection_mb_for_physical_available(
+        task_type,
         config,
         tool_name,
         resource_overrides,
@@ -89,6 +96,21 @@ fn config_has_explicit_memory_max_mb(config: Option<&ProjectConfig>, tool_name: 
             .is_some()
             || cfg.resources.memory_max_mb.is_some()
     })
+}
+
+fn required_default_memory_max_mb(
+    task_type: Option<&str>,
+    config: Option<&ProjectConfig>,
+    tool_name: &str,
+) -> Option<u64> {
+    let required_floor_mb =
+        crate::resource_admission_soft_limit::codex_soft_limit_required_floor_mb(
+            task_type, tool_name,
+        )?;
+    let soft_limit_percent = config
+        .and_then(|cfg| cfg.resources.soft_limit_percent)
+        .unwrap_or(memory_policy::DEFAULT_SOFT_LIMIT_PERCENT);
+    memory_policy::required_memory_max_for_soft_limit_mb(required_floor_mb, soft_limit_percent)
 }
 
 fn bound_default_spawn_projection_mb(
@@ -322,6 +344,10 @@ mod terminal_session_tests;
 mod state_root_tests;
 
 #[cfg(test)]
+#[path = "resource_admission_projection_tests.rs"]
+mod projection_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -381,6 +407,7 @@ mod tests {
 
         assert_eq!(
             spawn_memory_projection_mb_for_physical_available(
+                None,
                 Some(&cfg),
                 "codex",
                 RunResourceOverrides::absent(),
@@ -402,7 +429,7 @@ memory_max_mb = 16384
         let overrides = RunResourceOverrides::from_cli(Some(6144), None);
 
         assert_eq!(
-            spawn_memory_projection_mb_with_overrides(Some(&cfg), "codex", overrides),
+            spawn_memory_projection_mb_with_overrides(None, Some(&cfg), "codex", overrides),
             6144
         );
     }
@@ -419,7 +446,7 @@ memory_max_mb = 16384
         let inherited = RunResourceOverrides::from_cli(Some(6144), None).for_child();
 
         assert_eq!(
-            spawn_memory_projection_mb_with_overrides(Some(&cfg), "codex", inherited),
+            spawn_memory_projection_mb_with_overrides(None, Some(&cfg), "codex", inherited),
             6144
         );
     }
@@ -445,6 +472,7 @@ memory_max_mb = 16384
     fn spawn_projection_uses_tool_default_without_config() {
         assert_eq!(
             spawn_memory_projection_mb_for_physical_available(
+                None,
                 None,
                 "codex",
                 RunResourceOverrides::absent(),

--- a/crates/cli-sub-agent/src/resource_admission_projection_tests.rs
+++ b/crates/cli-sub-agent/src/resource_admission_projection_tests.rs
@@ -1,7 +1,104 @@
 use super::*;
+use csa_resource::ResourceCapability;
 
 #[test]
-fn writer_default_projection_is_raised_to_its_soft_limit_floor() {
+fn spawn_projection_uses_configured_tool_limit() {
+    let cfg: ProjectConfig =
+        toml::from_str("[resources]\nmemory_max_mb = 8192\n").expect("config should parse");
+
+    assert_eq!(
+        spawn_memory_projection_mb_for_physical_available(
+            None,
+            Some(&cfg),
+            "codex",
+            RunResourceOverrides::absent(),
+            ResourceCapability::None,
+            1,
+        ),
+        8192
+    );
+}
+
+#[test]
+fn spawn_projection_uses_run_override_before_tool_config() {
+    let cfg: ProjectConfig = toml::from_str(
+        r#"
+[tools.codex]
+memory_max_mb = 16384
+"#,
+    )
+    .expect("config should parse");
+    let overrides = RunResourceOverrides::from_cli(Some(6144), None);
+
+    assert_eq!(
+        spawn_memory_projection_mb_with_overrides(
+            None,
+            Some(&cfg),
+            "codex",
+            overrides,
+            ResourceCapability::None,
+        ),
+        6144
+    );
+}
+
+#[test]
+fn spawn_projection_uses_inherited_memory_override_before_tool_config() {
+    let cfg: ProjectConfig = toml::from_str(
+        r#"
+[tools.codex]
+memory_max_mb = 16384
+"#,
+    )
+    .expect("config should parse");
+    let inherited = RunResourceOverrides::from_cli(Some(6144), None).for_child();
+
+    assert_eq!(
+        spawn_memory_projection_mb_with_overrides(
+            None,
+            Some(&cfg),
+            "codex",
+            inherited,
+            ResourceCapability::None,
+        ),
+        6144
+    );
+}
+
+#[test]
+fn default_projection_is_bounded_by_physical_memory_after_reserve() {
+    assert_eq!(
+        bound_default_spawn_projection_mb(14_000, 12_000, 1024),
+        10_976
+    );
+    assert_eq!(
+        bound_default_spawn_projection_mb(14_000, 32_000, 1024),
+        14_000
+    );
+}
+
+#[test]
+fn default_projection_uses_a_minimum_when_host_headroom_is_exhausted() {
+    assert_eq!(bound_default_spawn_projection_mb(14_000, 1024, 2048), 256);
+}
+
+#[test]
+fn spawn_projection_uses_tool_default_without_config() {
+    assert_eq!(
+        spawn_memory_projection_mb_for_physical_available(
+            None,
+            None,
+            "codex",
+            RunResourceOverrides::absent(),
+            ResourceCapability::None,
+            12_000,
+        ),
+        7904
+    );
+}
+
+#[test]
+fn writer_default_projection_only_uses_soft_limit_floor_with_cgroup_monitoring() {
     let config: ProjectConfig =
         toml::from_str("[resources]\nsoft_limit_percent = 90\nmin_free_memory_mb = 100\n")
             .expect("config should parse");
@@ -12,10 +109,11 @@ fn writer_default_projection_is_raised_to_its_soft_limit_floor() {
             Some(&config),
             "codex",
             RunResourceOverrides::absent(),
-            10_100,
+            ResourceCapability::Setrlimit,
+            8_377,
         ),
-        10_000,
-        "a default writer projection must not fall below its 90% soft-limit floor"
+        8_277,
+        "Setrlimit does not run the soft-limit memory monitor, so the default stays bounded"
     );
     assert_eq!(
         spawn_memory_projection_mb_for_physical_available(
@@ -23,9 +121,10 @@ fn writer_default_projection_is_raised_to_its_soft_limit_floor() {
             Some(&config),
             "codex",
             RunResourceOverrides::absent(),
+            ResourceCapability::CgroupV2,
             8_377,
         ),
         10_000,
-        "the host gate must reject an impossible floor instead of selecting a sub-floor default"
+        "the cgroup memory monitor needs its writer soft-limit floor"
     );
 }

--- a/crates/cli-sub-agent/src/resource_admission_projection_tests.rs
+++ b/crates/cli-sub-agent/src/resource_admission_projection_tests.rs
@@ -128,3 +128,58 @@ fn writer_default_projection_only_uses_soft_limit_floor_with_cgroup_monitoring()
         "the cgroup memory monitor needs its writer soft-limit floor"
     );
 }
+
+#[test]
+fn final_recheck_uses_setrlimit_after_cgroup_landlock_plan_degradation() {
+    let project_root = tempfile::tempdir().expect("project root");
+    let resource_overrides = RunResourceOverrides::from_cli(None, Some(100));
+    let options = match crate::pipeline_sandbox::resolve_sandbox_options_with_capabilities(
+        crate::pipeline_sandbox::SandboxResolveInput {
+            config: None,
+            tool_name: "codex",
+            session_id: "projection-test",
+            project_root: project_root.path(),
+            stream_mode: csa_process::StreamMode::BufferOnly,
+            idle_timeout_seconds: 120,
+            liveness_dead_seconds: 600,
+            initial_response_timeout_seconds: None,
+            no_fs_sandbox: false,
+            allow_user_daemon_ipc: false,
+            readonly_project_root: false,
+            extra_writable: &[],
+            extra_readable: &[],
+            execution_env: None,
+        },
+        resource_overrides,
+        ResourceCapability::CgroupV2,
+        csa_resource::FilesystemCapability::Landlock,
+    ) {
+        crate::pipeline_sandbox::SandboxResolution::Ok(options) => options,
+        crate::pipeline_sandbox::SandboxResolution::RequiredButUnavailable(message) => {
+            panic!("default Codex plan should resolve: {message}")
+        }
+    };
+
+    assert_eq!(
+        options
+            .sandbox
+            .as_ref()
+            .expect("sandbox plan")
+            .isolation_plan
+            .resource,
+        ResourceCapability::Setrlimit,
+        "Landlock degrades the detected cgroup plan to setrlimit"
+    );
+    assert_eq!(
+        spawn_memory_projection_mb_for_physical_available(
+            Some("run"),
+            None,
+            "codex",
+            resource_overrides,
+            crate::pipeline_sandbox::resource_capability_for_spawn_admission(&options),
+            8_377,
+        ),
+        8_277,
+        "the final recheck must not apply a cgroup-only writer floor to Setrlimit"
+    );
+}

--- a/crates/cli-sub-agent/src/resource_admission_projection_tests.rs
+++ b/crates/cli-sub-agent/src/resource_admission_projection_tests.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+#[test]
+fn writer_default_projection_is_raised_to_its_soft_limit_floor() {
+    let config: ProjectConfig =
+        toml::from_str("[resources]\nsoft_limit_percent = 90\nmin_free_memory_mb = 100\n")
+            .expect("config should parse");
+
+    assert_eq!(
+        spawn_memory_projection_mb_for_physical_available(
+            Some("run"),
+            Some(&config),
+            "codex",
+            RunResourceOverrides::absent(),
+            10_100,
+        ),
+        10_000,
+        "a default writer projection must not fall below its 90% soft-limit floor"
+    );
+    assert_eq!(
+        spawn_memory_projection_mb_for_physical_available(
+            Some("run"),
+            Some(&config),
+            "codex",
+            RunResourceOverrides::absent(),
+            8_377,
+        ),
+        10_000,
+        "the host gate must reject an impossible floor instead of selecting a sub-floor default"
+    );
+}

--- a/crates/cli-sub-agent/src/resource_admission_soft_limit.rs
+++ b/crates/cli-sub-agent/src/resource_admission_soft_limit.rs
@@ -270,12 +270,16 @@ mod tests {
             MemorySoftLimitAdmissionError::TERMINATION_REASON,
             MEMORY_SOFT_LIMIT_ADMISSION_REASON
         );
-        assert!(err.to_string().contains("--memory-max-mb"));
-        assert!(err.to_string().contains("tools.codex.memory_max_mb"));
+        let guidance = err.guidance();
+        assert!(guidance.iter().any(|line| line.contains("--memory-max-mb")));
         assert!(
-            err.to_string()
-                .contains("remove a lower memory override so Codex can use its 16384MB default")
+            guidance
+                .iter()
+                .any(|line| line.contains("tools.codex.memory_max_mb"))
         );
+        assert!(guidance.iter().any(|line| {
+            line.contains("Remove a lower memory override so Codex can use its 16384MB default")
+        }));
     }
 
     #[test]
@@ -353,8 +357,8 @@ mod tests {
         assert_eq!(denial.required_threshold_mb, CODEX_REVIEW_MIN_SOFT_LIMIT_MB);
         assert_eq!(denial.required_memory_max_mb, 9103);
         assert!(
-            err.to_string().contains("to at least 9103MB"),
-            "error must point to the exact cap floor at soft90: {err}"
+            err.to_string()
+                .contains("floor-compliant envelope needs memory_max_mb at least 9103MB")
         );
         assert!(
             err.guidance()
@@ -381,7 +385,11 @@ mod tests {
             .expect_err("writer admission should fail");
         assert!(err.to_string().contains("writer soft memory threshold"));
         assert!(err.to_string().contains("after editing the worktree"));
-        assert!(err.to_string().contains("tools.codex.memory_max_mb"));
+        assert!(
+            err.guidance()
+                .iter()
+                .any(|line| line.contains("tools.codex.memory_max_mb"))
+        );
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/resource_admission_soft_limit.rs
+++ b/crates/cli-sub-agent/src/resource_admission_soft_limit.rs
@@ -93,19 +93,10 @@ impl SoftLimitAdmissionDenial {
 
     fn message(self, tool_name: &str) -> String {
         let required_memory_max_mb = self.required_memory_max_mb;
-        let recommendation = match self.session_kind {
-            CodexSoftLimitAdmissionKind::Reviewer => format!(
-                "Raise --memory-max-mb, resources.memory_max_mb, or \
-                 tools.{tool_name}.memory_max_mb to at least {required_memory_max_mb}MB, remove a lower \
-                 memory override so Codex can use its 16384MB default, or raise \
-                 resources.soft_limit_percent only when host RAM makes that safe."
-            ),
-            CodexSoftLimitAdmissionKind::Writer => format!(
-                "Raise --memory-max-mb, resources.memory_max_mb, or \
-                 tools.{tool_name}.memory_max_mb to at least {required_memory_max_mb}MB, or raise \
-                 resources.soft_limit_percent only when host RAM makes that safe."
-            ),
-        };
+        let recommendation = format!(
+            "A floor-compliant envelope needs memory_max_mb at least {required_memory_max_mb}MB; \
+             retry guidance will confirm whether the current host can admit that envelope."
+        );
         format!(
             "CSA: {reason} denied -- {tool_name} {session_kind} soft memory threshold is \
              {threshold}MB, below required={required}MB \

--- a/crates/cli-sub-agent/src/review_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_preflight.rs
@@ -283,6 +283,7 @@ fn validate_host_memory_before_session(
         min_free_memory_mb: resource_overrides.resolve_min_free_memory_mb(project_config),
     });
     let projected_spawn_mb = crate::resource_admission::spawn_memory_projection_mb_with_overrides(
+        Some(REVIEWER_SUB_SESSION_TASK_TYPE),
         project_config,
         tool.as_str(),
         resource_overrides,

--- a/crates/cli-sub-agent/src/review_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_preflight.rs
@@ -240,6 +240,12 @@ fn validate_review_candidate_resources_before_session(
                 anyhow::bail!(message)
             }
         };
+    let resource_capability = execute_options
+        .sandbox
+        .as_ref()
+        .map_or(csa_resource::ResourceCapability::None, |sandbox| {
+            sandbox.isolation_plan.resource
+        });
     crate::resource_admission_soft_limit::ensure_memory_soft_limit_admission(
         Some(REVIEWER_SUB_SESSION_TASK_TYPE),
         tool.as_str(),
@@ -269,8 +275,14 @@ fn validate_review_candidate_resources_before_session(
             err
         }
     })?;
-    validate_host_memory_before_session(project_root, project_config, tool, resource_overrides)
-        .with_context(|| format!("review preflight for tool '{tool}'"))
+    validate_host_memory_before_session(
+        project_root,
+        project_config,
+        tool,
+        resource_overrides,
+        resource_capability,
+    )
+    .with_context(|| format!("review preflight for tool '{tool}'"))
 }
 
 fn validate_host_memory_before_session(
@@ -278,6 +290,7 @@ fn validate_host_memory_before_session(
     project_config: Option<&ProjectConfig>,
     tool: ToolName,
     resource_overrides: RunResourceOverrides,
+    resource_capability: csa_resource::ResourceCapability,
 ) -> Result<()> {
     let mut resource_guard = ResourceGuard::new(ResourceLimits {
         min_free_memory_mb: resource_overrides.resolve_min_free_memory_mb(project_config),
@@ -287,6 +300,7 @@ fn validate_host_memory_before_session(
         project_config,
         tool.as_str(),
         resource_overrides,
+        resource_capability,
     );
     let admission = crate::resource_admission::build_spawn_memory_admission(
         project_root,

--- a/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
@@ -202,10 +202,17 @@ fn review_soft_limit_resource_admission_reports_unified_retry_guidance_before_se
     assert!(msg.contains("Retry feasibility:"), "{msg}");
     assert!(msg.contains("lower_bound=11703MB (role/tool soft-limit floor)"));
     assert!(msg.contains("physical/reserve upper="), "{msg}");
-    assert!(msg.contains("Suggested retry command: csa review"), "{msg}");
-    assert!(msg.contains("--memory-max-mb 11703"), "{msg}");
+    if msg.contains("Retry feasibility: infeasible.") {
+        assert!(msg.contains("No feasible retry window exists"), "{msg}");
+        assert!(!msg.contains("Suggested retry command:"), "{msg}");
+        assert!(!msg.contains("--memory-max-mb 11703"), "{msg}");
+    } else {
+        assert!(msg.contains("Retry feasibility: feasible"), "{msg}");
+        assert!(msg.contains("Suggested retry command: csa review"), "{msg}");
+        assert!(msg.contains("--memory-max-mb 11703"), "{msg}");
+        assert!(msg.contains("host_required="), "{msg}");
+    }
     assert!(!msg.contains("Retry command delta:"), "{msg}");
-    assert!(msg.contains("host_required="), "{msg}");
     assert!(
         msg.contains("soft-limit admission rejected before provider launch"),
         "{msg}"

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -84,10 +84,10 @@ async fn ri(request: RunLoopRequest<'_>, g: &mut Cg) -> Result<RunLoopCompletion
             request.run_timeout_seconds,
             tool_name_str,
         );
-        if (effective_session_arg.is_none() || is_fork)
+        let needs_admission = (effective_session_arg.is_none() || is_fork)
             && executed_session_id.is_none()
-            && pre_created_fork_session_id.is_none()
-        {
+            && pre_created_fork_session_id.is_none();
+        if needs_admission {
             memory_admission.validate(tool_name_str, initial_response_timeout_seconds)?;
         }
         let max_concurrent = request.global_config.max_concurrent(tool_name_str);
@@ -158,6 +158,10 @@ async fn ri(request: RunLoopRequest<'_>, g: &mut Cg) -> Result<RunLoopCompletion
                     return Ok(Exit(1));
                 }
             }
+        }
+
+        if needs_admission {
+            memory_admission.validate_host_memory_after_slot_acquisition(tool_name_str)?;
         }
 
         if is_fork && fork_resolution.is_none() {
@@ -265,8 +269,6 @@ async fn ri(request: RunLoopRequest<'_>, g: &mut Cg) -> Result<RunLoopCompletion
                 request.skill,
                 timeout_resume_session.as_deref(),
             )?;
-            // Break with synthetic timeout result instead of Exit, so the
-            // completion path (restore_cg + Completed) runs consistently.
             let timeout_result = csa_process::ExecutionResult {
                 output: String::new(),
                 stderr_output: String::new(),
@@ -444,12 +446,7 @@ async fn ri(request: RunLoopRequest<'_>, g: &mut Cg) -> Result<RunLoopCompletion
                     request.skill,
                     timeout_resume_session.as_deref(),
                 )?;
-                // Construct a synthetic timeout result and break to flow
-                // through restore_cg + Completed (instead of Exit), so that
-                // complete_session_execution runs (session state update,
-                // require-commit suppression for timeouts per #2611, commit-
-                // skill workspace guard restoration, and uncommitted tracking).
-                // Previously this path short-circuited completion (#2615).
+                // Complete synthetic timeouts so state, guards, and timeout policy run (#2611, #2615).
                 let timeout_result = csa_process::ExecutionResult {
                     output: String::new(),
                     stderr_output: String::new(),

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -87,9 +87,9 @@ async fn ri(request: RunLoopRequest<'_>, g: &mut Cg) -> Result<RunLoopCompletion
         let needs_admission = (effective_session_arg.is_none() || is_fork)
             && executed_session_id.is_none()
             && pre_created_fork_session_id.is_none();
-        if needs_admission {
-            memory_admission.validate(tool_name_str, initial_response_timeout_seconds)?;
-        }
+        let resource_capability = needs_admission
+            .then(|| memory_admission.validate(tool_name_str, initial_response_timeout_seconds))
+            .transpose()?;
         let max_concurrent = request.global_config.max_concurrent(tool_name_str);
         let mut _slot_guard = match acquire_attempt_slot(
             AttemptSlotRequest {
@@ -160,8 +160,9 @@ async fn ri(request: RunLoopRequest<'_>, g: &mut Cg) -> Result<RunLoopCompletion
             }
         }
 
-        if needs_admission {
-            memory_admission.validate_host_memory_after_slot_acquisition(tool_name_str)?;
+        if let Some(resource_capability) = resource_capability {
+            memory_admission
+                .validate_host_memory_after_slot_acquisition(tool_name_str, resource_capability)?;
         }
 
         if is_fork && fork_resolution.is_none() {

--- a/crates/cli-sub-agent/src/run_cmd_attempt.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt.rs
@@ -3,6 +3,10 @@ include!("run_cmd_attempt_prelude.rs");
 #[path = "run_cmd_attempt_admission.rs"]
 mod admission;
 
+#[cfg(test)]
+#[path = "run_cmd_attempt_test_events.rs"]
+mod test_events;
+
 pub(crate) async fn execute_run_loop(request: RunLoopRequest<'_>) -> Result<RunLoopCompletion> {
     let mut g = capture_cg(request.project_root, request.skill)?;
     let o = ri(request, &mut g).await;

--- a/crates/cli-sub-agent/src/run_cmd_attempt_admission.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_admission.rs
@@ -46,7 +46,7 @@ impl<'a> RunMemoryAdmission<'a> {
         &self,
         tool_name: &str,
         initial_response_timeout_seconds: Option<u64>,
-    ) -> Result<()> {
+    ) -> Result<csa_resource::ResourceCapability> {
         crate::run_cmd_preflight::validate_run_memory_soft_limit_before_session(
             crate::run_cmd_preflight::RunMemorySoftLimitPreflight {
                 project_root: self.project_root,
@@ -69,12 +69,14 @@ impl<'a> RunMemoryAdmission<'a> {
     pub(super) fn validate_host_memory_after_slot_acquisition(
         &self,
         tool_name: &str,
+        resource_capability: csa_resource::ResourceCapability,
     ) -> Result<()> {
         crate::run_cmd_preflight::validate_run_host_memory_after_slot_acquisition(
             self.project_root,
             self.project_config,
             tool_name,
             self.resource_overrides,
+            resource_capability,
         )
     }
 }

--- a/crates/cli-sub-agent/src/run_cmd_attempt_admission.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_admission.rs
@@ -65,4 +65,16 @@ impl<'a> RunMemoryAdmission<'a> {
             },
         )
     }
+
+    pub(super) fn validate_host_memory_after_slot_acquisition(
+        &self,
+        tool_name: &str,
+    ) -> Result<()> {
+        crate::run_cmd_preflight::validate_run_host_memory_after_slot_acquisition(
+            self.project_root,
+            self.project_config,
+            tool_name,
+            self.resource_overrides,
+        )
+    }
 }

--- a/crates/cli-sub-agent/src/run_cmd_attempt_admission.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_admission.rs
@@ -47,6 +47,8 @@ impl<'a> RunMemoryAdmission<'a> {
         tool_name: &str,
         initial_response_timeout_seconds: Option<u64>,
     ) -> Result<csa_resource::ResourceCapability> {
+        #[cfg(test)]
+        super::test_events::record(super::test_events::AttemptEvent::StaticSoftLimit);
         crate::run_cmd_preflight::validate_run_memory_soft_limit_before_session(
             crate::run_cmd_preflight::RunMemorySoftLimitPreflight {
                 project_root: self.project_root,
@@ -71,6 +73,8 @@ impl<'a> RunMemoryAdmission<'a> {
         tool_name: &str,
         resource_capability: csa_resource::ResourceCapability,
     ) -> Result<()> {
+        #[cfg(test)]
+        super::test_events::record(super::test_events::AttemptEvent::HostMemoryAfterSlot);
         crate::run_cmd_preflight::validate_run_host_memory_after_slot_acquisition(
             self.project_root,
             self.project_config,

--- a/crates/cli-sub-agent/src/run_cmd_attempt_admission_ordering_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_admission_ordering_tests.rs
@@ -1,0 +1,106 @@
+use super::{RunLoopRequest, execute_run_loop, test_events};
+use crate::run_helpers_branch_guard::BranchGuardRuntime;
+use crate::run_resource_overrides::RunResourceOverrides;
+use crate::startup_env::StartupSubtreeEnv;
+use crate::test_env_lock::ScopedEnvVarRestore;
+use crate::test_session_sandbox::ScopedSessionSandbox;
+use csa_config::GlobalConfig;
+use csa_core::types::{OutputFormat, ToolName, ToolSelectionStrategy};
+use std::time::Instant;
+
+#[tokio::test]
+async fn run_loop_acquires_slot_before_host_memory_admission() {
+    let project_dir = tempfile::tempdir().expect("temp project");
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    let _tools_available =
+        ScopedEnvVarRestore::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let _resource_capability =
+        ScopedEnvVarRestore::set(csa_resource::sandbox::TEST_ASSUME_CGROUP_V2_ENV, "1");
+    let mut config = crate::review_cmd::tests::project_config_with_enabled_tools(&["codex"]);
+    config.resources.memory_max_mb = Some(10_000);
+    config.resources.min_free_memory_mb = u64::MAX;
+    config.resources.soft_limit_percent = Some(90);
+    let global_config = GlobalConfig::default();
+    let model_catalog = csa_config::EffectiveModelCatalog::shipped().expect("shipped catalog");
+    let startup_env = StartupSubtreeEnv::default();
+    let recorder = test_events::EventRecorder::start();
+
+    let result = execute_run_loop(RunLoopRequest {
+        strategy: ToolSelectionStrategy::Explicit(ToolName::Codex),
+        initial_tool: ToolName::Codex,
+        initial_model_spec: None,
+        user_model_spec_explicit: false,
+        subtree_model_pin_spec: None,
+        subtree_model_pin_force_ignore_tier_setting: false,
+        initial_model: None,
+        runtime_fallback_candidates: Vec::new(),
+        project_root: project_dir.path(),
+        config: Some(&config),
+        global_config: &global_config,
+        model_catalog: &model_catalog,
+        prompt_text: "ordering regression",
+        skill: None,
+        skill_session_tag: None,
+        description: None,
+        parent: None,
+        output_format: OutputFormat::Text,
+        stream_mode: csa_process::StreamMode::BufferOnly,
+        thinking: None,
+        force: false,
+        force_override_user_config: false,
+        force_ignore_tier_setting: false,
+        no_failover: true,
+        fast_but_more_cost: false,
+        build_jobs: None,
+        resource_overrides: RunResourceOverrides::absent(),
+        wait: false,
+        idle_timeout_seconds: 120,
+        cli_idle_timeout: None,
+        cli_initial_response_timeout: None,
+        no_idle_timeout: false,
+        run_timeout_seconds: None,
+        run_started_at: Instant::now(),
+        is_fork: false,
+        is_auto_seed_fork: false,
+        caller_fork_resolution: None,
+        ephemeral: false,
+        fork_call: false,
+        session_arg: None,
+        effective_session_arg: None,
+        tier_auto_select: false,
+        failover_on_crash_enabled: false,
+        resolved_tier_name: None,
+        tier_failover_tool_filter: None,
+        context_load_options: None,
+        memory_injection: Default::default(),
+        pre_session_hook: None,
+        task_needs_edit: None,
+        no_fs_sandbox: false,
+        allow_user_daemon_ipc: false,
+        allow_git_push: false,
+        error_marker_scan_override: None,
+        no_hook_bypass_scan: false,
+        extra_writable: Vec::new(),
+        extra_readable: Vec::new(),
+        branch_guard: BranchGuardRuntime::for_run(false, Some(&config), &global_config),
+        startup_env: &startup_env,
+    })
+    .await;
+    let error = match result {
+        Err(error) => error,
+        Ok(_) => panic!("host-memory admission must stop the run before tool execution"),
+    };
+
+    assert!(
+        format!("{error:#}").contains("run preflight for writer tool 'codex'"),
+        "expected the post-slot host-memory admission error: {error:#}"
+    );
+    assert_eq!(
+        recorder.events(),
+        [
+            test_events::AttemptEvent::StaticSoftLimit,
+            test_events::AttemptEvent::SlotAcquired,
+            test_events::AttemptEvent::HostMemoryAfterSlot,
+        ]
+    );
+}

--- a/crates/cli-sub-agent/src/run_cmd_attempt_slot.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_slot.rs
@@ -58,6 +58,8 @@ pub(super) fn acquire_attempt_slot(
                 max = request.max_concurrent,
                 "Acquired global slot"
             );
+            #[cfg(test)]
+            super::test_events::record(super::test_events::AttemptEvent::SlotAcquired);
             Ok(AttemptSlotOutcome::Acquired(slot))
         }
         SlotAcquireResult::Exhausted(status) => {

--- a/crates/cli-sub-agent/src/run_cmd_attempt_test_events.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_test_events.rs
@@ -1,0 +1,29 @@
+use std::cell::RefCell;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum AttemptEvent {
+    StaticSoftLimit,
+    SlotAcquired,
+    HostMemoryAfterSlot,
+}
+
+std::thread_local! {
+    static EVENTS: RefCell<Vec<AttemptEvent>> = const { RefCell::new(Vec::new()) };
+}
+
+pub(super) struct EventRecorder;
+
+impl EventRecorder {
+    pub(super) fn start() -> Self {
+        EVENTS.with(|events| events.borrow_mut().clear());
+        Self
+    }
+
+    pub(super) fn events(&self) -> Vec<AttemptEvent> {
+        EVENTS.with(|events| events.borrow().clone())
+    }
+}
+
+pub(super) fn record(event: AttemptEvent) {
+    EVENTS.with(|events| events.borrow_mut().push(event));
+}

--- a/crates/cli-sub-agent/src/run_cmd_attempt_test_modules.rs
+++ b/crates/cli-sub-agent/src/run_cmd_attempt_test_modules.rs
@@ -8,5 +8,8 @@ mod git_push_tests;
 #[path = "run_cmd_attempt_http_failover_tests.rs"]
 mod http_failover_tests;
 #[cfg(test)]
+#[path = "run_cmd_attempt_admission_ordering_tests.rs"]
+mod admission_ordering_tests;
+#[cfg(test)]
 #[path = "run_cmd_attempt_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/run_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/run_cmd_preflight.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use csa_config::{ExecutionEnvOptions, GlobalConfig, ProjectConfig};
 use csa_process::StreamMode;
-use csa_resource::{ResourceGuard, ResourceLimits};
+use csa_resource::{ResourceCapability, ResourceGuard, ResourceLimits};
 use std::path::{Path, PathBuf};
 
 use csa_core::types::ToolArg;
@@ -46,7 +46,7 @@ pub(crate) fn validate_run_prompt_file(path: Option<&Path>) -> Result<()> {
 /// waits until the attempt holds a tool slot.
 pub(crate) fn validate_run_memory_soft_limit_before_session(
     input: RunMemorySoftLimitPreflight<'_>,
-) -> Result<()> {
+) -> Result<ResourceCapability> {
     let mut execution_env = input.global_config.build_execution_env(
         input.tool_name,
         ExecutionEnvOptions::with_no_flash_fallback(),
@@ -78,6 +78,12 @@ pub(crate) fn validate_run_memory_soft_limit_before_session(
                 anyhow::bail!(message)
             }
         };
+    let resource_capability = execute_options
+        .sandbox
+        .as_ref()
+        .map_or(ResourceCapability::None, |sandbox| {
+            sandbox.isolation_plan.resource
+        });
     crate::resource_admission_soft_limit::ensure_memory_soft_limit_admission(
         Some("run"),
         input.tool_name,
@@ -110,7 +116,7 @@ pub(crate) fn validate_run_memory_soft_limit_before_session(
     })
     .with_context(|| format!("run preflight for writer tool '{}'", input.tool_name))?;
 
-    Ok(())
+    Ok(resource_capability)
 }
 
 /// Validate dynamic host memory after a writer attempt has acquired its slot.
@@ -119,6 +125,7 @@ pub(crate) fn validate_run_host_memory_after_slot_acquisition(
     project_config: Option<&ProjectConfig>,
     tool_name: &str,
     resource_overrides: crate::run_resource_overrides::RunResourceOverrides,
+    resource_capability: ResourceCapability,
 ) -> Result<()> {
     let mut resource_guard = ResourceGuard::new(ResourceLimits {
         min_free_memory_mb: resource_overrides.resolve_min_free_memory_mb(project_config),
@@ -128,6 +135,7 @@ pub(crate) fn validate_run_host_memory_after_slot_acquisition(
         project_config,
         tool_name,
         resource_overrides,
+        resource_capability,
     );
     let admission = crate::resource_admission::build_spawn_memory_admission(
         project_root,

--- a/crates/cli-sub-agent/src/run_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/run_cmd_preflight.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result};
 use csa_config::{ExecutionEnvOptions, GlobalConfig, ProjectConfig};
 use csa_process::StreamMode;
+use csa_resource::{ResourceGuard, ResourceLimits};
 use std::path::{Path, PathBuf};
 
 use csa_core::types::ToolArg;
@@ -107,7 +108,45 @@ pub(crate) fn validate_run_memory_soft_limit_before_session(
             err
         }
     })
-    .with_context(|| format!("run preflight for writer tool '{}'", input.tool_name))
+    .with_context(|| format!("run preflight for writer tool '{}'", input.tool_name))?;
+
+    let mut resource_guard = ResourceGuard::new(ResourceLimits {
+        min_free_memory_mb: input
+            .resource_overrides
+            .resolve_min_free_memory_mb(input.project_config),
+    });
+    let projected_spawn_mb = crate::resource_admission::spawn_memory_projection_mb_with_overrides(
+        Some("run"),
+        input.project_config,
+        input.tool_name,
+        input.resource_overrides,
+    );
+    let admission = crate::resource_admission::build_spawn_memory_admission(
+        input.project_root,
+        None,
+        projected_spawn_mb,
+    )
+    .context("Failed to build host-memory admission")?;
+    resource_guard
+        .check_availability_with_admission(input.tool_name, Some(admission))
+        .map_err(|err| {
+            let guidance = crate::no_provider_launch::host_memory_guidance_from_error(
+                Some("run"),
+                input.tool_name,
+                input.project_config,
+                input.resource_overrides,
+                &err,
+            );
+            if let Some(guidance) = guidance {
+                err.context(format!(
+                    "writer host-memory retry guidance before session creation:\n- {}",
+                    guidance.join("\n- ")
+                ))
+            } else {
+                err
+            }
+        })
+        .with_context(|| format!("run preflight for writer tool '{}'", input.tool_name))
 }
 
 #[derive(Clone, Copy)]

--- a/crates/cli-sub-agent/src/run_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/run_cmd_preflight.rs
@@ -40,10 +40,10 @@ pub(crate) fn validate_run_prompt_file(path: Option<&Path>) -> Result<()> {
 
 /// Resolve the writer's actual sandbox plan before creating a fresh session.
 ///
-/// This deliberately uses the same resolved limits and soft-limit admission
-/// gate as session execution. A cap that is adequate for a reviewer may still
-/// be below the writer's role-specific floor; returning that error here keeps
-/// the caller from receiving a new, guaranteed-to-fail session.
+/// A cap that is adequate for a reviewer may still be below the writer's
+/// role-specific floor; returning that error here keeps the caller from
+/// receiving a new, guaranteed-to-fail session. Dynamic host-memory admission
+/// waits until the attempt holds a tool slot.
 pub(crate) fn validate_run_memory_soft_limit_before_session(
     input: RunMemorySoftLimitPreflight<'_>,
 ) -> Result<()> {
@@ -110,31 +110,39 @@ pub(crate) fn validate_run_memory_soft_limit_before_session(
     })
     .with_context(|| format!("run preflight for writer tool '{}'", input.tool_name))?;
 
+    Ok(())
+}
+
+/// Validate dynamic host memory after a writer attempt has acquired its slot.
+pub(crate) fn validate_run_host_memory_after_slot_acquisition(
+    project_root: &Path,
+    project_config: Option<&ProjectConfig>,
+    tool_name: &str,
+    resource_overrides: crate::run_resource_overrides::RunResourceOverrides,
+) -> Result<()> {
     let mut resource_guard = ResourceGuard::new(ResourceLimits {
-        min_free_memory_mb: input
-            .resource_overrides
-            .resolve_min_free_memory_mb(input.project_config),
+        min_free_memory_mb: resource_overrides.resolve_min_free_memory_mb(project_config),
     });
     let projected_spawn_mb = crate::resource_admission::spawn_memory_projection_mb_with_overrides(
         Some("run"),
-        input.project_config,
-        input.tool_name,
-        input.resource_overrides,
+        project_config,
+        tool_name,
+        resource_overrides,
     );
     let admission = crate::resource_admission::build_spawn_memory_admission(
-        input.project_root,
+        project_root,
         None,
         projected_spawn_mb,
     )
     .context("Failed to build host-memory admission")?;
     resource_guard
-        .check_availability_with_admission(input.tool_name, Some(admission))
+        .check_availability_with_admission(tool_name, Some(admission))
         .map_err(|err| {
             let guidance = crate::no_provider_launch::host_memory_guidance_from_error(
                 Some("run"),
-                input.tool_name,
-                input.project_config,
-                input.resource_overrides,
+                tool_name,
+                project_config,
+                resource_overrides,
                 &err,
             );
             if let Some(guidance) = guidance {
@@ -146,7 +154,7 @@ pub(crate) fn validate_run_memory_soft_limit_before_session(
                 err
             }
         })
-        .with_context(|| format!("run preflight for writer tool '{}'", input.tool_name))
+        .with_context(|| format!("run preflight for writer tool '{tool_name}'"))
 }
 
 #[derive(Clone, Copy)]

--- a/crates/cli-sub-agent/src/run_cmd_preflight_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_preflight_tests.rs
@@ -55,3 +55,35 @@ fn writer_soft_limit_floor_is_rejected_before_session_creation() {
         "memory floor preflight must not create a writer session"
     );
 }
+
+#[test]
+fn writer_soft_limit_preflight_does_not_admit_host_memory() {
+    let project_dir = tempfile::tempdir().expect("temp project");
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _tools_available =
+        ScopedEnvVarRestore::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let _resource_capability =
+        ScopedEnvVarRestore::set(csa_resource::sandbox::TEST_ASSUME_CGROUP_V2_ENV, "1");
+    let mut config = crate::review_cmd::tests::project_config_with_enabled_tools(&["codex"]);
+    config.resources.memory_max_mb = Some(10_000);
+    config.resources.min_free_memory_mb = u64::MAX;
+    config.resources.soft_limit_percent = Some(90);
+    let global_config = GlobalConfig::default();
+
+    validate_run_memory_soft_limit_before_session(RunMemorySoftLimitPreflight {
+        project_root: project_dir.path(),
+        project_config: Some(&config),
+        global_config: &global_config,
+        tool_name: "codex",
+        resource_overrides: RunResourceOverrides::absent(),
+        stream_mode: csa_process::StreamMode::BufferOnly,
+        idle_timeout_seconds: 120,
+        initial_response_timeout_seconds: Some(120),
+        build_jobs: Some(1),
+        no_fs_sandbox: false,
+        allow_user_daemon_ipc: true,
+        extra_writable: &[],
+        extra_readable: &[],
+    })
+    .expect("static writer preflight must not inspect dynamic host memory");
+}

--- a/crates/cli-sub-agent/src/run_cmd_preflight_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_preflight_tests.rs
@@ -1,4 +1,7 @@
-use super::{RunMemorySoftLimitPreflight, validate_run_memory_soft_limit_before_session};
+use super::{
+    RunMemorySoftLimitPreflight, validate_run_host_memory_after_slot_acquisition,
+    validate_run_memory_soft_limit_before_session,
+};
 use crate::run_resource_overrides::RunResourceOverrides;
 use crate::test_env_lock::ScopedEnvVarRestore;
 use crate::test_session_sandbox::ScopedSessionSandbox;
@@ -86,4 +89,50 @@ fn writer_soft_limit_preflight_does_not_admit_host_memory() {
         extra_readable: &[],
     })
     .expect("static writer preflight must not inspect dynamic host memory");
+}
+
+#[test]
+fn writer_host_memory_admission_is_deferred_to_the_post_slot_path() {
+    let project_dir = tempfile::tempdir().expect("temp project");
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _tools_available =
+        ScopedEnvVarRestore::set(crate::run_helpers::TEST_ASSUME_TOOLS_AVAILABLE_ENV, "1");
+    let _resource_capability =
+        ScopedEnvVarRestore::set(csa_resource::sandbox::TEST_ASSUME_CGROUP_V2_ENV, "1");
+    let mut config = crate::review_cmd::tests::project_config_with_enabled_tools(&["codex"]);
+    config.resources.memory_max_mb = Some(10_000);
+    config.resources.min_free_memory_mb = u64::MAX;
+    config.resources.soft_limit_percent = Some(90);
+    let global_config = GlobalConfig::default();
+
+    let resource_capability =
+        validate_run_memory_soft_limit_before_session(RunMemorySoftLimitPreflight {
+            project_root: project_dir.path(),
+            project_config: Some(&config),
+            global_config: &global_config,
+            tool_name: "codex",
+            resource_overrides: RunResourceOverrides::absent(),
+            stream_mode: csa_process::StreamMode::BufferOnly,
+            idle_timeout_seconds: 120,
+            initial_response_timeout_seconds: Some(120),
+            build_jobs: Some(1),
+            no_fs_sandbox: false,
+            allow_user_daemon_ipc: true,
+            extra_writable: &[],
+            extra_readable: &[],
+        })
+        .expect("static writer preflight must not inspect dynamic host memory");
+    assert_eq!(
+        resource_capability,
+        csa_resource::ResourceCapability::CgroupV2
+    );
+
+    validate_run_host_memory_after_slot_acquisition(
+        project_dir.path(),
+        Some(&config),
+        "codex",
+        RunResourceOverrides::absent(),
+        resource_capability,
+    )
+    .expect_err("dynamic host-memory admission belongs to the post-slot path");
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1136"
-weave = "0.1.1136"
+csa = "0.1.1137"
+weave = "0.1.1137"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
Closes memory soft-limit admission empty-interval and cgroup-floor false-reject defects for `#3044` / `#3043`.

- Unify soft-limit envelope and empty feasible-interval retry guidance
- Defer dynamic host-memory admission until after tool slot acquisition
- Apply soft-limit floor only for resolved CgroupV2 capability
- Final pre-spawn recheck uses resolved `IsolationPlan.resource` (not bare host detection)
- E2E run-loop regression pins static soft-limit → slot acquire → host memory order

## Verification
- focused: 126/126 PASS (`/home/obj/tmp/3044-focused-de6d6419.log`, sha256 `2af998315b2d0a172a853c832783cee594957057de7f810c3101e62de32788ce`)
- host `just pre-push`: GREEN 7547 pass (`/home/obj/tmp/3044-host-prepush-de6d6419-r2.log`, sha256 `7e47ff8fe05f8ff4cd7d203ae1467e83b3f43103010cfdaaa5412f76e638e831`)
- Tier-4: CSA Codex quota exhausted; native clean-room VERDICT PASS (`/home/obj/tmp/3044-3043-native-tier4-de6d6419.md`, sha256 `ed04adf505853529099f09208f5d068ef2a3907c4ac91516f41a8856ae28e510`)

## Commits
- `b81f4f0a` unify memory soft-limit envelope
- `a6321313` assert soft-limit guidance
- `41a9e7fb` defer host memory until after slot acquire
- `733b562f` scope soft-limit floor to cgroup
- `3dddbcfe` use resolved capability for pre-spawn recheck
- `de6d6419` pin slot-before-host-memory ordering

Closes #3044
Closes #3043