### PR TITLE
fix(review): parse and reconcile substantive prose findings

### DIFF
--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -77,24 +77,8 @@ pub(super) fn enforce_final_verdict_consistency(
         }
         canonical_findings.push(finding.clone());
     }
-    let mut unmatched_unlocated_structured_counts = zero_severity_counts();
-    for finding in &canonical_findings {
-        if finding.file_ranges.is_empty() && !finding_is_artifact_generation_placeholder(finding) {
-            *unmatched_unlocated_structured_counts
-                .entry(finding.severity.clone())
-                .or_insert(0) += 1;
-        }
-    }
     if !skip_prose_override {
         for finding in &prose_signals.findings {
-            if finding.file_ranges.is_empty()
-                && let Some(count) =
-                    unmatched_unlocated_structured_counts.get_mut(&finding.severity)
-                && *count > 0
-            {
-                *count -= 1;
-                continue;
-            }
             if canonical_findings
                 .iter()
                 .any(|existing| review_finding_payload_eq(existing, finding))

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -157,13 +157,22 @@ pub(super) fn enforce_final_verdict_consistency(
     let resume_to_fix_blocks_clean_recovery = resume_to_fix
         && !artifact_failure_reason_is_placeholder(artifact.failure_reason.as_deref())
         && !placeholder_findings_only;
+    let empty_fail_placeholder_allows_clean_recovery = artifact
+        .failure_reason
+        .as_deref()
+        .is_some_and(|reason| reason.trim() == EMPTY_FAIL_FINDINGS_ARTIFACT_REASON)
+        || (placeholder_findings_only
+            && findings_file.findings.first().is_some_and(|finding| {
+                finding
+                    .description
+                    .contains(EMPTY_FAIL_FINDINGS_ARTIFACT_REASON)
+            }));
 
     if clean_review_can_recover_to_pass(
         artifact,
         CleanReviewRecoverySignals {
             artifact_counts_clean: severity_counts_are_zero(&artifact.severity_counts)
-                || artifact_failure_reason_is_placeholder(artifact.failure_reason.as_deref())
-                || placeholder_findings_only,
+                || empty_fail_placeholder_allows_clean_recovery,
             has_structured_findings,
             has_prose_failure_evidence: has_hard_prose_failure_evidence,
             resume_to_fix: resume_to_fix_blocks_clean_recovery,

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -65,10 +65,12 @@ pub(super) fn enforce_final_verdict_consistency(
         || repair_prose_signals.checklist_violation_findings;
     let skip_prose_override =
         (extraction_confirmed_empty || synthetic_empty) && !has_prose_failure_evidence;
-    let findings_file = if findings_file.findings.is_empty()
+    let placeholder_findings_only =
+        findings_file_contains_only_artifact_generation_placeholder(&findings_file);
+    let prose_findings_recovered = (findings_file.findings.is_empty() || placeholder_findings_only)
         && !prose_signals.findings.is_empty()
-        && !skip_prose_override
-    {
+        && !skip_prose_override;
+    let findings_file = if prose_findings_recovered {
         let findings_file = FindingsFile {
             findings: prose_signals.findings.clone(),
         };
@@ -84,7 +86,7 @@ pub(super) fn enforce_final_verdict_consistency(
     };
 
     let placeholder_findings_only =
-        findings_file_contains_only_empty_fail_placeholder(&findings_file);
+        findings_file_contains_only_artifact_generation_placeholder(&findings_file);
     let effective_findings_empty = findings_file.findings.is_empty() || placeholder_findings_only;
     let findings_counts = if placeholder_findings_only {
         zero_severity_counts()
@@ -92,8 +94,11 @@ pub(super) fn enforce_final_verdict_consistency(
         severity_counts_from_review_findings(&findings_file.findings)
     };
     if !skip_prose_override {
-        artifact.severity_counts =
-            reconcile_counts_with_prose(artifact.severity_counts.clone(), &findings_counts);
+        artifact.severity_counts = if prose_findings_recovered {
+            findings_counts.clone()
+        } else {
+            reconcile_counts_with_prose(artifact.severity_counts.clone(), &findings_counts)
+        };
         artifact.severity_counts = reconcile_counts_with_prose(
             artifact.severity_counts.clone(),
             &prose_signals.severity_counts,
@@ -139,6 +144,16 @@ pub(super) fn enforce_final_verdict_consistency(
     let cross_dimension_blocker_mismatch = cross_dimension_blocker
         && !has_structured_findings
         && severity_counts_are_zero(&artifact.severity_counts);
+    let consistency_failure_persists = unparsed_findings_prose
+        || checklist_violation_mismatch
+        || cross_dimension_blocker_mismatch
+        || structured_mismatch;
+    if has_structured_findings
+        && !consistency_failure_persists
+        && artifact_failure_reason_is_placeholder(artifact.failure_reason.as_deref())
+    {
+        artifact.failure_reason = None;
+    }
     let resume_to_fix_blocks_clean_recovery = resume_to_fix
         && !artifact_failure_reason_is_placeholder(artifact.failure_reason.as_deref())
         && !placeholder_findings_only;
@@ -281,9 +296,7 @@ fn write_review_meta_preserving_extra(
         for (key, new_value) in updated {
             existing.insert(key.clone(), new_value.clone());
         }
-        if meta.decision == csa_core::types::ReviewDecision::Pass.as_str() {
-            remove_clean_pass_failure_keys(existing);
-        }
+        remove_absent_review_meta_failure_keys(existing, meta);
     } else {
         value = meta_value;
     }

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -18,7 +18,9 @@ use super::prose_signals::{
 };
 use super::review_meta_for_verdict_artifact;
 use super::text::zero_severity_counts;
-use crate::review_cmd::prose_findings::severity_counts_from_review_findings;
+use crate::review_cmd::prose_findings::{
+    review_finding_payload_eq, severity_counts_from_review_findings,
+};
 
 const PROSE_FINDINGS_UNPARSED_REASON: &str = "prose_findings_present_but_unparsed";
 const SEVERITY_FINDINGS_MISMATCH_REASON: &str = "severity_counts_findings_mismatch";
@@ -65,17 +67,39 @@ pub(super) fn enforce_final_verdict_consistency(
         || repair_prose_signals.checklist_violation_findings;
     let skip_prose_override =
         (extraction_confirmed_empty || synthetic_empty) && !has_prose_failure_evidence;
-    let placeholder_findings_only =
-        findings_file_contains_only_artifact_generation_placeholder(&findings_file);
-    let prose_findings_recovered = (findings_file.findings.is_empty() || placeholder_findings_only)
-        && !prose_signals.findings.is_empty()
-        && !skip_prose_override;
-    let findings_file = if prose_findings_recovered {
+    let mut canonical_findings = Vec::new();
+    for finding in &findings_file.findings {
+        if canonical_findings
+            .iter()
+            .any(|existing| review_finding_payload_eq(existing, finding))
+        {
+            continue;
+        }
+        canonical_findings.push(finding.clone());
+    }
+    if !skip_prose_override {
+        for finding in &prose_signals.findings {
+            if canonical_findings
+                .iter()
+                .any(|existing| review_finding_payload_eq(existing, finding))
+            {
+                continue;
+            }
+            canonical_findings.push(finding.clone());
+        }
+    }
+    if canonical_findings
+        .iter()
+        .any(|finding| !finding_is_artifact_generation_placeholder(finding))
+    {
+        canonical_findings.retain(|finding| !finding_is_artifact_generation_placeholder(finding));
+    }
+    let findings_file = if canonical_findings != findings_file.findings {
         let findings_file = FindingsFile {
-            findings: prose_signals.findings.clone(),
+            findings: canonical_findings,
         };
         write_findings_toml(session_dir, &findings_file)
-            .map_err(|error| anyhow::anyhow!("write prose-derived findings.toml: {error}"))?;
+            .map_err(|error| anyhow::anyhow!("write reconciled findings.toml: {error}"))?;
         let marker_path = session_dir
             .join("output")
             .join(super::super::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER);
@@ -94,15 +118,13 @@ pub(super) fn enforce_final_verdict_consistency(
         severity_counts_from_review_findings(&findings_file.findings)
     };
     if !skip_prose_override {
-        artifact.severity_counts = if prose_findings_recovered {
-            findings_counts.clone()
+        artifact.severity_counts = if effective_findings_empty {
+            let fallback_counts =
+                reconcile_counts_with_prose(artifact.severity_counts.clone(), &findings_counts);
+            reconcile_counts_with_prose(fallback_counts, &prose_signals.severity_counts)
         } else {
-            reconcile_counts_with_prose(artifact.severity_counts.clone(), &findings_counts)
+            findings_counts.clone()
         };
-        artifact.severity_counts = reconcile_counts_with_prose(
-            artifact.severity_counts.clone(),
-            &prose_signals.severity_counts,
-        );
     }
 
     let prose_grade = highest_prose_severity_grade(session_dir);

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -77,8 +77,24 @@ pub(super) fn enforce_final_verdict_consistency(
         }
         canonical_findings.push(finding.clone());
     }
+    let mut unmatched_unlocated_structured_counts = zero_severity_counts();
+    for finding in &canonical_findings {
+        if finding.file_ranges.is_empty() && !finding_is_artifact_generation_placeholder(finding) {
+            *unmatched_unlocated_structured_counts
+                .entry(finding.severity.clone())
+                .or_insert(0) += 1;
+        }
+    }
     if !skip_prose_override {
         for finding in &prose_signals.findings {
+            if finding.file_ranges.is_empty()
+                && let Some(count) =
+                    unmatched_unlocated_structured_counts.get_mut(&finding.severity)
+                && *count > 0
+            {
+                *count -= 1;
+                continue;
+            }
             if canonical_findings
                 .iter()
                 .any(|existing| review_finding_payload_eq(existing, finding))

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency_helpers.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency_helpers.rs
@@ -116,17 +116,21 @@ fn non_empty_str(value: &str) -> Option<&str> {
     (!value.is_empty()).then_some(value)
 }
 
+fn finding_is_artifact_generation_placeholder(finding: &ReviewFinding) -> bool {
+    finding.id == ARTIFACT_GENERATION_FINDING_ID
+        && finding.file_ranges.is_empty()
+        && finding
+            .description
+            .starts_with("Artifact generation failed:")
+}
+
 fn findings_file_contains_only_artifact_generation_placeholder(
     findings_file: &FindingsFile,
 ) -> bool {
     let [finding] = findings_file.findings.as_slice() else {
         return false;
     };
-    finding.id == ARTIFACT_GENERATION_FINDING_ID
-        && finding.file_ranges.is_empty()
-        && finding
-            .description
-            .starts_with("Artifact generation failed:")
+    finding_is_artifact_generation_placeholder(finding)
 }
 
 fn ensure_failed_verdict_findings_artifact(

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency_helpers.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency_helpers.rs
@@ -1,6 +1,15 @@
-fn remove_clean_pass_failure_keys(existing: &mut serde_json::Map<String, serde_json::Value>) {
-    for key in ["status_reason", "primary_failure", "failure_reason"] {
-        existing.remove(key);
+fn remove_absent_review_meta_failure_keys(
+    existing: &mut serde_json::Map<String, serde_json::Value>,
+    meta: &csa_session::ReviewSessionMeta,
+) {
+    for (key, absent) in [
+        ("status_reason", meta.status_reason.is_none()),
+        ("primary_failure", meta.primary_failure.is_none()),
+        ("failure_reason", meta.failure_reason.is_none()),
+    ] {
+        if absent {
+            existing.remove(key);
+        }
     }
 }
 
@@ -73,7 +82,8 @@ fn review_meta_has_hard_failure_evidence(meta: &csa_session::ReviewSessionMeta) 
     ) {
         return true;
     }
-    if non_empty(meta.status_reason.as_deref()).is_some()
+    if non_empty(meta.status_reason.as_deref())
+        .is_some_and(|reason| !artifact_failure_reason_is_placeholder(Some(reason)))
         || non_empty(meta.primary_failure.as_deref()).is_some()
         || meta
             .failure_reason
@@ -86,8 +96,15 @@ fn review_meta_has_hard_failure_evidence(meta: &csa_session::ReviewSessionMeta) 
     meta.fix_attempted && !meta.fix_clean_converged()
 }
 
-fn artifact_failure_reason_is_placeholder(reason: Option<&str>) -> bool {
-    reason.is_some_and(|reason| reason.trim() == EMPTY_FAIL_FINDINGS_ARTIFACT_REASON)
+pub(super) fn artifact_failure_reason_is_placeholder(reason: Option<&str>) -> bool {
+    reason.is_some_and(|reason| {
+        matches!(
+            reason.trim(),
+            EMPTY_FAIL_FINDINGS_ARTIFACT_REASON
+                | PROSE_FINDINGS_UNPARSED_REASON
+                | SEVERITY_FINDINGS_MISMATCH_REASON
+        )
+    })
 }
 
 fn non_empty(value: Option<&str>) -> Option<&str> {
@@ -99,7 +116,9 @@ fn non_empty_str(value: &str) -> Option<&str> {
     (!value.is_empty()).then_some(value)
 }
 
-fn findings_file_contains_only_empty_fail_placeholder(findings_file: &FindingsFile) -> bool {
+fn findings_file_contains_only_artifact_generation_placeholder(
+    findings_file: &FindingsFile,
+) -> bool {
     let [finding] = findings_file.findings.as_slice() else {
         return false;
     };
@@ -107,7 +126,7 @@ fn findings_file_contains_only_empty_fail_placeholder(findings_file: &FindingsFi
         && finding.file_ranges.is_empty()
         && finding
             .description
-            .contains(EMPTY_FAIL_FINDINGS_ARTIFACT_REASON)
+            .starts_with("Artifact generation failed:")
 }
 
 fn ensure_failed_verdict_findings_artifact(

--- a/crates/cli-sub-agent/src/review_cmd_output_meta.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_meta.rs
@@ -27,6 +27,16 @@ pub(in crate::review_cmd) fn review_meta_for_verdict_artifact(
     final_meta.verdict = artifact.verdict_legacy.clone();
     final_meta.exit_code =
         crate::verdict_exit_code::exit_code_from_review_decision(artifact.decision);
+    if meta.failure_reason.is_some()
+        || artifact.failure_reason.as_deref() != meta.status_reason.as_deref()
+    {
+        final_meta.failure_reason = artifact.failure_reason.clone();
+    }
+    if super::consistency::artifact_failure_reason_is_placeholder(meta.status_reason.as_deref())
+        && artifact.failure_reason.as_deref() != meta.status_reason.as_deref()
+    {
+        final_meta.status_reason = None;
+    }
     if artifact.decision == ReviewDecision::Pass {
         final_meta.status_reason = None;
         final_meta.primary_failure = None;

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -13,7 +13,7 @@ use super::text::{contains_blocking_issue_signal, zero_severity_counts};
 use crate::review_cmd::prose_findings::{
     FindingsSectionParse, classify_findings_section_body,
     extract_review_findings_from_prose_with_default, findings_section_bodies,
-    severity_counts_from_review_findings,
+    review_finding_payload_eq, severity_counts_from_review_findings,
 };
 
 #[derive(Debug, Clone)]
@@ -75,6 +75,7 @@ fn review_prose_signals_from_contents(
             default_unlabeled_severity.clone(),
         );
     }
+    signals.severity_counts = severity_counts_from_review_findings(&signals.findings);
 
     Ok(signals)
 }
@@ -200,9 +201,25 @@ fn record_review_prose_signal(
     signals.uncertain_conclusion |= detect_prose_uncertain_conclusion(content);
     let findings =
         extract_review_findings_from_prose_with_default(content, default_unlabeled_severity);
-    let counts = severity_counts_from_review_findings(&findings);
-    merge_severity_counts_add(&mut signals.severity_counts, &counts);
-    signals.findings.extend(findings);
+    for mut finding in findings {
+        if signals
+            .findings
+            .iter()
+            .any(|existing| review_finding_payload_eq(existing, &finding))
+        {
+            continue;
+        }
+        if finding.id.starts_with("prose-") {
+            let index = signals
+                .findings
+                .iter()
+                .filter(|existing| existing.id.starts_with("prose-"))
+                .count()
+                + 1;
+            finding.id = format!("prose-{index:03}");
+        }
+        signals.findings.push(finding);
+    }
 }
 
 fn classify_findings_sections(
@@ -362,15 +379,6 @@ fn token_looks_like_finding_id(token: &str) -> bool {
             || token.contains('_'))
 }
 
-fn merge_severity_counts_add(
-    target: &mut BTreeMap<Severity, u32>,
-    source: &BTreeMap<Severity, u32>,
-) {
-    for (severity, count) in source {
-        *target.entry(severity.clone()).or_insert(0) += *count;
-    }
-}
-
 pub(super) fn reconcile_counts_with_prose(
     mut structured_counts: BTreeMap<Severity, u32>,
     prose_counts: &BTreeMap<Severity, u32>,
@@ -419,5 +427,90 @@ mod tests {
             &review_contents(),
             candidate
         ));
+    }
+
+    #[test]
+    fn issue_2815_authoritative_findings_shrink_stale_verdict_counts() {
+        use csa_core::types::ReviewDecision;
+        use csa_session::{
+            FindingsFile, ReviewFinding, ReviewFindingFileRange, ReviewVerdictArtifact, Severity,
+        };
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_dir = temp.path();
+        std::fs::create_dir(session_dir.join("output")).expect("create output dir");
+        csa_session::persist_structured_output(
+            session_dir,
+            r#"<!-- CSA:SECTION:summary -->
+Review result: FAIL. One high and one medium finding remain.
+<!-- CSA:SECTION:summary:END -->
+<!-- CSA:SECTION:details -->
+## Findings
+1. [HIGH] High finding remains (`src/high.rs:10`).
+2. [MEDIUM] Medium finding remains (`src/medium.rs:20`).
+<!-- CSA:SECTION:details:END -->
+"#,
+        )
+        .expect("persist review prose");
+        let finding = |id: &str, severity, path: &str, start, description: &str| ReviewFinding {
+            id: id.to_string(),
+            severity,
+            file_ranges: vec![ReviewFindingFileRange {
+                path: path.to_string(),
+                start,
+                end: None,
+            }],
+            is_regression_of_commit: None,
+            suggested_test_scenario: None,
+            description: description.to_string(),
+        };
+        let expected = FindingsFile {
+            findings: vec![
+                finding(
+                    "structured-high",
+                    Severity::High,
+                    "src/high.rs",
+                    10,
+                    "High finding remains (`src/high.rs:10`).",
+                ),
+                finding(
+                    "structured-medium",
+                    Severity::Medium,
+                    "src/medium.rs",
+                    20,
+                    "Medium finding remains (`src/medium.rs:20`).",
+                ),
+            ],
+        };
+        csa_session::write_findings_toml(session_dir, &expected).expect("write findings");
+        let mut verdict = ReviewVerdictArtifact::from_parts(
+            "01TEST2815EXACTCOUNTS00".to_string(),
+            ReviewDecision::Fail,
+            "HAS_ISSUES",
+            &[],
+            Vec::new(),
+        );
+        verdict.severity_counts.insert(Severity::High, 7);
+        verdict.severity_counts.insert(Severity::Medium, 9);
+        csa_session::write_review_verdict(session_dir, &verdict).expect("write verdict");
+
+        assert!(
+            super::super::consistency::repair_clean_empty_fail_review_verdict(session_dir)
+                .expect("repair verdict")
+        );
+
+        let persisted: FindingsFile = toml::from_str(
+            &std::fs::read_to_string(session_dir.join("output/findings.toml"))
+                .expect("read findings"),
+        )
+        .expect("parse findings");
+        assert_eq!(persisted.findings, expected.findings);
+        let verdict: ReviewVerdictArtifact = serde_json::from_str(
+            &std::fs::read_to_string(session_dir.join("output/review-verdict.json"))
+                .expect("read verdict"),
+        )
+        .expect("parse verdict");
+        assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+        assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
     }
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_1852_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_1852_tests.rs
@@ -27,6 +27,65 @@ fn high_count(artifact: &ReviewVerdictArtifact) -> u32 {
         .unwrap_or(0)
 }
 
+const STRUCTURED_HIGH_DESCRIPTION: &str = "pre-existing structured high finding";
+const INDEPENDENT_HIGH_DESCRIPTION: &str =
+    "Untracked-file line counting can block prompt assembly on special files.";
+
+fn assert_payload_distinct_unlocated_highs_survive(test_name: &str, prose_descriptions: [&str; 2]) {
+    let session_id = "01TEST2664UNLOCATED000";
+    let (_env_lock, project_root, session_dir) = lock_test_session(test_name, session_id);
+
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        format!(
+            "[[findings]]\nid = \"2664-structured-high\"\nseverity = \"high\"\ndescription = \"{STRUCTURED_HIGH_DESCRIPTION}\"\n"
+        ),
+    )
+    .expect("write structured high findings.toml");
+    csa_session::persist_structured_output(
+        &session_dir,
+        &format!(
+            r#"<!-- CSA:SECTION:details -->
+1. [HIGH] {}
+2. [HIGH] {}
+<!-- CSA:SECTION:details:END -->
+"#,
+            prose_descriptions[0], prose_descriptions[1]
+        ),
+    )
+    .expect("persist structured output");
+
+    let mut artifact = ReviewVerdictArtifact::from_parts(
+        session_id,
+        ReviewDecision::Fail,
+        "HAS_ISSUES",
+        &[],
+        Vec::new(),
+    );
+    enforce_final_verdict_consistency(&session_dir, &mut artifact)
+        .expect("enforce final verdict consistency");
+
+    let findings = super::super::artifacts::load_findings_toml_from_output(&session_dir)
+        .expect("load findings.toml")
+        .expect("findings.toml exists");
+    assert_eq!(
+        findings
+            .findings
+            .iter()
+            .map(|finding| finding.description.as_str())
+            .collect::<Vec<_>>(),
+        [STRUCTURED_HIGH_DESCRIPTION, INDEPENDENT_HIGH_DESCRIPTION],
+        "payload-distinct findings must each survive exactly once"
+    );
+    assert_eq!(
+        high_count(&artifact),
+        2,
+        "both payload-distinct unlocated High findings must be counted"
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
 #[test]
 fn issue_1852_fail_closed_grade_reflects_backtick_high_prose() {
     let session_id = "01TEST1852BACKTICKHIGH000";
@@ -126,13 +185,15 @@ fn issue_1852_existing_high_count_is_not_inflated() {
 
     fs::write(
         session_dir.join("output").join("findings.toml"),
-        "[[findings]]\nid = \"1852-structured-high\"\nseverity = \"high\"\ndescription = \"pre-existing structured high finding\"\n",
+        format!(
+            "[[findings]]\nid = \"1852-structured-high\"\nseverity = \"high\"\ndescription = \"{INDEPENDENT_HIGH_DESCRIPTION}\"\n"
+        ),
     )
     .expect("write structured high findings.toml");
     csa_session::persist_structured_output(
         &session_dir,
         r#"<!-- CSA:SECTION:details -->
-1. `[HIGH]` Untracked-file line counting can block prompt assembly on special files.
+1. [HIGH] Untracked-file line counting can block prompt assembly on special files.
 <!-- CSA:SECTION:details:END -->
 "#,
     )
@@ -151,10 +212,34 @@ fn issue_1852_existing_high_count_is_not_inflated() {
     assert_eq!(
         high_count(&artifact),
         1,
-        "a structured High already matching the prose grade must not be double-counted"
+        "the same structured and prose High finding must not be double-counted"
+    );
+    let findings = super::super::artifacts::load_findings_toml_from_output(&session_dir)
+        .expect("load findings.toml")
+        .expect("findings.toml exists");
+    assert_eq!(findings.findings.len(), 1, "{findings:#?}");
+    assert_eq!(
+        findings.findings[0].description,
+        INDEPENDENT_HIGH_DESCRIPTION
     );
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_2664_payload_distinct_unlocated_highs_survive_prose_a_then_b() {
+    assert_payload_distinct_unlocated_highs_survive(
+        "issue-2664-unlocated-a-then-b",
+        [STRUCTURED_HIGH_DESCRIPTION, INDEPENDENT_HIGH_DESCRIPTION],
+    );
+}
+
+#[test]
+fn issue_2664_payload_distinct_unlocated_highs_survive_prose_b_then_a() {
+    assert_payload_distinct_unlocated_highs_survive(
+        "issue-2664-unlocated-b-then-a",
+        [INDEPENDENT_HIGH_DESCRIPTION, STRUCTURED_HIGH_DESCRIPTION],
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_2017_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_2017_tests.rs
@@ -197,6 +197,146 @@ Impact: a future retry change can reintroduce the deadline overrun.
 }
 
 #[test]
+fn issue_2664_priority_alias_prose_findings_reconcile_artifacts_and_result() {
+    let session_id = "01M06C1K96HC53JD4149Z6TNGC";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-2664-prose-findings", session_id);
+    let rejected_fragment = "Parser diagnostic appendix remains preserved verbatim.";
+
+    csa_session::persist_structured_output(
+        &session_dir,
+        &format!(
+            r#"<!-- CSA:SECTION:summary -->
+Decision: blocking findings present. Three high-severity defects and one medium regression remain.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+1. **[High/P1] Repeated pinned rebuild destroys the rollback artifact before the transaction starts**
+   Location: `scripts/llm_guard_proxy_cached_rebuild.sh:102`
+
+2. **[High/P1] The requested SHA still does not attest the bytes Cargo compiles**
+   Location: `scripts/llm_guard_proxy_cached_rebuild.sh:88`
+
+3. **[High/P1] Termination after publication bypasses rollback**
+   Location: `scripts/llm_guard_proxy_cached_rebuild.sh:135`
+
+4. **[Medium/P2] The lock path breaks the legacy custom SOURCE_DIR path on a fresh home**
+   Location: `scripts/llm_guard_proxy_cached_rebuild.sh:49`
+
+{rejected_fragment}
+<!-- CSA:SECTION:details:END -->
+"#
+        ),
+    )
+    .expect("persist structured output");
+
+    let mut meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    meta.status_reason = Some("prose_findings_present_but_unparsed".to_string());
+    meta.failure_reason = Some("prose_findings_present_but_unparsed".to_string());
+    csa_session::state::write_review_meta(&session_dir, &meta).expect("write stale review meta");
+    csa_session::write_findings_toml(
+        &session_dir,
+        &FindingsFile {
+            findings: vec![csa_session::ReviewFinding {
+                id: "artifact-generation-001".to_string(),
+                severity: Severity::Medium,
+                file_ranges: Vec::new(),
+                is_regression_of_commit: None,
+                suggested_test_scenario: None,
+                description: "Artifact generation failed: review verdict is FAIL but CSA could not extract a structured finding. Reason: prose_findings_present_but_unparsed. Inspect output/details.md and output/review-verdict.json.".to_string(),
+            }],
+        },
+    )
+    .expect("write stale placeholder findings");
+    let mut stale_verdict = ReviewVerdictArtifact::from_parts(
+        session_id.to_string(),
+        ReviewDecision::Fail,
+        "HAS_ISSUES".to_string(),
+        &[],
+        Vec::new(),
+    );
+    stale_verdict.severity_counts.insert(Severity::Medium, 2);
+    stale_verdict.failure_reason = Some("prose_findings_present_but_unparsed".to_string());
+    csa_session::write_review_verdict(&session_dir, &stale_verdict)
+        .expect("write stale review verdict");
+
+    let now = chrono::Utc::now();
+    csa_session::save_result(
+        &project_root,
+        session_id,
+        &csa_session::SessionResult {
+            status: "success".to_string(),
+            exit_code: 0,
+            summary: "Decision: blocking findings present.".to_string(),
+            tool: "codex".to_string(),
+            started_at: now,
+            completed_at: now,
+            ..Default::default()
+        },
+    )
+    .expect("write stale success result");
+
+    let result = crate::session_observability::refresh_and_repair_result(&project_root, session_id)
+        .expect("refresh session result")
+        .expect("session result exists");
+    let findings = read_findings_toml(&session_dir);
+    let expected = [
+        (Severity::High, 102),
+        (Severity::High, 88),
+        (Severity::High, 135),
+        (Severity::Medium, 49),
+    ];
+    assert_eq!(findings.findings.len(), expected.len(), "{findings:#?}");
+    for (finding, (severity, line)) in findings.findings.iter().zip(expected) {
+        assert_eq!(finding.severity, severity);
+        assert_eq!(
+            finding.file_ranges[0].path,
+            "scripts/llm_guard_proxy_cached_rebuild.sh"
+        );
+        assert_eq!(finding.file_ranges[0].start, line);
+    }
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&3));
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+    assert_eq!(verdict.failure_reason, None);
+
+    let repaired_meta: ReviewSessionMeta = serde_json::from_str(
+        &fs::read_to_string(session_dir.join("review_meta.json")).expect("read review meta"),
+    )
+    .expect("parse review meta");
+    assert_eq!(repaired_meta.decision, ReviewDecision::Fail.as_str());
+    assert_eq!(repaired_meta.verdict, "HAS_ISSUES");
+    assert_eq!(repaired_meta.exit_code, 1);
+    assert_eq!(repaired_meta.status_reason, None);
+    assert_eq!(repaired_meta.failure_reason, None);
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.exit_code, 1);
+
+    let wait_summary =
+        crate::session_cmds_daemon::render_wait_result_summary(&session_dir, session_id, &result);
+    assert!(
+        wait_summary.contains("Review verdict: FAIL"),
+        "{wait_summary}"
+    );
+    assert!(
+        !wait_summary.contains("prose_findings_present_but_unparsed"),
+        "{wait_summary}"
+    );
+    assert!(
+        fs::read_to_string(session_dir.join("output").join("details.md"))
+            .expect("read details")
+            .contains(rejected_fragment)
+    );
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn issue_2017_fail_verdict_with_unparseable_details_writes_explicit_artifact_error() {
     let session_id = "01TEST2017ARTIFACTERR";
     let (_env_lock, project_root, session_dir) =

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_2017_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_2017_tests.rs
@@ -337,6 +337,92 @@ Decision: blocking findings present. Three high-severity defects and one medium 
 }
 
 #[test]
+fn issue_2815_worktree_mutation_keeps_deduplicated_prose_findings() {
+    let session_id = "01TEST2815AUDITMERGE000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-2815-audit-merge", session_id);
+    let review_text = r#"<!-- CSA:SECTION:summary -->
+Review result: FAIL. One high and one medium product finding remain.
+<!-- CSA:SECTION:summary:END -->
+
+<!-- CSA:SECTION:details -->
+## Findings
+
+1. [HIGH] Indexed review bytes can diverge (`src/review.rs:10`).
+2. [MEDIUM] An unterminated line is omitted (`src/lines.rs:20`).
+<!-- CSA:SECTION:details:END -->
+"#;
+    csa_session::persist_structured_output(&session_dir, review_text)
+        .expect("persist structured output");
+    fs::write(
+        session_dir.join("output").join("full.md"),
+        format!("{review_text}\nRaw transcript appendix keeps the canonical source distinct.\n"),
+    )
+    .expect("write canonical raw output");
+
+    let audit_description = "Read-only review mutated repo-tracked file(s): weave.lock.";
+    csa_session::write_findings_toml(
+        &session_dir,
+        &FindingsFile {
+            findings: vec![csa_session::ReviewFinding {
+                id: "CSA-REVIEW-WORKTREE-MUTATION".to_string(),
+                severity: Severity::High,
+                file_ranges: vec![csa_session::ReviewFindingFileRange {
+                    path: "weave.lock".to_string(),
+                    start: 1,
+                    end: None,
+                }],
+                is_regression_of_commit: None,
+                suggested_test_scenario: Some("Inspect the mutated worktree.".to_string()),
+                description: audit_description.to_string(),
+            }],
+        },
+    )
+    .expect("write audit finding");
+    let mut stale_verdict = ReviewVerdictArtifact::from_parts(
+        session_id.to_string(),
+        ReviewDecision::Fail,
+        "HAS_ISSUES",
+        &[],
+        Vec::new(),
+    );
+    stale_verdict.severity_counts.insert(Severity::High, 1);
+    csa_session::write_review_verdict(&session_dir, &stale_verdict).expect("write stale verdict");
+
+    assert!(
+        super::super::consistency::repair_clean_empty_fail_review_verdict(&session_dir)
+            .expect("repair existing session")
+    );
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 3, "{findings:#?}");
+    assert_eq!(findings.findings[0].id, "CSA-REVIEW-WORKTREE-MUTATION");
+    assert_eq!(findings.findings[0].description, audit_description);
+    assert_eq!(
+        findings
+            .findings
+            .iter()
+            .filter(|finding| finding.description.contains("Indexed review bytes"))
+            .count(),
+        1,
+        "indexed and canonical copies must be payload-deduplicated: {findings:#?}"
+    );
+    assert!(
+        findings
+            .findings
+            .iter()
+            .any(|finding| finding.description.contains("unterminated line")),
+        "{findings:#?}"
+    );
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&2));
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn issue_2017_fail_verdict_with_unparseable_details_writes_explicit_artifact_error() {
     let session_id = "01TEST2017ARTIFACTERR";
     let (_env_lock, project_root, session_dir) =

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -49,6 +49,7 @@ pub(in crate::review_cmd) fn extract_review_findings_from_prose_with_default(
     let mut findings: Vec<ReviewFinding> = Vec::new();
     let mut in_findings_section = false;
     let mut in_code_fence = false;
+    let mut active_finding: Option<usize> = None;
 
     for line in text.lines() {
         let trimmed = line.trim();
@@ -61,31 +62,46 @@ pub(in crate::review_cmd) fn extract_review_findings_from_prose_with_default(
         }
         if is_findings_header(trimmed) {
             in_findings_section = true;
+            active_finding = None;
             continue;
         }
-        if in_findings_section && trimmed.starts_with('#') && !is_markdown_finding_heading(trimmed)
-        {
+        if trimmed.starts_with('#') && !is_markdown_finding_heading(trimmed) {
             in_findings_section = false;
+            active_finding = None;
             continue;
         }
 
         if let Some(range) = parse_file_reference_line(trimmed) {
-            if let Some(last) = findings.last_mut()
-                && last.file_ranges.is_empty()
+            if let Some(index) = active_finding
+                && findings[index].file_ranges.is_empty()
             {
-                last.file_ranges.push(range);
+                findings[index].file_ranges.push(range);
             }
             continue;
         }
 
-        let Some(parsed) = parse_finding_line(
+        if let Some(parsed) = parse_finding_line(
             trimmed,
             in_findings_section,
             default_unlabeled_severity.clone(),
-        ) else {
+        ) {
+            findings.push(parsed.into_review_finding(format!("prose-{:03}", findings.len() + 1)));
+            active_finding = Some(findings.len() - 1);
             continue;
-        };
-        findings.push(parsed.into_review_finding(format!("prose-{:03}", findings.len() + 1)));
+        }
+
+        if line.chars().next().is_some_and(char::is_whitespace)
+            && let Some(index) = active_finding
+        {
+            let finding = &mut findings[index];
+            if finding.file_ranges.is_empty()
+                && let Some(range) = parse_embedded_file_range(trimmed)
+            {
+                finding.file_ranges.push(range);
+            }
+            finding.description.push(' ');
+            finding.description.push_str(trimmed);
+        }
     }
 
     findings
@@ -474,7 +490,10 @@ fn non_empty_or_fallback(value: &str, fallback: &str) -> String {
     }
 }
 
-fn review_finding_payload_eq(left: &ReviewFinding, right: &ReviewFinding) -> bool {
+pub(in crate::review_cmd) fn review_finding_payload_eq(
+    left: &ReviewFinding,
+    right: &ReviewFinding,
+) -> bool {
     left.severity == right.severity
         && left.file_ranges == right.file_ranges
         && left.is_regression_of_commit == right.is_regression_of_commit

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -27,7 +27,9 @@ pub(in crate::review_cmd) fn findings_file_from_explicit_findings_sections(
             {
                 continue;
             }
-            finding.id = format!("prose-{:03}", findings.len() + 1);
+            if finding.id.starts_with("prose-") {
+                finding.id = format!("prose-{:03}", findings.len() + 1);
+            }
             findings.push(finding);
         }
     }
@@ -207,13 +209,18 @@ pub(in crate::review_cmd) fn zero_severity_counts() -> BTreeMap<Severity, u32> {
 
 pub(in crate::review_cmd) fn severity_from_label(level: &str) -> Option<Severity> {
     let normalized = level.trim().to_ascii_lowercase();
-    match normalized.as_str() {
+    let parse = |label: &str| match label {
         "critical" => Some(Severity::Critical),
         "high" => Some(Severity::High),
-        "medium" => Some(Severity::Medium),
+        "medium" | "moderate" => Some(Severity::Medium),
         "low" | "info" => Some(Severity::Low),
-        _ => priority_severity_from_label(&normalized),
-    }
+        _ => priority_severity_from_label(label),
+    };
+    let mut labels = normalized.split('/');
+    let severity = parse(labels.next()?)?;
+    labels
+        .all(|label| parse(label).as_ref() == Some(&severity))
+        .then_some(severity)
 }
 
 pub(in crate::review_cmd) fn contains_blocking_review_signal(text: &str) -> bool {
@@ -221,6 +228,7 @@ pub(in crate::review_cmd) fn contains_blocking_review_signal(text: &str) -> bool
 }
 
 struct ParsedProseFinding {
+    id: Option<String>,
     severity: Severity,
     file_range: Option<ReviewFindingFileRange>,
     description: String,
@@ -229,7 +237,7 @@ struct ParsedProseFinding {
 impl ParsedProseFinding {
     fn into_review_finding(self, id: String) -> ReviewFinding {
         ReviewFinding {
-            id,
+            id: self.id.unwrap_or(id),
             severity: self.severity,
             file_ranges: self.file_range.into_iter().collect(),
             is_regression_of_commit: None,
@@ -251,6 +259,10 @@ fn parse_finding_line(
         return Some(parsed);
     }
 
+    if let Some(parsed) = parse_identified_finding(body) {
+        return Some(parsed);
+    }
+
     if let Some(parsed) =
         parse_severity_prefixed_finding(body, structured_entry || in_findings_section)
     {
@@ -269,7 +281,7 @@ pub(in crate::review_cmd) fn structured_bracketed_finding_severity(line: &str) -
 }
 
 fn bracketed_finding_severity(body: &str) -> Option<Severity> {
-    let (label, _) = parse_bracketed_prefix(body.trim_start())?;
+    let (label, _) = parse_bracketed_prefix(trim_inline_markdown(body))?;
     severity_from_label(label)
 }
 
@@ -278,7 +290,9 @@ fn structured_finding_body(line: &str) -> Option<&str> {
     let line = line
         .strip_prefix('#')
         .map_or(line, |line| line.trim_start_matches('#').trim_start());
-    strip_numbered_prefix(line).or_else(|| strip_unordered_finding_prefix(line))
+    strip_numbered_prefix(line)
+        .or_else(|| strip_unordered_finding_prefix(line))
+        .or_else(|| parse_identified_finding(line).is_some().then_some(line))
 }
 
 fn is_markdown_finding_heading(line: &str) -> bool {
@@ -309,7 +323,8 @@ fn strip_unordered_finding_prefix(line: &str) -> Option<&str> {
 }
 
 fn parse_bracketed_finding(body: &str) -> Option<ParsedProseFinding> {
-    let (label, mut rest) = parse_bracketed_prefix(body.trim_start())?;
+    let body = trim_inline_markdown(body);
+    let (label, mut rest) = parse_bracketed_prefix(body)?;
     let severity = severity_from_label(label)?;
     rest = rest.trim_start();
 
@@ -327,10 +342,47 @@ fn parse_bracketed_finding(body: &str) -> Option<ParsedProseFinding> {
         return None;
     }
     Some(ParsedProseFinding {
+        id: None,
         severity,
         file_range: parse_embedded_file_range(rest),
         description: non_empty_or_fallback(rest, body),
     })
+}
+
+fn parse_identified_finding(body: &str) -> Option<ParsedProseFinding> {
+    let body = trim_inline_markdown(body);
+    let (id, rest) = body.split_once('—')?;
+    let (level, description) = rest.split_once('—')?;
+    let id = id.trim();
+    if !looks_like_finding_id(id) {
+        return None;
+    }
+    let severity = severity_from_label(level)?;
+    let description = trim_inline_markdown(description);
+    if finding_text_describes_resolved_issue(description) {
+        return None;
+    }
+    Some(ParsedProseFinding {
+        id: Some(id.to_string()),
+        severity,
+        file_range: parse_embedded_file_range(description),
+        description: non_empty_or_fallback(description, body),
+    })
+}
+
+fn looks_like_finding_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().any(|ch| ch.is_ascii_digit())
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
+}
+
+fn trim_inline_markdown(value: &str) -> &str {
+    value
+        .trim()
+        .trim_matches(|ch| matches!(ch, '*' | '_' | '`'))
+        .trim()
 }
 
 fn parse_bracketed_prefix(text: &str) -> Option<(&str, &str)> {
@@ -354,12 +406,14 @@ fn parse_severity_prefixed_finding(
     }
     if let Some((file_range, description)) = parse_leading_file_range(rest) {
         return Some(ParsedProseFinding {
+            id: None,
             severity,
             file_range: Some(file_range),
             description: non_empty_or_fallback(&description, body),
         });
     }
     allow_description_only.then(|| ParsedProseFinding {
+        id: None,
         severity,
         file_range: None,
         description: severity_prefixed_description(label, rest),
@@ -374,30 +428,14 @@ fn severity_prefixed_rest_is_zero_count(rest: &str) -> bool {
 fn parse_path_prefixed_finding(body: &str, severity: Severity) -> Option<ParsedProseFinding> {
     let (file_range, description) = parse_leading_file_range(body)?;
     Some(ParsedProseFinding {
+        id: None,
         severity,
         file_range: Some(file_range),
         description: non_empty_or_fallback(&description, body),
     })
 }
 
-fn parse_file_reference_line(line: &str) -> Option<ReviewFindingFileRange> {
-    let line = strip_unordered_list_prefix(line);
-    let (label, rest) = line.split_once(':')?;
-    if !(label.trim().eq_ignore_ascii_case("file") || label.trim().eq_ignore_ascii_case("location"))
-    {
-        return None;
-    }
-    parse_leading_file_range(rest.trim()).map(|(range, _)| range)
-}
-
-fn strip_unordered_list_prefix(line: &str) -> &str {
-    let trimmed = line.trim_start();
-    if matches!(trimmed.as_bytes().first(), Some(b'-' | b'*')) {
-        trimmed[1..].trim_start()
-    } else {
-        trimmed
-    }
-}
+include!("review_cmd_prose_findings_file_ranges.rs");
 
 fn leading_severity_from_title(title: &str) -> Option<Severity> {
     let mut segments = title.split('/');
@@ -428,59 +466,6 @@ fn severity_prefixed_description(label: &str, rest: &str) -> String {
     }
 }
 
-fn parse_leading_file_range(body: &str) -> Option<(ReviewFindingFileRange, String)> {
-    let trimmed = body.trim_start_matches(['`', '(', '[']).trim_start();
-    let mut parts = trimmed.splitn(2, char::is_whitespace);
-    let token = parts.next()?.trim_matches(['`', ',', '.', ')', ']']);
-    let description = parts
-        .next()
-        .unwrap_or_default()
-        .trim_start_matches(['-', ':'])
-        .trim()
-        .to_string();
-    let (path, line) = parse_file_line_token(token)?;
-    Some((
-        ReviewFindingFileRange {
-            path,
-            start: line,
-            end: None,
-        },
-        description,
-    ))
-}
-
-fn parse_embedded_file_range(body: &str) -> Option<ReviewFindingFileRange> {
-    body.split(char::is_whitespace)
-        .map(|token| token.trim_matches(['`', '(', ')', '[', ']', ',', '.', ';']))
-        .find_map(|token| {
-            parse_file_line_token(token).map(|(path, start)| ReviewFindingFileRange {
-                path,
-                start,
-                end: None,
-            })
-        })
-}
-
-fn parse_file_line_token(token: &str) -> Option<(String, u32)> {
-    let (path, line) = token.rsplit_once(':')?;
-    if path.is_empty() || !looks_like_file_path(path) {
-        return None;
-    }
-    let line = line.parse::<u32>().ok()?;
-    Some((path.to_string(), line))
-}
-
-fn looks_like_file_path(path: &str) -> bool {
-    if path.chars().any(char::is_whitespace) {
-        return false;
-    }
-    path.contains('/')
-        || path.contains('.')
-        || path.eq_ignore_ascii_case("justfile")
-        || path == "Makefile"
-        || path == "Dockerfile"
-}
-
 fn non_empty_or_fallback(value: &str, fallback: &str) -> String {
     if value.trim().is_empty() {
         fallback.trim().to_string()
@@ -502,8 +487,15 @@ pub(in crate::review_cmd) fn is_findings_header(line: &str) -> bool {
     let normalized = normalized
         .split_once('(')
         .map_or(normalized, |(heading, _)| heading.trim_end());
-    normalized.eq_ignore_ascii_case("findings")
-        || normalized.eq_ignore_ascii_case("review findings")
+    matches!(
+        normalized.to_ascii_lowercase().as_str(),
+        "finding"
+            | "findings"
+            | "blocking finding"
+            | "blocking findings"
+            | "review finding"
+            | "review findings"
+    )
 }
 
 const REVIEW_ISSUE_NOUNS: &[&str] = &[
@@ -522,7 +514,8 @@ const REVIEW_ISSUE_NOUNS: &[&str] = &[
     "violation",
     "violations",
 ];
-const BLOCKING_REVIEW_SEVERITIES: &[&str] = &["critical", "high", "medium", "p0", "p1", "p2"];
+const BLOCKING_REVIEW_SEVERITIES: &[&str] =
+    &["critical", "high", "medium", "moderate", "p0", "p1", "p2"];
 const ZERO_COUNT_WORDS: &[&str] = &["0", "zero", "none", "no"];
 const MAX_TOKENS_AFTER_REVIEW_SIGNAL: usize = 8;
 

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_file_ranges.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_file_ranges.rs
@@ -1,0 +1,102 @@
+fn parse_file_reference_line(line: &str) -> Option<ReviewFindingFileRange> {
+    let line = strip_unordered_list_prefix(line);
+    if line.trim_start().starts_with('`') {
+        return parse_leading_file_range(line).map(|(range, _)| range);
+    }
+    let (label, rest) = line
+        .split_once('\u{ff1a}')
+        .or_else(|| line.split_once(':'))?;
+    let label = label.trim();
+    if !(label.eq_ignore_ascii_case("file")
+        || label.eq_ignore_ascii_case("location")
+        || label == "\u{4f4d}\u{7f6e}")
+    {
+        return None;
+    }
+    parse_leading_file_range(rest.trim()).map(|(range, _)| range)
+}
+
+fn strip_unordered_list_prefix(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    if matches!(trimmed.as_bytes().first(), Some(b'-' | b'*')) {
+        trimmed[1..].trim_start()
+    } else {
+        trimmed
+    }
+}
+
+fn parse_leading_file_range(body: &str) -> Option<(ReviewFindingFileRange, String)> {
+    let trimmed = body.trim_start_matches(['`', '(', '[']).trim_start();
+    let mut parts = trimmed.splitn(2, char::is_whitespace);
+    let token = parts.next()?.trim_matches(['`', ',', '.', ')', ']']);
+    let description = parts
+        .next()
+        .unwrap_or_default()
+        .trim_start_matches(['-', ':'])
+        .trim()
+        .to_string();
+    let (path, line) = parse_file_reference_token(token)?;
+    Some((
+        ReviewFindingFileRange {
+            path,
+            start: line,
+            end: None,
+        },
+        description,
+    ))
+}
+
+fn parse_embedded_file_range(body: &str) -> Option<ReviewFindingFileRange> {
+    body.split(char::is_whitespace)
+        .map(|token| token.trim_matches(['`', '(', ')', '[', ']', ',', '.', ';']))
+        .find_map(|token| {
+            parse_file_reference_token(token).map(|(path, start)| ReviewFindingFileRange {
+                path,
+                start,
+                end: None,
+            })
+        })
+}
+
+fn parse_file_reference_token(token: &str) -> Option<(String, u32)> {
+    parse_markdown_file_line_token(token).or_else(|| parse_file_line_token(token))
+}
+
+fn parse_markdown_file_line_token(token: &str) -> Option<(String, u32)> {
+    let token = token.trim_matches(['`', '(', ')', ',', '.', ';']);
+    let (label, target) = token.split_once("](")?;
+    let label = label.trim_start_matches('[');
+    if !looks_like_file_path(label) {
+        return None;
+    }
+    let (_, line) = target.rsplit_once(':')?;
+    Some((label.to_string(), parse_line_number(line)?))
+}
+
+fn parse_file_line_token(token: &str) -> Option<(String, u32)> {
+    let (path, line) = token.rsplit_once(':')?;
+    if path.is_empty() || !looks_like_file_path(path) {
+        return None;
+    }
+    Some((path.to_string(), parse_line_number(line)?))
+}
+
+fn parse_line_number(value: &str) -> Option<u32> {
+    value
+        .split([',', '-'])
+        .next()?
+        .trim_matches(|ch: char| !ch.is_ascii_digit())
+        .parse()
+        .ok()
+}
+
+fn looks_like_file_path(path: &str) -> bool {
+    if path.chars().any(char::is_whitespace) {
+        return false;
+    }
+    path.contains('/')
+        || path.contains('.')
+        || path.eq_ignore_ascii_case("justfile")
+        || path == "Makefile"
+        || path == "Dockerfile"
+}

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
@@ -313,3 +313,62 @@ fn issue_2652_compound_severity_prefix_stays_rejected() {
         );
     }
 }
+
+#[test]
+fn issue_2664_cluster_parses_substantive_heading_and_location_variants() {
+    let cases = [
+        (
+            "## Findings\n### CSA-R1 — High — Cancellation can turn a wall timeout into an unbounded wait\n",
+            "CSA-R1",
+            Severity::High,
+            None,
+        ),
+        (
+            concat!(
+                "## Finding\n",
+                "### F001 — High — Strict classifier accepts an impossible receipt\n",
+                "\u{4f4d}\u{7f6e}\u{ff1a}`skills/smoke-test/scripts/smoke_receipts.py:128-139,165-177`\n",
+            ),
+            "F001",
+            Severity::High,
+            Some(("skills/smoke-test/scripts/smoke_receipts.py", 128)),
+        ),
+        (
+            concat!(
+                "## Blocking finding\n",
+                "1. [MODERATE][correctness/ordering] Latched limits can still be reclassified ",
+                "as cancellation ([lifecycle.rs](/project/rust-core/src/workflow_adk/lifecycle.rs:741), confidence 0.98).\n",
+            ),
+            "prose-001",
+            Severity::Medium,
+            Some(("lifecycle.rs", 741)),
+        ),
+        (
+            concat!(
+                "## Finding\n",
+                "1. [P1][security] Deleted-file ownership tokens have an inode-reuse ABA window\n",
+                "`llm/coding/scripts/test-fix-target.sh:104`, confidence 0.96\n",
+            ),
+            "prose-001",
+            Severity::High,
+            Some(("llm/coding/scripts/test-fix-target.sh", 104)),
+        ),
+    ];
+
+    for (text, id, severity, location) in cases {
+        let findings = extract_review_findings_from_prose(text);
+        let [finding] = findings.as_slice() else {
+            panic!("expected one finding for {id}, got {findings:#?}");
+        };
+        assert_eq!(finding.id, id);
+        assert_eq!(finding.severity, severity);
+        match location {
+            Some((path, line)) => {
+                assert_eq!(finding.file_ranges.len(), 1, "{finding:#?}");
+                assert_eq!(finding.file_ranges[0].path, path);
+                assert_eq!(finding.file_ranges[0].start, line);
+            }
+            None => assert!(finding.file_ranges.is_empty(), "{finding:#?}"),
+        }
+    }
+}

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
@@ -372,3 +372,27 @@ fn issue_2664_cluster_parses_substantive_heading_and_location_variants() {
         }
     }
 }
+
+#[test]
+fn issue_2975_wrapped_finding_keeps_continuation_and_source() {
+    let findings = extract_review_findings_from_prose(concat!(
+        "## Blocking finding\n",
+        "1. [MODERATE][correctness/ordering] Latched limits can still be\n",
+        "   reclassified as cancellation (lifecycle.rs:741, confidence 0.98; ",
+        "class sweep: 1 site).\n",
+        "\n## Recommended Actions\n",
+        "Location: `wrong.rs:1`\n",
+    ));
+
+    let [finding] = findings.as_slice() else {
+        panic!("expected one wrapped finding, got {findings:#?}");
+    };
+    assert_eq!(finding.severity, Severity::Medium);
+    assert_eq!(
+        finding.description,
+        "Latched limits can still be reclassified as cancellation (lifecycle.rs:741, confidence 0.98; class sweep: 1 site)."
+    );
+    assert_eq!(finding.file_ranges.len(), 1, "{finding:#?}");
+    assert_eq!(finding.file_ranges[0].path, "lifecycle.rs");
+    assert_eq!(finding.file_ranges[0].start, 741);
+}


### PR DESCRIPTION
## Summary

Parse substantive review prose findings into structured artifacts and reconcile verdict/session/result. Blocking counts stay fail-closed. Canonical merge is payload-deduplicated: same-finding Highs are not double-counted; payload-distinct unlocated Highs both survive.

Closes #2664
Closes #2975
Closes #2815
Closes #3025

## Test plan

- Exact-HEAD `just pre-push` GREEN: `drafts/cli-sub-agent/2664-prepush-9a304916.log` SHA-256 `4a992f556517bff24205bf6da5dca7aeb25bb74fb825f7bdba6f9e5998b6e668` (`7569 passed, 7 skipped`)
- Native clean-room Tier-4-equivalent PASS (NOT a CSA verdict): `drafts/cli-sub-agent/2664-native-tier4-report-9a304916.md` SHA-256 `bc3b06c67a4f38299f944d259f9db77923063eb5c62b2dc3b0a83ed39ed46029`
- CSA Codex quota-unavailable until 2026-08-17; bypass: `.csa/native-review-bypass/9a30491674055e893420fb6da5e044dd6702e88c.toml`

## Review note

This is an authorized native clean-room fallback because CSA Codex is quota-exhausted. It is **not** a CSA Tier-4 verdict.
