### PR TITLE
fix(sandbox): expose linked worktree Git admin paths

### DIFF
--- a/crates/cli-sub-agent/src/pipeline_sandbox.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox.rs
@@ -281,7 +281,8 @@ fn resolve_sandbox_options_with_capability_source(
                 defaults.memory_swap_max_mb,
                 None, // pids_max not available from profile defaults
             )
-            .with_readonly_project_root(readonly_project_root);
+            .with_readonly_project_root(readonly_project_root)
+            .with_project_root(project_root);
         if let Some(session_dir) = runtime_session_dir.as_deref() {
             builder = builder.with_tool_defaults_and_state_dirs(
                 tool_name,
@@ -337,9 +338,10 @@ fn resolve_sandbox_options_with_capability_source(
             }
         }
 
-        let plan = builder
-            .build()
-            .expect("BestEffort IsolationPlan should never fail");
+        let plan = match spawn_admission::build_isolation_plan(builder, tool_name) {
+            Ok(plan) => plan,
+            Err(message) => return SandboxResolution::RequiredButUnavailable(message),
+        };
         if let Some(message) =
             memory_override::plan_error_if_unenforced(tool_name, has_explicit_cli_memory_max, &plan)
         {
@@ -483,6 +485,7 @@ fn resolve_sandbox_options_with_capability_source(
         .with_filesystem_capability(fs_cap)
         .with_resource_limits(Some(memory_max_mb), memory_swap_max_mb, pids_max)
         .with_readonly_project_root(effective_readonly)
+        .with_project_root(project_root)
         .with_soft_limit_percent(cfg.resources.soft_limit_percent)
         .with_memory_monitor_interval(cfg.resources.memory_monitor_interval_seconds);
     if let Some(session_dir) = runtime_session_dir.as_deref() {
@@ -580,15 +583,9 @@ fn resolve_sandbox_options_with_capability_source(
         }
     }
 
-    let plan = builder.build();
-
-    let plan = match plan {
-        Ok(p) => p,
-        Err(e) => {
-            return SandboxResolution::RequiredButUnavailable(format!(
-                "Failed to build isolation plan for tool '{tool_name}': {e}"
-            ));
-        }
+    let plan = match spawn_admission::build_isolation_plan(builder, tool_name) {
+        Ok(plan) => plan,
+        Err(message) => return SandboxResolution::RequiredButUnavailable(message),
     };
     if let Some(message) =
         memory_override::plan_error_if_unenforced(tool_name, has_explicit_cli_memory_max, &plan)

--- a/crates/cli-sub-agent/src/pipeline_sandbox_spawn_admission.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_spawn_admission.rs
@@ -1,7 +1,22 @@
-//! Spawn-admission helpers derived from a resolved sandbox plan.
+//! Sandbox plan construction and spawn-admission helpers.
 
 use csa_executor::ExecuteOptions;
-use csa_resource::ResourceCapability;
+use csa_resource::{
+    ResourceCapability,
+    isolation_plan::{IsolationPlan, IsolationPlanBuilder},
+};
+
+pub(super) fn build_isolation_plan(
+    builder: IsolationPlanBuilder,
+    tool_name: &str,
+) -> Result<IsolationPlan, String> {
+    builder.build().map_err(|error| {
+        format!(
+            "Failed to build isolation plan for tool '{tool_name}': {error}. \
+             Repair the reported sandbox path or pass --no-fs-sandbox to disable filesystem isolation."
+        )
+    })
+}
 
 /// Resource capability from the resolved sandbox plan used for spawn admission.
 pub(crate) fn resource_capability_for_spawn_admission(

--- a/crates/cli-sub-agent/src/pipeline_sandbox_writable_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_writable_tests.rs
@@ -142,7 +142,90 @@ enforcement_mode = "best-effort"
     assert!(writer_paths.contains(&git_dir), "missing {git_dir:?}");
     assert!(writer_paths.contains(&common_dir), "missing {common_dir:?}");
 
+    let pre_session = resolve_sandbox_options_with_capability_source(
+        SandboxResolveInput {
+            config: Some(&cfg),
+            tool_name: "opencode",
+            session_id: "pre-session",
+            project_root: &worktree,
+            stream_mode: StreamMode::BufferOnly,
+            idle_timeout_seconds: 120,
+            liveness_dead_seconds: 600,
+            initial_response_timeout_seconds: Some(120),
+            no_fs_sandbox: false,
+            allow_user_daemon_ipc: false,
+            readonly_project_root: false,
+            extra_writable: &[],
+            extra_readable: &[],
+            execution_env: None,
+        },
+        RunResourceOverrides::absent(),
+        || csa_resource::ResourceCapability::Setrlimit,
+        || csa_resource::FilesystemCapability::Bwrap,
+        None,
+    );
+    let SandboxResolution::Ok(options) = pre_session else {
+        panic!("linked-worktree pre-session sandbox should resolve");
+    };
+    let pre_session_paths = options
+        .sandbox
+        .expect("pre-session sandbox context")
+        .isolation_plan
+        .writable_paths;
+    assert!(pre_session_paths.contains(&git_dir), "missing {git_dir:?}");
+    assert!(
+        pre_session_paths.contains(&common_dir),
+        "missing {common_dir:?}"
+    );
+
     let reader_paths = resolve(true, "reader");
     assert!(!reader_paths.contains(&git_dir));
     assert!(!reader_paths.contains(&common_dir));
+}
+
+#[test]
+fn no_config_pre_session_linked_worktree_admin_failure_is_actionable() {
+    let temp = tempfile::tempdir().expect("linked-worktree fixture");
+    let worktree = temp.path().join("linked");
+    let missing_git_dir = temp.path().join("main/.git/worktrees/missing");
+    std::fs::create_dir_all(&worktree).expect("linked worktree");
+    std::fs::write(
+        worktree.join(".git"),
+        format!("gitdir: {}\n", missing_git_dir.display()),
+    )
+    .expect("linked .git file");
+
+    let result = resolve_sandbox_options_with_capability_source(
+        SandboxResolveInput {
+            config: None,
+            tool_name: "claude-code",
+            session_id: "pre-session",
+            project_root: &worktree,
+            stream_mode: StreamMode::BufferOnly,
+            idle_timeout_seconds: 120,
+            liveness_dead_seconds: 600,
+            initial_response_timeout_seconds: Some(120),
+            no_fs_sandbox: false,
+            allow_user_daemon_ipc: false,
+            readonly_project_root: false,
+            extra_writable: &[],
+            extra_readable: &[],
+            execution_env: None,
+        },
+        RunResourceOverrides::absent(),
+        || csa_resource::ResourceCapability::Setrlimit,
+        || csa_resource::FilesystemCapability::Bwrap,
+        None,
+    );
+    let SandboxResolution::RequiredButUnavailable(message) = result else {
+        panic!("invalid linked-worktree admin path must fail before session creation");
+    };
+    assert!(
+        message.contains(&missing_git_dir.display().to_string()),
+        "missing failing Git admin path: {message}"
+    );
+    assert!(
+        message.contains("--no-fs-sandbox"),
+        "missing supported recovery action: {message}"
+    );
 }

--- a/crates/cli-sub-agent/src/pipeline_sandbox_writable_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_writable_tests.rs
@@ -62,3 +62,87 @@ enforcement_mode = "best-effort"
         "extra_writable uses APPEND semantics; project root stays writable"
     );
 }
+
+#[test]
+fn linked_worktree_git_admin_is_writable_only_for_writer_sandboxes() {
+    let temp = tempfile::tempdir().expect("linked-worktree fixture");
+    let worktree = temp.path().join("linked");
+    let common_git_dir = temp.path().join("main/.git");
+    let worktree_git_dir = common_git_dir.join("worktrees/linked");
+    std::fs::create_dir_all(common_git_dir.join("objects")).expect("common objects");
+    std::fs::create_dir_all(common_git_dir.join("refs/heads")).expect("common refs");
+    std::fs::create_dir_all(&worktree_git_dir).expect("worktree gitdir");
+    std::fs::create_dir_all(&worktree).expect("linked worktree");
+    std::fs::write(
+        worktree.join(".git"),
+        format!("gitdir: {}\n", worktree_git_dir.display()),
+    )
+    .expect("linked .git file");
+    std::fs::write(worktree_git_dir.join("commondir"), "../..\n").expect("commondir");
+    std::fs::write(worktree_git_dir.join("HEAD"), "ref: refs/heads/linked\n")
+        .expect("worktree HEAD");
+    std::fs::write(
+        worktree_git_dir.join("gitdir"),
+        format!("{}\n", worktree.join(".git").display()),
+    )
+    .expect("gitdir backlink");
+    std::fs::write(common_git_dir.join("HEAD"), "ref: refs/heads/main\n").expect("common HEAD");
+    std::fs::write(
+        common_git_dir.join("config"),
+        format!(
+            "[core]\n\trepositoryformatversion = 0\n\tbare = false\n\tworktree = {}\n",
+            worktree.display()
+        ),
+    )
+    .expect("common config");
+
+    let cfg: csa_config::ProjectConfig = toml::from_str(
+        r#"
+[resources]
+memory_max_mb = 2048
+enforcement_mode = "best-effort"
+"#,
+    )
+    .expect("test TOML should parse");
+    let resolve = |readonly_project_root, session_id| {
+        let result = resolve_sandbox_options_with_capabilities(
+            SandboxResolveInput {
+                config: Some(&cfg),
+                tool_name: "opencode",
+                session_id,
+                project_root: &worktree,
+                stream_mode: StreamMode::BufferOnly,
+                idle_timeout_seconds: 120,
+                liveness_dead_seconds: 600,
+                initial_response_timeout_seconds: Some(120),
+                no_fs_sandbox: false,
+                allow_user_daemon_ipc: false,
+                readonly_project_root,
+                extra_writable: &[],
+                extra_readable: &[],
+                execution_env: None,
+            },
+            RunResourceOverrides::absent(),
+            csa_resource::ResourceCapability::Setrlimit,
+            csa_resource::FilesystemCapability::Bwrap,
+        );
+        let SandboxResolution::Ok(options) = result else {
+            panic!("linked-worktree sandbox should resolve");
+        };
+        options
+            .sandbox
+            .expect("sandbox context")
+            .isolation_plan
+            .writable_paths
+    };
+
+    let git_dir = worktree_git_dir.canonicalize().expect("canonical gitdir");
+    let common_dir = common_git_dir.canonicalize().expect("canonical common dir");
+    let writer_paths = resolve(false, "writer");
+    assert!(writer_paths.contains(&git_dir), "missing {git_dir:?}");
+    assert!(writer_paths.contains(&common_dir), "missing {common_dir:?}");
+
+    let reader_paths = resolve(true, "reader");
+    assert!(!reader_paths.contains(&git_dir));
+    assert!(!reader_paths.contains(&common_dir));
+}

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -211,6 +211,12 @@ impl IsolationPlanBuilder {
         self
     }
 
+    /// Record the project root without applying session-owned runtime defaults.
+    pub fn with_project_root(mut self, project_root: &Path) -> Self {
+        self.project_root = Some(project_root.to_path_buf());
+        self
+    }
+
     /// Set the soft memory limit percentage for the memory monitor.
     pub fn with_soft_limit_percent(mut self, percent: Option<u8>) -> Self {
         self.soft_limit_percent = percent;

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -490,6 +490,15 @@ impl IsolationPlanBuilder {
             );
         }
 
+        if self.filesystem != FilesystemCapability::None
+            && !self.readonly_project_root
+            && let Some(project_root) = self.project_root.as_deref()
+            && let Some([git_dir, common_dir]) =
+                runtime_path::linked_worktree_git_admin_dirs(project_root)?
+        {
+            self.writable_paths.extend([common_dir, git_dir]);
+        }
+
         self.add_runtime_daemon_socket_readable_paths();
 
         codex_paths::validate_required_writable_dirs(

--- a/crates/csa-resource/src/isolation_plan_runtime_path.rs
+++ b/crates/csa-resource/src/isolation_plan_runtime_path.rs
@@ -88,7 +88,28 @@ pub(super) fn detect_superproject_root(project_root: &Path) -> Option<PathBuf> {
 pub(super) fn linked_worktree_git_admin_dirs(
     project_root: &Path,
 ) -> anyhow::Result<Option<[PathBuf; 2]>> {
-    if !project_root.join(".git").is_file() {
+    let dot_git = project_root.join(".git");
+    if !dot_git.is_file() {
+        return Ok(None);
+    }
+
+    let marker = std::fs::read_to_string(&dot_git)?;
+    let mut marker_lines = marker.lines();
+    let (Some(marker), None) = (marker_lines.next(), marker_lines.next()) else {
+        anyhow::bail!("invalid Git directory marker '{}'", dot_git.display());
+    };
+    let Some(git_dir) = marker
+        .trim()
+        .strip_prefix("gitdir:")
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+    else {
+        anyhow::bail!("invalid Git directory marker '{}'", dot_git.display());
+    };
+    // Submodules also use .git files; linked-worktree gitdirs end in worktrees/<id>.
+    if Path::new(git_dir).parent().and_then(Path::file_name)
+        != Some(std::ffi::OsStr::new("worktrees"))
+    {
         return Ok(None);
     }
 

--- a/crates/csa-resource/src/isolation_plan_runtime_path.rs
+++ b/crates/csa-resource/src/isolation_plan_runtime_path.rs
@@ -85,6 +85,58 @@ pub(super) fn detect_superproject_root(project_root: &Path) -> Option<PathBuf> {
     None
 }
 
+pub(super) fn linked_worktree_git_admin_dirs(
+    project_root: &Path,
+) -> anyhow::Result<Option<[PathBuf; 2]>> {
+    if !project_root.join(".git").is_file() {
+        return Ok(None);
+    }
+
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args([
+            "rev-parse",
+            "--absolute-git-dir",
+            "--path-format=absolute",
+            "--git-common-dir",
+        ])
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "failed to resolve Git admin paths for linked worktree '{}': {}",
+            project_root.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let paths = String::from_utf8_lossy(&output.stdout);
+    let mut paths = paths.lines().map(PathBuf::from);
+    let (Some(git_dir), Some(common_dir), None) = (paths.next(), paths.next(), paths.next()) else {
+        anyhow::bail!(
+            "git rev-parse returned invalid admin paths for linked worktree '{}'",
+            project_root.display()
+        );
+    };
+    let git_dir = git_dir.canonicalize()?;
+    let common_dir = common_dir.canonicalize()?;
+    if git_dir == common_dir {
+        return Ok(None);
+    }
+    if is_sensitive_system_path(&common_dir) || !git_dir.starts_with(common_dir.join("worktrees")) {
+        anyhow::bail!(
+            "refusing unsafe linked-worktree Git admin paths '{}' and '{}'",
+            git_dir.display(),
+            common_dir.display()
+        );
+    }
+
+    Ok(Some([git_dir, common_dir]))
+}
+
 /// Reject paths under sensitive system directories that should never be
 /// writable inside a sandbox.  Allows legitimate paths like home dirs,
 /// `/tmp`, `/usr/local/share/mise`, etc.


### PR DESCRIPTION
## Summary

Expose linked-worktree Git admin paths (`commondir` + per-worktree gitdir) to writable filesystem sandboxes so `git add`/`index.lock` can succeed. Read-only sandboxes get neither. Submodule `gitdir:` markers are not treated as linked worktrees. Pre-session discovery no longer depends on `runtime_session_dir`; fallible BestEffort plan builds fail closed with `RequiredButUnavailable` instead of panicking.

Closes #2820.

## Evidence

- HEAD: `5823db222743f1fe5ff87be8a8b0b52d41aade10`
- Tree: `306c3893b2aa1402c91b4539ce83b089adb309f8`
- Base: `d9f1bcc6d20835486b253c41a88a86036cdf438b`
- Exact-HEAD `just pre-push` GREEN: `drafts/cli-sub-agent/2820-prepush-5823db22.log` SHA-256 `04f166902b156b7d8691e533f76a0167df4dc85947bcba823ed2855e8ef32740` (`7562 passed, 7 skipped`)
- Native clean-room Tier-4-equivalent **PASS** (NOT a CSA verdict; Codex quota until 2026-08-17): `drafts/cli-sub-agent/2820-native-tier4-report-5823db22.md` SHA-256 `4ea0f1684797d3ea3a9509b1a6e5a47339ecb5b15a184e0cc140892723cacdb1`
- Prior FAIL on `56e49387` F1/F2 closed by successor. F3 real `git worktree add` fixture out of scope (repo forbids worktrees).

## Test plan

- [x] Focused writer-vs-readonly + pre-session + BestEffort fail-closed + submodule guard
- [x] Canonical exact-HEAD `just pre-push`
- [x] Native clean-room review of the explicit frozen range
