### PR TITLE
fix(session-wait): reclaim timed-out caller locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1138"
+version = "0.1.1139"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1138"
+version = "0.1.1139"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_lock.rs
@@ -15,13 +15,14 @@ use serde::{Deserialize, Serialize};
 /// The output descriptor is inherited from the launcher before this process
 /// can run, so it remains authoritative even if the waiter has already been
 /// reparented. A closed pipe/socket reports HUP or ERR through `poll(2)`;
-/// regular files and terminals remain valid result sinks without relying on a
-/// sampled parent PID.
+/// the startup parent is retained as a fallback for regular files, terminals,
+/// and supervisor-held channels that cannot report caller closure.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct WaitCallerIdentity {
     output_fd: Option<RawFd>,
     output_device: Option<u64>,
     output_inode: Option<u64>,
+    startup_parent_pid: Option<u32>,
 }
 
 impl WaitCallerIdentity {
@@ -46,13 +47,18 @@ impl WaitCallerIdentity {
     }
 
     fn from_output_fd(output_fd: RawFd) -> Self {
+        let startup_parent_pid = parent_pid(std::process::id());
         let Some((output_device, output_inode)) = descriptor_identity(output_fd) else {
-            return Self::default();
+            return Self {
+                startup_parent_pid,
+                ..Self::default()
+            };
         };
         Self {
             output_fd: Some(output_fd),
             output_device: Some(output_device),
             output_inode: Some(output_inode),
+            startup_parent_pid,
         }
     }
 
@@ -137,8 +143,8 @@ struct SessionWaitLockDiagnostic {
     caller_output_device: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     caller_output_inode: Option<u64>,
-    /// Legacy compatibility for diagnostics written before the caller-owned
-    /// output lifecycle contract.
+    /// Startup parent fallback for result channels whose closure is not
+    /// observable after the launcher exits.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     parent_pid: Option<u32>,
 }
@@ -193,8 +199,8 @@ pub(crate) fn try_acquire_session_wait_lock_with_caller(
         )?));
     }
 
-    // Older diagnostics used a sampled PPID. Preserve their verified reclaim
-    // path while current waiters release on caller-output closure themselves.
+    // Caller-output closure is primary; the captured startup PPID covers result
+    // channels that stay open after their launcher exits.
     if let Some(validated) = is_wait_lock_diagnostic_caller_gone(&lock_path)
         && descriptor_identity(fd)
             .is_some_and(|identity| kill_wait_lock_holder(&lock_path, identity, validated))
@@ -291,7 +297,7 @@ fn write_session_wait_lock_diagnostic(
         pid_start_time_ticks: process_start_time_ticks(pid),
         caller_output_device: caller_parts.map(|(_, device, _)| device),
         caller_output_inode: caller_parts.map(|(_, _, inode)| inode),
-        parent_pid: None,
+        parent_pid: caller_identity.startup_parent_pid,
     };
     let json = serde_json::to_string(&diagnostic)?;
 
@@ -319,11 +325,10 @@ fn is_wait_lock_diagnostic_pid_dead(lock_path: &Path) -> bool {
     true
 }
 
-/// Return a verified live legacy holder whose recorded parent changed.
+/// Return a verified live holder whose recorded parent changed.
 ///
-/// Current waiters observe their caller-owned output channel directly and
-/// release the flock themselves. This PPID comparison is retained only so a
-/// new binary can safely reclaim locks written by older versions.
+/// Caller-output closure remains the primary lifecycle signal. This PPID
+/// comparison is the fallback when the launcher's result channel stays open.
 fn is_wait_lock_diagnostic_caller_gone(lock_path: &Path) -> Option<SessionWaitLockDiagnostic> {
     let diagnostic = read_wait_lock_diagnostic(lock_path)?;
     let pid_start_time_ticks = diagnostic.pid_start_time_ticks.filter(|ticks| *ticks != 0);
@@ -356,7 +361,7 @@ fn is_wait_lock_diagnostic_caller_gone(lock_path: &Path) -> Option<SessionWaitLo
         holder_pid = diagnostic.pid,
         recorded_ppid,
         current_ppid,
-        "retrying legacy session wait lock flock after detecting reparented holder PID"
+        "retrying session wait lock flock after detecting reparented holder PID"
     );
     Some(diagnostic)
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::session_cmds_daemon::{
     WaitBehavior, WaitCallerIdentity, WaitLoopTiming, WaitReconciliationOutcome,
     handle_session_wait_with_hooks, handle_session_wait_with_hooks_at,
-    handle_session_wait_with_identity_for_test, try_acquire_session_wait_lock,
+    handle_session_wait_with_identity_for_test, parent_pid, try_acquire_session_wait_lock,
     try_acquire_session_wait_lock_with_caller,
 };
 use crate::test_env_lock::TEST_ENV_LOCK;
@@ -73,12 +73,14 @@ fn session_wait_lock_creates_dot_wait_lock_file_and_rejects_duplicates() {
 
 #[cfg(target_os = "linux")]
 #[test]
-fn session_wait_lock_persists_caller_output_identity() {
+fn session_wait_lock_persists_caller_identity_for_timeout_reclaim() {
     let td = tempdir().expect("tempdir");
     let (_caller_read_end, _wait_output_end, caller_identity) = caller_output_pipe();
     let (output_device, output_inode) = caller_identity
         .diagnostic_parts_for_test()
         .expect("pipe output should have a stable descriptor identity");
+    let expected_parent_pid = parent_pid(std::process::id())
+        .expect("Linux test process should expose its startup parent");
 
     let _lock = try_acquire_session_wait_lock_with_caller(td.path(), caller_identity)
         .expect("wait lock acquisition")
@@ -95,6 +97,11 @@ fn session_wait_lock_persists_caller_output_identity() {
     assert_eq!(
         diagnostic["caller_output_inode"].as_u64(),
         Some(output_inode)
+    );
+    assert_eq!(
+        diagnostic["parent_pid"].as_u64(),
+        Some(u64::from(expected_parent_pid)),
+        "the startup caller must remain identifiable after a tool timeout"
     );
 }
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1138"
-weave = "0.1.1138"
+csa = "0.1.1139"
+weave = "0.1.1139"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- persist the launcher PID with the wait caller output identity
- safely reclaim a reparented wait-lock holder after its caller times out or exits
- preserve start-time, flock, pidfd, and live-caller non-steal checks

## Verification
- focused wait-lock matrix: 24/24 PASS
- local `just pre-push`: PASS (7518/7518 static; 7548/7548 all-features)
- exact-HEAD native Tier-4 equivalent: PASS

Closes #3047