### PR TITLE
fix(git-guard): isolate hermetic local fixture Git environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1139"
+version = "0.1.1140"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1139"
+version = "0.1.1140"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/tests/skill_resource_inheritance.rs
+++ b/crates/cli-sub-agent/tests/skill_resource_inheritance.rs
@@ -2,8 +2,12 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
+#[path = "../src/test_bounded_command.rs"]
+mod test_bounded_command;
+
 const SKILL_RUN_TIMEOUT: Duration = Duration::from_secs(30);
 const SKILL_RUN_TERMINATION_GRACE: Duration = Duration::from_secs(1);
+const GIT_FIXTURE_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn csa_cmd(home: &Path) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_csa"));
@@ -85,6 +89,112 @@ fn find_file(root: &Path, name: &str) -> Option<PathBuf> {
     None
 }
 
+fn run_fixture_git(project: &Path, args: &[&str]) {
+    let mut command = Command::new("/usr/bin/git");
+    command
+        .env_clear()
+        .args([
+            "-c",
+            "commit.gpgSign=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "init.templateDir=",
+        ])
+        .args(args)
+        .current_dir(project)
+        .env("PATH", "/usr/bin:/bin")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("XDG_CONFIG_HOME", "/dev/null")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "test@test.com")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "test@test.com");
+    let output = test_bounded_command::output_with_timeout(command, GIT_FIXTURE_TIMEOUT);
+    assert!(
+        output.status.success(),
+        "fixture git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn skill_resource_git_fixture_ignores_hostile_ambient_config() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let ambient = tempfile::tempdir().expect("temporary hostile Git environment");
+    let hooks = ambient.path().join("hooks");
+    std::fs::create_dir(&hooks).expect("create hostile hooks directory");
+    let marker = ambient.path().join("ambient-git-ran");
+    let hostile_program = hooks.join("pre-commit");
+    std::fs::write(
+        &hostile_program,
+        "#!/bin/sh\nprintf reached > \"$HOSTILE_GIT_MARKER\"\nexit 91\n",
+    )
+    .expect("write hostile Git hook and signer");
+    std::fs::set_permissions(&hostile_program, std::fs::Permissions::from_mode(0o755))
+        .expect("make hostile Git hook and signer executable");
+    let config = ambient.path().join("hostile.gitconfig");
+    let config_contents = format!(
+        "[core]\n\thooksPath = {}\n[commit]\n\tgpgSign = true\n[gpg]\n\tprogram = {}\n[init]\n\ttemplateDir = {}\n",
+        hooks.display(),
+        hostile_program.display(),
+        ambient.path().display()
+    );
+    std::fs::write(&config, &config_contents).expect("write hostile Git config");
+    std::fs::create_dir(ambient.path().join("git")).expect("create hostile XDG Git directory");
+    std::fs::write(ambient.path().join("git/config"), config_contents)
+        .expect("write hostile XDG Git config");
+
+    let status = test_bounded_command::status_with_timeout(
+        {
+            let mut command = Command::new(std::env::current_exe().expect("current test binary"));
+            command
+                .args([
+                    "--exact",
+                    "skill_run_preserves_plan_parent_resource_snapshot_for_nested_child",
+                    "--nocapture",
+                ])
+                .env("HOME", ambient.path())
+                .env("XDG_CONFIG_HOME", ambient.path())
+                .env("GIT_CONFIG", &config)
+                .env("GIT_CONFIG_SYSTEM", &config)
+                .env("GIT_CONFIG_GLOBAL", &config)
+                .env("GIT_CONFIG_COUNT", "1")
+                .env("GIT_CONFIG_KEY_0", "core.hooksPath")
+                .env("GIT_CONFIG_VALUE_0", &hooks)
+                .env("GIT_TEMPLATE_DIR", ambient.path())
+                .env("HOSTILE_GIT_MARKER", &marker);
+            command
+        },
+        Duration::from_secs(45),
+    );
+
+    assert!(
+        status.success(),
+        "fixture failed under hostile ambient Git state with {status}"
+    );
+    let source = include_str!("skill_resource_inheritance.rs");
+    let unbounded_status = [".sta", "tus()"].concat();
+    assert!(
+        !source.contains(&unbounded_status),
+        "fixture Git setup must not use unbounded Command::status"
+    );
+    let bounded_call = [
+        "test_bounded_command::output_with_timeout",
+        "(command, GIT_FIXTURE_TIMEOUT)",
+    ]
+    .concat();
+    assert!(
+        source.contains(&bounded_call),
+        "fixture Git setup must use the existing bounded subprocess helper"
+    );
+}
+
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
 async fn skill_run_preserves_plan_parent_resource_snapshot_for_nested_child() {
@@ -137,28 +247,24 @@ enabled = false
         "resource inheritance fixture must disable unrelated filesystem enforcement"
     );
 
-    assert!(
-        Command::new("git")
-            .args(["-c", "init.defaultBranch=feat/resource-probe", "init", "-q"])
-            .current_dir(&project)
-            .status()
-            .expect("initialize fixture git repository")
-            .success(),
-        "fixture git repository initialization must succeed"
+    run_fixture_git(
+        &project,
+        &["-c", "init.defaultBranch=feat/resource-probe", "init", "-q"],
     );
-    assert!(
-        Command::new("git")
-            .args(["commit", "--allow-empty", "-qm", "init"])
-            .current_dir(&project)
-            .env("GIT_AUTHOR_NAME", "test")
-            .env("GIT_AUTHOR_EMAIL", "test@test.com")
-            .env("GIT_COMMITTER_NAME", "test")
-            .env("GIT_COMMITTER_EMAIL", "test@test.com")
-            .status()
-            .expect("commit fixture git repository")
-            .success(),
-        "fixture git repository commit must succeed"
-    );
+    let hostile_marker = std::env::var_os("HOSTILE_GIT_MARKER");
+    if hostile_marker.is_some() {
+        assert!(
+            !project.join(".git/hooks/pre-commit").exists(),
+            "ambient Git template altered fixture initialization"
+        );
+    }
+    run_fixture_git(&project, &["commit", "--allow-empty", "-qm", "init"]);
+    if let Some(marker) = hostile_marker {
+        assert!(
+            !Path::new(&marker).exists(),
+            "ambient Git hook or signer altered fixture setup"
+        );
+    }
 
     let fake_bin = install_fake_codex(&project);
     let mut command = csa_cmd(home.path());

--- a/crates/cli-sub-agent/tests/skill_resource_inheritance.rs
+++ b/crates/cli-sub-agent/tests/skill_resource_inheritance.rs
@@ -137,6 +137,29 @@ enabled = false
         "resource inheritance fixture must disable unrelated filesystem enforcement"
     );
 
+    assert!(
+        Command::new("git")
+            .args(["-c", "init.defaultBranch=feat/resource-probe", "init", "-q"])
+            .current_dir(&project)
+            .status()
+            .expect("initialize fixture git repository")
+            .success(),
+        "fixture git repository initialization must succeed"
+    );
+    assert!(
+        Command::new("git")
+            .args(["commit", "--allow-empty", "-qm", "init"])
+            .current_dir(&project)
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "test@test.com")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "test@test.com")
+            .status()
+            .expect("commit fixture git repository")
+            .success(),
+        "fixture git repository commit must succeed"
+    );
+
     let fake_bin = install_fake_codex(&project);
     let mut command = csa_cmd(home.path());
     command

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -214,10 +214,10 @@ descriptor_path_for() {
 }
 
 reset_hermetic_git_environment() {
-  # The projected local transport must not inherit caller-selected repository,
-  # config, protocol, or helper-routing inputs. The final push runs from an
-  # empty temporary Git directory, so repository-local remotes and URL
-  # rewrites never enter the transport decision.
+  # Hermetic Git operations must not inherit caller-selected repository,
+  # template, config, protocol, or helper-routing inputs. Projected pushes also
+  # run from an empty temporary Git directory, excluding local remotes and URL
+  # rewrites from transport decisions.
   unset GIT_CONFIG GIT_CONFIG_PARAMETERS GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_NAMESPACE || true
   unset GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM GIT_TEMPLATE_DIR || true
   unset GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES || true
@@ -457,6 +457,12 @@ if [ "${CSA_GIT_PUSH_ALLOWED:-}" != "true" ]; then
     && ! is_safe_local_command "${COMMAND}"; then
     block_untrusted_git_command "$@"
   fi
+fi
+
+# Every closed-grammar route that forwards caller argv uses the same hermetic
+# environment; the local-push route applies it inside its projection validator.
+if is_exact_git_version_grammar "$@" || is_exact_git_init_grammar "$@"; then
+  reset_hermetic_git_environment || block_untrusted_git_command "$@"
 fi
 
 if [ "${COMMAND}" != "commit" ]; then

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -136,6 +136,10 @@ for arg do
     --help|-h)
       continue
       ;;
+    --version*)
+      COMMAND="${arg}"
+      break
+      ;;
     -c|--config)
       EXPECT_VALUE="config"
       continue
@@ -382,6 +386,27 @@ format_git_command() {
   done
 }
 
+is_exact_git_version_grammar() {
+  [ "$#" -eq 1 ] || return 1
+  case "${1}" in
+    version|--version) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_exact_git_init_grammar() {
+  [ "${1:-}" = "init" ] || return 1
+  case "$#" in
+    1) return 0 ;;
+    2)
+      case "${2}" in
+        -q|--quiet) return 0 ;;
+      esac
+      ;;
+  esac
+  return 1
+}
+
 is_safe_local_command() {
   case "${1}" in
     ""|add|am|annotate|apply|bisect|blame|branch|cat-file|check-attr|check-ignore|check-mailmap|check-ref-format|checkout|cherry|cherry-pick|clean|commit|config|count-objects|describe|diff|difftool|fast-export|fast-import|format-patch|fsck|gc|grep|hash-object|log|ls-files|ls-tree|merge|merge-base|merge-file|merge-index|merge-tree|mv|name-rev|notes|pack-objects|prune|read-tree|rebase|reflog|reset|restore|rev-list|rev-parse|rm|show|show-branch|sparse-checkout|stash|status|switch|symbolic-ref|tag|update-index|update-ref|verify-commit|verify-pack|verify-tag|worktree|write-tree)
@@ -425,10 +450,11 @@ if [ "${CSA_GIT_PUSH_ALLOWED:-}" != "true" ]; then
     exit "${push_status}"
   fi
 
-  # A publication-capable plumbing command or unknown external subcommand can
-  # bypass literal `push` interception. Permit only common local-only Git
-  # commands; all other command surfaces are denied while leaf pushes are off.
-  if ! is_safe_local_command "${COMMAND}"; then
+  # Closed probes and local fixture bootstrap forms are admitted only with their
+  # exact argv; path/config steering and extra operands still fail closed.
+  if ! is_exact_git_version_grammar "$@" \
+    && ! is_exact_git_init_grammar "$@" \
+    && ! is_safe_local_command "${COMMAND}"; then
     block_untrusted_git_command "$@"
   fi
 fi

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -232,6 +232,11 @@ reset_hermetic_git_environment() {
     unset "${env_name}" || true
   done
 
+  export GIT_CONFIG_NOSYSTEM=1
+  export GIT_CONFIG_SYSTEM=/dev/null
+  export GIT_CONFIG_GLOBAL=/dev/null
+  export XDG_CONFIG_HOME=/dev/null
+
   trusted_exec_path="$("${REAL_GIT}" --exec-path 2>/dev/null)" || return 1
   case "${trusted_exec_path}" in
     /*) ;;
@@ -239,10 +244,6 @@ reset_hermetic_git_environment() {
   esac
   trusted_exec_path="$(canonical_directory "${trusted_exec_path}")" || return 1
 
-  export GIT_CONFIG_NOSYSTEM=1
-  export GIT_CONFIG_SYSTEM=/dev/null
-  export GIT_CONFIG_GLOBAL=/dev/null
-  export XDG_CONFIG_HOME=/dev/null
   export GIT_ALLOW_PROTOCOL=file
   export GIT_PROTOCOL_FROM_USER=0
   export GIT_EXEC_PATH="${trusted_exec_path}"

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -215,15 +215,20 @@ descriptor_path_for() {
 
 reset_hermetic_git_environment() {
   # Hermetic Git operations must not inherit caller-selected repository,
-  # template, config, protocol, or helper-routing inputs. Projected pushes also
-  # run from an empty temporary Git directory, excluding local remotes and URL
-  # rewrites from transport decisions.
+  # template, config, initialization defaults, trace output, protocol, or
+  # helper-routing inputs. Projected pushes also run from an empty temporary
+  # Git directory, excluding local remotes and URL rewrites from transport
+  # decisions.
   unset GIT_CONFIG GIT_CONFIG_PARAMETERS GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_NAMESPACE || true
   unset GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM GIT_TEMPLATE_DIR || true
   unset GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES || true
   unset GIT_EXEC_PATH GIT_SSH GIT_SSH_COMMAND GIT_SSH_VARIANT GIT_PROXY_COMMAND || true
   unset GIT_ASKPASS SSH_ASKPASS GIT_TRANSPORT_HELPER_DIR GIT_REMOTE_HELPER_DIR || true
-  for env_name in $(env | sed -n -e 's/^\(GIT_CONFIG_[A-Za-z0-9_]*\)=.*/\1/p'); do
+  for env_name in $(env | sed -n \
+    -e 's/^\(GIT_CONFIG_[A-Za-z0-9_]*\)=.*/\1/p' \
+    -e 's/^\(GIT_DEFAULT_[A-Za-z0-9_]*\)=.*/\1/p' \
+    -e 's/^\(GIT_TEST_DEFAULT_[A-Za-z0-9_]*\)=.*/\1/p' \
+    -e 's/^\(GIT_TRACE[A-Za-z0-9_]*\)=.*/\1/p'); do
     unset "${env_name}" || true
   done
 

--- a/crates/csa-hooks/src/git_guard_tests.rs
+++ b/crates/csa-hooks/src/git_guard_tests.rs
@@ -623,6 +623,8 @@ fn wrapper_allows_leading_dash_after_file_option() {
     );
 }
 
+include!("git_guard_tests_local_grammar.rs");
+
 #[cfg(unix)]
 #[test]
 fn wrapper_forwards_non_commit_commands() {

--- a/crates/csa-hooks/src/git_guard_tests_local_grammar.rs
+++ b/crates/csa-hooks/src/git_guard_tests_local_grammar.rs
@@ -200,6 +200,46 @@ exec "${GIT_GUARD_UNDER_TEST}" "$@"
 
 #[cfg(unix)]
 #[test]
+fn wrapper_isolates_exec_path_probe_from_global_trace2_config() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let home = temp.path().join("home");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&home).unwrap();
+    std::fs::create_dir(&repo).unwrap();
+    let trace = temp.path().join("external-trace2-event");
+    std::fs::write(
+        home.join(".gitconfig"),
+        format!("[trace2]\n\teventTarget = {}\n", trace.display()),
+    )
+    .unwrap();
+
+    let output = std::process::Command::new(&wrapper)
+        .arg("init")
+        .current_dir(&repo)
+        .env("CSA_REAL_GIT", "/usr/bin/git")
+        .env("HOME", &home)
+        .output_with_timeout()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(repo.join(".git").is_dir(), "exact local init did not run");
+    assert!(
+        !trace.exists(),
+        "exec-path probe wrote hostile global Trace2 target: {}",
+        trace.display()
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn wrapper_rejects_git_init_option_smuggling() {
     let _lock = ENV_LOCK.lock().expect("env lock poisoned");
     let temp = tempfile::tempdir().unwrap();

--- a/crates/csa-hooks/src/git_guard_tests_local_grammar.rs
+++ b/crates/csa-hooks/src/git_guard_tests_local_grammar.rs
@@ -134,6 +134,72 @@ exec "${GIT_GUARD_UNDER_TEST}" "$@"
 
 #[cfg(unix)]
 #[test]
+fn wrapper_scrubs_init_defaults_and_trace_environment() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let control_repo = temp.path().join("control");
+    let hostile_repo = temp.path().join("hostile");
+    std::fs::create_dir(&control_repo).unwrap();
+    std::fs::create_dir(&hostile_repo).unwrap();
+
+    let control = std::process::Command::new(&wrapper)
+        .arg("init")
+        .current_dir(&control_repo)
+        .env("CSA_REAL_GIT", "/usr/bin/git")
+        .output_with_timeout()
+        .unwrap();
+    assert!(
+        control.status.success(),
+        "control: {}",
+        String::from_utf8_lossy(&control.stderr)
+    );
+
+    let trace = temp.path().join("external-git-trace");
+    let launcher = temp.path().join("launch-hostile-git-guard");
+    write_executable(
+        &launcher,
+        r#"#!/bin/sh
+set -eu
+export GIT_DEFAULT_HASH=sha256
+export GIT_DEFAULT_REF_FORMAT=reftable
+export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=hostile-branch
+export GIT_TRACE="${HOSTILE_GIT_TRACE}"
+export GIT_TRACE2_EVENT="${HOSTILE_GIT_TRACE}"
+exec "${GIT_GUARD_UNDER_TEST}" "$@"
+"#,
+    );
+    let hostile = std::process::Command::new(&launcher)
+        .arg("init")
+        .current_dir(&hostile_repo)
+        .env("CSA_REAL_GIT", "/usr/bin/git")
+        .env("GIT_GUARD_UNDER_TEST", &wrapper)
+        .env("HOSTILE_GIT_TRACE", &trace)
+        .output_with_timeout()
+        .unwrap();
+    assert!(
+        hostile.status.success(),
+        "hostile: {}",
+        String::from_utf8_lossy(&hostile.stderr)
+    );
+
+    let format_changed = std::fs::read(control_repo.join(".git/config")).unwrap()
+        != std::fs::read(hostile_repo.join(".git/config")).unwrap();
+    let branch_changed = std::fs::read(control_repo.join(".git/HEAD")).unwrap()
+        != std::fs::read(hostile_repo.join(".git/HEAD")).unwrap();
+    let trace_written = trace.exists();
+    assert!(
+        !format_changed && !branch_changed && !trace_written,
+        "hostile Git environment altered exact local init: \
+         format_changed={format_changed}, branch_changed={branch_changed}, \
+         trace_written={trace_written}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn wrapper_rejects_git_init_option_smuggling() {
     let _lock = ENV_LOCK.lock().expect("env lock poisoned");
     let temp = tempfile::tempdir().unwrap();

--- a/crates/csa-hooks/src/git_guard_tests_local_grammar.rs
+++ b/crates/csa-hooks/src/git_guard_tests_local_grammar.rs
@@ -7,7 +7,10 @@ fn wrapper_allows_exact_git_version_grammar() {
     write_executable(&wrapper, git_wrapper_script());
 
     let fake_git = temp.path().join("real-git");
-    write_executable(&fake_git, "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\"\n");
+    write_executable(
+        &fake_git,
+        "#!/usr/bin/env bash\nif [ \"${1:-}\" = --exec-path ]; then exec /usr/bin/git --exec-path; fi\nprintf '%s\\n' \"$*\"\n",
+    );
 
     for args in [&["version"][..], &["--version"][..]] {
         let output = std::process::Command::new(&wrapper)
@@ -38,7 +41,10 @@ fn wrapper_allows_exact_git_init_grammar() {
     write_executable(&wrapper, git_wrapper_script());
 
     let fake_git = temp.path().join("real-git");
-    write_executable(&fake_git, "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\"\n");
+    write_executable(
+        &fake_git,
+        "#!/usr/bin/env bash\nif [ \"${1:-}\" = --exec-path ]; then exec /usr/bin/git --exec-path; fi\nprintf '%s\\n' \"$*\"\n",
+    );
 
     for args in [&["init"][..], &["init", "-q"][..], &["init", "--quiet"][..]] {
         let output = std::process::Command::new(&wrapper)
@@ -58,6 +64,72 @@ fn wrapper_allows_exact_git_init_grammar() {
             args.join(" ")
         );
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_isolates_exact_git_init_from_hostile_environment() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let launcher = temp.path().join("launch-git-guard");
+    write_executable(
+        &launcher,
+        r#"#!/bin/sh
+set -eu
+case "${HOSTILE_GIT_FAMILY}" in
+  repository-path) export GIT_DIR="${HOSTILE_GIT_VALUE}" ;;
+  template) export GIT_TEMPLATE_DIR="${HOSTILE_GIT_VALUE}" ;;
+  config)
+    export GIT_CONFIG_COUNT=1
+    export GIT_CONFIG_KEY_0=init.templateDir
+    export GIT_CONFIG_VALUE_0="${HOSTILE_GIT_VALUE}"
+    ;;
+esac
+exec "${GIT_GUARD_UNDER_TEST}" "$@"
+"#,
+    );
+
+    let mut altered = Vec::new();
+    for family in ["repository-path", "template", "config"] {
+        let repo = temp.path().join(format!("repo-{family}"));
+        std::fs::create_dir(&repo).unwrap();
+        let hostile = temp.path().join(format!("hostile-{family}"));
+        if family != "repository-path" {
+            std::fs::create_dir(&hostile).unwrap();
+            std::fs::write(hostile.join("ambient-template-marker"), "hostile\n").unwrap();
+        }
+
+        let output = std::process::Command::new(&launcher)
+            .arg("init")
+            .current_dir(&repo)
+            .env("CSA_REAL_GIT", "/usr/bin/git")
+            .env("GIT_GUARD_UNDER_TEST", &wrapper)
+            .env("HOSTILE_GIT_FAMILY", family)
+            .env("HOSTILE_GIT_VALUE", &hostile)
+            .output_with_timeout()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{family}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let initialized_here = repo.join(".git").is_dir();
+        let escaped = family == "repository-path" && hostile.exists();
+        let template_applied = repo.join(".git/ambient-template-marker").exists();
+        if !initialized_here || escaped || template_applied {
+            altered.push(family);
+        }
+    }
+
+    assert!(
+        altered.is_empty(),
+        "hostile Git environment altered exact local init: {}",
+        altered.join(", ")
+    );
 }
 
 #[cfg(unix)]

--- a/crates/csa-hooks/src/git_guard_tests_local_grammar.rs
+++ b/crates/csa-hooks/src/git_guard_tests_local_grammar.rs
@@ -1,0 +1,152 @@
+#[cfg(unix)]
+#[test]
+fn wrapper_allows_exact_git_version_grammar() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\"\n");
+
+    for args in [&["version"][..], &["--version"][..]] {
+        let output = std::process::Command::new(&wrapper)
+            .args(args)
+            .env("CSA_REAL_GIT", &fake_git)
+            .output_with_timeout()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{}: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            args.join(" ")
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_allows_exact_git_init_grammar() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\"\n");
+
+    for args in [&["init"][..], &["init", "-q"][..], &["init", "--quiet"][..]] {
+        let output = std::process::Command::new(&wrapper)
+            .args(args)
+            .env("CSA_REAL_GIT", &fake_git)
+            .output_with_timeout()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{}: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            args.join(" ")
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_rejects_git_init_option_smuggling() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let marker = temp.path().join("fake-git-reached");
+    let fake_git = temp.path().join("real-git");
+    write_executable(
+        &fake_git,
+        "#!/usr/bin/env bash\nprintf reached > \"$FAKE_GIT_MARKER\"\nprintf '%s\\n' \"$*\"\n",
+    );
+
+    let cases: &[(&[&str], &[&str])] = &[
+        (&["init", "secret-operand"], &["secret-operand"]),
+        (&["init", "-q", "secret-operand"], &["secret-operand"]),
+        (&["init", "--quiet", "secret-operand"], &["secret-operand"]),
+        (&["init", "--bare"], &[]),
+        (
+            &["init", "--template=/tmp/secret-template"],
+            &["secret-template"],
+        ),
+        (
+            &["init", "--separate-git-dir=/tmp/secret-git-dir"],
+            &["secret-git-dir"],
+        ),
+        (
+            &["init", "--initial-branch=secret-branch"],
+            &["secret-branch"],
+        ),
+        (
+            &["-C", "/tmp/secret-worktree", "init"],
+            &["secret-worktree"],
+        ),
+        (
+            &["--git-dir=/tmp/secret-git-dir", "init"],
+            &["secret-git-dir"],
+        ),
+        (
+            &["-c", "alias.bootstrap=init", "bootstrap"],
+            &["alias.bootstrap=init", "bootstrap"],
+        ),
+        (&["version", "secret-extra"], &["secret-extra"]),
+        (&["--version", "secret-extra"], &["secret-extra"]),
+        (&["--version=secret-extra"], &["secret-extra"]),
+        (&["--version", "--help"], &[]),
+        (
+            &["-C", "/tmp/secret-worktree", "--version"],
+            &["secret-worktree"],
+        ),
+        (
+            &["--git-dir=/tmp/secret-git-dir", "--version"],
+            &["secret-git-dir"],
+        ),
+    ];
+
+    for (args, secrets) in cases {
+        let _ = std::fs::remove_file(&marker);
+        let output = std::process::Command::new(&wrapper)
+            .args(*args)
+            .env("CSA_REAL_GIT", &fake_git)
+            .env("FAKE_GIT_MARKER", &marker)
+            .output_with_timeout()
+            .unwrap();
+
+        assert_eq!(output.status.code(), Some(128), "{}", args.join(" "));
+        assert!(
+            String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+            "fake Git stdout for {}",
+            args.join(" ")
+        );
+        assert!(!marker.exists(), "fake Git reached for {}", args.join(" "));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("CSA git-guard: blocked command: git"),
+            "{}: {stderr}",
+            args.join(" ")
+        );
+        assert!(
+            stderr.contains("hermetic local bare fixture"),
+            "{}: {stderr}",
+            args.join(" ")
+        );
+        for secret in *secrets {
+            assert!(!stderr.contains(secret), "{secret} leaked in {stderr}");
+        }
+    }
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1139"
-weave = "0.1.1139"
+csa = "0.1.1140"
+weave = "0.1.1140"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Closes hermetic local Git fixture gaps in the CSA git guard and isolates admitted `git init` / version from hostile ambient Git environment (config, path, defaults, Trace2 env, and HOME/.gitconfig Trace2 targets).

## Issues

- Closes #3049
- Closes #3052
- Closes #3053
- Closes #3054
- Closes #3057

## Commits

- `71bfd3bd` fix(git-guard): allow hermetic local fixture setup
- `12260135` test(skill): initialize resource fixture git branch
- `4f326788` fix(git-guard): isolate admitted git init execution
- `7fe275f0` fix(git-guard): scrub init defaults and trace env
- `3bdc9dc5` fix(git-guard): isolate config before exec-path probe

## Verification

- Exact-HEAD `just pre-push` GREEN on `3bdc9dc5b370560b1f2486dc86363ef83506fefb` / tree `5c29e662bf4c2b22c81fe855cc660b9f3a6ba1d7`
- Log: `drafts/3054-3057-prepush-3bdc9dc5.log` sha256 `12600b1e6739a41417e0e93d59cd30d2df239f9a77cf33f0e7a60b9807d6d1fc`
- Live 4/4 + 4/4; Static 7525/7525 + 7555/7555
- CSA Tier-4 session `01KZVADH271B7QD690EZJADPHV` returned UNAVAILABLE (Codex quota until 2026-08-17); this is a no-verdict, not PASS/FAIL
- Authorized native clean-room Tier-4-equivalent review of the same exact HEAD: **VERDICT: PASS**, zero findings
- Report: `/home/obj/project/github/RyderFreeman4Logos/drafts/cli-sub-agent/3054-3057-native-tier4-report-3bdc9dc5.md`
- Report SHA-256: `5ea298ccf17c7a5c7dac59c53d09a6446e59f535d37410577059608409e6784e`
- Pre-push uses the documented narrow `CSA_SKIP_REVIEW_CHECK=1` review-check override because `csa review --check-verdict` cannot be satisfied while Codex is quota-unavailable

## Notes

- Production unknown/detached/protected-branch fail-closed behavior is unchanged.
- Does not weaken argv smuggling rejection.
- Native review is not a CSA Tier-4 verdict and does not satisfy `csa review --check-verdict`.
