### PR TITLE
fix(require-commit): fail closed on sandbox hook stall without rescue

### DIFF
--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -139,11 +139,20 @@ pub(super) async fn complete_session_execution(
             && (!inside_git_worktree
                 || pre_run_workspace.is_none()
                 || post_run_workspace.is_none());
-        if require_commit::should_attempt_require_commit_rescue(
-            effective_require_commit_on_mutation,
-            commit_guard.as_ref(),
-        ) && let Some(new_head) =
-            crate::run_cmd::attempt_rescue_commit(input.project_root, input.executor.tool_name())
+        let sandbox_hook_blocked = effective_require_commit_on_mutation
+            && crate::run_cmd::sandbox_commit_failure_matches(
+                input.project_root,
+                &session.meta_session_id,
+            );
+        if !sandbox_hook_blocked
+            && require_commit::should_attempt_require_commit_rescue(
+                effective_require_commit_on_mutation,
+                commit_guard.as_ref(),
+            )
+            && let Some(new_head) = crate::run_cmd::attempt_rescue_commit(
+                input.project_root,
+                input.executor.tool_name(),
+            )
         {
             commit_created = Some(true);
             rescued_changed_paths = Some(require_commit::compute_changed_paths_from_snapshots(

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -139,12 +139,17 @@ pub(super) async fn complete_session_execution(
             && (!inside_git_worktree
                 || pre_run_workspace.is_none()
                 || post_run_workspace.is_none());
-        let sandbox_hook_blocked = effective_require_commit_on_mutation
-            && crate::run_cmd::sandbox_commit_failure_matches(
+        let sandbox_hook_probe = effective_require_commit_on_mutation.then(|| {
+            crate::run_cmd::sandbox_commit_failure_matches(
                 input.project_root,
                 &session.meta_session_id,
-            );
+            )
+        });
+        let sandbox_hook_blocked = matches!(sandbox_hook_probe, Some(Ok(true)));
+        let sandbox_hook_probe_uncertain = matches!(sandbox_hook_probe, Some(Err(_)));
+        policy_evaluation_failed |= sandbox_hook_probe_uncertain;
         if !sandbox_hook_blocked
+            && !sandbox_hook_probe_uncertain
             && require_commit::should_attempt_require_commit_rescue(
                 effective_require_commit_on_mutation,
                 commit_guard.as_ref(),

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -149,7 +149,14 @@ pub(super) async fn complete_session_execution(
         });
         let sandbox_hook_blocked = matches!(sandbox_hook_probe, Some(Ok(true)));
         let sandbox_hook_probe_uncertain = matches!(sandbox_hook_probe, Some(Err(_)))
-            || (git_commit_attempted && matches!(sandbox_hook_probe, Some(Ok(false))));
+            // Probe `Ok(false)` (no failure marker) is only ambiguous when the
+            // writer's commit did NOT advance HEAD. A successful commit removes
+            // the marker (and non-sandboxed runs never write one), so head
+            // advance plus a clean probe is verifiable: do not gate-fail it as
+            // commit-policy-unverifiable (F1/45240b4f).
+            || (git_commit_attempted
+                && commit_created != Some(true)
+                && matches!(sandbox_hook_probe, Some(Ok(false))));
         if !sandbox_hook_blocked
             && !sandbox_hook_probe_uncertain
             && require_commit::should_attempt_require_commit_rescue(

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -150,7 +150,6 @@ pub(super) async fn complete_session_execution(
         let sandbox_hook_blocked = matches!(sandbox_hook_probe, Some(Ok(true)));
         let sandbox_hook_probe_uncertain = matches!(sandbox_hook_probe, Some(Err(_)))
             || (git_commit_attempted && matches!(sandbox_hook_probe, Some(Ok(false))));
-        policy_evaluation_failed |= sandbox_hook_probe_uncertain;
         if !sandbox_hook_blocked
             && !sandbox_hook_probe_uncertain
             && require_commit::should_attempt_require_commit_rescue(
@@ -199,6 +198,7 @@ pub(super) async fn complete_session_execution(
         } else {
             None
         };
+        policy_evaluation_failed |= sandbox_hook_probe_uncertain && commit_reflog_race.is_none();
         crate::run_cmd::apply_post_session_commit_policies(
             &mut result,
             crate::run_cmd::PostSessionCommitPolicyArgs {

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion.rs
@@ -139,6 +139,8 @@ pub(super) async fn complete_session_execution(
             && (!inside_git_worktree
                 || pre_run_workspace.is_none()
                 || post_run_workspace.is_none());
+        let git_commit_attempted =
+            !crate::run_cmd::detect_git_commit_commands(&executed_shell_commands).is_empty();
         let sandbox_hook_probe = effective_require_commit_on_mutation.then(|| {
             crate::run_cmd::sandbox_commit_failure_matches(
                 input.project_root,
@@ -146,7 +148,8 @@ pub(super) async fn complete_session_execution(
             )
         });
         let sandbox_hook_blocked = matches!(sandbox_hook_probe, Some(Ok(true)));
-        let sandbox_hook_probe_uncertain = matches!(sandbox_hook_probe, Some(Err(_)));
+        let sandbox_hook_probe_uncertain = matches!(sandbox_hook_probe, Some(Err(_)))
+            || (git_commit_attempted && matches!(sandbox_hook_probe, Some(Ok(false))));
         policy_evaluation_failed |= sandbox_hook_probe_uncertain;
         if !sandbox_hook_blocked
             && !sandbox_hook_probe_uncertain
@@ -184,8 +187,6 @@ pub(super) async fn complete_session_execution(
                     || pre_run_workspace.is_none()
                     || post_run_workspace.is_none());
         }
-        let git_commit_attempted =
-            !crate::run_cmd::detect_git_commit_commands(&executed_shell_commands).is_empty();
         let commit_reflog_race = if git_commit_attempted && commit_created == Some(true) {
             let current_head = post_run_workspace
                 .as_ref()
@@ -366,6 +367,10 @@ mod fix_finding_tests;
 #[cfg(test)]
 #[path = "pipeline_session_exec_completion_require_commit_tests.rs"]
 mod require_commit_tests;
+
+#[cfg(test)]
+#[path = "pipeline_session_exec_completion_autofix_hook_tests.rs"]
+mod autofix_hook_tests;
 
 #[cfg(test)]
 #[path = "pipeline_session_exec_completion_tests.rs"]

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion_autofix_hook_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion_autofix_hook_tests.rs
@@ -1,0 +1,174 @@
+#[cfg(not(target_os = "macos"))]
+use std::process::Command;
+
+#[cfg(not(target_os = "macos"))]
+use csa_core::transport_events::StreamingMetadata;
+#[cfg(not(target_os = "macos"))]
+use csa_core::types::OutputFormat;
+#[cfg(not(target_os = "macos"))]
+use csa_executor::{CodexRuntimeMetadata, Executor, TransportResult};
+#[cfg(not(target_os = "macos"))]
+use csa_session::{create_session, get_session_dir};
+
+#[cfg(not(target_os = "macos"))]
+use super::*;
+#[cfg(not(target_os = "macos"))]
+use crate::test_session_sandbox::ScopedSessionSandbox;
+
+#[cfg(not(target_os = "macos"))]
+fn git(project_root: &std::path::Path, args: &[&str]) -> std::process::Output {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(output.status.success(), "git {} failed", args.join(" "));
+    output
+}
+
+#[cfg(not(target_os = "macos"))]
+fn git_text(project_root: &std::path::Path, args: &[&str]) -> String {
+    String::from_utf8_lossy(&git(project_root, args).stdout)
+        .trim()
+        .to_string()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn init_git_repo(project_root: &std::path::Path) {
+    git(project_root, &["init", "-q"]);
+    git(
+        project_root,
+        &["config", "user.email", "csa-test@example.com"],
+    );
+    git(project_root, &["config", "user.name", "CSA Test"]);
+    git(project_root, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(project_root.join("tracked.txt"), "initial\n").expect("write tracked");
+    git(project_root, &["add", "tracked.txt"]);
+    git(project_root, &["commit", "-q", "-m", "initial"]);
+}
+
+#[cfg(not(target_os = "macos"))]
+#[tokio::test]
+async fn completion_does_not_rescue_after_autofix_hook_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
+    let project_root = temp.path();
+    init_git_repo(project_root);
+    let initial_head = git_text(project_root, &["rev-parse", "HEAD"]);
+    let before =
+        crate::run_cmd::capture_git_workspace_snapshot(project_root, false).expect("snapshot");
+    std::fs::write(project_root.join("tracked.txt"), "changed\n").expect("write change");
+    git(project_root, &["add", "tracked.txt"]);
+
+    let mut session = create_session(
+        project_root,
+        Some("autofix hook failure"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_dir = get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().expect("wrapper parent")).expect("create wrapper dir");
+    std::fs::write(&wrapper, csa_hooks::git_wrapper_script()).expect("write git wrapper");
+    std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755))
+        .expect("make wrapper executable");
+    let hook = project_root.join(".git/hooks/pre-commit");
+    std::fs::write(
+        &hook,
+        "#!/bin/sh\nprintf 'autofixed\\n' > hook-generated.txt\n/usr/bin/git add hook-generated.txt\nexit 1\n",
+    )
+    .expect("write autofix hook");
+    std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755))
+        .expect("make hook executable");
+    assert!(
+        !Command::new(&wrapper)
+            .args(["commit", "-m", "sandbox commit"])
+            .current_dir(project_root)
+            .env("CSA_REAL_GIT", "/usr/bin/git")
+            .env("CSA_FS_SANDBOXED", "1")
+            .env("CSA_SESSION_DIR", &session_dir)
+            .output()
+            .expect("run autofix hook")
+            .status
+            .success()
+    );
+    assert!(
+        session_dir
+            .join(csa_hooks::git_guard::SANDBOX_COMMIT_FAILURE_MARKER_FILE)
+            .is_file()
+    );
+    let staged_tree = git_text(project_root, &["write-tree"]);
+
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: CodexRuntimeMetadata::current(),
+    };
+    let completed = complete_session_execution(
+        CompletionInput {
+            executor: &executor,
+            tool: &csa_core::types::ToolName::Codex,
+            prompt: "Fix, verify, and commit the work",
+            output_format: &OutputFormat::Json,
+            task_type: Some("run"),
+            readonly_project_root: false,
+            project_root,
+            config: None,
+            global_config: None,
+            session_dir: &session_dir,
+            memory_project_key: None,
+            effective_prompt: "Fix, verify, and commit the work".to_string(),
+            plan: SessionCompletionPlan {
+                merged_env: Default::default(),
+                hooks_config: Default::default(),
+                sessions_root: session_dir
+                    .parent()
+                    .expect("sessions root")
+                    .display()
+                    .to_string(),
+                edit_guard: None,
+                new_file_guard: None,
+                result_file_cleared: false,
+                execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
+                commit_guard_enabled: true,
+                require_commit_on_mutation: true,
+                hook_bypass_scan_enabled: true,
+                is_git: true,
+                inside_git_worktree: true,
+                pre_run_workspace: Some(before),
+                pre_exec_snapshot: None,
+                timeout_diagnostics: None,
+                sa_mode: false,
+            },
+            transport_result: TransportResult {
+                execution: csa_process::ExecutionResult {
+                    output: "writer completed but commit failed".to_string(),
+                    summary: "writer completed but commit failed".to_string(),
+                    model_completed: Some(true),
+                    ..Default::default()
+                },
+                provider_session_id: None,
+                events: Vec::new(),
+                metadata: StreamingMetadata {
+                    extracted_commands: vec!["git commit -m fix".to_string()],
+                    has_tool_calls: true,
+                    has_execute_tool_calls: true,
+                    turn_count: 1,
+                    ..Default::default()
+                },
+            },
+        },
+        &mut session,
+    )
+    .await
+    .expect("complete session");
+
+    assert_eq!(completed.commit_created, Some(false));
+    assert_ne!(completed.execution.exit_code, 0);
+    assert_eq!(git_text(project_root, &["rev-parse", "HEAD"]), initial_head);
+    assert_eq!(git_text(project_root, &["write-tree"]), staged_tree);
+}

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion_autofix_hook_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion_autofix_hook_tests.rs
@@ -77,9 +77,14 @@ async fn completion_does_not_rescue_after_autofix_hook_failure() {
     std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o755))
         .expect("make wrapper executable");
     let hook = project_root.join(".git/hooks/pre-commit");
+    let hook_generated = project_root.join("hook-generated.txt");
     std::fs::write(
         &hook,
-        "#!/bin/sh\nprintf 'autofixed\\n' > hook-generated.txt\n/usr/bin/git add hook-generated.txt\nexit 1\n",
+        format!(
+            "#!/bin/sh\nprintf 'autofixed\\n' > {}\n/usr/bin/git add {}\nexit 1\n",
+            hook_generated.display(),
+            hook_generated.display(),
+        ),
     )
     .expect("write autofix hook");
     std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755))

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion_require_commit_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion_require_commit_tests.rs
@@ -293,7 +293,7 @@ async fn signal_killed_require_commit_run_rescues_dirty_workspace() {
 
 #[cfg(not(target_os = "macos"))]
 #[tokio::test]
-async fn completion_rescues_require_commit_when_writer_left_uncommitted_changes() {
+async fn completion_does_not_rescue_after_sandbox_hook_failure_marker() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let _sandbox = ScopedSessionSandbox::new(&tmp).await;
     let project_root = tmp.path();
@@ -304,15 +304,21 @@ async fn completion_rescues_require_commit_when_writer_left_uncommitted_changes(
 
     std::fs::write(project_root.join("tracked.txt"), "changed\n").expect("write change");
     run_git(project_root, &["add", "tracked.txt"]);
+    let staged_tree = git_capture(project_root, &["write-tree"]);
 
     let mut session = create_session(
         project_root,
-        Some("require commit rescue"),
+        Some("sandbox hook blocked require commit"),
         None,
         Some("codex"),
     )
     .expect("create session");
     let session_dir = get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    std::fs::write(
+        session_dir.join(csa_hooks::git_guard::SANDBOX_COMMIT_FAILURE_MARKER_FILE),
+        format!("{initial_head} {staged_tree} args env config hooks\n"),
+    )
+    .expect("write sandbox hook marker");
     let executor = Executor::Codex {
         model_override: None,
         thinking_budget: None,
@@ -382,52 +388,17 @@ async fn completion_rescues_require_commit_when_writer_left_uncommitted_changes(
     .await
     .expect("complete session");
 
+    assert_eq!(completed.commit_created, Some(false));
+    assert_ne!(completed.execution.exit_code, 0);
     assert_eq!(
-        completed.execution.exit_code,
-        0,
-        "summary={}\ngate={:?}\nstderr={}",
-        completed.execution.summary,
-        completed.execution.csa_gate_failure,
-        completed.execution.stderr_output
-    );
-    assert!(completed.execution.csa_gate_failure.is_none());
-    assert_eq!(completed.commit_created, Some(true));
-    assert!(
-        completed
-            .changed_paths
-            .as_ref()
-            .is_some_and(|paths| paths.len() == 1 && paths[0] == "tracked.txt")
-    );
-    assert!(
-        completed
-            .execution
-            .stderr_output
-            .contains("CSA require-commit rescue: created commit"),
-        "{}",
-        completed.execution.stderr_output
-    );
-    assert!(
-        !completed
-            .execution
-            .stderr_output
-            .contains("post-run policy blocked"),
-        "{}",
-        completed.execution.stderr_output
-    );
-    assert_ne!(
         git_capture(project_root, &["rev-parse", "HEAD"]),
         initial_head
     );
-    assert_eq!(git_capture(project_root, &["status", "--porcelain=v1"]), "");
     assert_eq!(
-        git_capture(project_root, &["log", "-1", "--format=%s"]),
-        "feat: auto-rescue commit from CSA codex writer session"
+        git_capture(project_root, &["write-tree"]),
+        staged_tree,
+        "control-plane rescue must preserve the sandbox-blocked staged tree"
     );
-    let persisted = load_result(project_root, &session.meta_session_id)
-        .expect("load result")
-        .expect("result should be saved");
-    assert_eq!(persisted.status, "success");
-    assert_eq!(persisted.exit_code, 0);
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion_require_commit_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion_require_commit_tests.rs
@@ -292,10 +292,11 @@ async fn signal_killed_require_commit_run_rescues_dirty_workspace() {
 }
 
 #[cfg(not(target_os = "macos"))]
-#[tokio::test]
-async fn completion_does_not_rescue_after_sandbox_hook_failure_marker() {
+async fn assert_completion_does_not_rescue_after_sandbox_hook_failure_marker(hang_git_probe: bool) {
+    use std::os::unix::fs::PermissionsExt;
+
     let tmp = tempfile::tempdir().expect("tempdir");
-    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let mut sandbox = ScopedSessionSandbox::new(&tmp).await;
     let project_root = tmp.path();
     init_git_repo(project_root);
     let initial_head = git_capture(project_root, &["rev-parse", "HEAD"]);
@@ -319,6 +320,40 @@ async fn completion_does_not_rescue_after_sandbox_hook_failure_marker() {
         format!("{initial_head} {staged_tree} args env config hooks\n"),
     )
     .expect("write sandbox hook marker");
+
+    let original_path = hang_git_probe.then(|| std::env::var_os("PATH").unwrap_or_default());
+    if let Some(original_path) = original_path.as_ref() {
+        let fake_bin = project_root.join("fake-bin");
+        std::fs::create_dir(&fake_bin).expect("create fake bin");
+        let fake_git = fake_bin.join("git");
+        std::fs::write(
+            &fake_git,
+            r#"#!/bin/sh
+if [ "${1:-}" = "-C" ] && [ "${3:-}" = "rev-parse" ] && [ "${4:-}" = "--verify" ] && [ "${5:-}" = "HEAD" ]; then
+  count=0
+  [ ! -f "${GIT_PROBE_COUNT}" ] || count="$(cat "${GIT_PROBE_COUNT}")"
+  count=$((count + 1))
+  printf '%s\n' "${count}" > "${GIT_PROBE_COUNT}"
+  [ "${count}" -ne 2 ] || exec /usr/bin/sleep 2
+fi
+exec /usr/bin/git "$@"
+"#,
+        )
+        .expect("write hanging probe Git");
+        std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755))
+            .expect("make fake Git executable");
+        let probe_count = project_root.join("git-probe-count");
+        let mut path = fake_bin.into_os_string();
+        path.push(":");
+        path.push(original_path);
+        sandbox.track_env("PATH");
+        sandbox.track_env("GIT_PROBE_COUNT");
+        // SAFETY: ScopedSessionSandbox owns TEST_ENV_LOCK and restores both variables.
+        unsafe {
+            std::env::set_var("PATH", path);
+            std::env::set_var("GIT_PROBE_COUNT", probe_count);
+        }
+    }
     let executor = Executor::Codex {
         model_override: None,
         thinking_budget: None,
@@ -388,6 +423,14 @@ async fn completion_does_not_rescue_after_sandbox_hook_failure_marker() {
     .await
     .expect("complete session");
 
+    if let Some(original_path) = original_path {
+        // SAFETY: restore PATH before the fixture's final real-Git checks.
+        unsafe {
+            std::env::set_var("PATH", original_path);
+            std::env::remove_var("GIT_PROBE_COUNT");
+        }
+    }
+
     assert_eq!(completed.commit_created, Some(false));
     assert_ne!(completed.execution.exit_code, 0);
     assert_eq!(
@@ -399,6 +442,18 @@ async fn completion_does_not_rescue_after_sandbox_hook_failure_marker() {
         staged_tree,
         "control-plane rescue must preserve the sandbox-blocked staged tree"
     );
+}
+
+#[cfg(not(target_os = "macos"))]
+#[tokio::test]
+async fn completion_does_not_rescue_after_sandbox_hook_failure_marker() {
+    assert_completion_does_not_rescue_after_sandbox_hook_failure_marker(false).await;
+}
+
+#[cfg(not(target_os = "macos"))]
+#[tokio::test]
+async fn completion_does_not_rescue_when_sandbox_marker_probe_times_out() {
+    assert_completion_does_not_rescue_after_sandbox_hook_failure_marker(true).await;
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/pipeline_session_exec_completion_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_completion_tests.rs
@@ -358,6 +358,116 @@ async fn completion_reports_commit_created_when_head_advances_cleanly() {
     );
 }
 
+#[tokio::test]
+async fn completion_accepts_writer_commit_without_marker_when_head_advances() {
+    // F1 regression: a successful writer `git commit` under --require-commit must
+    // not be gate-failed as commit-policy-unverifiable just because the sandbox
+    // hook marker is absent on success (success removes the marker; non-sandboxed
+    // runs never write one).
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&tmp).await;
+    let project_root = tmp.path();
+    init_git_repo(project_root);
+    let before =
+        crate::run_cmd::capture_git_workspace_snapshot(project_root, false).expect("snapshot");
+
+    std::fs::write(project_root.join("tracked.txt"), "committed\n").expect("write change");
+    run_git(project_root, &["add", "tracked.txt"]);
+    run_git(project_root, &["commit", "-q", "-m", "clean commit"]);
+
+    let mut session = create_session(project_root, Some("clean commit"), None, Some("codex"))
+        .expect("create session");
+    let session_dir = get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let executor = Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: CodexRuntimeMetadata::current(),
+    };
+    let transport_result = TransportResult {
+        execution: csa_process::ExecutionResult {
+            output: "committed".to_string(),
+            stderr_output: String::new(),
+            summary: "committed".to_string(),
+            exit_code: 0,
+            model_completed: Some(true),
+            ..Default::default()
+        },
+        provider_session_id: None,
+        events: Vec::new(),
+        metadata: StreamingMetadata {
+            extracted_commands: vec!["git commit -m fix".to_string()],
+            has_tool_calls: true,
+            has_execute_tool_calls: true,
+            turn_count: 1,
+            ..Default::default()
+        },
+    };
+    let plan = SessionCompletionPlan {
+        merged_env: Default::default(),
+        hooks_config: Default::default(),
+        sessions_root: session_dir
+            .parent()
+            .expect("sessions root")
+            .display()
+            .to_string(),
+        edit_guard: None,
+        new_file_guard: None,
+        result_file_cleared: false,
+        execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
+        commit_guard_enabled: true,
+        require_commit_on_mutation: true,
+        hook_bypass_scan_enabled: true,
+        is_git: true,
+        inside_git_worktree: true,
+        pre_run_workspace: Some(before),
+        pre_exec_snapshot: None,
+        timeout_diagnostics: None,
+        sa_mode: false,
+    };
+
+    let completed = complete_session_execution(
+        CompletionInput {
+            executor: &executor,
+            tool: &csa_core::types::ToolName::Codex,
+            prompt: "Commit the work",
+            output_format: &OutputFormat::Json,
+            task_type: Some("run"),
+            readonly_project_root: false,
+            project_root,
+            config: None,
+            global_config: None,
+            session_dir: &session_dir,
+            memory_project_key: None,
+            effective_prompt: "Commit the work".to_string(),
+            plan,
+            transport_result,
+        },
+        &mut session,
+    )
+    .await
+    .expect("complete session");
+
+    assert_eq!(completed.commit_created, Some(true));
+    assert_eq!(completed.execution.exit_code, 0);
+    assert!(completed.execution.csa_gate_failure.is_none());
+    assert!(
+        !completed
+            .execution
+            .stderr_output
+            .contains("commit-policy-unverifiable"),
+        "{}",
+        completed.execution.stderr_output
+    );
+    assert!(
+        !completed
+            .execution
+            .stderr_output
+            .contains("unable to verify workspace mutation state"),
+        "{}",
+        completed.execution.stderr_output
+    );
+}
+
 #[test]
 fn fix_finding_terminal_guard_allows_dirty_side_effects_after_amend() {
     let mut session = MetaSessionState::default();

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -114,6 +114,7 @@ use prior_rounds::load_prior_rounds_section_or_persist_error;
 use resolve::build_review_instruction;
 #[cfg(test)]
 pub(crate) use resolve::resolve_review_tool;
+pub(crate) use resolve::run_command_with_timeout;
 use resolve::{
     ReviewProjectPromptOptions, build_review_instruction_for_project, derive_scope_for_project,
     resolve_review_effective_tier, resolve_review_model, resolve_review_readonly_configured,

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -329,7 +329,7 @@ mod scope;
 #[cfg(test)]
 pub(crate) use scope::derive_scope;
 pub(crate) use scope::{
-    derive_scope_for_project, review_scope_allows_auto_discovery,
+    derive_scope_for_project, review_scope_allows_auto_discovery, run_command_with_timeout,
     validate_single_parent_commit_scope,
 };
 

--- a/crates/cli-sub-agent/src/review_cmd_resolve_scope.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve_scope.rs
@@ -147,7 +147,7 @@ fn git_output_with_timeout(project_root: &Path, args: &[&str]) -> Option<Output>
     run_command_with_timeout(&mut command, GIT_SCOPE_PROBE_TIMEOUT)
 }
 
-fn run_command_with_timeout(command: &mut Command, timeout: Duration) -> Option<Output> {
+pub(crate) fn run_command_with_timeout(command: &mut Command, timeout: Duration) -> Option<Output> {
     let mut stdout = tempfile::tempfile().ok()?;
     let mut stderr = tempfile::tempfile().ok()?;
     command

--- a/crates/cli-sub-agent/src/run_cmd.rs
+++ b/crates/cli-sub-agent/src/run_cmd.rs
@@ -40,7 +40,8 @@ pub(crate) use policy::{
 pub(crate) use shell::{detect_git_commit_commands, detect_no_verify_commit_commands};
 pub(crate) use uncommitted::{
     collect_uncommitted_changes_for_changed_paths, format_large_diff_warning_block,
-    format_uncommitted_warning, is_writer_session, working_tree_changed_lines,
+    format_uncommitted_warning, is_writer_session, sandbox_commit_failure_matches,
+    working_tree_changed_lines,
 };
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -10,7 +10,9 @@ use tracing::warn;
 const MAX_UNCOMMITTED_FILES: usize = 20;
 const REQUIRE_COMMIT_REASON: &str =
     "require-commit contract failed: no qualifying commit or tracked dirty work remains";
+const REQUIRE_COMMIT_SANDBOX_HOOK_REASON: &str = "require-commit blocked: mandatory hook-enabled commit failed in the filesystem sandbox; staged tree preserved for host recovery";
 const REQUIRE_COMMIT_RECOVERY_ACTION: &str = "inspect_changed_paths_then_commit_or_revert";
+const REQUIRE_COMMIT_SANDBOX_HOOK_RECOVERY_ACTION: &str = "run_hook_enabled_commit_outside_sandbox";
 const REQUIRE_COMMIT_BLOCKER_SUMMARY_MAX_CHARS: usize = 240;
 const REDACTED_PATH: &str = "[redacted-path]";
 const LARGE_DIFF_WARNING_TEXT: &str = "This CSA session left a large changed surface. Do not proceed directly to a single commit/PR unless this was explicitly intended. First inspect the file list, split into atomic logical units if possible, and run review per unit. If intentionally large, record that rationale in the commit/PR.";
@@ -38,6 +40,10 @@ pub(crate) fn effective_writer_must_commit(
     config: Option<&csa_config::ProjectConfig>,
 ) -> bool {
     cli_require_commit || config.is_some_and(|cfg| cfg.run.writer_must_commit)
+}
+
+pub(crate) fn sandbox_commit_failure_matches(project_root: &Path, session_id: &str) -> bool {
+    require_commit::sandbox_commit_failure_matches(project_root, session_id)
 }
 
 #[cfg(test)]
@@ -201,6 +207,10 @@ fn record_writer_uncommitted_changes_with_config(
             || dirty_tracked_probe
                 .as_ref()
                 .is_some_and(|probe| !probe.is_clean()));
+    let sandbox_hook_blocked = require_commit_contract_failure
+        && session_id.is_some_and(|session_id| {
+            require_commit::sandbox_commit_failure_matches(project_root, session_id)
+        });
     let contract_changes = dirty_tracked_changes;
 
     let maybe_signal_exit = matches!(result.exit_code, 124 | 130 | 137 | 143);
@@ -210,7 +220,7 @@ fn record_writer_uncommitted_changes_with_config(
 
     let Some(session_id) = session_id else {
         if require_commit_contract_failure {
-            mark_require_commit_contract_failure(result);
+            mark_require_commit_contract_failure(result, sandbox_hook_blocked);
         }
         return warning;
     };
@@ -226,13 +236,14 @@ fn record_writer_uncommitted_changes_with_config(
                 record.require_commit,
             );
             let recovery = require_commit_contract_failure.then(|| {
-                build_require_commit_recovery_diagnostic_for_state(
+                require_commit::build_recovery_diagnostic_for_state(
                     &session_result,
                     contract_changes,
                     commit_created,
                     result.csa_gate_failure.as_deref(),
                     clean_tree_verification_failure,
                     Some(record.sa_mode),
+                    sandbox_hook_blocked,
                 )
             });
             let mut should_save = false;
@@ -285,7 +296,7 @@ fn record_writer_uncommitted_changes_with_config(
     }
 
     if require_commit_contract_failure {
-        mark_require_commit_contract_failure(result);
+        mark_require_commit_contract_failure(result, sandbox_hook_blocked);
     }
     warning
 }
@@ -302,13 +313,14 @@ pub(crate) fn apply_uncommitted_changes_to_result(
     result.require_commit_recovery = recovery;
     if require_commit_contract_failure {
         let recovery = result.require_commit_recovery.take().unwrap_or_else(|| {
-            build_require_commit_recovery_diagnostic_for_state(
+            require_commit::build_recovery_diagnostic_for_state(
                 result,
                 result.uncommitted_changes.as_ref(),
                 false,
                 None,
                 None,
                 None,
+                false,
             )
         });
         apply_require_commit_contract_failure_to_result(result, recovery);
@@ -322,7 +334,13 @@ fn apply_require_commit_contract_failure_to_result(
     remove_incidental_downgrade_warnings(&mut result.warnings);
     result.exit_code = 1;
     result.status = csa_session::SessionResult::status_from_exit_code(1);
-    result.summary = REQUIRE_COMMIT_REASON.to_string();
+    result.summary =
+        if recovery.suggested_recovery_action == REQUIRE_COMMIT_SANDBOX_HOOK_RECOVERY_ACTION {
+            REQUIRE_COMMIT_SANDBOX_HOOK_REASON
+        } else {
+            REQUIRE_COMMIT_REASON
+        }
+        .to_string();
     result.require_commit_recovery = Some(recovery);
 }
 
@@ -331,68 +349,32 @@ fn build_require_commit_recovery_diagnostic(
     result: &csa_session::SessionResult,
     changes: &csa_session::UncommittedChanges,
 ) -> csa_session::RequireCommitRecoveryDiagnostic {
-    build_require_commit_recovery_diagnostic_for_state(
+    require_commit::build_recovery_diagnostic_for_state(
         result,
         Some(changes),
         false,
         None,
         None,
         Some(false),
+        false,
     )
 }
 
-fn build_require_commit_recovery_diagnostic_for_state(
-    result: &csa_session::SessionResult,
-    changes: Option<&csa_session::UncommittedChanges>,
-    commit_created: bool,
-    gate_failure: Option<&str>,
-    clean_tree_verification_failure: Option<&str>,
-    sa_mode: Option<bool>,
-) -> csa_session::RequireCommitRecoveryDiagnostic {
-    let termination_exit_code = result.raw_process_exit_code.unwrap_or(result.exit_code);
-    let termination_status = result
-        .raw_process_exit_code
-        .map(raw_termination_status_from_exit_code)
-        .unwrap_or_else(|| result.status.clone());
-    csa_session::RequireCommitRecoveryDiagnostic {
-        require_commit: true,
-        sa_mode,
-        commit_created,
-        dirty_worktree: changes.is_some(),
-        changed_paths: changes
-            .map(|changes| {
-                changes
-                    .files
-                    .iter()
-                    .map(|path| sanitize_diagnostic_path(path))
-                    .collect()
-            })
-            .unwrap_or_default(),
-        changed_paths_truncated: changes.map(|changes| changes.truncated).unwrap_or_default(),
-        termination_status,
-        exit_code: termination_exit_code,
-        termination_signal: result
-            .kill_diagnostics
-            .as_ref()
-            .and_then(|diagnostics| diagnostics.signal)
-            .or_else(|| infer_signal_from_exit_code(termination_exit_code)),
-        kill_hint: result.kill_hint.clone(),
-        blocker_summary: require_commit::build_blocker_summary(
-            result,
-            gate_failure,
-            clean_tree_verification_failure,
-        ),
-        suggested_recovery_action: REQUIRE_COMMIT_RECOVERY_ACTION.to_string(),
-    }
-}
-
-fn mark_require_commit_contract_failure(result: &mut csa_process::ExecutionResult) {
+fn mark_require_commit_contract_failure(
+    result: &mut csa_process::ExecutionResult,
+    sandbox_hook_blocked: bool,
+) {
     result.mark_gate_failure("writer-uncommitted");
-    result.summary = REQUIRE_COMMIT_REASON.to_string();
+    let reason = if sandbox_hook_blocked {
+        REQUIRE_COMMIT_SANDBOX_HOOK_REASON
+    } else {
+        REQUIRE_COMMIT_REASON
+    };
+    result.summary = reason.to_string();
     if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
         result.stderr_output.push('\n');
     }
-    result.stderr_output.push_str(REQUIRE_COMMIT_REASON);
+    result.stderr_output.push_str(reason);
     result.stderr_output.push('\n');
 }
 

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -42,7 +42,10 @@ pub(crate) fn effective_writer_must_commit(
     cli_require_commit || config.is_some_and(|cfg| cfg.run.writer_must_commit)
 }
 
-pub(crate) fn sandbox_commit_failure_matches(project_root: &Path, session_id: &str) -> bool {
+pub(crate) fn sandbox_commit_failure_matches(
+    project_root: &Path,
+    session_id: &str,
+) -> Result<bool, String> {
     require_commit::sandbox_commit_failure_matches(project_root, session_id)
 }
 
@@ -207,10 +210,15 @@ fn record_writer_uncommitted_changes_with_config(
             || dirty_tracked_probe
                 .as_ref()
                 .is_some_and(|probe| !probe.is_clean()));
-    let sandbox_hook_blocked = require_commit_contract_failure
-        && session_id.is_some_and(|session_id| {
+    let sandbox_hook_probe = if require_commit_contract_failure {
+        session_id.map(|session_id| {
             require_commit::sandbox_commit_failure_matches(project_root, session_id)
-        });
+        })
+    } else {
+        None
+    };
+    let sandbox_hook_state =
+        require_commit::SandboxHookProbeState::from_result(sandbox_hook_probe.as_ref());
     let contract_changes = dirty_tracked_changes;
 
     let maybe_signal_exit = matches!(result.exit_code, 124 | 130 | 137 | 143);
@@ -220,7 +228,7 @@ fn record_writer_uncommitted_changes_with_config(
 
     let Some(session_id) = session_id else {
         if require_commit_contract_failure {
-            mark_require_commit_contract_failure(result, sandbox_hook_blocked);
+            mark_require_commit_contract_failure(result, sandbox_hook_state);
         }
         return warning;
     };
@@ -243,7 +251,7 @@ fn record_writer_uncommitted_changes_with_config(
                     result.csa_gate_failure.as_deref(),
                     clean_tree_verification_failure,
                     Some(record.sa_mode),
-                    sandbox_hook_blocked,
+                    sandbox_hook_state,
                 )
             });
             let mut should_save = false;
@@ -296,7 +304,7 @@ fn record_writer_uncommitted_changes_with_config(
     }
 
     if require_commit_contract_failure {
-        mark_require_commit_contract_failure(result, sandbox_hook_blocked);
+        mark_require_commit_contract_failure(result, sandbox_hook_state);
     }
     warning
 }
@@ -320,7 +328,7 @@ pub(crate) fn apply_uncommitted_changes_to_result(
                 None,
                 None,
                 None,
-                false,
+                require_commit::SandboxHookProbeState::Clear,
             )
         });
         apply_require_commit_contract_failure_to_result(result, recovery);
@@ -334,13 +342,7 @@ fn apply_require_commit_contract_failure_to_result(
     remove_incidental_downgrade_warnings(&mut result.warnings);
     result.exit_code = 1;
     result.status = csa_session::SessionResult::status_from_exit_code(1);
-    result.summary =
-        if recovery.suggested_recovery_action == REQUIRE_COMMIT_SANDBOX_HOOK_RECOVERY_ACTION {
-            REQUIRE_COMMIT_SANDBOX_HOOK_REASON
-        } else {
-            REQUIRE_COMMIT_REASON
-        }
-        .to_string();
+    result.summary = require_commit::persisted_contract_failure_reason(&recovery).to_string();
     result.require_commit_recovery = Some(recovery);
 }
 
@@ -356,20 +358,16 @@ fn build_require_commit_recovery_diagnostic(
         None,
         None,
         Some(false),
-        false,
+        require_commit::SandboxHookProbeState::Clear,
     )
 }
 
 fn mark_require_commit_contract_failure(
     result: &mut csa_process::ExecutionResult,
-    sandbox_hook_blocked: bool,
+    sandbox_hook_state: require_commit::SandboxHookProbeState<'_>,
 ) {
     result.mark_gate_failure("writer-uncommitted");
-    let reason = if sandbox_hook_blocked {
-        REQUIRE_COMMIT_SANDBOX_HOOK_REASON
-    } else {
-        REQUIRE_COMMIT_REASON
-    };
+    let reason = require_commit::contract_failure_reason(sandbox_hook_state);
     result.summary = reason.to_string();
     if !result.stderr_output.is_empty() && !result.stderr_output.ends_with('\n') {
         result.stderr_output.push('\n');

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted.rs
@@ -13,6 +13,8 @@ const REQUIRE_COMMIT_REASON: &str =
 const REQUIRE_COMMIT_SANDBOX_HOOK_REASON: &str = "require-commit blocked: mandatory hook-enabled commit failed in the filesystem sandbox; staged tree preserved for host recovery";
 const REQUIRE_COMMIT_RECOVERY_ACTION: &str = "inspect_changed_paths_then_commit_or_revert";
 const REQUIRE_COMMIT_SANDBOX_HOOK_RECOVERY_ACTION: &str = "run_hook_enabled_commit_outside_sandbox";
+const REQUIRE_COMMIT_SANDBOX_HOOK_PROBE_RECOVERY_ACTION: &str =
+    "run_hook_enabled_commit_outside_sandbox_probe_uncertain";
 const REQUIRE_COMMIT_BLOCKER_SUMMARY_MAX_CHARS: usize = 240;
 const REDACTED_PATH: &str = "[redacted-path]";
 const LARGE_DIFF_WARNING_TEXT: &str = "This CSA session left a large changed surface. Do not proceed directly to a single commit/PR unless this was explicitly intended. First inspect the file list, split into atomic logical units if possible, and run review per unit. If intentionally large, record that rationale in the commit/PR.";
@@ -212,7 +214,7 @@ fn record_writer_uncommitted_changes_with_config(
                 .is_some_and(|probe| !probe.is_clean()));
     let sandbox_hook_probe = if require_commit_contract_failure {
         session_id.map(|session_id| {
-            require_commit::sandbox_commit_failure_matches(project_root, session_id)
+            require_commit::sandbox_commit_failure_state(project_root, session_id)
         })
     } else {
         None

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, Read};
+use std::io::Read;
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
@@ -7,6 +7,54 @@ use std::time::Duration;
 
 const SANDBOX_COMMIT_FAILURE_MARKER_MAX_BYTES: usize = 1024;
 const REQUIRE_COMMIT_GIT_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+const SANDBOX_HOOK_PROBE_REASON: &str = "require-commit blocked: sandbox hook failure state could not be verified; staged tree preserved for host recovery";
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum SandboxHookProbeState<'a> {
+    Clear,
+    Blocked,
+    Uncertain(&'a str),
+}
+
+impl<'a> SandboxHookProbeState<'a> {
+    pub(super) fn from_result(probe: Option<&'a Result<bool, String>>) -> Self {
+        match probe {
+            Some(Ok(true)) => Self::Blocked,
+            Some(Err(error)) => Self::Uncertain(error),
+            Some(Ok(false)) | None => Self::Clear,
+        }
+    }
+
+    fn requires_host_recovery(self) -> bool {
+        !matches!(self, Self::Clear)
+    }
+}
+
+pub(super) fn contract_failure_reason(state: SandboxHookProbeState<'_>) -> &'static str {
+    match state {
+        SandboxHookProbeState::Blocked => super::REQUIRE_COMMIT_SANDBOX_HOOK_REASON,
+        SandboxHookProbeState::Uncertain(_) => SANDBOX_HOOK_PROBE_REASON,
+        SandboxHookProbeState::Clear => super::REQUIRE_COMMIT_REASON,
+    }
+}
+
+pub(super) fn persisted_contract_failure_reason(
+    recovery: &csa_session::RequireCommitRecoveryDiagnostic,
+) -> &'static str {
+    if recovery
+        .blocker_summary
+        .as_deref()
+        .is_some_and(|summary| summary.contains("sandbox_hook_probe="))
+    {
+        SANDBOX_HOOK_PROBE_REASON
+    } else if recovery.suggested_recovery_action
+        == super::REQUIRE_COMMIT_SANDBOX_HOOK_RECOVERY_ACTION
+    {
+        super::REQUIRE_COMMIT_SANDBOX_HOOK_REASON
+    } else {
+        super::REQUIRE_COMMIT_REASON
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(super) enum DirtyTrackedWorktree {
@@ -39,14 +87,18 @@ pub(super) fn build_blocker_summary(
     result: &csa_session::SessionResult,
     gate_failure: Option<&str>,
     clean_tree_verification_failure: Option<&str>,
-    sandbox_hook_blocked: bool,
+    sandbox_hook_state: SandboxHookProbeState<'_>,
 ) -> Option<String> {
     let mut parts = Vec::new();
-    if sandbox_hook_blocked {
-        parts.push(
+    match sandbox_hook_state {
+        SandboxHookProbeState::Blocked => parts.push(
             "sandbox_hook=mandatory hook-enabled commit failed for unchanged staged tree"
                 .to_string(),
-        );
+        ),
+        SandboxHookProbeState::Uncertain(error) => {
+            parts.push(format!("sandbox_hook_probe={error}"));
+        }
+        SandboxHookProbeState::Clear => {}
     }
     if let Some(gate_failure) = gate_failure
         .map(str::trim)
@@ -99,7 +151,7 @@ pub(super) fn build_recovery_diagnostic_for_state(
     gate_failure: Option<&str>,
     clean_tree_verification_failure: Option<&str>,
     sa_mode: Option<bool>,
-    sandbox_hook_blocked: bool,
+    sandbox_hook_state: SandboxHookProbeState<'_>,
 ) -> csa_session::RequireCommitRecoveryDiagnostic {
     let termination_exit_code = result.raw_process_exit_code.unwrap_or(result.exit_code);
     let termination_status = result
@@ -133,9 +185,9 @@ pub(super) fn build_recovery_diagnostic_for_state(
             result,
             gate_failure,
             clean_tree_verification_failure,
-            sandbox_hook_blocked,
+            sandbox_hook_state,
         ),
-        suggested_recovery_action: if sandbox_hook_blocked {
+        suggested_recovery_action: if sandbox_hook_state.requires_host_recovery() {
             super::REQUIRE_COMMIT_SANDBOX_HOOK_RECOVERY_ACTION
         } else {
             super::REQUIRE_COMMIT_RECOVERY_ACTION
@@ -144,65 +196,91 @@ pub(super) fn build_recovery_diagnostic_for_state(
     }
 }
 
-pub(super) fn sandbox_commit_failure_matches(project_root: &Path, session_id: &str) -> bool {
-    let Ok(session_dir) = csa_session::get_session_dir(project_root, session_id) else {
-        return false;
-    };
+pub(super) fn sandbox_commit_failure_matches(
+    project_root: &Path,
+    session_id: &str,
+) -> Result<bool, String> {
+    let session_dir = csa_session::get_session_dir(project_root, session_id)
+        .map_err(|_| "sandbox-hook-marker-session-dir-unavailable".to_string())?;
     let Some(marker) = read_sandbox_commit_failure_marker(
         &session_dir.join(csa_hooks::git_guard::SANDBOX_COMMIT_FAILURE_MARKER_FILE),
-    ) else {
-        return false;
+    )?
+    else {
+        return Ok(false);
     };
     let fields = marker.split_whitespace().collect::<Vec<_>>();
     if fields.len() != 6 {
-        return false;
+        return Err("sandbox-hook-marker-invalid-record".to_string());
     }
-    let Some(head_output) = run_git_output(project_root, &["rev-parse", "--verify", "HEAD"]) else {
-        return false;
-    };
+    let head_output = run_git_output(project_root, &["rev-parse", "--verify", "HEAD"])
+        .ok_or_else(|| "sandbox-hook-marker-head-probe-spawn-or-timeout".to_string())?;
     let current_head = if head_output.status.success() {
         String::from_utf8_lossy(&head_output.stdout)
             .trim()
             .to_string()
-    } else {
+    } else if head_output.status.code() == Some(128) {
         "unborn".to_string()
+    } else {
+        return Err(format!(
+            "sandbox-hook-marker-head-probe-failed exit_code={}",
+            head_output
+                .status
+                .code()
+                .map_or_else(|| "unknown".to_string(), |code| code.to_string())
+        ));
     };
     if fields[0] != current_head {
-        return false;
+        return Ok(false);
     }
-    let Ok(current_index_tree) = run_git_status_porcelain(project_root, &["write-tree"]) else {
-        return false;
-    };
-    fields[1] == current_index_tree.trim()
+    let current_index_tree = run_git_status_porcelain(project_root, &["write-tree"])
+        .map_err(|error| format!("sandbox-hook-marker-index-probe={error}"))?;
+    Ok(fields[1] == current_index_tree.trim())
 }
 
 #[cfg(unix)]
-fn read_sandbox_commit_failure_marker(path: &Path) -> Option<String> {
-    let file = std::fs::OpenOptions::new()
+fn read_sandbox_commit_failure_marker(path: &Path) -> Result<Option<String>, String> {
+    let file = match std::fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
         .open(path)
-        .ok()?;
-    let metadata = file.metadata().ok()?;
-    if !metadata.is_file()
-        || metadata.len() > u64::try_from(SANDBOX_COMMIT_FAILURE_MARKER_MAX_BYTES).ok()?
     {
-        return None;
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err("sandbox-hook-marker-open-failed".to_string()),
+    };
+    let metadata = file
+        .metadata()
+        .map_err(|_| "sandbox-hook-marker-metadata-failed".to_string())?;
+    if !metadata.is_file()
+        || metadata.len()
+            > u64::try_from(SANDBOX_COMMIT_FAILURE_MARKER_MAX_BYTES)
+                .map_err(|_| "sandbox-hook-marker-size-limit-invalid".to_string())?
+    {
+        return Err("sandbox-hook-marker-not-bounded-regular-file".to_string());
     }
 
     let mut record = Vec::new();
-    let mut reader = std::io::BufReader::new(file)
-        .take(u64::try_from(SANDBOX_COMMIT_FAILURE_MARKER_MAX_BYTES + 1).ok()?);
-    reader.read_until(b'\n', &mut record).ok()?;
+    let mut reader = file.take(
+        u64::try_from(SANDBOX_COMMIT_FAILURE_MARKER_MAX_BYTES + 1)
+            .map_err(|_| "sandbox-hook-marker-size-limit-invalid".to_string())?,
+    );
+    reader
+        .read_to_end(&mut record)
+        .map_err(|_| "sandbox-hook-marker-read-failed".to_string())?;
     if record.len() > SANDBOX_COMMIT_FAILURE_MARKER_MAX_BYTES {
-        return None;
+        return Err("sandbox-hook-marker-too-large".to_string());
     }
-    String::from_utf8(record).ok()
+    if record.last() != Some(&b'\n') || record[..record.len() - 1].contains(&b'\n') {
+        return Err("sandbox-hook-marker-not-single-record".to_string());
+    }
+    String::from_utf8(record)
+        .map(Some)
+        .map_err(|_| "sandbox-hook-marker-not-utf8".to_string())
 }
 
 #[cfg(not(unix))]
-fn read_sandbox_commit_failure_marker(_path: &Path) -> Option<String> {
-    None
+fn read_sandbox_commit_failure_marker(_path: &Path) -> Result<Option<String>, String> {
+    Err("sandbox-hook-marker-reader-unavailable".to_string())
 }
 
 pub(super) fn inspect_dirty_tracked_changes(project_root: &Path) -> DirtyTrackedWorktree {

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit.rs
@@ -1,5 +1,12 @@
+use std::io::{BufRead, Read};
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output};
+use std::time::Duration;
+
+const SANDBOX_COMMIT_FAILURE_MARKER_MAX_BYTES: usize = 1024;
+const REQUIRE_COMMIT_GIT_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone)]
 pub(super) enum DirtyTrackedWorktree {
@@ -141,8 +148,8 @@ pub(super) fn sandbox_commit_failure_matches(project_root: &Path, session_id: &s
     let Ok(session_dir) = csa_session::get_session_dir(project_root, session_id) else {
         return false;
     };
-    let Ok(marker) = std::fs::read_to_string(
-        session_dir.join(csa_hooks::git_guard::SANDBOX_COMMIT_FAILURE_MARKER_FILE),
+    let Some(marker) = read_sandbox_commit_failure_marker(
+        &session_dir.join(csa_hooks::git_guard::SANDBOX_COMMIT_FAILURE_MARKER_FILE),
     ) else {
         return false;
     };
@@ -150,13 +157,52 @@ pub(super) fn sandbox_commit_failure_matches(project_root: &Path, session_id: &s
     if fields.len() != 6 {
         return false;
     }
-    let current_head = run_git_status_porcelain(project_root, &["rev-parse", "--verify", "HEAD"])
-        .map(|head| head.trim().to_string())
-        .unwrap_or_else(|_| "unborn".to_string());
+    let Some(head_output) = run_git_output(project_root, &["rev-parse", "--verify", "HEAD"]) else {
+        return false;
+    };
+    let current_head = if head_output.status.success() {
+        String::from_utf8_lossy(&head_output.stdout)
+            .trim()
+            .to_string()
+    } else {
+        "unborn".to_string()
+    };
+    if fields[0] != current_head {
+        return false;
+    }
     let Ok(current_index_tree) = run_git_status_porcelain(project_root, &["write-tree"]) else {
         return false;
     };
-    fields[0] == current_head && fields[1] == current_index_tree.trim()
+    fields[1] == current_index_tree.trim()
+}
+
+#[cfg(unix)]
+fn read_sandbox_commit_failure_marker(path: &Path) -> Option<String> {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .ok()?;
+    let metadata = file.metadata().ok()?;
+    if !metadata.is_file()
+        || metadata.len() > u64::try_from(SANDBOX_COMMIT_FAILURE_MARKER_MAX_BYTES).ok()?
+    {
+        return None;
+    }
+
+    let mut record = Vec::new();
+    let mut reader = std::io::BufReader::new(file)
+        .take(u64::try_from(SANDBOX_COMMIT_FAILURE_MARKER_MAX_BYTES + 1).ok()?);
+    reader.read_until(b'\n', &mut record).ok()?;
+    if record.len() > SANDBOX_COMMIT_FAILURE_MARKER_MAX_BYTES {
+        return None;
+    }
+    String::from_utf8(record).ok()
+}
+
+#[cfg(not(unix))]
+fn read_sandbox_commit_failure_marker(_path: &Path) -> Option<String> {
+    None
 }
 
 pub(super) fn inspect_dirty_tracked_changes(project_root: &Path) -> DirtyTrackedWorktree {
@@ -189,12 +235,8 @@ pub(super) fn inspect_dirty_tracked_changes(project_root: &Path) -> DirtyTracked
 }
 
 fn run_git_status_porcelain(project_root: &Path, args: &[&str]) -> Result<String, String> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(project_root)
-        .args(args)
-        .output()
-        .map_err(|_| "git-status-probe-spawn-failed".to_string())?;
+    let output = run_git_output(project_root, args)
+        .ok_or_else(|| "git-status-probe-spawn-or-timeout".to_string())?;
     if !output.status.success() {
         let exit_code = output
             .status
@@ -204,4 +246,10 @@ fn run_git_status_porcelain(project_root: &Path, args: &[&str]) -> Result<String
         return Err(format!("git-status-probe-failed exit_code={exit_code}"));
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn run_git_output(project_root: &Path, args: &[&str]) -> Option<Output> {
+    let mut command = Command::new("git");
+    command.arg("-C").arg(project_root).args(args);
+    crate::review_cmd::run_command_with_timeout(&mut command, REQUIRE_COMMIT_GIT_PROBE_TIMEOUT)
 }

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit.rs
@@ -32,8 +32,15 @@ pub(super) fn build_blocker_summary(
     result: &csa_session::SessionResult,
     gate_failure: Option<&str>,
     clean_tree_verification_failure: Option<&str>,
+    sandbox_hook_blocked: bool,
 ) -> Option<String> {
     let mut parts = Vec::new();
+    if sandbox_hook_blocked {
+        parts.push(
+            "sandbox_hook=mandatory hook-enabled commit failed for unchanged staged tree"
+                .to_string(),
+        );
+    }
     if let Some(gate_failure) = gate_failure
         .map(str::trim)
         .filter(|value| !value.is_empty())
@@ -76,6 +83,80 @@ fn bound_redacted_one_line(value: &str, max_chars: usize) -> String {
     truncated = truncated.trim_end().to_string();
     truncated.push_str("...");
     truncated
+}
+
+pub(super) fn build_recovery_diagnostic_for_state(
+    result: &csa_session::SessionResult,
+    changes: Option<&csa_session::UncommittedChanges>,
+    commit_created: bool,
+    gate_failure: Option<&str>,
+    clean_tree_verification_failure: Option<&str>,
+    sa_mode: Option<bool>,
+    sandbox_hook_blocked: bool,
+) -> csa_session::RequireCommitRecoveryDiagnostic {
+    let termination_exit_code = result.raw_process_exit_code.unwrap_or(result.exit_code);
+    let termination_status = result
+        .raw_process_exit_code
+        .map(super::raw_termination_status_from_exit_code)
+        .unwrap_or_else(|| result.status.clone());
+    csa_session::RequireCommitRecoveryDiagnostic {
+        require_commit: true,
+        sa_mode,
+        commit_created,
+        dirty_worktree: changes.is_some(),
+        changed_paths: changes
+            .map(|changes| {
+                changes
+                    .files
+                    .iter()
+                    .map(|path| super::sanitize_diagnostic_path(path))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        changed_paths_truncated: changes.map(|changes| changes.truncated).unwrap_or_default(),
+        termination_status,
+        exit_code: termination_exit_code,
+        termination_signal: result
+            .kill_diagnostics
+            .as_ref()
+            .and_then(|diagnostics| diagnostics.signal)
+            .or_else(|| super::infer_signal_from_exit_code(termination_exit_code)),
+        kill_hint: result.kill_hint.clone(),
+        blocker_summary: build_blocker_summary(
+            result,
+            gate_failure,
+            clean_tree_verification_failure,
+            sandbox_hook_blocked,
+        ),
+        suggested_recovery_action: if sandbox_hook_blocked {
+            super::REQUIRE_COMMIT_SANDBOX_HOOK_RECOVERY_ACTION
+        } else {
+            super::REQUIRE_COMMIT_RECOVERY_ACTION
+        }
+        .to_string(),
+    }
+}
+
+pub(super) fn sandbox_commit_failure_matches(project_root: &Path, session_id: &str) -> bool {
+    let Ok(session_dir) = csa_session::get_session_dir(project_root, session_id) else {
+        return false;
+    };
+    let Ok(marker) = std::fs::read_to_string(
+        session_dir.join(csa_hooks::git_guard::SANDBOX_COMMIT_FAILURE_MARKER_FILE),
+    ) else {
+        return false;
+    };
+    let fields = marker.split_whitespace().collect::<Vec<_>>();
+    if fields.len() != 6 {
+        return false;
+    }
+    let current_head = run_git_status_porcelain(project_root, &["rev-parse", "--verify", "HEAD"])
+        .map(|head| head.trim().to_string())
+        .unwrap_or_else(|_| "unborn".to_string());
+    let Ok(current_index_tree) = run_git_status_porcelain(project_root, &["write-tree"]) else {
+        return false;
+    };
+    fields[0] == current_head && fields[1] == current_index_tree.trim()
 }
 
 pub(super) fn inspect_dirty_tracked_changes(project_root: &Path) -> DirtyTrackedWorktree {

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit.rs
@@ -13,26 +13,27 @@ const SANDBOX_HOOK_PROBE_REASON: &str = "require-commit blocked: sandbox hook fa
 pub(super) enum SandboxHookProbeState<'a> {
     Clear,
     Blocked,
+    Retryable,
     Uncertain(&'a str),
 }
 
 impl<'a> SandboxHookProbeState<'a> {
-    pub(super) fn from_result(probe: Option<&'a Result<bool, String>>) -> Self {
+    pub(super) fn from_result(
+        probe: Option<&'a Result<SandboxHookProbeState<'static>, String>>,
+    ) -> Self {
         match probe {
-            Some(Ok(true)) => Self::Blocked,
+            Some(Ok(state)) => *state,
             Some(Err(error)) => Self::Uncertain(error),
-            Some(Ok(false)) | None => Self::Clear,
+            None => Self::Clear,
         }
-    }
-
-    fn requires_host_recovery(self) -> bool {
-        !matches!(self, Self::Clear)
     }
 }
 
 pub(super) fn contract_failure_reason(state: SandboxHookProbeState<'_>) -> &'static str {
     match state {
-        SandboxHookProbeState::Blocked => super::REQUIRE_COMMIT_SANDBOX_HOOK_REASON,
+        SandboxHookProbeState::Blocked | SandboxHookProbeState::Retryable => {
+            super::REQUIRE_COMMIT_SANDBOX_HOOK_REASON
+        }
         SandboxHookProbeState::Uncertain(_) => SANDBOX_HOOK_PROBE_REASON,
         SandboxHookProbeState::Clear => super::REQUIRE_COMMIT_REASON,
     }
@@ -41,10 +42,8 @@ pub(super) fn contract_failure_reason(state: SandboxHookProbeState<'_>) -> &'sta
 pub(super) fn persisted_contract_failure_reason(
     recovery: &csa_session::RequireCommitRecoveryDiagnostic,
 ) -> &'static str {
-    if recovery
-        .blocker_summary
-        .as_deref()
-        .is_some_and(|summary| summary.contains("sandbox_hook_probe="))
+    if recovery.suggested_recovery_action
+        == super::REQUIRE_COMMIT_SANDBOX_HOOK_PROBE_RECOVERY_ACTION
     {
         SANDBOX_HOOK_PROBE_REASON
     } else if recovery.suggested_recovery_action
@@ -93,6 +92,10 @@ pub(super) fn build_blocker_summary(
     match sandbox_hook_state {
         SandboxHookProbeState::Blocked => parts.push(
             "sandbox_hook=mandatory hook-enabled commit failed for unchanged staged tree"
+                .to_string(),
+        ),
+        SandboxHookProbeState::Retryable => parts.push(
+            "sandbox_hook=mandatory hook-enabled commit failed after changing staged state"
                 .to_string(),
         ),
         SandboxHookProbeState::Uncertain(error) => {
@@ -187,10 +190,14 @@ pub(super) fn build_recovery_diagnostic_for_state(
             clean_tree_verification_failure,
             sandbox_hook_state,
         ),
-        suggested_recovery_action: if sandbox_hook_state.requires_host_recovery() {
-            super::REQUIRE_COMMIT_SANDBOX_HOOK_RECOVERY_ACTION
-        } else {
-            super::REQUIRE_COMMIT_RECOVERY_ACTION
+        suggested_recovery_action: match sandbox_hook_state {
+            SandboxHookProbeState::Uncertain(_) => {
+                super::REQUIRE_COMMIT_SANDBOX_HOOK_PROBE_RECOVERY_ACTION
+            }
+            SandboxHookProbeState::Blocked | SandboxHookProbeState::Retryable => {
+                super::REQUIRE_COMMIT_SANDBOX_HOOK_RECOVERY_ACTION
+            }
+            SandboxHookProbeState::Clear => super::REQUIRE_COMMIT_RECOVERY_ACTION,
         }
         .to_string(),
     }
@@ -200,14 +207,27 @@ pub(super) fn sandbox_commit_failure_matches(
     project_root: &Path,
     session_id: &str,
 ) -> Result<bool, String> {
+    Ok(!matches!(
+        sandbox_commit_failure_state(project_root, session_id)?,
+        SandboxHookProbeState::Clear
+    ))
+}
+
+pub(super) fn sandbox_commit_failure_state(
+    project_root: &Path,
+    session_id: &str,
+) -> Result<SandboxHookProbeState<'static>, String> {
     let session_dir = csa_session::get_session_dir(project_root, session_id)
         .map_err(|_| "sandbox-hook-marker-session-dir-unavailable".to_string())?;
     let Some(marker) = read_sandbox_commit_failure_marker(
         &session_dir.join(csa_hooks::git_guard::SANDBOX_COMMIT_FAILURE_MARKER_FILE),
     )?
     else {
-        return Ok(false);
+        return Ok(SandboxHookProbeState::Clear);
     };
+    let (retryable, marker) = marker
+        .strip_prefix("retryable ")
+        .map_or((false, marker.as_str()), |marker| (true, marker));
     let fields = marker.split_whitespace().collect::<Vec<_>>();
     if fields.len() != 6 {
         return Err("sandbox-hook-marker-invalid-record".to_string());
@@ -230,11 +250,18 @@ pub(super) fn sandbox_commit_failure_matches(
         ));
     };
     if fields[0] != current_head {
-        return Ok(false);
+        return Ok(SandboxHookProbeState::Clear);
     }
     let current_index_tree = run_git_status_porcelain(project_root, &["write-tree"])
         .map_err(|error| format!("sandbox-hook-marker-index-probe={error}"))?;
-    Ok(fields[1] == current_index_tree.trim())
+    if fields[1] != current_index_tree.trim() {
+        return Ok(SandboxHookProbeState::Clear);
+    }
+    Ok(if retryable {
+        SandboxHookProbeState::Retryable
+    } else {
+        SandboxHookProbeState::Blocked
+    })
 }
 
 #[cfg(unix)]

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit_marker_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit_marker_tests.rs
@@ -31,6 +31,72 @@ fn with_valid_sandbox_failure_marker(
 }
 
 #[test]
+fn sandbox_commit_failure_marker_valid_nonmatch_is_clear() {
+    with_valid_sandbox_failure_marker(|root, session_id, marker, _sandbox| {
+        let valid_record = std::fs::read_to_string(marker).expect("read valid marker");
+        let (_, rest) = valid_record.split_once(' ').expect("valid marker fields");
+        std::fs::write(marker, format!("{} {rest}", "0".repeat(40)))
+            .expect("write nonmatching marker");
+
+        assert!(matches!(
+            require_commit::sandbox_commit_failure_matches(root, session_id),
+            Ok(false)
+        ));
+    });
+}
+
+#[test]
+fn require_commit_recovery_rejects_multi_record_marker_as_probe_uncertainty() {
+    with_valid_sandbox_failure_marker(|root, session_id, marker, _sandbox| {
+        let valid_record = std::fs::read_to_string(marker).expect("read valid marker");
+        std::fs::write(marker, format!("{valid_record}trailing record\n"))
+            .expect("write multi-record marker");
+        csa_session::save_result(root, session_id, &session_result("success", 0))
+            .expect("save session result");
+        let mut execution = csa_process::ExecutionResult {
+            exit_code: 0,
+            summary: "writer claimed success".to_string(),
+            ..Default::default()
+        };
+
+        record_writer_uncommitted_changes_with_config(
+            root,
+            Some(session_id),
+            &mut execution,
+            WriterUncommittedRecord {
+                sa_mode: false,
+                require_commit: true,
+                changed_paths: Some(&["tracked.txt".to_string()]),
+                commit_created: Some(false),
+                large_diff_config: &RunLargeDiffWarningConfig::default(),
+            },
+        );
+
+        let loaded = csa_session::load_result(root, session_id)
+            .expect("load result")
+            .expect("persisted result");
+        let recovery = loaded
+            .require_commit_recovery
+            .expect("probe uncertainty recovery");
+        let expected_reason = require_commit::contract_failure_reason(
+            require_commit::SandboxHookProbeState::Uncertain("probe-failed"),
+        );
+        assert_eq!(execution.summary, expected_reason);
+        assert_eq!(loaded.summary, expected_reason);
+        assert_eq!(
+            recovery.suggested_recovery_action,
+            REQUIRE_COMMIT_SANDBOX_HOOK_RECOVERY_ACTION
+        );
+        assert!(
+            recovery
+                .blocker_summary
+                .as_deref()
+                .is_some_and(|summary| summary.contains("sandbox_hook_probe="))
+        );
+    });
+}
+
+#[test]
 fn sandbox_commit_failure_marker_rejects_fifo_in_bounded_time() {
     use std::os::unix::ffi::OsStrExt;
     use std::time::Duration;
@@ -53,7 +119,7 @@ fn sandbox_commit_failure_marker_rejects_fifo_in_bounded_time() {
         let matched = rx
             .recv_timeout(Duration::from_millis(500))
             .expect("FIFO marker inspection must return within 500ms");
-        assert!(!matched, "FIFO marker must fail closed");
+        assert!(matched.is_err(), "FIFO marker must be uncertain");
     });
 }
 
@@ -67,8 +133,8 @@ fn sandbox_commit_failure_marker_rejects_symlink() {
         symlink(&target, marker).expect("create marker symlink");
 
         assert!(
-            !require_commit::sandbox_commit_failure_matches(root, session_id),
-            "sandbox marker symlinks must fail closed"
+            require_commit::sandbox_commit_failure_matches(root, session_id).is_err(),
+            "sandbox marker symlinks must be uncertain"
         );
     });
 }
@@ -87,8 +153,8 @@ fn sandbox_commit_failure_marker_rejects_oversized_sparse_file_in_bounded_time()
         let started = Instant::now();
 
         assert!(
-            !require_commit::sandbox_commit_failure_matches(root, session_id),
-            "oversized sparse marker must fail closed"
+            require_commit::sandbox_commit_failure_matches(root, session_id).is_err(),
+            "oversized sparse marker must be uncertain"
         );
         assert!(
             started.elapsed() < Duration::from_millis(500),
@@ -128,8 +194,8 @@ fn sandbox_commit_failure_git_probe_times_out_reaps_and_preserves_index() {
         let started = Instant::now();
 
         assert!(
-            !require_commit::sandbox_commit_failure_matches(root, session_id),
-            "timed-out Git marker probe must fail closed"
+            require_commit::sandbox_commit_failure_matches(root, session_id).is_err(),
+            "timed-out Git marker probe must be uncertain"
         );
         assert!(
             started.elapsed() < Duration::from_secs(2),

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit_marker_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit_marker_tests.rs
@@ -1,0 +1,157 @@
+use super::*;
+
+fn with_valid_sandbox_failure_marker(
+    test: impl FnOnce(&Path, &str, &Path, &mut ScopedSessionSandbox),
+) {
+    let (temp, mut sandbox) = init_repo_with_initial_commit();
+    let root = temp.path();
+    std::fs::write(root.join("tracked.txt"), "staged but not committed\n")
+        .expect("write staged change");
+    run_git(root, &["add", "tracked.txt"]);
+    let head = git_capture(root, &["rev-parse", "HEAD"]);
+    let staged_tree = git_capture(root, &["write-tree"]);
+    let session = csa_session::create_session(root, Some("run"), None, Some("codex"))
+        .expect("session should be created");
+    let session_dir = csa_session::get_session_dir(root, &session.meta_session_id)
+        .expect("session dir should resolve");
+    let marker = session_dir.join(csa_hooks::git_guard::SANDBOX_COMMIT_FAILURE_MARKER_FILE);
+    std::fs::write(
+        &marker,
+        format!("{head} {staged_tree} args env config hooks\n"),
+    )
+    .expect("write valid sandbox commit marker");
+
+    test(root, &session.meta_session_id, &marker, &mut sandbox);
+
+    assert_eq!(
+        git_capture(root, &["write-tree"]),
+        staged_tree,
+        "marker rejection must preserve the staged index"
+    );
+}
+
+#[test]
+fn sandbox_commit_failure_marker_rejects_fifo_in_bounded_time() {
+    use std::os::unix::ffi::OsStrExt;
+    use std::time::Duration;
+
+    with_valid_sandbox_failure_marker(|root, session_id, marker, _sandbox| {
+        std::fs::remove_file(marker).expect("remove regular marker");
+        let marker_c = std::ffi::CString::new(marker.as_os_str().as_bytes()).expect("marker path");
+        // SAFETY: marker_c is a valid, NUL-terminated path owned for this call.
+        assert_eq!(unsafe { libc::mkfifo(marker_c.as_ptr(), 0o600) }, 0);
+
+        let root = root.to_path_buf();
+        let session_id = session_id.to_string();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(require_commit::sandbox_commit_failure_matches(
+                &root,
+                &session_id,
+            ));
+        });
+        let matched = rx
+            .recv_timeout(Duration::from_millis(500))
+            .expect("FIFO marker inspection must return within 500ms");
+        assert!(!matched, "FIFO marker must fail closed");
+    });
+}
+
+#[test]
+fn sandbox_commit_failure_marker_rejects_symlink() {
+    use std::os::unix::fs::symlink;
+
+    with_valid_sandbox_failure_marker(|root, session_id, marker, _sandbox| {
+        let target = marker.with_extension("target");
+        std::fs::rename(marker, &target).expect("move valid marker to symlink target");
+        symlink(&target, marker).expect("create marker symlink");
+
+        assert!(
+            !require_commit::sandbox_commit_failure_matches(root, session_id),
+            "sandbox marker symlinks must fail closed"
+        );
+    });
+}
+
+#[test]
+fn sandbox_commit_failure_marker_rejects_oversized_sparse_file_in_bounded_time() {
+    use std::time::{Duration, Instant};
+
+    with_valid_sandbox_failure_marker(|root, session_id, marker, _sandbox| {
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(marker)
+            .expect("open marker");
+        file.set_len(1024 * 1024)
+            .expect("make oversized sparse marker");
+        let started = Instant::now();
+
+        assert!(
+            !require_commit::sandbox_commit_failure_matches(root, session_id),
+            "oversized sparse marker must fail closed"
+        );
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "oversized sparse marker must be rejected before reading its payload"
+        );
+    });
+}
+
+#[test]
+fn sandbox_commit_failure_git_probe_times_out_reaps_and_preserves_index() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::time::{Duration, Instant};
+
+    with_valid_sandbox_failure_marker(|root, session_id, _marker, sandbox| {
+        let fake_bin = root.join("fake-bin");
+        std::fs::create_dir(&fake_bin).expect("create fake bin");
+        let fake_git = fake_bin.join("git");
+        std::fs::write(
+            &fake_git,
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" > \"${GIT_PROBE_PID_FILE}\"\nexec /usr/bin/sleep 2\n",
+        )
+        .expect("write hanging git");
+        std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755))
+            .expect("make hanging git executable");
+        let pid_file = root.join("git-probe.pid");
+        let original_path = std::env::var_os("PATH").unwrap_or_default();
+        let mut path = fake_bin.into_os_string();
+        path.push(":");
+        path.push(&original_path);
+        sandbox.track_env("PATH");
+        sandbox.track_env("GIT_PROBE_PID_FILE");
+        // SAFETY: ScopedSessionSandbox owns TEST_ENV_LOCK and restores both variables.
+        unsafe {
+            std::env::set_var("PATH", path);
+            std::env::set_var("GIT_PROBE_PID_FILE", &pid_file);
+        }
+        let started = Instant::now();
+
+        assert!(
+            !require_commit::sandbox_commit_failure_matches(root, session_id),
+            "timed-out Git marker probe must fail closed"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "Git marker probe must honor its deadline"
+        );
+        let pid = std::fs::read_to_string(&pid_file)
+            .expect("hanging Git pid")
+            .trim()
+            .parse::<i32>()
+            .expect("numeric hanging Git pid");
+        // SAFETY: signal 0 only checks the exact child PID recorded by the fixture.
+        assert_eq!(unsafe { libc::kill(pid, 0) }, -1, "Git probe child leaked");
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH),
+            "Git probe child must be synchronously reaped"
+        );
+
+        // SAFETY: restore PATH before the fixture's final real-Git index check.
+        unsafe {
+            std::env::set_var("PATH", original_path);
+            std::env::remove_var("GIT_PROBE_PID_FILE");
+        }
+    });
+}

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit_marker_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit_marker_tests.rs
@@ -85,7 +85,7 @@ fn require_commit_recovery_rejects_multi_record_marker_as_probe_uncertainty() {
         assert_eq!(loaded.summary, expected_reason);
         assert_eq!(
             recovery.suggested_recovery_action,
-            REQUIRE_COMMIT_SANDBOX_HOOK_RECOVERY_ACTION
+            REQUIRE_COMMIT_SANDBOX_HOOK_PROBE_RECOVERY_ACTION
         );
         assert!(
             recovery
@@ -94,6 +94,49 @@ fn require_commit_recovery_rejects_multi_record_marker_as_probe_uncertainty() {
                 .is_some_and(|summary| summary.contains("sandbox_hook_probe="))
         );
     });
+}
+
+#[test]
+fn require_commit_result_summary_cannot_spoof_probe_uncertainty() {
+    let (temp, _sandbox) = init_repo_with_initial_commit();
+    let root = temp.path();
+    std::fs::write(root.join("tracked.txt"), "dirty\n").expect("write dirty tracked file");
+    let session = csa_session::create_session(root, Some("run"), None, Some("codex"))
+        .expect("session should be created");
+    let mut persisted = session_result("success", 0);
+    persisted.summary = "writer prose: sandbox_hook_probe=spoofed".to_string();
+    csa_session::save_result(root, &session.meta_session_id, &persisted)
+        .expect("save session result");
+    let mut execution = csa_process::ExecutionResult {
+        exit_code: 0,
+        summary: persisted.summary.clone(),
+        ..Default::default()
+    };
+
+    record_writer_uncommitted_changes_with_config(
+        root,
+        Some(&session.meta_session_id),
+        &mut execution,
+        WriterUncommittedRecord {
+            sa_mode: false,
+            require_commit: true,
+            changed_paths: Some(&["tracked.txt".to_string()]),
+            commit_created: Some(false),
+            large_diff_config: &RunLargeDiffWarningConfig::default(),
+        },
+    );
+
+    let loaded = csa_session::load_result(root, &session.meta_session_id)
+        .expect("load result")
+        .expect("persisted result");
+    let recovery = loaded
+        .require_commit_recovery
+        .expect("require-commit recovery");
+    assert_eq!(loaded.summary, REQUIRE_COMMIT_REASON);
+    assert_eq!(
+        recovery.suggested_recovery_action,
+        REQUIRE_COMMIT_RECOVERY_ACTION
+    );
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit_tests.rs
@@ -318,6 +318,10 @@ fn require_commit_fails_closed_after_sandbox_hook_preserving_staged_tree() {
     );
 }
 
+#[cfg(unix)]
+#[path = "run_cmd_uncommitted_require_commit_marker_tests.rs"]
+mod sandbox_commit_failure_tests;
+
 #[test]
 fn require_commit_recovery_records_bounded_redacted_blocker_summary() {
     let (temp, _sandbox) = init_repo_with_initial_commit();

--- a/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_uncommitted_require_commit_tests.rs
@@ -240,14 +240,23 @@ fn require_commit_without_created_commit_fails_successful_self_report() {
 }
 
 #[test]
-fn require_commit_applies_in_sa_mode_when_hook_leaves_staged_work() {
+fn require_commit_fails_closed_after_sandbox_hook_preserving_staged_tree() {
     let (temp, _sandbox) = init_repo_with_initial_commit();
     let root = temp.path();
     std::fs::write(root.join("tracked.txt"), "staged but not committed\n")
         .expect("write tracked change");
     run_git(root, &["add", "tracked.txt"]);
+    let head_before = git_capture(root, &["rev-parse", "HEAD"]);
+    let staged_tree_before = git_capture(root, &["write-tree"]);
     let session = csa_session::create_session(root, Some("run"), None, Some("codex"))
         .expect("session should be created");
+    let session_dir = csa_session::get_session_dir(root, &session.meta_session_id)
+        .expect("session dir should resolve");
+    std::fs::write(
+        session_dir.join(csa_hooks::git_guard::SANDBOX_COMMIT_FAILURE_MARKER_FILE),
+        format!("{head_before} {staged_tree_before} args env config hooks\n"),
+    )
+    .expect("sandbox commit failure marker should be written");
     let session_result = session_result("success", 0);
     csa_session::save_result(root, &session.meta_session_id, &session_result)
         .expect("result should be saved");
@@ -273,14 +282,17 @@ fn require_commit_applies_in_sa_mode_when_hook_leaves_staged_work() {
     let loaded = csa_session::load_result(root, &session.meta_session_id)
         .expect("load result")
         .expect("result should exist");
+    let expected_summary = "require-commit blocked: mandatory hook-enabled commit failed in the filesystem sandbox; staged tree preserved for host recovery";
     assert_eq!(execution.exit_code, 1);
     assert_eq!(
         execution.csa_gate_failure.as_deref(),
         Some("writer-uncommitted")
     );
+    assert_eq!(execution.summary, expected_summary);
+    assert!(execution.stderr_output.contains(expected_summary));
     assert_eq!(loaded.status, "failure");
     assert_eq!(loaded.exit_code, 1);
-    assert_eq!(loaded.summary, REQUIRE_COMMIT_REASON);
+    assert_eq!(loaded.summary, expected_summary);
     let recovery = loaded
         .require_commit_recovery
         .expect("explicit require-commit must fail closed in sa-mode");
@@ -288,9 +300,21 @@ fn require_commit_applies_in_sa_mode_when_hook_leaves_staged_work() {
     assert!(!recovery.commit_created);
     assert!(recovery.dirty_worktree);
     assert_eq!(recovery.changed_paths, vec!["tracked.txt".to_string()]);
+    assert!(
+        recovery
+            .blocker_summary
+            .as_deref()
+            .is_some_and(|summary| summary.contains("sandbox_hook=mandatory hook-enabled commit"))
+    );
     assert_eq!(
         recovery.suggested_recovery_action,
-        REQUIRE_COMMIT_RECOVERY_ACTION
+        "run_hook_enabled_commit_outside_sandbox"
+    );
+    assert_eq!(git_capture(root, &["rev-parse", "HEAD"]), head_before);
+    assert_eq!(
+        git_capture(root, &["write-tree"]),
+        staged_tree_before,
+        "persisting the blocker must not alter the staged tree"
     );
 }
 
@@ -416,7 +440,7 @@ fn session_result(status: &str, exit_code: i32) -> csa_session::SessionResult {
     }
 }
 
-fn run_git(root: &Path, args: &[&str]) {
+fn git_capture(root: &Path, args: &[&str]) -> String {
     let output = Command::new("git")
         .arg("-C")
         .arg(root)
@@ -429,6 +453,11 @@ fn run_git(root: &Path, args: &[&str]) {
         args.join(" "),
         String::from_utf8_lossy(&output.stderr)
     );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn run_git(root: &Path, args: &[&str]) {
+    git_capture(root, args);
 }
 
 /// A throwaway git repo with one commit so `HEAD` exists. Hooks and GPG

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -12,6 +12,7 @@ use anyhow::{Context, Result};
 const FALLBACK_GUARD_DIR_NAME: &str = "guards";
 const SESSION_GUARD_DIR_NAME: &str = "bin";
 const CSA_SESSION_DIR_ENV: &str = "CSA_SESSION_DIR";
+pub const SANDBOX_COMMIT_FAILURE_MARKER_FILE: &str = ".git-guard-commit-failure";
 static GUARD_SETUP_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 const GIT_WRAPPER_TEMPLATE: &str = r#"#!/bin/sh
 # CSA git guard: strips git commit hook bypass and blocks leaf-worker pushes.
@@ -566,8 +567,23 @@ if [ "${STRIPPED_NO_VERIFY}" = "true" ]; then
   echo "CSA git-guard: stripped --no-verify from git commit (hook bypass forbidden)" >&2
 fi
 
+top=""
+hooks_path=""
 if "${REAL_GIT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   top="$("${REAL_GIT}" rev-parse --show-toplevel 2>/dev/null || pwd)"
+  hooks_path="$("${REAL_GIT}" config --path --get core.hooksPath 2>/dev/null || true)"
+  hook_path_for() {
+    hook_name="$1"
+    if [ -n "${hooks_path}" ]; then
+      case "${hooks_path}" in
+        /*) printf '%s\n' "${hooks_path}/${hook_name}" ;;
+        *) printf '%s\n' "${top}/${hooks_path}/${hook_name}" ;;
+      esac
+    else
+      "${REAL_GIT}" rev-parse --git-path "hooks/${hook_name}" 2>/dev/null || true
+    fi
+  }
+
   lefthook_config=""
   for cfg in lefthook.yml lefthook.yaml .lefthook.yml .lefthook.yaml; do
     if [ -f "${top}/${cfg}" ]; then
@@ -577,19 +593,6 @@ if "${REAL_GIT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   done
 
   if [ -n "${lefthook_config}" ]; then
-    hooks_path="$("${REAL_GIT}" config --path --get core.hooksPath 2>/dev/null || true)"
-    hook_path_for() {
-      hook_name="$1"
-      if [ -n "${hooks_path}" ]; then
-        case "${hooks_path}" in
-          /*) printf '%s\n' "${hooks_path}/${hook_name}" ;;
-          *) printf '%s\n' "${top}/${hooks_path}/${hook_name}" ;;
-        esac
-      else
-        "${REAL_GIT}" rev-parse --git-path "hooks/${hook_name}" 2>/dev/null || true
-      fi
-    }
-
     while IFS= read -r line || [ -n "${line}" ]; do
       case "${line}" in
         ""|\#*|" "*) continue ;;
@@ -614,14 +617,23 @@ if "${REAL_GIT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 eval "set -- ${SANITIZED_ARGS}"
-exec "${REAL_GIT}" "$@"
+__CSA_GIT_SANDBOX_COMMIT_FAIL_CLOSED__
 "#;
 
 static GIT_WRAPPER: LazyLock<String> = LazyLock::new(|| {
-    GIT_WRAPPER_TEMPLATE.replace(
-        "__CSA_GIT_EXACT_GRAMMARS__",
-        include_str!("git_guard_exact_grammars.sh"),
-    )
+    GIT_WRAPPER_TEMPLATE
+        .replace(
+            "__CSA_GIT_EXACT_GRAMMARS__",
+            include_str!("git_guard_exact_grammars.sh"),
+        )
+        .replace(
+            "__CSA_GIT_SANDBOX_COMMIT_FAIL_CLOSED__",
+            include_str!("git_guard_sandbox_commit_fail_closed.sh"),
+        )
+        .replace(
+            "__CSA_GIT_COMMIT_FAILURE_MARKER__",
+            SANDBOX_COMMIT_FAILURE_MARKER_FILE,
+        )
 });
 
 pub fn ensure_git_guard_dir() -> Result<PathBuf> {

--- a/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed.sh
+++ b/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed.sh
@@ -1,41 +1,231 @@
-commit_attempt_fingerprint() {
-  head="$("${REAL_GIT}" rev-parse --verify HEAD 2>/dev/null || printf '%s' unborn)"
-  index_tree="$("${REAL_GIT}" write-tree 2>/dev/null)" || return 1
-  args_hash="$(for arg do printf '%s:%s\n' "${#arg}" "${arg}"; done | "${REAL_GIT}" hash-object --stdin)" || return 1
-  env_hash="$(env | LC_ALL=C sort | "${REAL_GIT}" hash-object --stdin)" || return 1
-  config_hash="$("${REAL_GIT}" config --null --list --show-origin 2>/dev/null | "${REAL_GIT}" hash-object --stdin)" || return 1
+FINGERPRINT_MAX_BYTES=8388608
+FINGERPRINT_MAX_BLOCKS=16384
+FINGERPRINT_MAX_FILES=64
+FINGERPRINT_FILE_MAX_BYTES=1048576
+FINGERPRINT_COMMAND_TIMEOUT=2
+FINGERPRINT_FILE_TIMEOUT=1
+MARKER_MAX_BYTES=1024
+
+copy_bounded_regular_file() {
+  copy_source="$1"
+  copy_destination="$2"
+  copy_max_bytes="$3"
+  [ -f "${copy_source}" ] && [ ! -L "${copy_source}" ] || return 1
+  copy_identity_before="$(/usr/bin/stat -c '%d:%i:%s:%f:%y:%z' -- "${copy_source}" 2>/dev/null)" || return 1
+  copy_size_before="$(/usr/bin/stat -c '%s' -- "${copy_source}" 2>/dev/null)" || return 1
+  case "${copy_size_before}" in ""|*[!0-9]*) return 1 ;; esac
+  [ "${copy_size_before}" -le "${copy_max_bytes}" ] || return 1
+  timeout "${FINGERPRINT_FILE_TIMEOUT}" dd if="${copy_source}" of="${copy_destination}" \
+    iflag=nofollow,nonblock,count_bytes count="$((copy_max_bytes + 1))" status=none \
+    2>/dev/null || return 1
+  copy_size="$(/usr/bin/stat -c '%s' -- "${copy_destination}" 2>/dev/null)" || return 1
+  case "${copy_size}" in ""|*[!0-9]*) return 1 ;; esac
+  [ "${copy_size}" -le "${copy_max_bytes}" ] || return 1
+  copy_identity_after="$(/usr/bin/stat -c '%d:%i:%s:%f:%y:%z' -- "${copy_source}" 2>/dev/null)" || return 1
+  [ "${copy_identity_before}" = "${copy_identity_after}" ] || return 1
+  [ "${copy_size}" = "${copy_size_before}" ] || return 1
+}
+
+read_bounded_single_record() {
+  record_source="$1"
+  record_max_bytes="$2"
+  record_dir="$(mktemp -d "${session_dir}/.git-guard-record.XXXXXX" 2>/dev/null)" || return 1
+  record_copy="${record_dir}/record"
+  if ! copy_bounded_regular_file "${record_source}" "${record_copy}" "${record_max_bytes}"; then
+    /usr/bin/rm -rf -- "${record_dir}" 2>/dev/null || true
+    return 1
+  fi
+  record_size="$(/usr/bin/stat -c '%s' -- "${record_copy}" 2>/dev/null)" || {
+    /usr/bin/rm -rf -- "${record_dir}" 2>/dev/null || true
+    return 1
+  }
+  if [ "${record_size}" -eq 0 ]; then
+    /usr/bin/rm -rf -- "${record_dir}" 2>/dev/null || true
+    return 1
+  fi
+  record_lines="$(wc -l < "${record_copy}")" || {
+    /usr/bin/rm -rf -- "${record_dir}" 2>/dev/null || true
+    return 1
+  }
+  case "${record_lines}" in ""|*[!0-9]*) record_lines=0 ;; esac
+  printf '\n' > "${record_dir}/newline" || return 1
+  dd if="${record_copy}" of="${record_dir}/last" iflag=skip_bytes,count_bytes \
+    skip="$((record_size - 1))" count=1 status=none 2>/dev/null || return 1
+  if [ "${record_lines}" -ne 1 ] || ! cmp -s "${record_dir}/last" "${record_dir}/newline"; then
+    /usr/bin/rm -rf -- "${record_dir}" 2>/dev/null || true
+    return 1
+  fi
+  IFS= read -r record_value < "${record_copy}" || {
+    /usr/bin/rm -rf -- "${record_dir}" 2>/dev/null || true
+    return 1
+  }
+  /usr/bin/rm -rf -- "${record_dir}" 2>/dev/null || true
+  printf '%s\n' "${record_value}"
+}
+
+bounded_capture_status() {
+  capture_name="$1"
+  shift
+  capture_path="${fingerprint_tmp_dir}/${capture_name}"
+  if (
+    ulimit -f "${FINGERPRINT_MAX_BLOCKS}" || exit 1
+    exec timeout "${FINGERPRINT_COMMAND_TIMEOUT}" "$@"
+  ) > "${capture_path}" 2>/dev/null; then
+    capture_status=0
+  else
+    capture_status=$?
+  fi
+  capture_size="$(/usr/bin/stat -c '%s' -- "${capture_path}" 2>/dev/null)" || return 1
+  case "${capture_size}" in ""|*[!0-9]*) return 1 ;; esac
+  [ "${capture_size}" -le "${FINGERPRINT_MAX_BYTES}" ]
+}
+
+bounded_capture() {
+  bounded_capture_status "$@" || return 1
+  [ "${capture_status}" -eq 0 ]
+}
+
+hash_input_file() {
+  fingerprint_hash_serial=$((fingerprint_hash_serial + 1))
+  hash_output="hash.${fingerprint_hash_serial}"
+  bounded_capture "${hash_output}" "${REAL_GIT}" hash-object "$1" || return 1
+  hash_value="$(read_bounded_single_record "${fingerprint_tmp_dir}/${hash_output}" 128)" || return 1
+  case "${hash_value}" in *[!0-9a-f]*) return 1 ;; esac
+  case "${#hash_value}" in 40|64) ;; *) return 1 ;; esac
+  printf '%s\n' "${hash_value}"
+}
+
+append_hashed_file() {
+  hashed_label="$1"
+  hashed_path="$2"
+  hashed_manifest="$3"
+  has_control_bytes "${hashed_path}" && return 1
+  fingerprint_file_count=$((fingerprint_file_count + 1))
+  [ "${fingerprint_file_count}" -le "${FINGERPRINT_MAX_FILES}" ] || return 1
+  hashed_copy="${fingerprint_tmp_dir}/file.${fingerprint_file_count}"
+  copy_bounded_regular_file "${hashed_path}" "${hashed_copy}" \
+    "${FINGERPRINT_FILE_MAX_BYTES}" || return 1
+  hashed_size="$(/usr/bin/stat -c '%s' -- "${hashed_copy}" 2>/dev/null)" || return 1
+  fingerprint_total_file_bytes=$((fingerprint_total_file_bytes + hashed_size))
+  [ "${fingerprint_total_file_bytes}" -le "${FINGERPRINT_MAX_BYTES}" ] || return 1
+  hashed_value="$(hash_input_file "${hashed_copy}")" || return 1
+  printf '%s:%s:%s:%s\n' "${hashed_label}" "${#hashed_path}" "${hashed_path}" \
+    "${hashed_value}" >> "${hashed_manifest}" || return 1
+}
+
+commit_attempt_fingerprint_inner() {
+  LC_ALL=C
+  export LC_ALL
+  fingerprint_hash_serial=0
+  fingerprint_file_count=0
+  fingerprint_total_file_bytes=0
+
+  bounded_capture_status head "${REAL_GIT}" rev-parse --verify HEAD || return 1
+  case "${capture_status}" in
+    0) head="$(read_bounded_single_record "${fingerprint_tmp_dir}/head" 128)" || return 1 ;;
+    128) head=unborn ;;
+    *) return 1 ;;
+  esac
+  bounded_capture index "${REAL_GIT}" write-tree || return 1
+  index_tree="$(read_bounded_single_record "${fingerprint_tmp_dir}/index" 128)" || return 1
+
+  (
+    ulimit -f "${FINGERPRINT_MAX_BLOCKS}" || exit 1
+    for arg do
+      printf '%s:%s\n' "${#arg}" "${arg}" || exit 1
+    done
+  ) > "${fingerprint_tmp_dir}/args" || return 1
+  args_size="$(/usr/bin/stat -c '%s' -- "${fingerprint_tmp_dir}/args" 2>/dev/null)" || return 1
+  [ "${args_size}" -le "${FINGERPRINT_MAX_BYTES}" ] || return 1
+  args_hash="$(hash_input_file "${fingerprint_tmp_dir}/args")" || return 1
+
+  bounded_capture env.raw env || return 1
+  bounded_capture env.sorted sort "${fingerprint_tmp_dir}/env.raw" || return 1
+  env_hash="$(hash_input_file "${fingerprint_tmp_dir}/env.sorted")" || return 1
+
+  bounded_capture config "${REAL_GIT}" config --null --list --show-origin || return 1
+  config_hash="$(hash_input_file "${fingerprint_tmp_dir}/config")" || return 1
+
   if [ -n "${top}" ]; then
-    worktree_hash="$("${REAL_GIT}" -C "${top}" diff --no-ext-diff --no-textconv --binary -- | "${REAL_GIT}" hash-object --stdin)" || return 1
+    bounded_capture worktree "${REAL_GIT}" -C "${top}" diff --no-ext-diff \
+      --no-textconv --binary -- || return 1
+    worktree_hash="$(hash_input_file "${fingerprint_tmp_dir}/worktree")" || return 1
   else
     worktree_hash=absent
   fi
-  hooks_hash="$(
-    {
-      printf 'worktree:%s\n' "${worktree_hash}"
-      if [ -n "${lefthook_config:-}" ] && [ -f "${lefthook_config}" ]; then
-        config_name="${lefthook_config##*/}"
-        printf 'lefthook:%s:%s\n' "${#config_name}" "${config_name}"
-        "${REAL_GIT}" hash-object "${lefthook_config}" 2>/dev/null || printf '%s\n' unreadable
-      else
-        printf '%s\n' lefthook:absent
-      fi
-      if [ -n "${top}" ]; then
-        hooks_dir="$(dirname "$(hook_path_for pre-commit)")"
-        found_hook=false
-        for hook_path in "${hooks_dir}"/*; do
-          [ -f "${hook_path}" ] || continue
-          found_hook=true
-          hook_name="${hook_path##*/}"
-          if [ -x "${hook_path}" ]; then hook_mode=x; else hook_mode=-; fi
-          printf 'hook:%s:%s:%s\n' "${#hook_name}" "${hook_name}" "${hook_mode}"
-          "${REAL_GIT}" hash-object "${hook_path}" 2>/dev/null || printf '%s\n' unreadable
-        done
-        [ "${found_hook}" = true ] || printf '%s\n' hooks:absent
-      fi
-    } | "${REAL_GIT}" hash-object --stdin
-  )" || return 1
-  printf '%s %s %s %s %s %s\n' "${head}" "${index_tree}" "${args_hash}" "${env_hash}" "${config_hash}" "${hooks_hash}"
+
+  hooks_manifest="${fingerprint_tmp_dir}/hooks.manifest"
+  : > "${hooks_manifest}" || return 1
+  printf 'worktree:%s\n' "${worktree_hash}" >> "${hooks_manifest}" || return 1
+  if [ -n "${lefthook_config:-}" ]; then
+    append_hashed_file lefthook "${lefthook_config}" "${hooks_manifest}" || return 1
+  else
+    printf '%s\n' lefthook:absent >> "${hooks_manifest}" || return 1
+  fi
+
+  found_hook=false
+  if [ -n "${top}" ]; then
+    pre_commit_path="$(hook_path_for pre-commit)" || return 1
+    [ -n "${pre_commit_path}" ] || return 1
+    hooks_dir="$(dirname "${pre_commit_path}")" || return 1
+    bounded_capture hooks.raw find -P "${hooks_dir}" -type f -print || return 1
+    bounded_capture hooks.sorted sort "${fingerprint_tmp_dir}/hooks.raw" || return 1
+    while IFS= read -r hook_path || [ -n "${hook_path}" ]; do
+      [ -n "${hook_path}" ] || continue
+      found_hook=true
+      if [ -x "${hook_path}" ]; then hook_mode=x; else hook_mode=-; fi
+      append_hashed_file "hook:${hook_mode}" "${hook_path}" "${hooks_manifest}" || return 1
+    done < "${fingerprint_tmp_dir}/hooks.sorted"
+  fi
+
+  # The supported helper closure is every regular file below the active hooks
+  # directory plus colon-delimited absolute files declared here. Tracked
+  # worktree helpers are already covered by worktree_hash; untracked or
+  # out-of-tree helpers must be declared explicitly.
+  declared_helpers="${CSA_GIT_GUARD_HOOK_HELPERS:-}"
+  if [ -n "${declared_helpers}" ]; then
+    case ":${declared_helpers}:" in *::*) return 1 ;; esac
+  fi
+  while [ -n "${declared_helpers}" ]; do
+    case "${declared_helpers}" in
+      *:*) helper_path="${declared_helpers%%:*}"; declared_helpers="${declared_helpers#*:}" ;;
+      *) helper_path="${declared_helpers}"; declared_helpers="" ;;
+    esac
+    case "${helper_path}" in /*) ;; *) return 1 ;; esac
+    append_hashed_file helper "${helper_path}" "${hooks_manifest}" || return 1
+  done
+  [ "${found_hook}" = true ] || printf '%s\n' hooks:absent >> "${hooks_manifest}" || return 1
+  hooks_hash="$(hash_input_file "${hooks_manifest}")" || return 1
+
+  printf '%s %s %s %s %s %s\n' "${head}" "${index_tree}" "${args_hash}" \
+    "${env_hash}" "${config_hash}" "${hooks_hash}"
 }
+
+commit_attempt_fingerprint() {
+  fingerprint_tmp_dir="$(mktemp -d "${session_dir}/.git-guard-fingerprint.XXXXXX" 2>/dev/null)" || return 1
+  commit_attempt_fingerprint_inner "$@"
+  fingerprint_status=$?
+  /usr/bin/rm -rf -- "${fingerprint_tmp_dir}" 2>/dev/null || true
+  return "${fingerprint_status}"
+}
+
+write_commit_failure_marker() {
+  marker_value="$1"
+  marker_tmp="$(mktemp "${commit_failure_marker}.XXXXXX" 2>/dev/null)" || return 1
+  if printf '%s\n' "${marker_value}" > "${marker_tmp}" \
+    && mv -f "${marker_tmp}" "${commit_failure_marker}"; then
+    return 0
+  fi
+  /usr/bin/rm -f -- "${marker_tmp}" 2>/dev/null || true
+  return 1
+}
+
+block_unavailable_fingerprint() {
+  echo "BLOCKED: sandbox commit fingerprint state is unavailable; mandatory hooks will not run on uncertain state." >&2
+  echo "The staged tree is preserved. Inspect the fingerprint failure, then run the same hook-enabled commit outside the sandbox." >&2
+  exit 1
+}
+
 commit_failure_marker="" commit_fingerprint=""
 if [ "${CSA_FS_SANDBOXED:-}" = "1" ] && [ -n "${CSA_SESSION_DIR:-}" ]; then
   session_dir="$(canonical_directory "${CSA_SESSION_DIR}")" || session_dir=""
@@ -43,41 +233,46 @@ if [ "${CSA_FS_SANDBOXED:-}" = "1" ] && [ -n "${CSA_SESSION_DIR:-}" ]; then
   expected_guard_dir="$(canonical_directory "${session_dir}/bin")" || expected_guard_dir=""
   if [ -n "${session_dir}" ] && [ "${guard_dir}" = "${expected_guard_dir}" ]; then
     commit_failure_marker="${session_dir}/__CSA_GIT_COMMIT_FAILURE_MARKER__"
-    commit_fingerprint="$(commit_attempt_fingerprint "$@" || true)"
-    blocked_fingerprint=""
-    if [ -f "${commit_failure_marker}" ]; then
-      IFS= read -r blocked_fingerprint < "${commit_failure_marker}" || true
+    if ! commit_fingerprint="$(commit_attempt_fingerprint "$@")"; then
+      write_commit_failure_marker "uncertain fingerprint producer failure" || true
+      block_unavailable_fingerprint
     fi
-    if [ -n "${commit_fingerprint}" ] && [ "${blocked_fingerprint}" = "${commit_fingerprint}" ]; then
-      echo "BLOCKED: hook-enabled commit already failed for this unchanged staged tree in the filesystem sandbox; mandatory hooks will not be rerun." >&2
-      echo "The staged tree is preserved. Inspect the first hook failure, then run the same hook-enabled commit outside the sandbox if it needs host resources." >&2
-      exit 1
+    if [ -e "${commit_failure_marker}" ] || [ -L "${commit_failure_marker}" ]; then
+      if blocked_fingerprint="$(read_bounded_single_record "${commit_failure_marker}" "${MARKER_MAX_BYTES}")"; then
+        if [ "${blocked_fingerprint}" = "${commit_fingerprint}" ]; then
+          echo "BLOCKED: hook-enabled commit already failed for this unchanged staged tree in the filesystem sandbox; mandatory hooks will not be rerun." >&2
+          echo "The staged tree is preserved. Inspect the first hook failure, then run the same hook-enabled commit outside the sandbox if it needs host resources." >&2
+          exit 1
+        fi
+      else
+        write_commit_failure_marker "uncertain invalid fingerprint marker" || true
+        block_unavailable_fingerprint
+      fi
     fi
   fi
 fi
 
-if [ -z "${commit_failure_marker}" ] || [ -z "${commit_fingerprint}" ]; then
+if [ -z "${commit_failure_marker}" ]; then
   exec "${REAL_GIT}" "$@"
 fi
 
 if "${REAL_GIT}" "$@"; then
-  rm -f "${commit_failure_marker}"
+  /usr/bin/rm -f -- "${commit_failure_marker}" 2>/dev/null || true
   exit 0
 else
   commit_status=$?
 fi
-post_fingerprint="$(commit_attempt_fingerprint "$@" || true)"
-if [ "${post_fingerprint}" = "${commit_fingerprint}" ]; then
-  marker_tmp="$(mktemp "${commit_failure_marker}.XXXXXX" 2>/dev/null || true)"
-  if [ -n "${marker_tmp}" ] \
-    && printf '%s\n' "${commit_fingerprint}" > "${marker_tmp}" \
-    && mv -f "${marker_tmp}" "${commit_failure_marker}"; then
-    echo "CSA git-guard: hook-enabled commit failed inside the filesystem sandbox; the staged tree is preserved." >&2
-    echo "CSA git-guard: an identical retry is blocked. Inspect the hook failure, then use the same hook-enabled commit outside the sandbox if host resources are required." >&2
+if post_fingerprint="$(commit_attempt_fingerprint "$@")"; then
+  if [ "${post_fingerprint}" = "${commit_fingerprint}" ]; then
+    if write_commit_failure_marker "${commit_fingerprint}"; then
+      echo "CSA git-guard: hook-enabled commit failed inside the filesystem sandbox; the staged tree is preserved." >&2
+      echo "CSA git-guard: an identical retry is blocked. Inspect the hook failure, then use the same hook-enabled commit outside the sandbox if host resources are required." >&2
+    fi
   else
-    rm -f "${marker_tmp:-}"
+    /usr/bin/rm -f -- "${commit_failure_marker}" 2>/dev/null || true
   fi
 else
-  rm -f "${commit_failure_marker}"
+  write_commit_failure_marker "uncertain fingerprint producer failure" || true
+  echo "CSA git-guard: post-hook fingerprint state is unavailable; the staged tree is preserved for host recovery." >&2
 fi
 exit "${commit_status}"

--- a/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed.sh
+++ b/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed.sh
@@ -1,0 +1,67 @@
+commit_attempt_fingerprint() {
+  head="$("${REAL_GIT}" rev-parse --verify HEAD 2>/dev/null || printf '%s' unborn)"
+  index_tree="$("${REAL_GIT}" write-tree 2>/dev/null)" || return 1
+  args_hash="$(for arg do printf '%s:%s\n' "${#arg}" "${arg}"; done | "${REAL_GIT}" hash-object --stdin)" || return 1
+  env_hash="$(env | LC_ALL=C sort | "${REAL_GIT}" hash-object --stdin)" || return 1
+  config_hash="$("${REAL_GIT}" config --null --list --show-origin 2>/dev/null | "${REAL_GIT}" hash-object --stdin)" || return 1
+  hooks_hash="$(
+    {
+      if [ -n "${top}" ]; then
+        for hook_name in pre-commit prepare-commit-msg commit-msg; do
+          hook_path="$(hook_path_for "${hook_name}")"
+          if [ -f "${hook_path}" ]; then
+            "${REAL_GIT}" hash-object "${hook_path}" 2>/dev/null || printf '%s\n' unreadable
+          else
+            printf '%s\n' absent
+          fi
+        done
+      fi
+    } | "${REAL_GIT}" hash-object --stdin
+  )" || return 1
+  printf '%s %s %s %s %s %s\n' "${head}" "${index_tree}" "${args_hash}" "${env_hash}" "${config_hash}" "${hooks_hash}"
+}
+commit_failure_marker="" commit_fingerprint=""
+if [ "${CSA_FS_SANDBOXED:-}" = "1" ] && [ -n "${CSA_SESSION_DIR:-}" ]; then
+  session_dir="$(canonical_directory "${CSA_SESSION_DIR}")" || session_dir=""
+  guard_dir="$(canonical_directory "$(dirname "$0")")" || guard_dir=""
+  expected_guard_dir="$(canonical_directory "${session_dir}/bin")" || expected_guard_dir=""
+  if [ -n "${session_dir}" ] && [ "${guard_dir}" = "${expected_guard_dir}" ]; then
+    commit_failure_marker="${session_dir}/__CSA_GIT_COMMIT_FAILURE_MARKER__"
+    commit_fingerprint="$(commit_attempt_fingerprint "$@" || true)"
+    blocked_fingerprint=""
+    if [ -f "${commit_failure_marker}" ]; then
+      IFS= read -r blocked_fingerprint < "${commit_failure_marker}" || true
+    fi
+    if [ -n "${commit_fingerprint}" ] && [ "${blocked_fingerprint}" = "${commit_fingerprint}" ]; then
+      echo "BLOCKED: hook-enabled commit already failed for this unchanged staged tree in the filesystem sandbox; mandatory hooks will not be rerun." >&2
+      echo "The staged tree is preserved. Inspect the first hook failure, then run the same hook-enabled commit outside the sandbox if it needs host resources." >&2
+      exit 1
+    fi
+  fi
+fi
+
+if [ -z "${commit_failure_marker}" ] || [ -z "${commit_fingerprint}" ]; then
+  exec "${REAL_GIT}" "$@"
+fi
+
+if "${REAL_GIT}" "$@"; then
+  rm -f "${commit_failure_marker}"
+  exit 0
+else
+  commit_status=$?
+fi
+post_fingerprint="$(commit_attempt_fingerprint "$@" || true)"
+if [ "${post_fingerprint}" = "${commit_fingerprint}" ]; then
+  marker_tmp="$(mktemp "${commit_failure_marker}.XXXXXX" 2>/dev/null || true)"
+  if [ -n "${marker_tmp}" ] \
+    && printf '%s\n' "${commit_fingerprint}" > "${marker_tmp}" \
+    && mv -f "${marker_tmp}" "${commit_failure_marker}"; then
+    echo "CSA git-guard: hook-enabled commit failed inside the filesystem sandbox; the staged tree is preserved." >&2
+    echo "CSA git-guard: an identical retry is blocked. Inspect the hook failure, then use the same hook-enabled commit outside the sandbox if host resources are required." >&2
+  else
+    rm -f "${marker_tmp:-}"
+  fi
+else
+  rm -f "${commit_failure_marker}"
+fi
+exit "${commit_status}"

--- a/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed.sh
+++ b/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed.sh
@@ -113,6 +113,33 @@ append_hashed_file() {
     "${hashed_value}" >> "${hashed_manifest}" || return 1
 }
 
+append_hashed_symlink_identity() {
+  symlink_label="$1"
+  symlink_path="$2"
+  symlink_manifest="$3"
+  [ -L "${symlink_path}" ] || return 1
+  fingerprint_file_count=$((fingerprint_file_count + 1))
+  [ "${fingerprint_file_count}" -le "${FINGERPRINT_MAX_FILES}" ] || return 1
+  symlink_capture="symlink.${fingerprint_file_count}"
+  bounded_capture "${symlink_capture}.identity" /usr/bin/stat -c '%d:%i:%f:%y:%z' -- "${symlink_path}" || return 1
+  symlink_identity_hash="$(hash_input_file "${fingerprint_tmp_dir}/${symlink_capture}.identity")" || return 1
+  bounded_capture "${symlink_capture}.target" readlink -- "${symlink_path}" || return 1
+  symlink_target_hash="$(hash_input_file "${fingerprint_tmp_dir}/${symlink_capture}.target")" || return 1
+  printf '%s:%s:%s:%s:%s\n' "${symlink_label}" "${#symlink_path}" "${symlink_path}" \
+    "${symlink_identity_hash}" "${symlink_target_hash}" >> "${symlink_manifest}" || return 1
+}
+
+append_hashed_symlink_hook() {
+  symlink_label="$1"
+  symlink_path="$2"
+  symlink_manifest="$3"
+  append_hashed_symlink_identity "${symlink_label}" "${symlink_path}" "${symlink_manifest}" || return 1
+  symlink_capture="symlink.${fingerprint_file_count}"
+  bounded_capture "${symlink_capture}.resolved" readlink -f -- "${symlink_path}" || return 1
+  symlink_target="$(read_bounded_single_record "${fingerprint_tmp_dir}/${symlink_capture}.resolved" "${FINGERPRINT_FILE_MAX_BYTES}")" || return 1
+  append_hashed_file "${symlink_label}-target" "${symlink_target}" "${symlink_manifest}"
+}
+
 commit_attempt_fingerprint_inner() {
   LC_ALL=C
   export LC_ALL
@@ -168,13 +195,21 @@ commit_attempt_fingerprint_inner() {
     pre_commit_path="$(hook_path_for pre-commit)" || return 1
     [ -n "${pre_commit_path}" ] || return 1
     hooks_dir="$(dirname "${pre_commit_path}")" || return 1
-    bounded_capture hooks.raw find -P "${hooks_dir}" -type f -print || return 1
+    if [ -L "${hooks_dir}" ]; then
+      append_hashed_symlink_identity hooks-dir "${hooks_dir}" "${hooks_manifest}" || return 1
+    fi
+    bounded_capture hooks.raw find -H "${hooks_dir}" \( -type f -o -type l \) -print || return 1
     bounded_capture hooks.sorted sort "${fingerprint_tmp_dir}/hooks.raw" || return 1
     while IFS= read -r hook_path || [ -n "${hook_path}" ]; do
       [ -n "${hook_path}" ] || continue
       found_hook=true
       if [ -x "${hook_path}" ]; then hook_mode=x; else hook_mode=-; fi
-      append_hashed_file "hook:${hook_mode}" "${hook_path}" "${hooks_manifest}" || return 1
+      if [ -L "${hook_path}" ]; then
+        [ "${hook_mode}" = x ] || continue
+        append_hashed_symlink_hook "hook:${hook_mode}" "${hook_path}" "${hooks_manifest}" || return 1
+      else
+        append_hashed_file "hook:${hook_mode}" "${hook_path}" "${hooks_manifest}" || return 1
+      fi
     done < "${fingerprint_tmp_dir}/hooks.sorted"
   fi
 
@@ -234,18 +269,28 @@ if [ "${CSA_FS_SANDBOXED:-}" = "1" ] && [ -n "${CSA_SESSION_DIR:-}" ]; then
   if [ -n "${session_dir}" ] && [ "${guard_dir}" = "${expected_guard_dir}" ]; then
     commit_failure_marker="${session_dir}/__CSA_GIT_COMMIT_FAILURE_MARKER__"
     if ! commit_fingerprint="$(commit_attempt_fingerprint "$@")"; then
-      write_commit_failure_marker "uncertain fingerprint producer failure" || true
+      write_commit_failure_marker "uncertain fingerprint producer failure" || block_unavailable_fingerprint
       block_unavailable_fingerprint
     fi
     if [ -e "${commit_failure_marker}" ] || [ -L "${commit_failure_marker}" ]; then
       if blocked_fingerprint="$(read_bounded_single_record "${commit_failure_marker}" "${MARKER_MAX_BYTES}")"; then
-        if [ "${blocked_fingerprint}" = "${commit_fingerprint}" ]; then
-          echo "BLOCKED: hook-enabled commit already failed for this unchanged staged tree in the filesystem sandbox; mandatory hooks will not be rerun." >&2
-          echo "The staged tree is preserved. Inspect the first hook failure, then run the same hook-enabled commit outside the sandbox if it needs host resources." >&2
-          exit 1
-        fi
+        case "${blocked_fingerprint}" in
+          "retryable "*)
+            retryable_fingerprint="${blocked_fingerprint#retryable }"
+            if [ "${retryable_fingerprint}" = "${commit_fingerprint}" ]; then
+              /usr/bin/rm -f -- "${commit_failure_marker}" || block_unavailable_fingerprint
+            fi
+            ;;
+          *)
+            if [ "${blocked_fingerprint}" = "${commit_fingerprint}" ]; then
+              echo "BLOCKED: hook-enabled commit already failed for this unchanged staged tree in the filesystem sandbox; mandatory hooks will not be rerun." >&2
+              echo "The staged tree is preserved. Inspect the first hook failure, then run the same hook-enabled commit outside the sandbox if it needs host resources." >&2
+              exit 1
+            fi
+            ;;
+        esac
       else
-        write_commit_failure_marker "uncertain invalid fingerprint marker" || true
+        write_commit_failure_marker "uncertain invalid fingerprint marker" || block_unavailable_fingerprint
         block_unavailable_fingerprint
       fi
     fi
@@ -267,12 +312,18 @@ if post_fingerprint="$(commit_attempt_fingerprint "$@")"; then
     if write_commit_failure_marker "${commit_fingerprint}"; then
       echo "CSA git-guard: hook-enabled commit failed inside the filesystem sandbox; the staged tree is preserved." >&2
       echo "CSA git-guard: an identical retry is blocked. Inspect the hook failure, then use the same hook-enabled commit outside the sandbox if host resources are required." >&2
+    else
+      echo "CSA git-guard: unable to persist hook-failure state; staged tree is preserved and host recovery is required." >&2
     fi
   else
-    /usr/bin/rm -f -- "${commit_failure_marker}" 2>/dev/null || true
+    if ! write_commit_failure_marker "retryable ${post_fingerprint}"; then
+      echo "CSA git-guard: unable to persist retryable hook-failure state; staged tree is preserved and host recovery is required." >&2
+    fi
   fi
 else
-  write_commit_failure_marker "uncertain fingerprint producer failure" || true
+  if ! write_commit_failure_marker "uncertain fingerprint producer failure"; then
+    echo "CSA git-guard: unable to persist uncertain hook-failure state; staged tree is preserved and host recovery is required." >&2
+  fi
   echo "CSA git-guard: post-hook fingerprint state is unavailable; the staged tree is preserved for host recovery." >&2
 fi
 exit "${commit_status}"

--- a/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed.sh
+++ b/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed.sh
@@ -4,17 +4,33 @@ commit_attempt_fingerprint() {
   args_hash="$(for arg do printf '%s:%s\n' "${#arg}" "${arg}"; done | "${REAL_GIT}" hash-object --stdin)" || return 1
   env_hash="$(env | LC_ALL=C sort | "${REAL_GIT}" hash-object --stdin)" || return 1
   config_hash="$("${REAL_GIT}" config --null --list --show-origin 2>/dev/null | "${REAL_GIT}" hash-object --stdin)" || return 1
+  if [ -n "${top}" ]; then
+    worktree_hash="$("${REAL_GIT}" -C "${top}" diff --no-ext-diff --no-textconv --binary -- | "${REAL_GIT}" hash-object --stdin)" || return 1
+  else
+    worktree_hash=absent
+  fi
   hooks_hash="$(
     {
+      printf 'worktree:%s\n' "${worktree_hash}"
+      if [ -n "${lefthook_config:-}" ] && [ -f "${lefthook_config}" ]; then
+        config_name="${lefthook_config##*/}"
+        printf 'lefthook:%s:%s\n' "${#config_name}" "${config_name}"
+        "${REAL_GIT}" hash-object "${lefthook_config}" 2>/dev/null || printf '%s\n' unreadable
+      else
+        printf '%s\n' lefthook:absent
+      fi
       if [ -n "${top}" ]; then
-        for hook_name in pre-commit prepare-commit-msg commit-msg; do
-          hook_path="$(hook_path_for "${hook_name}")"
-          if [ -f "${hook_path}" ]; then
-            "${REAL_GIT}" hash-object "${hook_path}" 2>/dev/null || printf '%s\n' unreadable
-          else
-            printf '%s\n' absent
-          fi
+        hooks_dir="$(dirname "$(hook_path_for pre-commit)")"
+        found_hook=false
+        for hook_path in "${hooks_dir}"/*; do
+          [ -f "${hook_path}" ] || continue
+          found_hook=true
+          hook_name="${hook_path##*/}"
+          if [ -x "${hook_path}" ]; then hook_mode=x; else hook_mode=-; fi
+          printf 'hook:%s:%s:%s\n' "${#hook_name}" "${hook_name}" "${hook_mode}"
+          "${REAL_GIT}" hash-object "${hook_path}" 2>/dev/null || printf '%s\n' unreadable
         done
+        [ "${found_hook}" = true ] || printf '%s\n' hooks:absent
       fi
     } | "${REAL_GIT}" hash-object --stdin
   )" || return 1

--- a/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed_tests.rs
+++ b/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed_tests.rs
@@ -1,0 +1,144 @@
+use super::*;
+
+#[test]
+fn wrapper_blocks_repeated_sandbox_commit_for_unchanged_staged_tree() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().unwrap()).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    let repo = temp.path().join("repo");
+    init_worktree_repo(&repo);
+    std::fs::write(repo.join("fixture.txt"), "staged change\n").unwrap();
+    run_git(&repo, &["add", "fixture.txt"]);
+
+    let hook_count = temp.path().join("hook-count");
+    let hook_helper = repo.join("hook-helper.sh");
+    write_executable(
+        repo.join(".git/hooks/pre-commit").as_path(),
+        r#"#!/bin/sh
+count=0
+[ ! -f "${HOOK_COUNT}" ] || count="$(cat "${HOOK_COUNT}")"
+count=$((count + 1))
+printf '%s\n' "${count}" > "${HOOK_COUNT}"
+echo "hook cannot write /var/tmp: Read-only file system" >&2
+exit 1
+"#,
+    );
+
+    let run_commit = || {
+        Command::new(&wrapper)
+            .args(["commit", "-m", "sandbox commit"])
+            .current_dir(&repo)
+            .env("CSA_REAL_GIT", "/usr/bin/git")
+            .env("CSA_FS_SANDBOXED", "1")
+            .env("CSA_SESSION_DIR", &session_dir)
+            .env("HOOK_COUNT", &hook_count)
+            .env("HOOK_HELPER", &hook_helper)
+            .output_with_timeout()
+            .expect("run guarded commit")
+    };
+    let head_before = git_output(&repo, &["rev-parse", "HEAD"]).stdout;
+    let staged_tree_before = git_output(&repo, &["write-tree"]).stdout;
+
+    let first = run_commit();
+    assert!(!first.status.success());
+    assert_eq!(std::fs::read_to_string(&hook_count).unwrap().trim(), "1");
+    assert!(
+        session_dir.join(".git-guard-commit-failure").is_file(),
+        "the first unchanged-tree hook failure must leave a fail-closed marker"
+    );
+    assert_eq!(
+        git_output(&repo, &["rev-parse", "HEAD"]).stdout,
+        head_before
+    );
+    assert_eq!(
+        git_output(&repo, &["write-tree"]).stdout,
+        staged_tree_before,
+        "failed hook must preserve the staged tree"
+    );
+
+    let second = run_commit();
+    assert!(!second.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&hook_count).unwrap().trim(),
+        "1",
+        "unchanged staged tree must not rerun the known-failing hook"
+    );
+    let stderr = String::from_utf8_lossy(&second.stderr);
+    assert!(stderr.contains("filesystem sandbox"), "{stderr}");
+    assert!(stderr.contains("staged tree is preserved"), "{stderr}");
+    assert!(stderr.contains("outside the sandbox"), "{stderr}");
+
+    std::fs::write(repo.join("fixture.txt"), "repaired staged change\n").unwrap();
+    run_git(&repo, &["add", "fixture.txt"]);
+    let third = run_commit();
+    assert!(!third.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&hook_count).unwrap().trim(),
+        "2",
+        "a changed staged tree must get one fresh hook attempt"
+    );
+
+    std::fs::write(
+        repo.join("lefthook.yml"),
+        "pre-commit:\n  commands:\n    check:\n      run: ./hook-helper.sh\n",
+    )
+    .unwrap();
+    let after_lefthook_change = run_commit();
+    assert!(!after_lefthook_change.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&hook_count).unwrap().trim(),
+        "3",
+        "changing lefthook config must allow one fresh hook attempt"
+    );
+
+    write_executable(
+        &hook_helper,
+        r#"#!/bin/sh
+count="$(cat "${HOOK_COUNT}")"
+printf '%s\n' "$((count + 1))" > "${HOOK_COUNT}"
+echo "helper rejects commit" >&2
+exit 1
+"#,
+    );
+    run_git(&repo, &["add", "hook-helper.sh"]);
+    write_executable(
+        repo.join(".git/hooks/pre-commit").as_path(),
+        "#!/bin/sh\nexec \"${HOOK_HELPER}\"\n",
+    );
+    let with_referenced_helper = run_commit();
+    assert!(!with_referenced_helper.status.success());
+    assert_eq!(std::fs::read_to_string(&hook_count).unwrap().trim(), "4");
+
+    write_executable(
+        &hook_helper,
+        r#"#!/bin/sh
+count="$(cat "${HOOK_COUNT}")"
+printf '%s\n' "$((count + 1))" > "${HOOK_COUNT}"
+echo "repaired helper still rejects in sandbox" >&2
+exit 1
+"#,
+    );
+    let after_helper_change = run_commit();
+    assert!(!after_helper_change.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&hook_count).unwrap().trim(),
+        "5",
+        "changing a hook-referenced script must allow one fresh hook attempt"
+    );
+
+    write_executable(
+        repo.join(".git/hooks/reference-transaction").as_path(),
+        "#!/bin/sh\necho reference transaction rejects >&2\nexit 1\n",
+    );
+    let after_other_hook_change = run_commit();
+    assert!(!after_other_hook_change.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&hook_count).unwrap().trim(),
+        "6",
+        "changing another rejecting hook must allow one fresh hook attempt"
+    );
+}

--- a/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed_tests.rs
+++ b/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed_tests.rs
@@ -1,4 +1,75 @@
 use super::*;
+use crate::git_guard::SANDBOX_COMMIT_FAILURE_MARKER_FILE;
+
+struct SandboxCommitFixture {
+    _temp: tempfile::TempDir,
+    session_dir: std::path::PathBuf,
+    wrapper: std::path::PathBuf,
+    repo: std::path::PathBuf,
+    hook_count: std::path::PathBuf,
+}
+
+impl SandboxCommitFixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_dir = temp.path().join("session");
+        let wrapper = session_dir.join("bin/git");
+        std::fs::create_dir_all(wrapper.parent().expect("wrapper parent"))
+            .expect("create wrapper dir");
+        write_executable(&wrapper, git_wrapper_script());
+        let repo = temp.path().join("repo");
+        init_worktree_repo(&repo);
+        std::fs::write(repo.join("fixture.txt"), "staged change\n").expect("write staged file");
+        run_git(&repo, &["add", "fixture.txt"]);
+        let hook_count = temp.path().join("hook-count");
+        write_executable(
+            &repo.join(".git/hooks/pre-commit"),
+            r#"#!/bin/sh
+count=0
+[ ! -f "${HOOK_COUNT}" ] || count="$(cat "${HOOK_COUNT}")"
+printf '%s\n' "$((count + 1))" > "${HOOK_COUNT}"
+echo "hook cannot write /var/tmp: Read-only file system" >&2
+exit 1
+"#,
+        );
+        Self {
+            _temp: temp,
+            session_dir,
+            wrapper,
+            repo,
+            hook_count,
+        }
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(&self.wrapper);
+        command
+            .args(["commit", "-m", "sandbox commit"])
+            .current_dir(&self.repo)
+            .env("CSA_REAL_GIT", "/usr/bin/git")
+            .env("CSA_FS_SANDBOXED", "1")
+            .env("CSA_SESSION_DIR", &self.session_dir)
+            .env("HOOK_COUNT", &self.hook_count);
+        command
+    }
+
+    fn run(&self) -> Output {
+        self.command()
+            .output_with_timeout()
+            .expect("run guarded commit")
+    }
+
+    fn marker(&self) -> std::path::PathBuf {
+        self.session_dir.join(SANDBOX_COMMIT_FAILURE_MARKER_FILE)
+    }
+
+    fn hook_count(&self) -> u32 {
+        std::fs::read_to_string(&self.hook_count)
+            .ok()
+            .and_then(|value| value.trim().parse().ok())
+            .unwrap_or(0)
+    }
+}
 
 #[test]
 fn wrapper_blocks_repeated_sandbox_commit_for_unchanged_staged_tree() {
@@ -141,4 +212,234 @@ exit 1
         "6",
         "changing another rejecting hook must allow one fresh hook attempt"
     );
+}
+
+#[test]
+fn wrapper_rejects_malformed_markers_without_rerunning_hooks() {
+    use std::os::unix::fs::symlink;
+
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    for marker_kind in ["symlink", "oversized", "multi-record"] {
+        let fixture = SandboxCommitFixture::new();
+        let first = fixture.run();
+        assert!(!first.status.success());
+        assert_eq!(
+            fixture.hook_count(),
+            1,
+            "first attempt: {}",
+            String::from_utf8_lossy(&first.stderr)
+        );
+        let marker = fixture.marker();
+        let valid_record = std::fs::read(&marker).expect("read valid marker");
+        match marker_kind {
+            "symlink" => {
+                let target = marker.with_extension("target");
+                std::fs::rename(&marker, &target).expect("move marker");
+                symlink(target, &marker).expect("symlink marker");
+            }
+            "oversized" => {
+                let file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .truncate(true)
+                    .open(&marker)
+                    .expect("open marker");
+                file.set_len(1024 * 1024).expect("grow marker");
+            }
+            "multi-record" => {
+                let mut records = valid_record;
+                records.extend_from_slice(b"trailing record\n");
+                std::fs::write(&marker, records).expect("write multi-record marker");
+            }
+            _ => unreachable!(),
+        }
+
+        let output = fixture.run();
+        assert!(!output.status.success(), "{marker_kind}");
+        assert_eq!(
+            fixture.hook_count(),
+            1,
+            "{marker_kind} marker must not rerun the hook"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("fingerprint state is unavailable"),
+            "{marker_kind}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+fn rejecting_helper_body(message: &str) -> String {
+    format!(
+        "#!/bin/sh\ncount=0\n[ ! -f \"${{HOOK_COUNT}}\" ] || count=\"$(cat \"${{HOOK_COUNT}}\")\"\nprintf '%s\\n' \"$((count + 1))\" > \"${{HOOK_COUNT}}\"\necho '{message}' >&2\nexit 1\n"
+    )
+}
+
+#[test]
+fn wrapper_fingerprints_supported_hook_helpers() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    for helper_kind in ["untracked", "nested", "hidden", "outside"] {
+        let fixture = SandboxCommitFixture::new();
+        let helper = match helper_kind {
+            "untracked" => fixture.repo.join("hook-helper.sh"),
+            "nested" => fixture.repo.join(".git/hooks/lib/check.sh"),
+            "hidden" => fixture.repo.join(".git/hooks/.check"),
+            "outside" => fixture
+                .session_dir
+                .parent()
+                .expect("fixture root")
+                .join("outside-helper.sh"),
+            _ => unreachable!(),
+        };
+        std::fs::create_dir_all(helper.parent().expect("helper parent"))
+            .expect("create helper parent");
+        write_executable(&helper, rejecting_helper_body("first rejection"));
+        write_executable(
+            &fixture.repo.join(".git/hooks/pre-commit"),
+            "#!/bin/sh\nexec \"${HOOK_HELPER}\"\n",
+        );
+        let declared = matches!(helper_kind, "untracked" | "outside");
+        let run = || {
+            let mut command = fixture.command();
+            command.env("HOOK_HELPER", &helper);
+            if declared {
+                command.env("CSA_GIT_GUARD_HOOK_HELPERS", &helper);
+            }
+            command
+                .output_with_timeout()
+                .expect("run helper-backed commit")
+        };
+
+        assert!(!run().status.success());
+        assert_eq!(fixture.hook_count(), 1, "{helper_kind}");
+        write_executable(&helper, rejecting_helper_body("repaired rejection"));
+        assert!(!run().status.success());
+        assert_eq!(
+            fixture.hook_count(),
+            2,
+            "changed {helper_kind} helper must allow one fresh hook attempt"
+        );
+    }
+}
+
+#[test]
+fn wrapper_fails_closed_when_fingerprint_producers_fail() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    for producer in [
+        "env",
+        "sort",
+        "head",
+        "config",
+        "diff",
+        "diff-timeout",
+        "hooks",
+    ] {
+        let fixture = SandboxCommitFixture::new();
+        let fake_bin = fixture
+            .session_dir
+            .parent()
+            .expect("fixture root")
+            .join("fake-bin");
+        std::fs::create_dir(&fake_bin).expect("create fake bin");
+        let fake_git = fake_bin.join("git-producer");
+        std::fs::write(
+            &fake_git,
+            r#"#!/bin/sh
+case "${FAIL_PRODUCER}:$*" in
+  "head:rev-parse --verify HEAD") exit 42 ;;
+  "config:config --null --list --show-origin"|diff:*" diff --no-ext-diff --no-textconv --binary --") exit 42 ;;
+  diff-timeout:*" diff --no-ext-diff --no-textconv --binary --") exec /usr/bin/sleep 5 ;;
+esac
+exec /usr/bin/git "$@"
+"#,
+        )
+        .expect("write producer-failing Git");
+        std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755))
+            .expect("make fake Git executable");
+        for utility in ["env", "sort", "find"] {
+            let fake_utility = fake_bin.join(utility);
+            let body = if producer == utility || (producer == "hooks" && utility == "find") {
+                "#!/bin/sh\nexit 42\n"
+            } else {
+                match utility {
+                    "env" => "#!/bin/sh\nexec /usr/bin/env \"$@\"\n",
+                    "sort" => "#!/bin/sh\nexec /usr/bin/sort \"$@\"\n",
+                    "find" => "#!/bin/sh\nexec /usr/bin/find \"$@\"\n",
+                    _ => unreachable!(),
+                }
+            };
+            write_executable(&fake_utility, body);
+        }
+        let original_path = std::env::var_os("PATH").unwrap_or_default();
+        let mut path = fake_bin.into_os_string();
+        path.push(":");
+        path.push(original_path);
+        let mut command = fixture.command();
+        command
+            .env("PATH", path)
+            .env("CSA_REAL_GIT", &fake_git)
+            .env("FAIL_PRODUCER", producer);
+
+        let output = command
+            .output_with_timeout()
+            .expect("run producer failure fixture");
+        assert!(!output.status.success(), "{producer}");
+        assert_eq!(
+            fixture.hook_count(),
+            0,
+            "{producer} failure must block before the hook"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("fingerprint state is unavailable"),
+            "{producer}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn wrapper_fails_closed_on_oversized_fingerprint_inputs() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    for input_kind in ["worktree", "hook-size", "hook-count"] {
+        let fixture = SandboxCommitFixture::new();
+        match input_kind {
+            "worktree" => {
+                std::fs::write(
+                    fixture.repo.join("fixture.txt"),
+                    vec![b'x'; 9 * 1024 * 1024],
+                )
+                .expect("write oversized worktree diff");
+            }
+            "hook-size" => {
+                std::fs::write(
+                    fixture.repo.join(".git/hooks/large-helper"),
+                    vec![b'x'; 2 * 1024 * 1024],
+                )
+                .expect("write oversized hook helper");
+            }
+            "hook-count" => {
+                let helpers = fixture.repo.join(".git/hooks/lib");
+                std::fs::create_dir(&helpers).expect("create hook helper dir");
+                for index in 0..65 {
+                    std::fs::write(helpers.join(format!("helper-{index}")), b"exit 1\n")
+                        .expect("write hook helper");
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        let output = fixture.run();
+        assert!(!output.status.success(), "{input_kind}");
+        assert_eq!(
+            fixture.hook_count(),
+            0,
+            "{input_kind} must block before the hook"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("fingerprint state is unavailable"),
+            "{input_kind}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }

--- a/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed_tests.rs
+++ b/crates/csa-hooks/src/git_guard_sandbox_commit_fail_closed_tests.rs
@@ -322,6 +322,82 @@ fn wrapper_fingerprints_supported_hook_helpers() {
 }
 
 #[test]
+fn wrapper_fingerprints_active_symlink_hooks() {
+    use std::os::unix::fs::symlink;
+
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    for symlink_kind in ["hook", "hooks-dir"] {
+        let fixture = SandboxCommitFixture::new();
+        let hooks_dir = fixture.repo.join(".git/hooks");
+        let target = match symlink_kind {
+            "hook" => {
+                let target = hooks_dir.join("pre-commit.target");
+                std::fs::remove_file(hooks_dir.join("pre-commit")).expect("remove hook");
+                write_executable(&target, rejecting_helper_body("first symlink rejection"));
+                symlink(&target, hooks_dir.join("pre-commit")).expect("symlink hook");
+                target
+            }
+            "hooks-dir" => {
+                let target_dir = fixture.repo.join(".git/hooks.target");
+                std::fs::rename(&hooks_dir, &target_dir).expect("move hooks dir");
+                symlink(&target_dir, &hooks_dir).expect("symlink hooks dir");
+                target_dir.join("pre-commit")
+            }
+            _ => unreachable!(),
+        };
+        if symlink_kind == "hooks-dir" {
+            write_executable(&target, rejecting_helper_body("first symlink rejection"));
+        }
+
+        assert!(!fixture.run().status.success(), "{symlink_kind}");
+        assert_eq!(fixture.hook_count(), 1, "{symlink_kind}");
+        write_executable(&target, rejecting_helper_body("repaired symlink rejection"));
+        assert!(!fixture.run().status.success(), "{symlink_kind}");
+        assert_eq!(
+            fixture.hook_count(),
+            2,
+            "changing {symlink_kind} target must allow one fresh hook attempt"
+        );
+    }
+}
+
+#[test]
+fn wrapper_keeps_a_durable_marker_when_an_autofix_hook_changes_the_index() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let fixture = SandboxCommitFixture::new();
+    write_executable(
+        &fixture.repo.join(".git/hooks/pre-commit"),
+        r#"#!/bin/sh
+printf 'autofixed\n' > hook-generated.txt
+/usr/bin/git add hook-generated.txt
+exit 1
+"#,
+    );
+    let head_before = git_output(&fixture.repo, &["rev-parse", "HEAD"]).stdout;
+
+    assert!(!fixture.run().status.success());
+    let staged_tree_after_hook = git_output(&fixture.repo, &["write-tree"]).stdout;
+    assert!(
+        fixture.marker().is_file(),
+        "a changed hook failure must remain distinguishable from no failure"
+    );
+    assert!(
+        std::fs::read_to_string(fixture.marker())
+            .expect("read marker")
+            .starts_with("retryable "),
+        "the changed failure marker may permit a hook-enabled retry but not rescue"
+    );
+    assert_eq!(
+        git_output(&fixture.repo, &["rev-parse", "HEAD"]).stdout,
+        head_before
+    );
+    assert_eq!(
+        git_output(&fixture.repo, &["write-tree"]).stdout,
+        staged_tree_after_hook
+    );
+}
+
+#[test]
 fn wrapper_fails_closed_when_fingerprint_producers_fail() {
     use std::os::unix::fs::PermissionsExt;
 

--- a/crates/csa-hooks/src/git_guard_tests.rs
+++ b/crates/csa-hooks/src/git_guard_tests.rs
@@ -118,12 +118,17 @@ printf '%s\n' "$*"
 }
 
 #[cfg(unix)]
-fn run_git(current_dir: &Path, args: &[&str]) {
-    let output = Command::new("git")
+fn git_output(current_dir: &Path, args: &[&str]) -> Output {
+    Command::new("git")
         .args(args)
         .current_dir(current_dir)
         .output_with_timeout()
-        .expect("run git fixture command");
+        .expect("run git fixture command")
+}
+
+#[cfg(unix)]
+fn run_git(current_dir: &Path, args: &[&str]) {
+    let output = git_output(current_dir, args);
     assert!(
         output.status.success(),
         "git {} failed:\nstdout:\n{}\nstderr:\n{}",
@@ -509,6 +514,88 @@ fn wrapper_requires_pre_commit_when_lefthook_config_defines_it() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!output.status.success());
     assert!(stderr.contains("pre-commit"), "{stderr}");
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_blocks_repeated_sandbox_commit_for_unchanged_staged_tree() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let session_dir = temp.path().join("session");
+    let wrapper = session_dir.join("bin/git");
+    std::fs::create_dir_all(wrapper.parent().unwrap()).unwrap();
+    write_executable(&wrapper, git_wrapper_script());
+
+    let repo = temp.path().join("repo");
+    init_worktree_repo(&repo);
+    std::fs::write(repo.join("fixture.txt"), "staged change\n").unwrap();
+    run_git(&repo, &["add", "fixture.txt"]);
+
+    let hook_count = temp.path().join("hook-count");
+    write_executable(
+        repo.join(".git/hooks/pre-commit").as_path(),
+        r#"#!/bin/sh
+count=0
+[ ! -f "${HOOK_COUNT}" ] || count="$(cat "${HOOK_COUNT}")"
+count=$((count + 1))
+printf '%s\n' "${count}" > "${HOOK_COUNT}"
+echo "hook cannot write /var/tmp: Read-only file system" >&2
+exit 1
+"#,
+    );
+
+    let run_commit = || {
+        Command::new(&wrapper)
+            .args(["commit", "-m", "sandbox commit"])
+            .current_dir(&repo)
+            .env("CSA_REAL_GIT", "/usr/bin/git")
+            .env("CSA_FS_SANDBOXED", "1")
+            .env("CSA_SESSION_DIR", &session_dir)
+            .env("HOOK_COUNT", &hook_count)
+            .output_with_timeout()
+            .expect("run guarded commit")
+    };
+    let head_before = git_output(&repo, &["rev-parse", "HEAD"]).stdout;
+    let staged_tree_before = git_output(&repo, &["write-tree"]).stdout;
+
+    let first = run_commit();
+    assert!(!first.status.success());
+    assert_eq!(std::fs::read_to_string(&hook_count).unwrap().trim(), "1");
+    assert!(
+        session_dir.join(".git-guard-commit-failure").is_file(),
+        "the first unchanged-tree hook failure must leave a fail-closed marker"
+    );
+    assert_eq!(
+        git_output(&repo, &["rev-parse", "HEAD"]).stdout,
+        head_before
+    );
+    assert_eq!(
+        git_output(&repo, &["write-tree"]).stdout,
+        staged_tree_before,
+        "failed hook must preserve the staged tree"
+    );
+
+    let second = run_commit();
+    assert!(!second.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&hook_count).unwrap().trim(),
+        "1",
+        "unchanged staged tree must not rerun the known-failing hook"
+    );
+    let stderr = String::from_utf8_lossy(&second.stderr);
+    assert!(stderr.contains("filesystem sandbox"), "{stderr}");
+    assert!(stderr.contains("staged tree is preserved"), "{stderr}");
+    assert!(stderr.contains("outside the sandbox"), "{stderr}");
+
+    std::fs::write(repo.join("fixture.txt"), "repaired staged change\n").unwrap();
+    run_git(&repo, &["add", "fixture.txt"]);
+    let third = run_commit();
+    assert!(!third.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&hook_count).unwrap().trim(),
+        "2",
+        "a changed staged tree must get one fresh hook attempt"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/csa-hooks/src/git_guard_tests.rs
+++ b/crates/csa-hooks/src/git_guard_tests.rs
@@ -517,86 +517,8 @@ fn wrapper_requires_pre_commit_when_lefthook_config_defines_it() {
 }
 
 #[cfg(unix)]
-#[test]
-fn wrapper_blocks_repeated_sandbox_commit_for_unchanged_staged_tree() {
-    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-    let temp = tempfile::tempdir().unwrap();
-    let session_dir = temp.path().join("session");
-    let wrapper = session_dir.join("bin/git");
-    std::fs::create_dir_all(wrapper.parent().unwrap()).unwrap();
-    write_executable(&wrapper, git_wrapper_script());
-
-    let repo = temp.path().join("repo");
-    init_worktree_repo(&repo);
-    std::fs::write(repo.join("fixture.txt"), "staged change\n").unwrap();
-    run_git(&repo, &["add", "fixture.txt"]);
-
-    let hook_count = temp.path().join("hook-count");
-    write_executable(
-        repo.join(".git/hooks/pre-commit").as_path(),
-        r#"#!/bin/sh
-count=0
-[ ! -f "${HOOK_COUNT}" ] || count="$(cat "${HOOK_COUNT}")"
-count=$((count + 1))
-printf '%s\n' "${count}" > "${HOOK_COUNT}"
-echo "hook cannot write /var/tmp: Read-only file system" >&2
-exit 1
-"#,
-    );
-
-    let run_commit = || {
-        Command::new(&wrapper)
-            .args(["commit", "-m", "sandbox commit"])
-            .current_dir(&repo)
-            .env("CSA_REAL_GIT", "/usr/bin/git")
-            .env("CSA_FS_SANDBOXED", "1")
-            .env("CSA_SESSION_DIR", &session_dir)
-            .env("HOOK_COUNT", &hook_count)
-            .output_with_timeout()
-            .expect("run guarded commit")
-    };
-    let head_before = git_output(&repo, &["rev-parse", "HEAD"]).stdout;
-    let staged_tree_before = git_output(&repo, &["write-tree"]).stdout;
-
-    let first = run_commit();
-    assert!(!first.status.success());
-    assert_eq!(std::fs::read_to_string(&hook_count).unwrap().trim(), "1");
-    assert!(
-        session_dir.join(".git-guard-commit-failure").is_file(),
-        "the first unchanged-tree hook failure must leave a fail-closed marker"
-    );
-    assert_eq!(
-        git_output(&repo, &["rev-parse", "HEAD"]).stdout,
-        head_before
-    );
-    assert_eq!(
-        git_output(&repo, &["write-tree"]).stdout,
-        staged_tree_before,
-        "failed hook must preserve the staged tree"
-    );
-
-    let second = run_commit();
-    assert!(!second.status.success());
-    assert_eq!(
-        std::fs::read_to_string(&hook_count).unwrap().trim(),
-        "1",
-        "unchanged staged tree must not rerun the known-failing hook"
-    );
-    let stderr = String::from_utf8_lossy(&second.stderr);
-    assert!(stderr.contains("filesystem sandbox"), "{stderr}");
-    assert!(stderr.contains("staged tree is preserved"), "{stderr}");
-    assert!(stderr.contains("outside the sandbox"), "{stderr}");
-
-    std::fs::write(repo.join("fixture.txt"), "repaired staged change\n").unwrap();
-    run_git(&repo, &["add", "fixture.txt"]);
-    let third = run_commit();
-    assert!(!third.status.success());
-    assert_eq!(
-        std::fs::read_to_string(&hook_count).unwrap().trim(),
-        "2",
-        "a changed staged tree must get one fresh hook attempt"
-    );
-}
+#[path = "git_guard_sandbox_commit_fail_closed_tests.rs"]
+mod sandbox_commit_fail_closed_tests;
 
 #[cfg(unix)]
 #[test]


### PR DESCRIPTION
## Summary

Fail closed when a sandboxed `--require-commit` hook cannot run: preserve the staged tree, never `git add -A` / `--no-verify` after hook failure or probe uncertainty, and accept a successful writer commit that already advanced HEAD.

Closes #2932

## Test plan

- Exact-HEAD `just pre-push` GREEN: `drafts/cli-sub-agent/2932-prepush-c33b7755.log` SHA-256 `318906e1a77f625bad00fc919375e311083efc41d0a29c3ed3975e368d3d6d94` (`7586 passed, 7 skipped`)
- Native clean-room PASS (NOT a CSA verdict): `drafts/cli-sub-agent/2932-native-tier4-report-c33b7755.md` SHA-256 `159f29ea265e40c363bfc95df214221733806b0a24f6af3c98c7b586e02d3f48`
- CSA Codex quota-unavailable until 2026-08-19 22:19 (session `01M0889NFHTMM4V0BNBPBPYSB9` on predecessor `45240b4f`); bypass: `.csa/native-review-bypass/c33b775577271c3bf49e48a475bbd8d37acccd2b.toml`

## Review note

This is an authorized native clean-room fallback because CSA Codex is quota-exhausted. It is **not** a CSA Tier-4 verdict.
