### PR TITLE
fix(git-guard): allow read-only show-ref and ls-remote attestation

### DIFF
--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -1,10 +1,4 @@
-//! Git guard: deterministic gate preventing hook bypass on `git commit`.
-//!
-//! CSA tool subprocesses share the caller's `.git` directory, so Git hooks are
-//! the last deterministic local gate before an agent-created commit lands in
-//! the repository.  This module injects a `git` wrapper ahead of the real Git
-//! binary in `PATH`, strips hook-bypass inputs from commits, and blocks leaf
-//! worker pushes.
+//! Git wrapper that preserves commit hooks and blocks leaf-worker publication.
 
 use std::collections::HashMap;
 use std::fs;
@@ -214,11 +208,7 @@ descriptor_path_for() {
 }
 
 reset_hermetic_git_environment() {
-  # Hermetic Git operations must not inherit caller-selected repository,
-  # template, config, initialization defaults, trace output, protocol, or
-  # helper-routing inputs. Projected pushes also run from an empty temporary
-  # Git directory, excluding local remotes and URL rewrites from transport
-  # decisions.
+  # Remove caller-selected repository, config, and transport routing.
   unset GIT_CONFIG GIT_CONFIG_PARAMETERS GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_NAMESPACE || true
   unset GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM GIT_TEMPLATE_DIR || true
   unset GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES || true
@@ -250,10 +240,7 @@ reset_hermetic_git_environment() {
 }
 
 create_hermetic_push_projection() {
-  # Git has no switch to ignore only the source repository's config. Build a
-  # minimal, configless source snapshot instead: object alternates plus copied
-  # refs give real pack negotiation without allowing local remote/pushurl or
-  # URL-rewrite settings into the final invocation.
+  # Push from a configless ref snapshot backed by source object alternates.
   source_common_dir="$("${REAL_GIT}" rev-parse --git-common-dir 2>/dev/null)" || return 1
   source_common_dir="$(canonical_directory "${source_common_dir}")" || return 1
   source_objects="${source_common_dir}/objects"
@@ -286,9 +273,7 @@ cleanup_hermetic_push_projection() {
 }
 
 is_hermetic_local_bare_push() {
-  # Closed grammar for the one fixture exception: no global options, exactly
-  # `push <absolute-path|file:///local> <non-force-refspec...>`. Requiring a
-  # refspec also prevents repository push defaults from becoming policy input.
+  # Exact fixture grammar: push <absolute|file URL> <non-force-refspec...>.
   [ "${1:-}" = "push" ] || return 1
   [ "$#" -ge 3 ] || return 1
   destination="${2}"
@@ -330,9 +315,7 @@ is_hermetic_local_bare_push() {
     is_descendant_of "${destination_path}" "${project_root}" && return 1
   fi
 
-  # Keep both the fixture root and bare destination open. Re-canonicalizing
-  # their descriptor paths after open makes a concurrent symlink/rename swap
-  # fail closed; the transfer receives the pinned destination descriptor.
+  # Pin opened fixture paths against concurrent rename or symlink swaps.
   exec 8<"${fixture_root}" || return 1
   exec 9<"${destination_path}" || return 1
   fixture_root_descriptor="$(descriptor_path_for 8)" || return 1
@@ -413,6 +396,13 @@ is_exact_git_init_grammar() {
   return 1
 }
 
+is_head_ref() {
+  case "${1}" in
+    refs/heads/?*) "${REAL_GIT}" check-ref-format "${1}" >/dev/null 2>&1 ;;
+    *) return 1 ;;
+  esac
+}
+
 is_safe_local_command() {
   case "${1}" in
     ""|add|am|annotate|apply|bisect|blame|branch|cat-file|check-attr|check-ignore|check-mailmap|check-ref-format|checkout|cherry|cherry-pick|clean|commit|config|count-objects|describe|diff|difftool|fast-export|fast-import|format-patch|fsck|gc|grep|hash-object|log|ls-files|ls-tree|merge|merge-base|merge-file|merge-index|merge-tree|mv|name-rev|notes|pack-objects|prune|read-tree|rebase|reflog|reset|restore|rev-list|rev-parse|rm|show|show-branch|sparse-checkout|stash|status|switch|symbolic-ref|tag|update-index|update-ref|verify-commit|verify-pack|verify-tag|worktree|write-tree)
@@ -454,6 +444,30 @@ if [ "${CSA_GIT_PUSH_ALLOWED:-}" != "true" ]; then
     fi
     cleanup_hermetic_push_projection
     exit "${push_status}"
+  fi
+
+  if [ "$#" -eq 4 ] \
+    && [ "${1}" = "show-ref" ] \
+    && [ "${2}" = "--verify" ] \
+    && [ "${3}" = "--hash" ]; then
+    reset_hermetic_git_environment || block_untrusted_git_command "$@"
+    is_head_ref "${4}" || block_untrusted_git_command "$@"
+    exec "${REAL_GIT}" "$@"
+  fi
+
+  if [ "$#" -ge 4 ] && [ "${1}" = "ls-remote" ] && [ "${2}" = "--heads" ]; then
+    remote="${3}"
+    has_control_bytes "${remote}" && block_untrusted_git_command "$@"
+    case "${remote}" in
+      ""|-*) block_untrusted_git_command "$@" ;;
+    esac
+    shift 3
+    reset_hermetic_git_environment || block_untrusted_git_command "$@"
+    for reference do
+      is_head_ref "${reference}" || block_untrusted_git_command "$@"
+    done
+    export GIT_ALLOW_PROTOCOL=file:https
+    exec "${REAL_GIT}" ls-remote --upload-pack=git-upload-pack --heads "${remote}" "$@"
   fi
 
   # Closed probes and local fixture bootstrap forms are admitted only with their

--- a/crates/csa-hooks/src/git_guard_tests_local_grammar.rs
+++ b/crates/csa-hooks/src/git_guard_tests_local_grammar.rs
@@ -68,6 +68,246 @@ fn wrapper_allows_exact_git_init_grammar() {
 
 #[cfg(unix)]
 #[test]
+fn wrapper_allows_exact_show_ref_attestation() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(
+        &fake_git,
+        "#!/usr/bin/env bash\nif [ \"${1:-}\" = --exec-path ]; then exec /usr/bin/git --exec-path; fi\nprintf '%s\\n' \"$*\"\n",
+    );
+    let args = [
+        "show-ref",
+        "--verify",
+        "--hash",
+        "refs/heads/feat/comp-003-closed-operators",
+    ];
+
+    let output = std::process::Command::new(&wrapper)
+        .args(args)
+        .env("CSA_REAL_GIT", &fake_git)
+        .output_with_timeout()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        args.join(" ")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_allows_exact_ls_remote_attestation_with_pinned_upload_pack() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let repo = temp.path().join("repo");
+    init_worktree_repo(&repo);
+    let remote = temp.path().join("remote.git");
+    init_bare_repo(temp.path(), &remote);
+    run_git(
+        &repo,
+        &[
+            "push",
+            remote.to_str().expect("UTF-8 remote path"),
+            "HEAD:refs/heads/main",
+        ],
+    );
+    run_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            remote.to_str().expect("UTF-8 remote path"),
+        ],
+    );
+
+    let hostile_upload_pack = temp.path().join("hostile-upload-pack");
+    let hostile_marker = temp.path().join("hostile-upload-pack-ran");
+    write_executable(
+        &hostile_upload_pack,
+        "#!/usr/bin/env bash\nprintf reached > \"$HOSTILE_UPLOAD_PACK_MARKER\"\nexit 99\n",
+    );
+    run_git(
+        &repo,
+        &[
+            "config",
+            "remote.origin.uploadpack",
+            hostile_upload_pack
+                .to_str()
+                .expect("UTF-8 hostile upload-pack path"),
+        ],
+    );
+
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "ls-remote",
+            "--heads",
+            "origin",
+            "refs/heads/main",
+            "refs/heads/feat/comp-003-closed-operators",
+        ])
+        .current_dir(&repo)
+        .env("CSA_REAL_GIT", "/usr/bin/git")
+        .env("HOSTILE_UPLOAD_PACK_MARKER", &hostile_marker)
+        .output_with_timeout()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("refs/heads/main"),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        !hostile_marker.exists(),
+        "named remote upload-pack override escaped the guard"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_rejects_read_only_attestation_smuggling() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let marker = temp.path().join("fake-git-reached");
+    let fake_git = temp.path().join("real-git");
+    write_executable(
+        &fake_git,
+        r#"#!/usr/bin/env bash
+case "${1:-}" in
+  --exec-path) exec /usr/bin/git --exec-path ;;
+  check-ref-format) exec /usr/bin/git "$@" ;;
+esac
+printf reached > "$FAKE_GIT_MARKER"
+printf '%s\n' "$*"
+"#,
+    );
+
+    let cases: &[&[&str]] = &[
+        &[
+            "show-ref",
+            "--verify",
+            "--hash",
+            "refs/heads/main",
+            "refs/heads/extra",
+        ],
+        &["show-ref", "--verify", "-s", "refs/heads/main"],
+        &["show-ref", "--verify", "--hash", "--"],
+        &[
+            "show-ref",
+            "--verify",
+            "--hash",
+            "refs/heads/main:refs/heads/dest",
+        ],
+        &["show-ref", "--verify", "--hash", "refs/tags/main"],
+        &["show-ref", "--verify", "--hash", "refs/heads/bad..name"],
+        &[
+            "show-ref",
+            "--verify",
+            "--hash",
+            "refs/heads/main",
+            "--exclude-existing",
+        ],
+        &["show-ref", "--unknown", "--hash", "refs/heads/main"],
+        &[
+            "-c",
+            "alias.attest=show-ref",
+            "attest",
+            "--verify",
+            "--hash",
+            "refs/heads/main",
+        ],
+        &["ls-remote", "--heads", "origin"],
+        &["ls-remote", "--heads", "origin", "refs/heads/main", "extra"],
+        &[
+            "ls-remote",
+            "--upload-pack=/tmp/evil",
+            "--heads",
+            "origin",
+            "refs/heads/main",
+        ],
+        &[
+            "ls-remote",
+            "--upload-pack",
+            "/tmp/evil",
+            "--heads",
+            "origin",
+            "refs/heads/main",
+        ],
+        &[
+            "ls-remote",
+            "--heads",
+            "origin",
+            "refs/heads/main:refs/heads/dest",
+        ],
+        &["ls-remote", "--heads", "origin", "HEAD:refs/heads/dest"],
+        &["ls-remote", "--heads", "origin", "refs/heads/*"],
+        &["ls-remote", "--heads", "origin", "--"],
+        &[
+            "-c",
+            "remote.origin.uploadpack=/tmp/evil",
+            "ls-remote",
+            "--heads",
+            "origin",
+            "refs/heads/main",
+        ],
+        &[
+            "-c",
+            "alias.attest=ls-remote",
+            "attest",
+            "--heads",
+            "origin",
+            "refs/heads/main",
+        ],
+        &["ls-remote", "--unknown", "origin", "refs/heads/main"],
+    ];
+
+    for args in cases {
+        let _ = std::fs::remove_file(&marker);
+        let output = std::process::Command::new(&wrapper)
+            .args(*args)
+            .env("CSA_REAL_GIT", &fake_git)
+            .env("FAKE_GIT_MARKER", &marker)
+            .output_with_timeout()
+            .unwrap();
+
+        assert_eq!(output.status.code(), Some(128), "{}", args.join(" "));
+        assert!(
+            String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+            "fake Git stdout for {}",
+            args.join(" ")
+        );
+        assert!(!marker.exists(), "fake Git reached for {}", args.join(" "));
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("CSA git-guard: blocked command: git"),
+            "{}: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
 fn wrapper_isolates_exact_git_init_from_hostile_environment() {
     let _lock = ENV_LOCK.lock().expect("env lock poisoned");
     let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Allows fail-closed read-only Git attestation through the CSA git-guard: exact `git show-ref --verify --hash refs/heads/<name>` and exact `git ls-remote --heads` with validated head refs. Named remotes can only select a read source URL; `--upload-pack` is pinned; only `file`/`https` transports are admitted. Does not weaken push protection or hermetic init/version isolation.

## Issues

- Closes #3058

## Verification

- Exact-HEAD `just pre-push` GREEN on `220b9e7bf33f12bdc3f4665e3550d267fd80a360` / tree `4b3927b373d4585d3253fd11cede831cc0d0ada0`
- Log: `drafts/3058-prepush-220b9e7b.log` sha256 `f310077a2112ae34cdb053f840b7dbff7ccd00ab1b1709bbe4f5fd60e3d7a4ea`
- Live 4/4 + 4/4; Static 7528/7528 + 7558/7558
- CSA Codex quota-unavailable until 2026-08-17; authorized native clean-room Tier-4-equivalent review **VERDICT: PASS**, zero findings
- Report: `/home/obj/project/github/RyderFreeman4Logos/drafts/cli-sub-agent/3058-native-tier4-report-220b9e7b.md`
- Report SHA-256: `4338aa5d0d6536d324ef01a1635c7bf68ff3e2cb57648f830b883032d9a92bbe`
- Pre-push uses documented narrow `CSA_SKIP_REVIEW_CHECK=1` because `csa review --check-verdict` cannot be satisfied while Codex is quota-unavailable

## Notes

- Native review is not a CSA Tier-4 verdict.
- `origin` remains a read-source selector only; push/send-pack/receive-pack stay blocked.
