### PR TITLE
fix(admission): reconcile active session holders (#3036/#2960/#3035)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1137"
+version = "0.1.1138"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1137"
+version = "0.1.1138"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/resource_admission.rs
+++ b/crates/cli-sub-agent/src/resource_admission.rs
@@ -23,12 +23,13 @@ const RECENT_ACTIVE_FALLBACK_WINDOW_SECS: i64 = 15 * 60;
 const PRE_SPAWN_ADMISSION_MODE: &str = "admission";
 const PRE_SPAWN_MEMORY_ADMITTED_FILE: &str = ".pre-spawn-memory-admitted.toml";
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 struct ActiveSessionMemory {
     active_count: u64,
     sampled_count: u64,
     sampled_rss_mb: u64,
     projected_mb: u64,
+    holders: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -207,8 +208,16 @@ pub(crate) fn build_spawn_memory_admission(
             project_root.display()
         )
     })?;
-    let active =
-        aggregate_active_session_memory(&sessions, current, Utc::now(), sample_session_memory);
+    let daemon_current = current
+        .is_none()
+        .then(|| csa_session::preassigned_daemon_session_id_from_env(project_root))
+        .flatten();
+    let active = aggregate_active_session_memory(
+        &sessions,
+        current.or(daemon_current.as_deref()),
+        Utc::now(),
+        sample_session_memory,
+    );
 
     Ok(SpawnMemoryAdmission {
         projected_spawn_mb,
@@ -216,6 +225,7 @@ pub(crate) fn build_spawn_memory_admission(
         active_session_projected_mb: active.projected_mb,
         active_session_count: active.active_count,
         sampled_session_count: active.sampled_count,
+        active_session_holders: active.holders.join(", "),
     })
 }
 
@@ -240,6 +250,10 @@ fn aggregate_active_session_memory(
         };
 
         memory.active_count = memory.active_count.saturating_add(1);
+        memory.holders.push(format!(
+            "session_id={:?} project_path={:?}",
+            session.meta_session_id, session.project_path
+        ));
 
         if let Some(rss_mb) = observation.sampled_rss_mb {
             memory.sampled_count = memory.sampled_count.saturating_add(1);
@@ -507,13 +521,11 @@ mod tests {
     }
 
     #[test]
-    fn active_memory_counts_old_session_with_live_sample() {
+    fn active_memory_identifies_stale_live_holder() {
         let now = Utc::now();
-        let sessions = vec![active_session(
-            "live",
-            now - TimeDelta::hours(2),
-            Some(12_288),
-        )];
+        let mut live = active_session("live", now - TimeDelta::hours(2), Some(12_288));
+        live.project_path = "/repo/live".to_string();
+        let sessions = vec![live];
 
         let memory = aggregate_active_session_memory(&sessions, Some("current"), now, |_| {
             SessionMemorySample::RssMb(1024)
@@ -523,6 +535,10 @@ mod tests {
         assert_eq!(memory.sampled_count, 1);
         assert_eq!(memory.sampled_rss_mb, 1024);
         assert_eq!(memory.projected_mb, 12_288);
+        assert_eq!(
+            memory.holders,
+            vec![r#"session_id="live" project_path="/repo/live""#.to_string()]
+        );
     }
 
     #[test]

--- a/crates/cli-sub-agent/src/resource_admission_projection_tests.rs
+++ b/crates/cli-sub-agent/src/resource_admission_projection_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::test_env_lock::ScopedEnvVarRestore;
+use crate::test_session_sandbox::ScopedSessionSandbox;
 use csa_resource::ResourceCapability;
 
 #[test]
@@ -182,4 +184,31 @@ fn final_recheck_uses_setrlimit_after_cgroup_landlock_plan_degradation() {
         8_277,
         "the final recheck must not apply a cgroup-only writer floor to Setrlimit"
     );
+}
+
+#[test]
+fn pre_session_admission_excludes_preassigned_daemon_session() {
+    let project = tempfile::tempdir().expect("project");
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project);
+    let mut session =
+        csa_session::create_session(project.path(), Some("current"), None, Some("codex"))
+            .expect("create current session");
+    persist_spawn_memory_projection(
+        &mut session,
+        12_000,
+        RunResourceOverrides::absent().resolution_info(None, "codex"),
+    )
+    .expect("persist current projection");
+    let session_dir = csa_session::get_session_dir(project.path(), &session.meta_session_id)
+        .expect("current session dir");
+    let _daemon_id = ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_ID", &session.meta_session_id);
+    let _daemon_dir = ScopedEnvVarRestore::set("CSA_DAEMON_SESSION_DIR", &session_dir);
+    let _daemon_project = ScopedEnvVarRestore::set("CSA_DAEMON_PROJECT_ROOT", project.path());
+
+    let admission = build_spawn_memory_admission(project.path(), None, 12_000)
+        .expect("build pre-session admission");
+
+    assert_eq!(admission.active_session_count, 0);
+    assert_eq!(admission.active_session_projected_mb, 0);
+    assert!(admission.active_session_holders.is_empty());
 }

--- a/crates/csa-resource/src/guard.rs
+++ b/crates/csa-resource/src/guard.rs
@@ -24,7 +24,7 @@ impl Default for ResourceLimits {
 }
 
 /// Host-memory projection for a session spawn admission decision.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpawnMemoryAdmission {
     /// Memory the new session is expected to be allowed to consume.
     pub projected_spawn_mb: u64,
@@ -36,6 +36,8 @@ pub struct SpawnMemoryAdmission {
     pub active_session_count: u64,
     /// Number of active sessions whose process tree RSS was sampled successfully.
     pub sampled_session_count: u64,
+    /// Counted session IDs and project paths for operator diagnostics.
+    pub active_session_holders: String,
 }
 
 /// Upper-bound inputs for a retry after host-memory admission denial.
@@ -301,7 +303,7 @@ fn evaluate_memory_availability(
     reserve_mb: u64,
     admission: Option<SpawnMemoryAdmission>,
 ) -> Result<()> {
-    let admission_retry = admission.map(|admission| {
+    let admission_retry = admission.as_ref().map(|admission| {
         let retry_bounds = retry_bounds_for(available_phys_mb, total_ram_mb, reserve_mb, admission);
         (
             admission,
@@ -315,12 +317,21 @@ fn evaluate_memory_availability(
         available_combined_mb,
         total_ram_mb,
         reserve_mb,
-        projected_spawn_mb: admission.map(|admission| admission.projected_spawn_mb),
-        active_session_rss_mb: admission.map(|admission| admission.active_session_rss_mb),
+        projected_spawn_mb: admission
+            .as_ref()
+            .map(|admission| admission.projected_spawn_mb),
+        active_session_rss_mb: admission
+            .as_ref()
+            .map(|admission| admission.active_session_rss_mb),
         active_session_projected_mb: admission
+            .as_ref()
             .map(|admission| admission.active_session_projected_mb),
-        active_session_count: admission.map(|admission| admission.active_session_count),
-        sampled_session_count: admission.map(|admission| admission.sampled_session_count),
+        active_session_count: admission
+            .as_ref()
+            .map(|admission| admission.active_session_count),
+        sampled_session_count: admission
+            .as_ref()
+            .map(|admission| admission.sampled_session_count),
         retry_bounds: admission_retry
             .as_ref()
             .map(|(_, retry_bounds, _)| *retry_bounds),
@@ -382,7 +393,8 @@ fn evaluate_memory_availability(
                  required={required_available_mb}MB (reserve={reserve_mb}MB + \
                  projected_spawn={projected_spawn_mb}MB). active_sessions={active_sessions} \
                  sampled_sessions={sampled_sessions} active_session_rss_mb={active_rss} \
-                 active_session_projected_mb={active_projected} swap_available_mb={available_swap_mb} \
+                 active_session_projected_mb={active_projected} \
+                 active_session_holders=[{active_session_holders}] swap_available_mb={available_swap_mb} \
                  combined_available_mb={available_combined_mb}. Pre-exec memory admission is \
                  infrastructure/session-unavailable before provider launch, not a \
                  product/test/review failure. {retry_note}",
@@ -391,6 +403,7 @@ fn evaluate_memory_availability(
                 sampled_sessions = admission.sampled_session_count,
                 active_rss = admission.active_session_rss_mb,
                 active_projected = admission.active_session_projected_mb,
+                active_session_holders = admission.active_session_holders,
             );
             eprintln!("{message}");
             let error = MemoryAdmissionError::new(
@@ -432,15 +445,17 @@ fn evaluate_memory_availability(
                  > host_safe_limit={host_safe_limit_mb}MB ({safe_num}/{safe_den} of total_ram={total_ram_mb}MB). \
                  active_sessions={active_sessions} sampled_sessions={sampled_sessions} \
                  active_session_rss_mb={active_rss} active_session_projected_mb={active_projected} \
-                 projected_spawn_mb={projected_spawn_mb} available_mb={available_phys_mb}. \
-                 Pre-exec memory admission is infrastructure/session-unavailable before provider \
-                 launch, not a product/test/review failure. {retry_note}",
+                 active_session_holders=[{active_session_holders}] projected_spawn_mb={projected_spawn_mb} \
+                 available_mb={available_phys_mb}. Pre-exec memory admission is \
+                 infrastructure/session-unavailable before provider launch, not a \
+                 product/test/review failure. {retry_note}",
                 safe_num = ACTIVE_SESSION_SAFE_FRACTION_NUM,
                 safe_den = ACTIVE_SESSION_SAFE_FRACTION_DEN,
                 active_sessions = admission.active_session_count,
                 sampled_sessions = admission.sampled_session_count,
                 active_rss = admission.active_session_rss_mb,
                 active_projected = admission.active_session_projected_mb,
+                active_session_holders = admission.active_session_holders,
                 projected_spawn_mb = admission.projected_spawn_mb,
             );
             eprintln!("{message}");
@@ -495,7 +510,7 @@ fn retry_bounds_for(
     available_phys_mb: u64,
     total_ram_mb: u64,
     reserve_mb: u64,
-    admission: SpawnMemoryAdmission,
+    admission: &SpawnMemoryAdmission,
 ) -> MemoryAdmissionRetryBounds {
     let physical_upper_mb = available_phys_mb.saturating_sub(reserve_mb);
     let active_session_upper_mb = active_session_retry_upper_mb(total_ram_mb, admission);
@@ -512,7 +527,7 @@ fn retry_bounds_for(
 
 fn active_session_retry_upper_mb(
     total_ram_mb: u64,
-    admission: SpawnMemoryAdmission,
+    admission: &SpawnMemoryAdmission,
 ) -> Option<u64> {
     let host_safe_limit_mb = total_ram_mb.saturating_mul(ACTIVE_SESSION_SAFE_FRACTION_NUM)
         / ACTIVE_SESSION_SAFE_FRACTION_DEN;

--- a/crates/csa-resource/src/guard_retry_snapshot.rs
+++ b/crates/csa-resource/src/guard_retry_snapshot.rs
@@ -5,7 +5,7 @@ use super::*;
 /// The snapshot reuses the same physical/reserve and active-session bound rules
 /// as pre-spawn host-memory admission, but it is available when another
 /// pre-exec admission (such as a soft-limit floor) failed first.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemoryAdmissionRetrySnapshot {
     /// Effective physical MemAvailable after enclosing cgroup limits are applied.
     pub available_phys_mb: u64,
@@ -32,7 +32,8 @@ impl ResourceGuard {
             effective_available_memory_bytes(self.sys.available_memory()) / 1024 / 1024;
         let total_ram_mb = self.sys.total_memory() / 1024 / 1024;
         let reserve_mb = self.limits.min_free_memory_mb;
-        let retry_bounds = retry_bounds_for(available_phys_mb, total_ram_mb, reserve_mb, admission);
+        let retry_bounds =
+            retry_bounds_for(available_phys_mb, total_ram_mb, reserve_mb, &admission);
 
         MemoryAdmissionRetrySnapshot {
             available_phys_mb,

--- a/crates/csa-resource/src/guard_tests.rs
+++ b/crates/csa-resource/src/guard_tests.rs
@@ -175,6 +175,7 @@ fn test_evaluate_blocks_when_spawn_projection_exceeds_available_headroom() {
         active_session_projected_mb: 4096,
         active_session_count: 1,
         sampled_session_count: 1,
+        active_session_holders: String::new(),
     };
 
     let result =
@@ -201,13 +202,15 @@ fn test_evaluate_blocks_when_spawn_projection_exceeds_available_headroom() {
 }
 
 #[test]
-fn test_evaluate_blocks_when_active_projection_exceeds_host_safe_limit() {
+fn test_active_projection_denial_lists_counted_session_holders() {
     let admission = SpawnMemoryAdmission {
         projected_spawn_mb: 8192,
         active_session_rss_mb: 16_000,
         active_session_projected_mb: 20_000,
         active_session_count: 3,
         sampled_session_count: 2,
+        active_session_holders: r#"session_id="01HOLDER" project_path="/repo/codeseek""#
+            .to_string(),
     };
 
     let result =
@@ -224,6 +227,9 @@ fn test_evaluate_blocks_when_active_projection_exceeds_host_safe_limit() {
     let msg = err.to_string();
     assert!(msg.contains("active-session memory admission denied"));
     assert!(msg.contains("projected_active=28192MB"));
+    assert!(msg.contains(
+        r#"active_session_holders=[session_id="01HOLDER" project_path="/repo/codeseek"]"#
+    ));
     assert!(msg.contains("Retry upper bound: memory_max_mb <= 4000MB"));
     assert!(msg.contains("--memory-max-mb <MB>"));
     assert!(msg.contains("resources.memory_max_mb"));
@@ -237,6 +243,7 @@ fn test_evaluate_allows_safe_spawn_projection() {
         active_session_projected_mb: 4096,
         active_session_count: 1,
         sampled_session_count: 1,
+        active_session_holders: String::new(),
     };
 
     let result = evaluate_memory_availability(

--- a/crates/csa-session/src/lib.rs
+++ b/crates/csa-session/src/lib.rs
@@ -203,9 +203,9 @@ pub use manager::{
     list_sessions_from_root_readonly, list_sessions_readonly, load_metadata, load_result,
     load_result_view, load_session, load_session_global_exact,
     next_turn_contract_result_artifact_path, next_turn_contract_result_path,
-    observed_session_artifact, redact_result_sidecar_value, render_redacted_result_sidecar,
-    resolve_fork_source, resolve_resume_session, save_result, save_result_with_options,
-    save_result_with_signal_metadata, save_session, save_session_in,
+    observed_session_artifact, preassigned_daemon_session_id_from_env, redact_result_sidecar_value,
+    render_redacted_result_sidecar, resolve_fork_source, resolve_resume_session, save_result,
+    save_result_with_options, save_result_with_signal_metadata, save_session, save_session_in,
     turn_contract_result_artifact_path, turn_contract_result_path, update_last_accessed,
     validate_tool_access, write_audit_warning_artifact,
 };

--- a/crates/csa-session/src/manager.rs
+++ b/crates/csa-session/src/manager.rs
@@ -34,8 +34,10 @@ pub(crate) use manager_access::load_metadata_in;
 pub(crate) use manager_access::validate_tool_access_in;
 pub use manager_access::{load_metadata, resolve_fork_source, validate_tool_access};
 pub use manager_audit::{RepoWriteAudit, compute_repo_write_audit, write_audit_warning_artifact};
-pub use manager_daemon::{ResumeSessionResolution, create_session_with_daemon_env};
-use manager_daemon::{SessionIdStrategy, preassigned_daemon_session_id_from_env};
+use manager_daemon::SessionIdStrategy;
+pub use manager_daemon::{
+    ResumeSessionResolution, create_session_with_daemon_env, preassigned_daemon_session_id_from_env,
+};
 pub use manager_inventory::list_all_sessions_all_projects_strict;
 pub use manager_legacy::decode_session_created_at;
 #[cfg(test)]

--- a/crates/csa-session/src/manager_daemon.rs
+++ b/crates/csa-session/src/manager_daemon.rs
@@ -9,7 +9,8 @@ pub(crate) enum SessionIdStrategy {
     Fresh,
 }
 
-pub(crate) fn preassigned_daemon_session_id_from_env(project_path: &Path) -> Option<String> {
+/// Return the daemon-owned session ID when its environment contract matches this project.
+pub fn preassigned_daemon_session_id_from_env(project_path: &Path) -> Option<String> {
     let session_id = std::env::var(super::DAEMON_SESSION_ID_ENV)
         .ok()
         .filter(|value| !value.is_empty())?;

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1137"
-weave = "0.1.1137"
+csa = "0.1.1138"
+weave = "0.1.1138"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
Closes phantom active-session memory admission false denials for `#3036` / `#2960` / `#3035`.

- Exclude preassigned daemon/current session from active-session inventory during its own pre-session admission
- Identify every counted live holder by session ID + project path on denial
- Keep stale/non-observable sessions from inventing projected floors without live evidence
- Avoid double-counting current spawn projection against active_session_projected_mb

## Verification
- focused: 51/51 PASS (`/home/obj/tmp/3036-focused-b95578d9.log`, sha256 `5e98d1d824f8548920e24e76326ffde7018bf30a8c0a4d86c009be407bfb9a50`)
- host `just pre-push`: GREEN static 7518 + all-features 7548 (`/home/obj/tmp/3036-host-prepush-b95578d9-r3.log`, sha256 `be33046ee388d6115f9a1582edb360853d693f0361788b754b84713768cca7c5`)
- Tier-4: CSA Codex quota exhausted; native clean-room VERDICT PASS (`/home/obj/tmp/3036-native-tier4-b95578d9.md`, sha256 `1b4efd534eea6f13cfa16099385e6cce91768a17d09ce7ccecb0033c9a7eba1b`)

## Commit
- `b95578d9` fix(admission): reconcile active session holders

Closes #3036
Closes #2960
Closes #3035