### PR TITLE
fix(review): preserve prose findings and Linux wait-lock identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1761,7 +1761,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -2873,7 +2873,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1140"
+version = "0.1.1141"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1140"
+version = "0.1.1141"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_dirty_tree.rs
+++ b/crates/cli-sub-agent/src/review_cmd_dirty_tree.rs
@@ -155,6 +155,10 @@ pub(super) fn append_repo_write_audit_finding(
                 .join("output")
                 .join(super::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER);
             let _ = std::fs::remove_file(synthetic_marker);
+            let prose_derived_marker = session_dir
+                .join("output")
+                .join(super::findings_toml::FINDINGS_TOML_PROSE_DERIVED_MARKER);
+            let _ = std::fs::remove_file(prose_derived_marker);
         }
     }
 

--- a/crates/cli-sub-agent/src/review_cmd_dirty_tree.rs
+++ b/crates/cli-sub-agent/src/review_cmd_dirty_tree.rs
@@ -7,7 +7,7 @@ use csa_session::{
 };
 use tracing::{debug, warn};
 
-const REVIEW_WORKTREE_MUTATION_FINDING_ID: &str = "CSA-REVIEW-WORKTREE-MUTATION";
+pub(super) const REVIEW_WORKTREE_MUTATION_FINDING_ID: &str = "CSA-REVIEW-WORKTREE-MUTATION";
 const REVIEW_WORKTREE_MUTATION_RULE_ID: &str = "csa.review.readonly-worktree-mutation";
 
 /// Returns the set of file paths (relative to project root) that have uncommitted
@@ -155,10 +155,6 @@ pub(super) fn append_repo_write_audit_finding(
                 .join("output")
                 .join(super::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER);
             let _ = std::fs::remove_file(synthetic_marker);
-            let prose_derived_marker = session_dir
-                .join("output")
-                .join(super::findings_toml::FINDINGS_TOML_PROSE_DERIVED_MARKER);
-            let _ = std::fs::remove_file(prose_derived_marker);
         }
     }
 

--- a/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
+++ b/crates/cli-sub-agent/src/review_cmd_findings_toml.rs
@@ -24,6 +24,10 @@ pub(super) const FINDINGS_TOML_SYNTHETIC_MARKER: &str = ".findings.toml.syntheti
 /// is suppressed only when this marker is present (#2002).
 pub(super) const FINDINGS_TOML_EXTRACTED_MARKER: &str = ".findings.toml.extracted";
 
+/// Sidecar marker written when findings were synthesized from prose rather than
+/// loaded from reviewer-authored structured TOML.
+pub(super) const FINDINGS_TOML_PROSE_DERIVED_MARKER: &str = ".findings.toml.prose-derived";
+
 /// Persist `output/findings.toml` extracted from the reviewer message.
 ///
 /// Best-effort: missing/invalid fenced TOML produces a synthetic empty file and
@@ -41,6 +45,10 @@ pub(super) fn persist_review_findings_toml(project_root: &Path, meta: &ReviewSes
                     .join("output")
                     .join(FINDINGS_TOML_SYNTHETIC_MARKER);
                 let _ = fs::remove_file(&marker_path);
+                let prose_marker_path = session_dir
+                    .join("output")
+                    .join(FINDINGS_TOML_PROSE_DERIVED_MARKER);
+                let _ = fs::remove_file(prose_marker_path);
                 debug!(
                     session_id = %meta.session_id,
                     "Skipped synthetic findings.toml for failed review execution"
@@ -48,7 +56,9 @@ pub(super) fn persist_review_findings_toml(project_root: &Path, meta: &ReviewSes
                 return;
             }
 
-            let (artifact, warning_reason) = match derive_findings_toml_artifact(&session_dir) {
+            let (artifact, warning_reason, prose_derived) = match derive_findings_toml_artifact(
+                &session_dir,
+            ) {
                 Ok(artifact) => artifact,
                 Err(error) => {
                     warn!(
@@ -56,7 +66,7 @@ pub(super) fn persist_review_findings_toml(project_root: &Path, meta: &ReviewSes
                         error = %error,
                         "Failed to derive review findings.toml; writing synthetic empty artifact"
                     );
-                    (FindingsFile::default(), Some("derivation failure"))
+                    (FindingsFile::default(), Some("derivation failure"), false)
                 }
             };
 
@@ -100,6 +110,14 @@ pub(super) fn persist_review_findings_toml(project_root: &Path, meta: &ReviewSes
                     .join(FINDINGS_TOML_EXTRACTED_MARKER);
                 let _ = fs::write(&extracted_marker, b"");
             }
+            let prose_marker_path = session_dir
+                .join("output")
+                .join(FINDINGS_TOML_PROSE_DERIVED_MARKER);
+            if prose_derived {
+                let _ = fs::write(prose_marker_path, b"");
+            } else {
+                let _ = fs::remove_file(prose_marker_path);
+            }
         }
         Err(error) => {
             warn!(
@@ -113,9 +131,13 @@ pub(super) fn persist_review_findings_toml(project_root: &Path, meta: &ReviewSes
 
 fn derive_findings_toml_artifact(
     session_dir: &Path,
-) -> Result<(FindingsFile, Option<&'static str>), anyhow::Error> {
+) -> Result<(FindingsFile, Option<&'static str>, bool), anyhow::Error> {
     let Some(review_text) = load_canonical_review_text(session_dir)? else {
-        return Ok((FindingsFile::default(), Some("review text unavailable")));
+        return Ok((
+            FindingsFile::default(),
+            Some("review text unavailable"),
+            false,
+        ));
     };
 
     let prose_artifact = findings_file_from_prose(&review_text);
@@ -127,23 +149,24 @@ fn derive_findings_toml_artifact(
             // support/evidence prose (e.g. "P1 supported by ...") from being
             // misclassified as blocking findings (#2536).
             if review_explicitly_states_no_findings(&review_text) {
-                Ok((artifact, None))
+                Ok((artifact, None, false))
             } else if let Some(prose_artifact) =
                 findings_file_from_explicit_findings_sections(&review_text)
             {
-                Ok((prose_artifact, None))
+                Ok((prose_artifact, None, true))
             } else {
-                Ok((artifact, None))
+                Ok((artifact, None, false))
             }
         }
-        Some(artifact) => Ok((artifact, None)),
+        Some(artifact) => Ok((artifact, None, false)),
         None => {
             if let Some(artifact) = prose_artifact {
-                Ok((artifact, None))
+                Ok((artifact, None, true))
             } else {
                 Ok((
                     FindingsFile::default(),
                     Some("findings.toml block missing or invalid"),
+                    false,
                 ))
             }
         }

--- a/crates/cli-sub-agent/src/review_cmd_multi_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi_tests.rs
@@ -125,6 +125,11 @@ fn repo_write_audit_blocks_clean_multi_reviewer_majority_and_parent_verdict() {
 
     let (dirty_session_id, dirty_session_dir) =
         create_review_session(project.path(), "dirty reviewer");
+    csa_session::persist_structured_output(
+        &dirty_session_dir,
+        "<!-- CSA:SECTION:summary -->\nReview result: FAIL. One low severity prose finding remains.\n<!-- CSA:SECTION:summary:END -->\n\n<!-- CSA:SECTION:details -->\n## Findings\n1. [LOW][style] Independent prose-only finding remains.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist prose review");
     save_result_with_repo_write_audit(project.path(), &dirty_session_id);
     let (clean_session_id_1, _) = create_review_session(project.path(), "clean reviewer 1");
     let (clean_session_id_2, _) = create_review_session(project.path(), "clean reviewer 2");
@@ -195,6 +200,7 @@ fn repo_write_audit_blocks_clean_multi_reviewer_majority_and_parent_verdict() {
             .expect("child findings.toml should exist"),
     )
     .expect("child findings.toml should parse");
+    assert_eq!(child_findings.findings.len(), 2, "{child_findings:#?}");
     let child_finding = child_findings
         .findings
         .iter()

--- a/crates/cli-sub-agent/src/review_cmd_multi_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_multi_tests.rs
@@ -300,6 +300,81 @@ fn repo_write_audit_blocks_clean_multi_reviewer_majority_and_parent_verdict() {
 }
 
 #[test]
+fn repo_write_audit_reconciles_split_section_prose_in_multi_reviewer_sidecars() {
+    let _guard = TEST_ENV_LOCK.clone().blocking_lock_owned();
+    let project = tempfile::tempdir().expect("tempdir should be created");
+    let _state_home = ScopedEnvVarRestore::set("XDG_STATE_HOME", project.path().join("state"));
+
+    let (dirty_session_id, dirty_session_dir) =
+        create_review_session(project.path(), "split-section dirty reviewer");
+    csa_session::persist_structured_output(
+        &dirty_session_dir,
+        "<!-- CSA:SECTION:summary -->\nReview result: FAIL. One canonical prose finding remains.\n## Findings\n1. [LOW][style] Canonical prose-only finding remains.\n<!-- CSA:SECTION:summary:END -->\n\n<!-- CSA:SECTION:details -->\nHIGH: Cross-section prose row must not be extracted.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist split-section prose review");
+    save_result_with_repo_write_audit(project.path(), &dirty_session_id);
+
+    let outcomes = vec![outcome_with_session_id(
+        0,
+        ToolName::Codex,
+        dirty_session_id,
+        CLEAN,
+        None,
+    )];
+    persist_multi_review_sidecars(
+        project.path(),
+        None,
+        "range:main...HEAD",
+        &outcomes,
+        "HEADSHA",
+        ReviewRunMeta {
+            review_iterations: 1,
+            diff_fingerprint: None,
+            review_mode: Some("standard"),
+        },
+        super::super::diff_size::ReviewDiffReport {
+            diff_size: None,
+            large_diff_warning: None,
+        },
+    );
+
+    let findings: FindingsFile = toml::from_str(
+        &std::fs::read_to_string(dirty_session_dir.join("output").join("findings.toml"))
+            .expect("child findings.toml should exist"),
+    )
+    .expect("child findings.toml should parse");
+    assert_eq!(findings.findings.len(), 2, "{findings:#?}");
+    assert!(
+        findings
+            .findings
+            .iter()
+            .any(|finding| finding.description == "Canonical prose-only finding remains.")
+    );
+    assert!(
+        !findings
+            .findings
+            .iter()
+            .any(|finding| finding.description.contains("Cross-section prose row"))
+    );
+    assert!(
+        findings
+            .findings
+            .iter()
+            .any(|finding| finding.id == "CSA-REVIEW-WORKTREE-MUTATION")
+    );
+
+    let verdict: ReviewVerdictArtifact = serde_json::from_str(
+        &std::fs::read_to_string(dirty_session_dir.join("output").join("review-verdict.json"))
+            .expect("child review-verdict.json should exist"),
+    )
+    .expect("child verdict should parse");
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+    assert_eq!(verdict.severity_counts.get(&Severity::Low), Some(&1));
+    assert_eq!(verdict.severity_counts.values().sum::<u32>(), 2);
+}
+
+#[test]
 fn parent_startup_env_for_multi_review_uses_daemon_session_context() {
     let temp = tempfile::tempdir().expect("tempdir should be created");
     let session_id = "01PARENTSESSION000000000000";

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -19,7 +19,7 @@ use super::prose_signals::{
 use super::review_meta_for_verdict_artifact;
 use super::text::zero_severity_counts;
 use crate::review_cmd::prose_findings::{
-    review_finding_payload_eq, severity_counts_from_review_findings,
+    is_generated_prose_finding_id, review_finding_payload_eq, severity_counts_from_review_findings,
 };
 
 const PROSE_FINDINGS_UNPARSED_REASON: &str = "prose_findings_present_but_unparsed";
@@ -69,11 +69,11 @@ pub(super) fn enforce_final_verdict_consistency(
         (extraction_confirmed_empty || synthetic_empty) && !has_prose_failure_evidence;
     let mut canonical_findings = Vec::new();
     for finding in &findings_file.findings {
-        // `prose-*` rows are parser output, not reviewer-authored identities.
+        // `prose-###` rows are parser output, not reviewer-authored identities.
         // Rebuild them from the current canonical prose so stale parser
         // diagnostics (for example a standalone `confidence=...` row) cannot
         // survive beside the source-located finding they came from.
-        if !prose_signals.findings.is_empty() && finding.id.starts_with("prose-") {
+        if !prose_signals.findings.is_empty() && is_generated_prose_finding_id(&finding.id) {
             continue;
         }
         if canonical_findings

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -76,8 +76,12 @@ pub(super) fn enforce_final_verdict_consistency(
     let mut canonical_findings = Vec::new();
     for finding in &findings_file.findings {
         // Parser-derived rows are rebuilt from current prose only when the
-        // extractor explicitly marked the artifact as prose-derived.
-        if prose_derived_findings && !prose_signals.findings.is_empty() {
+        // extractor explicitly marked the artifact as prose-derived. Keep
+        // the independent repo-write audit row added after extraction.
+        if prose_derived_findings
+            && !prose_signals.findings.is_empty()
+            && finding.id != super::super::dirty_tree::REVIEW_WORKTREE_MUTATION_FINDING_ID
+        {
             continue;
         }
         if canonical_findings

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -69,7 +69,7 @@ pub(super) fn enforce_final_verdict_consistency(
         (extraction_confirmed_empty || synthetic_empty) && !has_prose_failure_evidence;
     let mut canonical_findings = Vec::new();
     for finding in &findings_file.findings {
-        // `prose-###` rows are parser output, not reviewer-authored identities.
+        // `prose-generated-###` rows are parser output, not reviewer-authored identities.
         // Rebuild them from the current canonical prose so stale parser
         // diagnostics (for example a standalone `confidence=...` row) cannot
         // survive beside the source-located finding they came from.

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 
@@ -19,6 +20,7 @@ use super::prose_signals::{
 use super::review_meta_for_verdict_artifact;
 use super::text::zero_severity_counts;
 use crate::review_cmd::prose_findings::{
+    allocate_unique_generated_prose_finding_id, is_generated_prose_finding_id,
     review_finding_payload_eq, severity_counts_from_review_findings,
 };
 
@@ -86,6 +88,11 @@ pub(super) fn enforce_final_verdict_consistency(
         }
         canonical_findings.push(finding.clone());
     }
+    let mut used_finding_ids = canonical_findings
+        .iter()
+        .map(|finding| finding.id.clone())
+        .collect::<HashSet<_>>();
+    let mut next_generated_index = 1;
     if !skip_prose_override {
         for finding in &prose_signals.findings {
             if canonical_findings
@@ -94,7 +101,16 @@ pub(super) fn enforce_final_verdict_consistency(
             {
                 continue;
             }
-            canonical_findings.push(finding.clone());
+            let mut finding = finding.clone();
+            if is_generated_prose_finding_id(&finding.id) {
+                finding.id = allocate_unique_generated_prose_finding_id(
+                    &mut used_finding_ids,
+                    &mut next_generated_index,
+                );
+            } else {
+                used_finding_ids.insert(finding.id.clone());
+            }
+            canonical_findings.push(finding);
         }
     }
     if canonical_findings

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -69,6 +69,13 @@ pub(super) fn enforce_final_verdict_consistency(
         (extraction_confirmed_empty || synthetic_empty) && !has_prose_failure_evidence;
     let mut canonical_findings = Vec::new();
     for finding in &findings_file.findings {
+        // `prose-*` rows are parser output, not reviewer-authored identities.
+        // Rebuild them from the current canonical prose so stale parser
+        // diagnostics (for example a standalone `confidence=...` row) cannot
+        // survive beside the source-located finding they came from.
+        if !prose_signals.findings.is_empty() && finding.id.starts_with("prose-") {
+            continue;
+        }
         if canonical_findings
             .iter()
             .any(|existing| review_finding_payload_eq(existing, finding))

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -19,7 +19,7 @@ use super::prose_signals::{
 use super::review_meta_for_verdict_artifact;
 use super::text::zero_severity_counts;
 use crate::review_cmd::prose_findings::{
-    is_generated_prose_finding_id, review_finding_payload_eq, severity_counts_from_review_findings,
+    review_finding_payload_eq, severity_counts_from_review_findings,
 };
 
 const PROSE_FINDINGS_UNPARSED_REASON: &str = "prose_findings_present_but_unparsed";
@@ -34,6 +34,10 @@ pub(super) fn enforce_final_verdict_consistency(
 ) -> Result<(), anyhow::Error> {
     let prose_signals = review_prose_signals(session_dir)?;
     let findings_file = load_findings_toml_from_output(session_dir)?.unwrap_or_default();
+    let prose_derived_findings = session_dir
+        .join("output")
+        .join(super::super::findings_toml::FINDINGS_TOML_PROSE_DERIVED_MARKER)
+        .exists();
     let extraction_confirmed_empty = findings_file.findings.is_empty()
         && session_dir
             .join("output")
@@ -69,11 +73,9 @@ pub(super) fn enforce_final_verdict_consistency(
         (extraction_confirmed_empty || synthetic_empty) && !has_prose_failure_evidence;
     let mut canonical_findings = Vec::new();
     for finding in &findings_file.findings {
-        // `prose-generated-###` rows are parser output, not reviewer-authored identities.
-        // Rebuild them from the current canonical prose so stale parser
-        // diagnostics (for example a standalone `confidence=...` row) cannot
-        // survive beside the source-located finding they came from.
-        if !prose_signals.findings.is_empty() && is_generated_prose_finding_id(&finding.id) {
+        // Parser-derived rows are rebuilt from current prose only when the
+        // extractor explicitly marked the artifact as prose-derived.
+        if prose_derived_findings && !prose_signals.findings.is_empty() {
             continue;
         }
         if canonical_findings
@@ -115,6 +117,12 @@ pub(super) fn enforce_final_verdict_consistency(
     } else {
         findings_file
     };
+    if prose_derived_findings && !prose_signals.findings.is_empty() {
+        let marker_path = session_dir
+            .join("output")
+            .join(super::super::findings_toml::FINDINGS_TOML_PROSE_DERIVED_MARKER);
+        let _ = fs::remove_file(marker_path);
+    }
 
     let placeholder_findings_only =
         findings_file_contains_only_artifact_generation_placeholder(&findings_file);

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency_helpers.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency_helpers.rs
@@ -233,6 +233,7 @@ fn clear_empty_findings_markers(session_dir: &Path) {
     for marker in [
         super::super::findings_toml::FINDINGS_TOML_SYNTHETIC_MARKER,
         super::super::findings_toml::FINDINGS_TOML_EXTRACTED_MARKER,
+        super::super::findings_toml::FINDINGS_TOML_PROSE_DERIVED_MARKER,
     ] {
         let _ = fs::remove_file(session_dir.join("output").join(marker));
     }

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -13,7 +13,7 @@ use super::text::{contains_blocking_issue_signal, zero_severity_counts};
 use crate::review_cmd::prose_findings::{
     FindingsSectionParse, classify_findings_section_body,
     extract_review_findings_from_prose_with_default, findings_section_bodies,
-    review_finding_payload_eq, severity_counts_from_review_findings,
+    is_generated_prose_finding_id, review_finding_payload_eq, severity_counts_from_review_findings,
 };
 
 #[derive(Debug, Clone)]
@@ -209,11 +209,11 @@ fn record_review_prose_signal(
         {
             continue;
         }
-        if finding.id.starts_with("prose-") {
+        if is_generated_prose_finding_id(&finding.id) {
             let index = signals
                 .findings
                 .iter()
-                .filter(|existing| existing.id.starts_with("prose-"))
+                .filter(|existing| is_generated_prose_finding_id(&existing.id))
                 .count()
                 + 1;
             finding.id = format!("prose-{index:03}");

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -13,7 +13,8 @@ use super::text::{contains_blocking_issue_signal, zero_severity_counts};
 use crate::review_cmd::prose_findings::{
     FindingsSectionParse, classify_findings_section_body,
     extract_review_findings_from_prose_with_default, findings_section_bodies,
-    is_generated_prose_finding_id, review_finding_payload_eq, severity_counts_from_review_findings,
+    generated_prose_finding_id, is_generated_prose_finding_id, review_finding_payload_eq,
+    severity_counts_from_review_findings,
 };
 
 #[derive(Debug, Clone)]
@@ -216,7 +217,7 @@ fn record_review_prose_signal(
                 .filter(|existing| is_generated_prose_finding_id(&existing.id))
                 .count()
                 + 1;
-            finding.id = format!("prose-{index:03}");
+            finding.id = generated_prose_finding_id(index);
         }
         signals.findings.push(finding);
     }

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_signals.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 
 use anyhow::Result;
@@ -11,9 +11,9 @@ use super::clean_detection::{
 };
 use super::text::{contains_blocking_issue_signal, zero_severity_counts};
 use crate::review_cmd::prose_findings::{
-    FindingsSectionParse, classify_findings_section_body,
-    extract_review_findings_from_prose_with_default, findings_section_bodies,
-    generated_prose_finding_id, is_generated_prose_finding_id, review_finding_payload_eq,
+    FindingsSectionParse, allocate_unique_generated_prose_finding_id,
+    classify_findings_section_body, extract_review_findings_from_prose_with_default,
+    findings_section_bodies, is_generated_prose_finding_id, review_finding_payload_eq,
     severity_counts_from_review_findings,
 };
 
@@ -202,6 +202,12 @@ fn record_review_prose_signal(
     signals.uncertain_conclusion |= detect_prose_uncertain_conclusion(content);
     let findings =
         extract_review_findings_from_prose_with_default(content, default_unlabeled_severity);
+    let mut used_ids = signals
+        .findings
+        .iter()
+        .map(|finding| finding.id.clone())
+        .collect::<HashSet<_>>();
+    let mut next_generated_index = 1;
     for mut finding in findings {
         if signals
             .findings
@@ -211,13 +217,12 @@ fn record_review_prose_signal(
             continue;
         }
         if is_generated_prose_finding_id(&finding.id) {
-            let index = signals
-                .findings
-                .iter()
-                .filter(|existing| is_generated_prose_finding_id(&existing.id))
-                .count()
-                + 1;
-            finding.id = generated_prose_finding_id(index);
+            finding.id = allocate_unique_generated_prose_finding_id(
+                &mut used_ids,
+                &mut next_generated_index,
+            );
+        } else {
+            used_ids.insert(finding.id.clone());
         }
         signals.findings.push(finding);
     }

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_2017_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_2017_tests.rs
@@ -588,3 +588,8 @@ fn issue_2601_pass_summary_chinese_positive_evidence_keeps_review_verdict_pass()
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
+
+include!("review_cmd_output_verdict_3071_support.rs");
+include!("review_cmd_output_verdict_3071_a_tests.rs");
+include!("review_cmd_output_verdict_3071_b_tests.rs");
+include!("review_cmd_output_verdict_3071_c_tests.rs");

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_a_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_a_tests.rs
@@ -1,0 +1,48 @@
+#[test]
+fn issue_3071_class_a_replaces_artifact_placeholder_with_source_located_finding() {
+    let (_env_lock, project_root, session_dir) = persist_fixture_review(
+        "issue-3071-class-a",
+        "01TEST3071CLASSA000000",
+        "\\u{53d1}\\u{73b0} 1 \\u{9879} MEDIUM/P2 \\u{95ee}\\u{9898}：CLI \\u{5951}\\u{7ea6}\\u{6d4b}\\u{8bd5}\\u{7684}\\u{5b50}\\u{8fdb}\\u{7a0b}\\u{6ca1}\\u{6709}\\u{8d85}\\u{65f6}。\\u{7ed9}\\u{5b9a}\\u{4e0a}\\u{4e0b}\\u{6587}\\u{8981}\\u{6c42}\\u{96f6} findings，\\u{56e0}\\u{6b64}\\u{4e0d}\\u{80fd}\\u{901a}\\u{8fc7}。",
+        r#"## Finding
+1. **[MEDIUM/P2][test-gap] \\u{5b50}\\u{8fdb}\\u{7a0b}\\u{6d4b}\\u{8bd5}\\u{53ef}\\u{80fd}\\u{65e0}\\u{9650}\\u{6302}\\u{8d77}**
+   `crates/workflowctl/tests/cli_contracts.rs:13`
+
+   - Trigger：`workflowctl` \\u{56de}\\u{5f52}\\u{4e3a}\\u{6b7b}\\u{5faa}\\u{73af}、\\u{6b7b}\\u{9501}，\\u{6216}\\u{5176}\\u{540e}\\u{4ee3}\\u{8fdb}\\u{7a0b}\\u{6301}\\u{7eed}\\u{6301}\\u{6709}\\u{8f93}\\u{51fa}\\u{7ba1}\\u{9053}。
+   - Expected：\\u{6d4b}\\u{8bd5}\\u{5728}\\u{6709}\\u{754c}\\u{671f}\\u{9650}\\u{540e}\\u{6740}\\u{6b7b}\\u{5e76}\\u{56de}\\u{6536}\\u{5b50}\\u{8fdb}\\u{7a0b}，\\u{7136}\\u{540e}\\u{62a5}\\u{544a}\\u{5931}\\u{8d25}。
+   - Actual：\\u{5171}\\u{4eab}\\u{52a9}\\u{624b}\\u{76f4}\\u{63a5}\\u{8c03}\\u{7528} `Command::output()`，\\u{6ca1}\\u{6709}\\u{8d85}\\u{65f6}\\u{6216}\\u{6e05}\\u{7406}\\u{8def}\\u{5f84}。
+   - Impact：`just test`、\\u{672c}\\u{5730}\\u{8d28}\\u{91cf}\\u{95e8}\\u{548c}\\u{63d0}\\u{4ea4}\\u{94a9}\\u{5b50}\\u{53ef}\\u{80fd}\\u{6c38}\\u{4e45}\\u{7b49}\\u{5f85}。
+   - Evidence：\\u{56db}\\u{4e2a}\\u{6d4b}\\u{8bd5}\\u{7684} 21 \\u{6b21}\\u{8fdb}\\u{7a0b}\\u{6267}\\u{884c}\\u{5747}\\u{7ecf}\\u{8fc7}\\u{8be5}\\u{8c03}\\u{7528}。
+   - Class sweep：1 \\u{4e2a}\\u{5171}\\u{4eab}\\u{5b9e}\\u{73b0}\\u{4f4d}\\u{7f6e}。
+   - Rules：`Rust 015 subprocess-lifecycle`、`bug_category.subprocess_timeout`。
+   - Fix：\\u{5728}\\u{73b0}\\u{6709} `output()` \\u{52a9}\\u{624b}\\u{4e2d}\\u{96c6}\\u{4e2d}\\u{5b9e}\\u{73b0}\\u{6709}\\u{754c} spawn/wait/kill/reap，\\u{5e76}\\u{7ee7}\\u{7eed}\\u{5b8c}\\u{6574}\\u{6536}\\u{96c6} stdout/stderr。
+   - Confidence：0.99。"#,
+        r#"[[findings]]
+ id = "artifact-generation-001"
+ severity = "medium"
+ file_ranges = []
+ description = "Artifact generation failed: review verdict is FAIL but CSA could not extract a structured finding. Reason: fail_verdict_empty_findings_artifact. Inspect output/details.md and output/review-verdict.json."
+"#,
+        false,
+    );
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 1, "{findings:#?}");
+    assert_eq!(findings.findings[0].severity, Severity::Medium);
+    assert_eq!(
+        findings.findings[0].file_ranges,
+        vec![csa_session::ReviewFindingFileRange {
+            path: "crates/workflowctl/tests/cli_contracts.rs".to_string(),
+            start: 13,
+            end: None,
+        }]
+    );
+    assert!(
+        !findings.findings[0]
+            .description
+            .starts_with("Artifact generation failed:")
+    );
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&1));
+    assert_eq!(verdict.severity_counts.values().sum::<u32>(), 1);
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_a_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_a_tests.rs
@@ -24,6 +24,7 @@ fn issue_3071_class_a_replaces_artifact_placeholder_with_source_located_finding(
  description = "Artifact generation failed: review verdict is FAIL but CSA could not extract a structured finding. Reason: fail_verdict_empty_findings_artifact. Inspect output/details.md and output/review-verdict.json."
 "#,
         false,
+        false,
     );
     let findings = read_findings_toml(&session_dir);
     assert_eq!(findings.findings.len(), 1, "{findings:#?}");

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_b_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_b_tests.rs
@@ -133,3 +133,41 @@ file_ranges = [{ path = "crates/workflowctl/src/main.rs", start = 122 }]
     assert_eq!(verdict.severity_counts.values().sum::<u32>(), 3);
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
+
+#[test]
+fn issue_3071_structured_prose_prefixed_id_survives_reconciliation() {
+    let (_env_lock, project_root, session_dir) = persist_fixture_review(
+        "issue-3071-structured-prose-id",
+        "01TEST3071PROSEID00000",
+        "Review found one high-severity security finding.",
+        "## Findings\n1. [HIGH][security] Active security regression remains.\n",
+        r#"[[findings]]
+id = "prose-security-1"
+severity = "high"
+description = "Structured security finding"
+"#,
+        true,
+    );
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 2, "{findings:#?}");
+    assert!(
+        findings
+            .findings
+            .iter()
+            .any(|finding| finding.id == "prose-security-1"),
+        "structured prose-prefixed finding was removed: {findings:#?}"
+    );
+    assert!(
+        findings
+            .findings
+            .iter()
+            .any(|finding| finding.description == "Active security regression remains."),
+        "parsed prose finding was removed: {findings:#?}"
+    );
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&2));
+    assert_eq!(verdict.severity_counts.values().sum::<u32>(), 2);
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_b_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_b_tests.rs
@@ -50,67 +50,67 @@ fn issue_3071_class_b_counts_three_frozen_findings_once() {
         "\\u{5ba1}\\u{67e5}\\u{53d1}\\u{73b0} 3 \\u{4e2a}\\u{7f3a}\\u{9677}：1 \\u{4e2a} HIGH \\u{8d44}\\u{6e90}\\u{8017}\\u{5c3d}\\u{5b89}\\u{5168}\\u{95ee}\\u{9898}、2 \\u{4e2a} MEDIUM CLI \\u{5408}\\u{540c}\\u{95ee}\\u{9898}。",
         CLASS_B_DETAILS,
         r#"[[findings]]
-id = "prose-001"
+id = "prose-generated-001"
 severity = "high"
 description = "\\u{6587}\\u{4ef6}\\u{7f16}\\u{8bd1}\\u{5165}\\u{53e3}\\u{53ef}\\u{65e0}\\u{9650}\\u{8bfb}\\u{53d6}\\u{6216}\\u{6c38}\\u{4e45}\\u{963b}\\u{585e}"
 
 [[findings]]
-id = "prose-002"
+id = "prose-generated-002"
 severity = "medium"
 description = "confidence=0.99"
 file_ranges = [{ path = "crates/workflow-compiler/src/lib.rs", start = 98 }]
 
 [[findings]]
-id = "prose-003"
+id = "prose-generated-003"
 severity = "medium"
 description = "`--` \\u{540e}\\u{7684}\\u{8def}\\u{5f84} `--json` \\u{88ab}\\u{9519}\\u{8bef}\\u{8bc6}\\u{522b}\\u{4e3a}\\u{683c}\\u{5f0f}\\u{9009}\\u{9879}"
 
 [[findings]]
-id = "prose-004"
+id = "prose-generated-004"
 severity = "medium"
 description = "confidence=0.98"
 file_ranges = [{ path = "crates/workflowctl/src/main.rs", start = 81 }]
 
 [[findings]]
-id = "prose-005"
+id = "prose-generated-005"
 severity = "medium"
 description = "\\u{6210}\\u{529f}\\u{8f93}\\u{51fa}\\u{5199}\\u{5165}\\u{5931}\\u{8d25}\\u{4f1a} panic，\\u{800c}\\u{4e0d}\\u{662f}\\u{9075}\\u{5b88}\\u{9000}\\u{51fa}\\u{5408}\\u{540c}"
 
 [[findings]]
-id = "prose-006"
+id = "prose-generated-006"
 severity = "medium"
 description = "confidence=0.97"
 file_ranges = [{ path = "crates/workflowctl/src/main.rs", start = 122 }]
 
 [[findings]]
-id = "prose-007"
+id = "prose-generated-007"
 severity = "high"
 description = "\\u{6587}\\u{4ef6}\\u{7f16}\\u{8bd1}\\u{5165}\\u{53e3}\\u{53ef}\\u{65e0}\\u{9650}\\u{8bfb}\\u{53d6}\\u{6216}\\u{6c38}\\u{4e45}\\u{963b}\\u{585e}"
 
 [[findings]]
-id = "prose-008"
+id = "prose-generated-008"
 severity = "medium"
 description = "confidence=0.99"
 file_ranges = [{ path = "crates/workflow-compiler/src/lib.rs", start = 98 }]
 
 [[findings]]
-id = "prose-009"
+id = "prose-generated-009"
 severity = "medium"
 description = "`--` \\u{540e}\\u{7684}\\u{8def}\\u{5f84} `--json` \\u{88ab}\\u{9519}\\u{8bef}\\u{8bc6}\\u{522b}\\u{4e3a}\\u{683c}\\u{5f0f}\\u{9009}\\u{9879}"
 
 [[findings]]
-id = "prose-010"
+id = "prose-generated-010"
 severity = "medium"
 description = "confidence=0.98"
 file_ranges = [{ path = "crates/workflowctl/src/main.rs", start = 81 }]
 
 [[findings]]
-id = "prose-011"
+id = "prose-generated-011"
 severity = "medium"
 description = "\\u{6210}\\u{529f}\\u{8f93}\\u{51fa}\\u{5199}\\u{5165}\\u{5931}\\u{8d25}\\u{4f1a} panic，\\u{800c}\\u{4e0d}\\u{662f}\\u{9075}\\u{5b88}\\u{9000}\\u{51fa}\\u{5408}\\u{540c}"
 
 [[findings]]
-id = "prose-012"
+id = "prose-generated-012"
 severity = "medium"
 description = "confidence=0.97"
 file_ranges = [{ path = "crates/workflowctl/src/main.rs", start = 122 }]
@@ -163,6 +163,44 @@ description = "Structured security finding"
             .findings
             .iter()
             .any(|finding| finding.description == "Active security regression remains."),
+        "parsed prose finding was removed: {findings:#?}"
+    );
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&2));
+    assert_eq!(verdict.severity_counts.values().sum::<u32>(), 2);
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_3071_structured_numeric_prose_id_survives_reconciliation() {
+    let (_env_lock, project_root, session_dir) = persist_fixture_review(
+        "issue-3071-structured-numeric-prose-id",
+        "01TEST3071NUMERICID0000",
+        "Review found one high-severity security finding.",
+        "## Findings\n1. [HIGH][security] Parsed security regression remains.\n",
+        r#"[[findings]]
+id = "prose-123"
+severity = "high"
+description = "Structured numeric prose ID"
+"#,
+        true,
+    );
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 2, "{findings:#?}");
+    assert!(
+        findings
+            .findings
+            .iter()
+            .any(|finding| finding.id == "prose-123"),
+        "structured numeric prose finding was removed: {findings:#?}"
+    );
+    assert!(
+        findings
+            .findings
+            .iter()
+            .any(|finding| finding.description == "Parsed security regression remains."),
         "parsed prose finding was removed: {findings:#?}"
     );
 

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_b_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_b_tests.rs
@@ -116,6 +116,7 @@ description = "confidence=0.97"
 file_ranges = [{ path = "crates/workflowctl/src/main.rs", start = 122 }]
 "#,
         true,
+        true,
     );
     let findings = read_findings_toml(&session_dir);
     assert_eq!(findings.findings.len(), 3, "{findings:#?}");
@@ -147,6 +148,7 @@ severity = "high"
 description = "Structured security finding"
 "#,
         true,
+        false,
     );
 
     let findings = read_findings_toml(&session_dir);
@@ -173,6 +175,46 @@ description = "Structured security finding"
 }
 
 #[test]
+fn issue_3071_authored_generated_prose_id_survives_reconciliation() {
+    let (_env_lock, project_root, session_dir) = persist_fixture_review(
+        "issue-3071-authored-generated-prose-id",
+        "01TEST3071AUTHOREDGEN000",
+        "Review found one high-severity structured finding and one low-severity prose finding.",
+        "## Findings\n1. [LOW][style] Independent prose-only finding remains.\n",
+        r#"[[findings]]
+id = "prose-generated-001"
+severity = "high"
+description = "Reviewer-authored generated namespace ID"
+"#,
+        true,
+        false,
+    );
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 2, "{findings:#?}");
+    assert!(
+        findings
+            .findings
+            .iter()
+            .any(|finding| finding.id == "prose-generated-001"),
+        "reviewer-authored generated namespace ID was removed: {findings:#?}"
+    );
+    assert!(
+        findings
+            .findings
+            .iter()
+            .any(|finding| finding.description == "Independent prose-only finding remains."),
+        "prose finding was removed: {findings:#?}"
+    );
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+    assert_eq!(verdict.severity_counts.get(&Severity::Low), Some(&1));
+    assert_eq!(verdict.severity_counts.values().sum::<u32>(), 2);
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn issue_3071_structured_numeric_prose_id_survives_reconciliation() {
     let (_env_lock, project_root, session_dir) = persist_fixture_review(
         "issue-3071-structured-numeric-prose-id",
@@ -185,6 +227,7 @@ severity = "high"
 description = "Structured numeric prose ID"
 "#,
         true,
+        false,
     );
 
     let findings = read_findings_toml(&session_dir);

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_b_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_b_tests.rs
@@ -1,0 +1,135 @@
+const CLASS_B_DETAILS: &str = r#"# Code Review Report
+## Findings
+
+1. [HIGH][security] \\u{6587}\\u{4ef6}\\u{7f16}\\u{8bd1}\\u{5165}\\u{53e3}\\u{53ef}\\u{65e0}\\u{9650}\\u{8bfb}\\u{53d6}\\u{6216}\\u{6c38}\\u{4e45}\\u{963b}\\u{585e}
+   `crates/workflow-compiler/src/lib.rs:98`, confidence=0.99
+
+   - Trigger: `workflowctl validate /dev/zero`、FIFO，\\u{6216}\\u{8d85}\\u{5927}\\u{5de5}\\u{4f5c}\\u{6d41}\\u{6587}\\u{4ef6}。
+   - Expected: \\u{8f93}\\u{5165}\\u{53d7}\\u{5230}\\u{5927}\\u{5c0f}\\u{548c}\\u{6587}\\u{4ef6}\\u{7c7b}\\u{578b}\\u{9650}\\u{5236}，\\u{5931}\\u{8d25}\\u{65f6}\\u{8f93}\\u{51fa}\\u{7a33}\\u{5b9a} Diagnostic \\u{5e76}\\u{4ee5} 2 \\u{9000}\\u{51fa}。
+   - Actual: \\u{65b0}\\u{589e}\\u{7684} `compile_file` \\u{65e0}\\u{6761}\\u{4ef6}\\u{8c03}\\u{7528} `parse_file`；\\u{540e}\\u{8005}\\u{5728} `crates/workflow-spec/src/lib.rs:410` \\u{4f7f}\\u{7528}\\u{65e0}\\u{4e0a}\\u{9650} `std::fs::read`。\\u{5b57}\\u{7b26}\\u{8bbe}\\u{5907}\\u{53ef}\\u{6301}\\u{7eed}\\u{4ea7}\\u{751f}\\u{6570}\\u{636e}\\u{76f4}\\u{81f3} OOM，FIFO \\u{53ef}\\u{65e0}\\u{9650}\\u{7b49}\\u{5f85}。
+   - Impact: \\u{653b}\\u{51fb}\\u{8005}\\u{63a7}\\u{5236}\\u{5de5}\\u{4f5c}\\u{6d41}\\u{8def}\\u{5f84}\\u{6216}\\u{4ed3}\\u{5e93}\\u{5185}\\u{5bb9}\\u{65f6}，\\u{53ef}\\u{6302}\\u{8d77}\\u{6216}\\u{8017}\\u{5c3d} CLI/CI \\u{4e3b}\\u{673a}\\u{8d44}\\u{6e90}。
+   - AGENTS.md: `Practice 014|security|validate ALL input`
+   - Class sweep: 3 sites — `validate`、`graph`、`lock` \\u{5747}\\u{7ecf}\\u{8fc7}\\u{8be5}\\u{5171}\\u{4eab}\\u{5165}\\u{53e3}（`main.rs:121,136,151`）。
+   - Fix: \\u{6253}\\u{5f00}\\u{6587}\\u{4ef6}\\u{540e}\\u{68c0}\\u{67e5}\\u{6587}\\u{4ef6}\\u{53e5}\\u{67c4}\\u{5143}\\u{6570}\\u{636e}，\\u{5e76}\\u{901a}\\u{8fc7}\\u{6709}\\u{660e}\\u{786e}\\u{4e0a}\\u{9650}\\u{7684}\\u{8bfb}\\u{53d6}\\u{5668}\\u{8bfb}\\u{53d6} `limit + 1` \\u{5b57}\\u{8282}；\\u{62d2}\\u{7edd}\\u{975e}\\u{666e}\\u{901a}\\u{6587}\\u{4ef6}\\u{548c}\\u{8d85}\\u{9650}\\u{8f93}\\u{5165}，\\u{65b0}\\u{589e}\\u{7a33}\\u{5b9a}\\u{8bca}\\u{65ad}。
+   - Test: \\u{7528}\\u{8d85}\\u{9650}\\u{666e}\\u{901a}\\u{6587}\\u{4ef6}\\u{548c} `/dev/zero` \\u{9a8c}\\u{8bc1}\\u{4e09}\\u{4e2a}\\u{547d}\\u{4ee4}\\u{5747}\\u{5728}\\u{73b0}\\u{6709} 5 \\u{79d2}\\u{5b88}\\u{536b}\\u{5185}\\u{4ee5}\\u{8bca}\\u{65ad}\\u{9000}\\u{51fa}。
+
+2. [MEDIUM][regression] `--` \\u{540e}\\u{7684}\\u{8def}\\u{5f84} `--json` \\u{88ab}\\u{9519}\\u{8bef}\\u{8bc6}\\u{522b}\\u{4e3a}\\u{683c}\\u{5f0f}\\u{9009}\\u{9879}
+   `crates/workflowctl/src/main.rs:81`, confidence=0.98
+
+   - Trigger: `workflowctl validate -- --json`。
+   - Expected: Clap \\u{5c06} `--` \\u{540e}\\u{7684} `--json` \\u{4f5c}\\u{4e3a}\\u{8def}\\u{5f84}；\\u{7f3a}\\u{5931}\\u{6587}\\u{4ef6}\\u{5e94}\\u{4ea7}\\u{751f}\\u{4eba}\\u{7c7b}\\u{53ef}\\u{8bfb}\\u{8bca}\\u{65ad}。
+   - Actual: \\u{89e3}\\u{6790}\\u{524d}\\u{7684}\\u{5168}\\u{53c2}\\u{6570}\\u{626b}\\u{63cf}\\u{628a}\\u{4efb}\\u{4f55}\\u{4f4d}\\u{7f6e}\\u{7684} `--json` \\u{90fd}\\u{8bbe}\\u{4e3a} JSON \\u{6a21}\\u{5f0f}，\\u{56e0}\\u{6b64}\\u{8f93}\\u{51fa} JSON \\u{8bca}\\u{65ad}。
+   - Impact: \\u{5408}\\u{6cd5}\\u{6587}\\u{4ef6}\\u{540d}\\u{88ab}\\u{8bef}\\u{5206}\\u{7c7b}，\\u{8fdd}\\u{53cd}“`--json` \\u{53ea}\\u{4f5c}\\u{4e3a}\\u{9519}\\u{8bef}\\u{683c}\\u{5f0f}\\u{9009}\\u{9879}”\\u{7684} CLI \\u{5408}\\u{540c}。
+   - Class sweep: 3 sites — \\u{6240}\\u{6709}\\u{5e26} `PATH` \\u{7684}\\u{5b50}\\u{547d}\\u{4ee4}\\u{5171}\\u{4eab}\\u{8be5}\\u{626b}\\u{63cf}。
+   - Fix: \\u{539f}\\u{59cb}\\u{53c2}\\u{6570}\\u{626b}\\u{63cf}\\u{5fc5}\\u{987b}\\u{5728}\\u{7b2c}\\u{4e00}\\u{4e2a} `--` \\u{5904}\\u{505c}\\u{6b62}。
+   - Test: \\u{8986}\\u{76d6}\\u{4e09}\\u{4e2a}\\u{5b50}\\u{547d}\\u{4ee4}\\u{7684} `-- --json` \\u{8def}\\u{5f84}。
+
+3. [MEDIUM][regression] \\u{6210}\\u{529f}\\u{8f93}\\u{51fa}\\u{5199}\\u{5165}\\u{5931}\\u{8d25}\\u{4f1a} panic，\\u{800c}\\u{4e0d}\\u{662f}\\u{9075}\\u{5b88}\\u{9000}\\u{51fa}\\u{5408}\\u{540c}
+   `crates/workflowctl/src/main.rs:122`, confidence=0.97
+
+   - Trigger: \\u{5bf9}\\u{6709}\\u{6548}\\u{8f93}\\u{5165}\\u{542f}\\u{52a8}\\u{547d}\\u{4ee4}\\u{540e}\\u{7acb}\\u{5373}\\u{5173}\\u{95ed}\\u{5176} stdout \\u{8bfb}\\u{53d6}\\u{7aef}。
+   - Expected: \\u{8f93}\\u{51fa}\\u{5931}\\u{8d25}\\u{5e94}\\u{6210}\\u{4e3a}\\u{53d7}\\u{63a7}\\u{9519}\\u{8bef}；\\u{6309}\\u{5df2}\\u{6279}\\u{51c6}\\u{5408}\\u{540c}\\u{8f93}\\u{51fa} Diagnostic \\u{5e76}\\u{4ee5} 2 \\u{9000}\\u{51fa}。
+   - Actual: `println!`/`print!` \\u{5728} stdout \\u{5199}\\u{5165}\\u{9519}\\u{8bef}\\u{65f6} panic，\\u{4ea7}\\u{751f}\\u{975e} 2 \\u{9000}\\u{51fa}\\u{72b6}\\u{6001}\\u{548c}\\u{4e0d}\\u{7a33}\\u{5b9a}\\u{7684} panic \\u{6587}\\u{672c}。
+   - Impact: \\u{5e38}\\u{89c1}\\u{7684}\\u{63d0}\\u{524d}\\u{5173}\\u{95ed}\\u{7ba1}\\u{9053}\\u{4f1a}\\u{4f7f}\\u{811a}\\u{672c}\\u{89c2}\\u{5bdf}\\u{5230}\\u{5408}\\u{540c}\\u{5916}\\u{7684}\\u{5d29}\\u{6e83}\\u{884c}\\u{4e3a}。
+   - AGENTS.md: `Practice 009|error-handling`
+   - Class sweep: 3 sites — `validate`、`graph`、`lock` \\u{7684}\\u{6210}\\u{529f}\\u{8f93}\\u{51fa}\\u{4f4d}\\u{4e8e} `main.rs:122,137,172`。
+   - Fix: \\u{4f7f}\\u{7528}\\u{663e}\\u{5f0f} `Write` \\u{8c03}\\u{7528}\\u{5e76}\\u{6295}\\u{5f71}\\u{5199}\\u{5165}\\u{9519}\\u{8bef}。
+   - Test: \\u{542f}\\u{52a8}\\u{5b50}\\u{8fdb}\\u{7a0b}\\u{540e}\\u{4e22}\\u{5f03} stdout pipe \\u{7684}\\u{8bfb}\\u{53d6}\\u{7aef}，\\u{5e76}\\u{65ad}\\u{8a00}\\u{53d7}\\u{63a7}\\u{9000}\\u{51fa}。
+
+## Cross-Dimension Blocking Enumeration
+
+1. Security: Finding 1 \\u{662f}\\u{5f53}\\u{524d}\\u{552f}\\u{4e00} HIGH/P1 \\u{963b}\\u{585e}\\u{9879}。
+2. Correctness、concurrency、contract/doc-sync、ordering、completeness \\u{672a}\\u{53d1}\\u{73b0}\\u{5176}\\u{4ed6} HIGH/CRITICAL \\u{72ec}\\u{7acb}\\u{7f3a}\\u{9677}；Findings 2–3 \\u{4e3a} MEDIUM，\\u{4f46}\\u{5f53}\\u{524d}\\u{5ba1}\\u{67e5}\\u{95e8}\\u{8981}\\u{6c42}\\u{96f6}\\u{4e25}\\u{91cd}\\u{5ea6}\\u{53d1}\\u{73b0}。
+"#;
+
+#[test]
+fn issue_3071_class_b_counts_three_frozen_findings_once() {
+    let (_env_lock, project_root, session_dir) = persist_fixture_review(
+        "issue-3071-class-b",
+        "01TEST3071CLASSB000000",
+        "\\u{5ba1}\\u{67e5}\\u{53d1}\\u{73b0} 3 \\u{4e2a}\\u{7f3a}\\u{9677}：1 \\u{4e2a} HIGH \\u{8d44}\\u{6e90}\\u{8017}\\u{5c3d}\\u{5b89}\\u{5168}\\u{95ee}\\u{9898}、2 \\u{4e2a} MEDIUM CLI \\u{5408}\\u{540c}\\u{95ee}\\u{9898}。",
+        CLASS_B_DETAILS,
+        r#"[[findings]]
+id = "prose-001"
+severity = "high"
+description = "\\u{6587}\\u{4ef6}\\u{7f16}\\u{8bd1}\\u{5165}\\u{53e3}\\u{53ef}\\u{65e0}\\u{9650}\\u{8bfb}\\u{53d6}\\u{6216}\\u{6c38}\\u{4e45}\\u{963b}\\u{585e}"
+
+[[findings]]
+id = "prose-002"
+severity = "medium"
+description = "confidence=0.99"
+file_ranges = [{ path = "crates/workflow-compiler/src/lib.rs", start = 98 }]
+
+[[findings]]
+id = "prose-003"
+severity = "medium"
+description = "`--` \\u{540e}\\u{7684}\\u{8def}\\u{5f84} `--json` \\u{88ab}\\u{9519}\\u{8bef}\\u{8bc6}\\u{522b}\\u{4e3a}\\u{683c}\\u{5f0f}\\u{9009}\\u{9879}"
+
+[[findings]]
+id = "prose-004"
+severity = "medium"
+description = "confidence=0.98"
+file_ranges = [{ path = "crates/workflowctl/src/main.rs", start = 81 }]
+
+[[findings]]
+id = "prose-005"
+severity = "medium"
+description = "\\u{6210}\\u{529f}\\u{8f93}\\u{51fa}\\u{5199}\\u{5165}\\u{5931}\\u{8d25}\\u{4f1a} panic，\\u{800c}\\u{4e0d}\\u{662f}\\u{9075}\\u{5b88}\\u{9000}\\u{51fa}\\u{5408}\\u{540c}"
+
+[[findings]]
+id = "prose-006"
+severity = "medium"
+description = "confidence=0.97"
+file_ranges = [{ path = "crates/workflowctl/src/main.rs", start = 122 }]
+
+[[findings]]
+id = "prose-007"
+severity = "high"
+description = "\\u{6587}\\u{4ef6}\\u{7f16}\\u{8bd1}\\u{5165}\\u{53e3}\\u{53ef}\\u{65e0}\\u{9650}\\u{8bfb}\\u{53d6}\\u{6216}\\u{6c38}\\u{4e45}\\u{963b}\\u{585e}"
+
+[[findings]]
+id = "prose-008"
+severity = "medium"
+description = "confidence=0.99"
+file_ranges = [{ path = "crates/workflow-compiler/src/lib.rs", start = 98 }]
+
+[[findings]]
+id = "prose-009"
+severity = "medium"
+description = "`--` \\u{540e}\\u{7684}\\u{8def}\\u{5f84} `--json` \\u{88ab}\\u{9519}\\u{8bef}\\u{8bc6}\\u{522b}\\u{4e3a}\\u{683c}\\u{5f0f}\\u{9009}\\u{9879}"
+
+[[findings]]
+id = "prose-010"
+severity = "medium"
+description = "confidence=0.98"
+file_ranges = [{ path = "crates/workflowctl/src/main.rs", start = 81 }]
+
+[[findings]]
+id = "prose-011"
+severity = "medium"
+description = "\\u{6210}\\u{529f}\\u{8f93}\\u{51fa}\\u{5199}\\u{5165}\\u{5931}\\u{8d25}\\u{4f1a} panic，\\u{800c}\\u{4e0d}\\u{662f}\\u{9075}\\u{5b88}\\u{9000}\\u{51fa}\\u{5408}\\u{540c}"
+
+[[findings]]
+id = "prose-012"
+severity = "medium"
+description = "confidence=0.97"
+file_ranges = [{ path = "crates/workflowctl/src/main.rs", start = 122 }]
+"#,
+        true,
+    );
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 3, "{findings:#?}");
+    assert_eq!(
+        findings
+            .findings
+            .iter()
+            .map(|finding| finding.severity.clone())
+            .collect::<Vec<_>>(),
+        [Severity::High, Severity::Medium, Severity::Medium]
+    );
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+    assert_eq!(verdict.severity_counts.get(&Severity::Medium), Some(&2));
+    assert_eq!(verdict.severity_counts.values().sum::<u32>(), 3);
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_b_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_b_tests.rs
@@ -192,6 +192,12 @@ description = "Reviewer-authored generated namespace ID"
 
     let findings = read_findings_toml(&session_dir);
     assert_eq!(findings.findings.len(), 2, "{findings:#?}");
+    let finding_ids = findings
+        .findings
+        .iter()
+        .map(|finding| finding.id.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(finding_ids.len(), 2, "distinct findings reused one ID: {findings:#?}");
     assert!(
         findings
             .findings
@@ -205,6 +211,18 @@ description = "Reviewer-authored generated namespace ID"
             .iter()
             .any(|finding| finding.description == "Independent prose-only finding remains."),
         "prose finding was removed: {findings:#?}"
+    );
+
+    let session_findings = crate::review_session_findings::read_session_findings_or_fall_back(
+        &session_dir,
+    )
+    .expect("read session findings")
+    .expect("findings.toml should be authoritative");
+    let consolidated = crate::review_consensus::consolidate_findings(session_findings);
+    assert_eq!(
+        consolidated.len(),
+        2,
+        "consensus dropped a distinct finding: {consolidated:#?}"
     );
 
     let verdict = read_verdict(&session_dir);
@@ -250,5 +268,42 @@ description = "Structured numeric prose ID"
     let verdict = read_verdict(&session_dir);
     assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&2));
     assert_eq!(verdict.severity_counts.values().sum::<u32>(), 2);
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn issue_3071_single_review_preserves_post_prose_audit_finding() {
+    let session_id = "01M06C1K96HC53JD4149Z6TNGC";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-3071-single-post-prose-audit", session_id);
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nReview result: FAIL. One low severity prose finding remains.\n<!-- CSA:SECTION:summary:END -->\n\n<!-- CSA:SECTION:details -->\n## Findings\n1. [LOW][style] Independent prose-only finding remains.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist prose review");
+    save_result_with_repo_write_audit(&project_root, session_id);
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    let exit_code = crate::review_cmd::flow::persist_review_sidecars_if_session_exists(
+        &project_root,
+        &meta,
+        Some(session_id),
+    )
+    .expect("persist single-review sidecars");
+    assert_eq!(exit_code, 1);
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 2, "{findings:#?}");
+    let audit = findings
+        .findings
+        .iter()
+        .find(|finding| finding.id == "CSA-REVIEW-WORKTREE-MUTATION")
+        .expect("post-prose audit finding should survive");
+    assert_eq!(audit.severity, Severity::High);
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+    assert_eq!(verdict.severity_counts.get(&Severity::Low), Some(&1));
+    assert_eq!(verdict.severity_counts.values().sum::<u32>(), 2);
+
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_b_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_b_tests.rs
@@ -307,3 +307,46 @@ fn issue_3071_single_review_preserves_post_prose_audit_finding() {
 
     fs::remove_dir_all(project_root).expect("remove temp project root");
 }
+
+#[test]
+fn issue_3071_single_review_reconciles_split_section_prose_with_post_prose_audit() {
+    let session_id = "01M06C1K96HC53JD4149Z6TNGC";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-3071-single-split-section-audit", session_id);
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nReview result: FAIL. One canonical prose finding remains.\n## Findings\n1. [LOW][style] Canonical prose-only finding remains.\n<!-- CSA:SECTION:summary:END -->\n\n<!-- CSA:SECTION:details -->\nHIGH: Cross-section prose row must not be extracted.\n<!-- CSA:SECTION:details:END -->\n",
+    )
+    .expect("persist split-section prose review");
+    save_result_with_repo_write_audit(&project_root, session_id);
+
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    let exit_code = crate::review_cmd::flow::persist_review_sidecars_if_session_exists(
+        &project_root,
+        &meta,
+        Some(session_id),
+    )
+    .expect("persist single-review sidecars");
+    assert_eq!(exit_code, 1);
+
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 2, "{findings:#?}");
+    assert!(findings.findings.iter().any(|finding| {
+        finding.description == "Canonical prose-only finding remains."
+    }));
+    assert!(!findings
+        .findings
+        .iter()
+        .any(|finding| finding.description.contains("Cross-section prose row")));
+    assert!(findings
+        .findings
+        .iter()
+        .any(|finding| finding.id == "CSA-REVIEW-WORKTREE-MUTATION"));
+
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+    assert_eq!(verdict.severity_counts.get(&Severity::Low), Some(&1));
+    assert_eq!(verdict.severity_counts.values().sum::<u32>(), 2);
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_c_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_c_tests.rs
@@ -27,6 +27,7 @@ severity = "high"
 description = "\\u{6587}\\u{4ef6}\\u{7c7b}\\u{578b}\\u{68c0}\\u{67e5}\\u{4e0e}\\u{6253}\\u{5f00}\\u{4e0d}\\u{662f}\\u{540c}\\u{4e00}\\u{6587}\\u{4ef6}\\u{5bf9}\\u{8c61}（`crates/workflow-spec/src/lib.rs:423`，confidence=0.99）"
 "#,
         true,
+        true,
     );
     let findings = read_findings_toml(&session_dir);
     assert_eq!(findings.findings.len(), 1, "{findings:#?}");

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_c_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_c_tests.rs
@@ -1,0 +1,46 @@
+#[test]
+fn issue_3071_class_c_counts_one_frozen_finding_once() {
+    let (_env_lock, project_root, session_dir) = persist_fixture_review(
+        "issue-3071-class-c",
+        "01TEST3071CLASSC000000",
+        "\\u{53d1}\\u{73b0} 1 \\u{4e2a} HIGH/P1 \\u{5b89}\\u{5168}\\u{7f3a}\\u{9677}：\\u{6587}\\u{4ef6}\\u{7c7b}\\u{578b}\\u{68c0}\\u{67e5}\\u{4e0e}\\u{6253}\\u{5f00}\\u{5b58}\\u{5728} TOCTOU。",
+        r#"# Code Review Report
+## Findings
+1. [P1][security] \\u{6587}\\u{4ef6}\\u{7c7b}\\u{578b}\\u{68c0}\\u{67e5}\\u{4e0e}\\u{6253}\\u{5f00}\\u{4e0d}\\u{662f}\\u{540c}\\u{4e00}\\u{6587}\\u{4ef6}\\u{5bf9}\\u{8c61}（`crates/workflow-spec/src/lib.rs:423`，confidence=0.99）
+
+   - Trigger: \\u{6709}\\u{6743}\\u{4fee}\\u{6539}\\u{7236}\\u{76ee}\\u{5f55}\\u{7684}\\u{8fdb}\\u{7a0b}\\u{5728} `metadata(path)` \\u{8fd4}\\u{56de}\\u{540e}、`File::open(path)` \\u{6267}\\u{884c}\\u{524d}，\\u{5c06}\\u{666e}\\u{901a}\\u{6587}\\u{4ef6}\\u{66ff}\\u{6362}\\u{4e3a}\\u{65e0}\\u{5199}\\u{5165}\\u{7aef}\\u{7684} FIFO。
+   - Expected: \\u{975e}\\u{666e}\\u{901a}\\u{6587}\\u{4ef6}\\u{5fc5}\\u{987b}\\u{5728}\\u{4e0d}\\u{963b}\\u{585e}\\u{7684}\\u{60c5}\\u{51b5}\\u{4e0b}\\u{88ab}\\u{62d2}\\u{7edd}，\\u{4e14}\\u{6821}\\u{9a8c}\\u{5e94}\\u{7ed1}\\u{5b9a}\\u{5230}\\u{5b9e}\\u{9645}\\u{8bfb}\\u{53d6}\\u{7684}\\u{6587}\\u{4ef6}\\u{63cf}\\u{8ff0}\\u{7b26}。
+   - Actual: \\u{7b2c} 423–425 \\u{884c}\\u{68c0}\\u{67e5}\\u{7b2c}\\u{4e00}\\u{6b21}\\u{8def}\\u{5f84}\\u{89e3}\\u{6790}，\\u{7b2c} 435–436 \\u{884c}\\u{518d}\\u{6b21}\\u{89e3}\\u{6790}\\u{8def}\\u{5f84}；\\u{7b2c}\\u{4e8c}\\u{6b21}\\u{6253}\\u{5f00} FIFO \\u{4f1a}\\u{65e0}\\u{9650}\\u{7b49}\\u{5f85}。
+   - Impact: \\u{6062}\\u{590d}\\u{4e86}\\u{4e0a}\\u{4e00}\\u{8f6e}\\u{8981}\\u{6c42}\\u{6d88}\\u{9664}\\u{7684}\\u{6c38}\\u{4e45}\\u{963b}\\u{585e}/\\u{62d2}\\u{7edd}\\u{670d}\\u{52a1}。
+   - Class sweep: 3 sites—`validate`、`graph`、`lock` \\u{5747}\\u{7ecf} `compile_file` \\u{5230}\\u{8fbe}\\u{8be5}\\u{5171}\\u{4eab}\\u{8bfb}\\u{53d6}\\u{51fd}\\u{6570}。
+   - Fix：\\u{5728} Linux \\u{4e0a}\\u{4ee5} nonblocking \\u{6a21}\\u{5f0f}\\u{6253}\\u{5f00}\\u{4e00}\\u{6b21}，\\u{518d}\\u{7528} `file.metadata()` \\u{68c0}\\u{67e5}\\u{540c}\\u{4e00}\\u{63cf}\\u{8ff0}\\u{7b26}，\\u{968f}\\u{540e}\\u{4ece}\\u{540c}\\u{4e00}\\u{63cf}\\u{8ff0}\\u{7b26}\\u{6267}\\u{884c}\\u{9650}\\u{957f}\\u{8bfb}\\u{53d6}。
+   - Test gap: \\u{5f53}\\u{524d} `/dev/null` \\u{6d4b}\\u{8bd5}\\u{53ea}\\u{8986}\\u{76d6}\\u{7a33}\\u{5b9a}\\u{7684}\\u{975e}\\u{666e}\\u{901a}\\u{6587}\\u{4ef6}，\\u{6ca1}\\u{6709}\\u{8986}\\u{76d6}\\u{68c0}\\u{67e5}\\u{4e0e}\\u{6253}\\u{5f00}\\u{4e4b}\\u{95f4}\\u{7684}\\u{8def}\\u{5f84}\\u{66ff}\\u{6362}。
+"#,
+        r#"[[findings]]
+id = "prose-001"
+severity = "high"
+description = "\\u{6587}\\u{4ef6}\\u{7c7b}\\u{578b}\\u{68c0}\\u{67e5}\\u{4e0e}\\u{6253}\\u{5f00}\\u{4e0d}\\u{662f}\\u{540c}\\u{4e00}\\u{6587}\\u{4ef6}\\u{5bf9}\\u{8c61}（`crates/workflow-spec/src/lib.rs:423`，confidence=0.99）"
+
+[[findings]]
+id = "prose-002"
+severity = "high"
+description = "\\u{6587}\\u{4ef6}\\u{7c7b}\\u{578b}\\u{68c0}\\u{67e5}\\u{4e0e}\\u{6253}\\u{5f00}\\u{4e0d}\\u{662f}\\u{540c}\\u{4e00}\\u{6587}\\u{4ef6}\\u{5bf9}\\u{8c61}（`crates/workflow-spec/src/lib.rs:423`，confidence=0.99）"
+"#,
+        true,
+    );
+    let findings = read_findings_toml(&session_dir);
+    assert_eq!(findings.findings.len(), 1, "{findings:#?}");
+    assert_eq!(findings.findings[0].severity, Severity::High);
+    assert_eq!(
+        findings.findings[0].file_ranges,
+        vec![csa_session::ReviewFindingFileRange {
+            path: "crates/workflow-spec/src/lib.rs".to_string(),
+            start: 423,
+            end: None,
+        }]
+    );
+    let verdict = read_verdict(&session_dir);
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+    assert_eq!(verdict.severity_counts.values().sum::<u32>(), 1);
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_c_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_c_tests.rs
@@ -17,12 +17,12 @@ fn issue_3071_class_c_counts_one_frozen_finding_once() {
    - Test gap: \\u{5f53}\\u{524d} `/dev/null` \\u{6d4b}\\u{8bd5}\\u{53ea}\\u{8986}\\u{76d6}\\u{7a33}\\u{5b9a}\\u{7684}\\u{975e}\\u{666e}\\u{901a}\\u{6587}\\u{4ef6}，\\u{6ca1}\\u{6709}\\u{8986}\\u{76d6}\\u{68c0}\\u{67e5}\\u{4e0e}\\u{6253}\\u{5f00}\\u{4e4b}\\u{95f4}\\u{7684}\\u{8def}\\u{5f84}\\u{66ff}\\u{6362}。
 "#,
         r#"[[findings]]
-id = "prose-001"
+id = "prose-generated-001"
 severity = "high"
 description = "\\u{6587}\\u{4ef6}\\u{7c7b}\\u{578b}\\u{68c0}\\u{67e5}\\u{4e0e}\\u{6253}\\u{5f00}\\u{4e0d}\\u{662f}\\u{540c}\\u{4e00}\\u{6587}\\u{4ef6}\\u{5bf9}\\u{8c61}（`crates/workflow-spec/src/lib.rs:423`，confidence=0.99）"
 
 [[findings]]
-id = "prose-002"
+id = "prose-generated-002"
 severity = "high"
 description = "\\u{6587}\\u{4ef6}\\u{7c7b}\\u{578b}\\u{68c0}\\u{67e5}\\u{4e0e}\\u{6253}\\u{5f00}\\u{4e0d}\\u{662f}\\u{540c}\\u{4e00}\\u{6587}\\u{4ef6}\\u{5bf9}\\u{8c61}（`crates/workflow-spec/src/lib.rs:423`，confidence=0.99）"
 "#,

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_support.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_support.rs
@@ -1,0 +1,72 @@
+fn expand_unicode_escapes(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let mut expanded = String::with_capacity(text.len());
+    let mut index = 0;
+    while index < chars.len() {
+        if chars[index] != '\\' {
+            expanded.push(chars[index]);
+            index += 1;
+            continue;
+        }
+        let mut cursor = index;
+        while cursor < chars.len() && chars[cursor] == '\\' {
+            cursor += 1;
+        }
+        if chars.get(cursor) == Some(&'u') && chars.get(cursor + 1) == Some(&'{') {
+            let Some(end) = chars[cursor + 2..].iter().position(|ch| *ch == '}') else {
+                expanded.extend(&chars[index..cursor]);
+                index = cursor;
+                continue;
+            };
+            let end = cursor + 2 + end;
+            if let Ok(codepoint) = chars[cursor + 2..end].iter().collect::<String>().parse::<u32>() {
+                if let Some(character) = char::from_u32(codepoint) {
+                    expanded.push(character);
+                    index = end + 1;
+                    continue;
+                }
+            }
+        }
+        expanded.push('\\');
+        index += 1;
+    }
+    expanded
+}
+
+fn persist_fixture_review(
+    test_name: &str,
+    session_id: &str,
+    summary: &str,
+    details: &str,
+    findings_toml: &str,
+    extracted_marker: bool,
+) -> (OwnedMutexGuard<()>, PathBuf, PathBuf) {
+    let summary = expand_unicode_escapes(summary);
+    let details = expand_unicode_escapes(details);
+    let findings_toml = expand_unicode_escapes(findings_toml);
+    let (env_lock, project_root, session_dir) = lock_test_session(test_name, session_id);
+    csa_session::persist_structured_output(
+        &session_dir,
+        &format!(
+            "<!-- CSA:SECTION:summary -->\n{summary}\n<!-- CSA:SECTION:summary:END -->\n\n<!-- CSA:SECTION:details -->\n{details}\n<!-- CSA:SECTION:details:END -->\n"
+        ),
+    )
+    .expect("persist fixture review prose");
+    fs::write(
+        session_dir.join("output").join("findings.toml"),
+        findings_toml,
+    )
+    .expect("write fixture findings.toml");
+    if extracted_marker {
+        fs::write(
+            session_dir
+                .join("output")
+                .join(crate::review_cmd::findings_toml::FINDINGS_TOML_EXTRACTED_MARKER),
+            b"",
+        )
+        .expect("write extracted marker");
+    }
+    let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+    (env_lock, project_root, session_dir)
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_support.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_support.rs
@@ -40,6 +40,7 @@ fn persist_fixture_review(
     details: &str,
     findings_toml: &str,
     extracted_marker: bool,
+    prose_derived: bool,
 ) -> (OwnedMutexGuard<()>, PathBuf, PathBuf) {
     let summary = expand_unicode_escapes(summary);
     let details = expand_unicode_escapes(details);
@@ -65,6 +66,15 @@ fn persist_fixture_review(
             b"",
         )
         .expect("write extracted marker");
+    }
+    if prose_derived {
+        fs::write(
+            session_dir
+                .join("output")
+                .join(crate::review_cmd::findings_toml::FINDINGS_TOML_PROSE_DERIVED_MARKER),
+            b"",
+        )
+        .expect("write prose-derived marker");
     }
     let meta = make_review_meta_with_decision(session_id, ReviewDecision::Fail, "HAS_ISSUES");
     persist_review_verdict(&project_root, &meta, &[], Vec::new());

--- a/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_support.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_verdict_3071_support.rs
@@ -80,3 +80,31 @@ fn persist_fixture_review(
     persist_review_verdict(&project_root, &meta, &[], Vec::new());
     (env_lock, project_root, session_dir)
 }
+
+fn save_result_with_repo_write_audit(project_root: &Path, session_id: &str) {
+    let mut repo_write_audit = toml::map::Map::new();
+    repo_write_audit.insert(
+        "modified".to_string(),
+        toml::Value::Array(vec![toml::Value::String("weave.lock".to_string())]),
+    );
+    let mut artifacts = toml::map::Map::new();
+    artifacts.insert(
+        "repo_write_audit".to_string(),
+        toml::Value::Table(repo_write_audit),
+    );
+    let now = chrono::Utc::now();
+    let result = csa_session::SessionResult {
+        status: "success".to_string(),
+        exit_code: 0,
+        summary: "Clean textual verdict".to_string(),
+        tool: "codex".to_string(),
+        started_at: now,
+        completed_at: now + chrono::TimeDelta::seconds(1),
+        manager_fields: csa_session::SessionManagerFields {
+            artifacts: Some(toml::Value::Table(artifacts)),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    csa_session::save_result(project_root, session_id, &result).expect("save review result");
+}

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -14,6 +14,13 @@ pub(in crate::review_cmd) fn findings_file_from_prose(text: &str) -> Option<Find
     }
 }
 
+pub(in crate::review_cmd) fn is_generated_prose_finding_id(id: &str) -> bool {
+    let Some(index) = id.strip_prefix("prose-") else {
+        return false;
+    };
+    index.len() == 3 && index.bytes().all(|byte| byte.is_ascii_digit())
+}
+
 pub(in crate::review_cmd) fn findings_file_from_explicit_findings_sections(
     text: &str,
 ) -> Option<FindingsFile> {
@@ -27,7 +34,7 @@ pub(in crate::review_cmd) fn findings_file_from_explicit_findings_sections(
             {
                 continue;
             }
-            if finding.id.starts_with("prose-") {
+            if is_generated_prose_finding_id(&finding.id) {
                 finding.id = format!("prose-{:03}", findings.len() + 1);
             }
             findings.push(finding);

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -5,6 +5,13 @@ use super::prose_resolution::{
 };
 use csa_session::{FindingsFile, ReviewFinding, ReviewFindingFileRange, Severity};
 
+#[path = "review_cmd_prose_findings_generated.rs"]
+mod generated_prose_findings;
+pub(in crate::review_cmd) use generated_prose_findings::{
+    findings_file_from_explicit_findings_sections, generated_prose_finding_id,
+    is_generated_prose_finding_id,
+};
+
 pub(in crate::review_cmd) fn findings_file_from_prose(text: &str) -> Option<FindingsFile> {
     let findings = extract_review_findings_from_prose(text);
     if findings.is_empty() {
@@ -12,35 +19,6 @@ pub(in crate::review_cmd) fn findings_file_from_prose(text: &str) -> Option<Find
     } else {
         Some(FindingsFile { findings })
     }
-}
-
-pub(in crate::review_cmd) fn is_generated_prose_finding_id(id: &str) -> bool {
-    let Some(index) = id.strip_prefix("prose-") else {
-        return false;
-    };
-    index.len() == 3 && index.bytes().all(|byte| byte.is_ascii_digit())
-}
-
-pub(in crate::review_cmd) fn findings_file_from_explicit_findings_sections(
-    text: &str,
-) -> Option<FindingsFile> {
-    let mut findings = Vec::new();
-    for body in findings_section_bodies(text) {
-        let parser_input = format!("Findings\n{}", body.as_str());
-        for mut finding in extract_review_findings_from_prose_with_default(&parser_input, None) {
-            if findings
-                .iter()
-                .any(|existing| review_finding_payload_eq(existing, &finding))
-            {
-                continue;
-            }
-            if is_generated_prose_finding_id(&finding.id) {
-                finding.id = format!("prose-{:03}", findings.len() + 1);
-            }
-            findings.push(finding);
-        }
-    }
-    (!findings.is_empty()).then_some(FindingsFile { findings })
 }
 
 pub(in crate::review_cmd) fn extract_review_findings_from_prose(text: &str) -> Vec<ReviewFinding> {
@@ -92,7 +70,8 @@ pub(in crate::review_cmd) fn extract_review_findings_from_prose_with_default(
             in_findings_section,
             default_unlabeled_severity.clone(),
         ) {
-            findings.push(parsed.into_review_finding(format!("prose-{:03}", findings.len() + 1)));
+            findings
+                .push(parsed.into_review_finding(generated_prose_finding_id(findings.len() + 1)));
             active_finding = Some(findings.len() - 1);
             continue;
         }

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use super::prose_resolution::{
     finding_text_describes_resolved_issue, review_signal_describes_resolved_issue,
@@ -8,7 +8,7 @@ use csa_session::{FindingsFile, ReviewFinding, ReviewFindingFileRange, Severity}
 #[path = "review_cmd_prose_findings_generated.rs"]
 mod generated_prose_findings;
 pub(in crate::review_cmd) use generated_prose_findings::{
-    findings_file_from_explicit_findings_sections, generated_prose_finding_id,
+    allocate_unique_generated_prose_finding_id, findings_file_from_explicit_findings_sections,
     is_generated_prose_finding_id,
 };
 
@@ -32,6 +32,8 @@ pub(in crate::review_cmd) fn extract_review_findings_from_prose_with_default(
     default_unlabeled_severity: Option<Severity>,
 ) -> Vec<ReviewFinding> {
     let mut findings: Vec<ReviewFinding> = Vec::new();
+    let mut used_ids = HashSet::new();
+    let mut next_generated_index = 1;
     let mut in_findings_section = false;
     let mut in_code_fence = false;
     let mut active_finding: Option<usize> = None;
@@ -70,8 +72,11 @@ pub(in crate::review_cmd) fn extract_review_findings_from_prose_with_default(
             in_findings_section,
             default_unlabeled_severity.clone(),
         ) {
-            findings
-                .push(parsed.into_review_finding(generated_prose_finding_id(findings.len() + 1)));
+            let id = allocate_unique_generated_prose_finding_id(
+                &mut used_ids,
+                &mut next_generated_index,
+            );
+            findings.push(parsed.into_review_finding(id));
             active_finding = Some(findings.len() - 1);
             continue;
         }

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_file_ranges.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_file_ranges.rs
@@ -28,13 +28,12 @@ fn strip_unordered_list_prefix(line: &str) -> &str {
 fn parse_leading_file_range(body: &str) -> Option<(ReviewFindingFileRange, String)> {
     let trimmed = body
         .trim_start_matches(|ch: char| {
-            ch.is_ascii_punctuation()
-                || matches!(ch, '（' | '）' | '，' | '。' | '；' | '：' | '、')
+            matches!(ch, '`' | '(' | '[' | '（' | '）' | '，' | '。' | '；' | '：' | '、')
         })
         .trim_start();
     let mut parts = trimmed.splitn(2, char::is_whitespace);
     let token = parts.next()?.trim_matches(|ch: char| {
-        ch.is_ascii_punctuation() || matches!(ch, '（' | '）' | '，' | '。' | '；' | '：' | '、')
+        matches!(ch, '`' | ',' | '.' | ')' | ']' | '（' | '）' | '，' | '。' | '；' | '：' | '、')
     });
     let description = parts
         .next()
@@ -59,8 +58,11 @@ fn parse_embedded_file_range(body: &str) -> Option<ReviewFindingFileRange> {
     })
         .map(|token| {
             token.trim_matches(|ch: char| {
-                ch.is_ascii_punctuation()
-                    || matches!(ch, '（' | '）' | '，' | '。' | '；' | '：' | '、')
+                matches!(
+                    ch,
+                    '`' | '(' | ')' | '[' | ']' | ',' | '.' | ';'
+                        | '（' | '）' | '，' | '。' | '；' | '：' | '、'
+                )
             })
         })
         .find_map(|token| {

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_file_ranges.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_file_ranges.rs
@@ -26,9 +26,16 @@ fn strip_unordered_list_prefix(line: &str) -> &str {
 }
 
 fn parse_leading_file_range(body: &str) -> Option<(ReviewFindingFileRange, String)> {
-    let trimmed = body.trim_start_matches(['`', '(', '[']).trim_start();
+    let trimmed = body
+        .trim_start_matches(|ch: char| {
+            ch.is_ascii_punctuation()
+                || matches!(ch, '（' | '）' | '，' | '。' | '；' | '：' | '、')
+        })
+        .trim_start();
     let mut parts = trimmed.splitn(2, char::is_whitespace);
-    let token = parts.next()?.trim_matches(['`', ',', '.', ')', ']']);
+    let token = parts.next()?.trim_matches(|ch: char| {
+        ch.is_ascii_punctuation() || matches!(ch, '（' | '）' | '，' | '。' | '；' | '：' | '、')
+    });
     let description = parts
         .next()
         .unwrap_or_default()
@@ -47,8 +54,15 @@ fn parse_leading_file_range(body: &str) -> Option<(ReviewFindingFileRange, Strin
 }
 
 fn parse_embedded_file_range(body: &str) -> Option<ReviewFindingFileRange> {
-    body.split(char::is_whitespace)
-        .map(|token| token.trim_matches(['`', '(', ')', '[', ']', ',', '.', ';']))
+    body.split(|ch: char| {
+        ch.is_whitespace() || matches!(ch, '（' | '）' | '，' | '。' | '；' | '：' | '、')
+    })
+        .map(|token| {
+            token.trim_matches(|ch: char| {
+                ch.is_ascii_punctuation()
+                    || matches!(ch, '（' | '）' | '，' | '。' | '；' | '：' | '、')
+            })
+        })
         .find_map(|token| {
             parse_file_reference_token(token).map(|(path, start)| ReviewFindingFileRange {
                 path,

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_file_ranges.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_file_ranges.rs
@@ -28,12 +28,12 @@ fn strip_unordered_list_prefix(line: &str) -> &str {
 fn parse_leading_file_range(body: &str) -> Option<(ReviewFindingFileRange, String)> {
     let trimmed = body
         .trim_start_matches(|ch: char| {
-            matches!(ch, '`' | '(' | '[' | '（' | '）' | '，' | '。' | '；' | '：' | '、')
+            matches!(ch, '`' | '(' | '[' | '（' | '）')
         })
         .trim_start();
     let mut parts = trimmed.splitn(2, char::is_whitespace);
     let token = parts.next()?.trim_matches(|ch: char| {
-        matches!(ch, '`' | ',' | '.' | ')' | ']' | '（' | '）' | '，' | '。' | '；' | '：' | '、')
+        matches!(ch, '`' | ',' | '.' | ')' | ']' | '（' | '）')
     });
     let description = parts
         .next()
@@ -53,15 +53,18 @@ fn parse_leading_file_range(body: &str) -> Option<(ReviewFindingFileRange, Strin
 }
 
 fn parse_embedded_file_range(body: &str) -> Option<ReviewFindingFileRange> {
-    body.split(|ch: char| {
-        ch.is_whitespace() || matches!(ch, '（' | '）' | '，' | '。' | '；' | '：' | '、')
-    })
+    body.split(char::is_whitespace)
         .map(|token| {
+            if let Some(start) = token.find('`')
+                && let Some(relative_end) = token[start + 1..].find('`')
+            {
+                let end = start + 1 + relative_end;
+                return &token[start + 1..end];
+            }
             token.trim_matches(|ch: char| {
                 matches!(
                     ch,
-                    '`' | '(' | ')' | '[' | ']' | ',' | '.' | ';'
-                        | '（' | '）' | '，' | '。' | '；' | '：' | '、'
+                    '`' | '(' | ')' | '[' | ']' | ',' | '.' | ';' | '（' | '）'
                 )
             })
         })

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_file_ranges.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_file_ranges.rs
@@ -36,9 +36,15 @@ fn parse_leading_file_range(body: &str) -> Option<(ReviewFindingFileRange, Strin
             })
             .trim_start()
     };
-    let (token, description, quoted) = if let Some(quoted_body) = trimmed.strip_prefix('`') {
-        let end = quoted_body.find('`')?;
-        (&quoted_body[..end], &quoted_body[end + 1..], true)
+    let (token, description, quoted) = if trimmed.starts_with('`') {
+        let delimiter_len = backtick_run_length(trimmed, 0);
+        let content_start = delimiter_len;
+        let end = find_closing_backtick(trimmed, content_start, delimiter_len)?;
+        (
+            &trimmed[content_start..end],
+            &trimmed[end + delimiter_len..],
+            true,
+        )
     } else {
         let mut parts = trimmed.splitn(2, char::is_whitespace);
         (parts.next()?, parts.next().unwrap_or_default(), false)
@@ -70,20 +76,22 @@ fn parse_embedded_file_range(body: &str) -> Option<ReviewFindingFileRange> {
         let mut search_start = 0;
         let mut found_span = false;
         while let Some(relative_start) = token[search_start..].find('`') {
-            let start = search_start + relative_start + 1;
-            let Some(relative_end) = token[start..].find('`') else {
-                break;
+            let opening_start = search_start + relative_start;
+            let delimiter_len = backtick_run_length(token, opening_start);
+            let content_start = opening_start + delimiter_len;
+            let Some(end) = find_closing_backtick(token, content_start, delimiter_len) else {
+                search_start = content_start;
+                continue;
             };
             found_span = true;
-            let end = start + relative_end;
-            if let Some((path, start)) = parse_file_reference_token(&token[start..end]) {
+            if let Some((path, start)) = parse_file_reference_token(&token[content_start..end]) {
                 return Some(ReviewFindingFileRange {
                     path,
                     start,
                     end: None,
                 });
             }
-            search_start = end + 1;
+            search_start = end + delimiter_len;
         }
         if !found_span {
             let token = token.trim_matches(|ch: char| {
@@ -100,6 +108,29 @@ fn parse_embedded_file_range(body: &str) -> Option<ReviewFindingFileRange> {
                 });
             }
         }
+    }
+    None
+}
+
+fn backtick_run_length(text: &str, start: usize) -> usize {
+    text.as_bytes()[start..]
+        .iter()
+        .take_while(|&&byte| byte == b'`')
+        .count()
+}
+
+fn find_closing_backtick(
+    text: &str,
+    mut search_start: usize,
+    delimiter_len: usize,
+) -> Option<usize> {
+    while let Some(relative_end) = text[search_start..].find('`') {
+        let end = search_start + relative_end;
+        let closing_len = backtick_run_length(text, end);
+        if closing_len == delimiter_len {
+            return Some(end);
+        }
+        search_start = end + closing_len;
     }
     None
 }

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_file_ranges.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_file_ranges.rs
@@ -26,18 +26,31 @@ fn strip_unordered_list_prefix(line: &str) -> &str {
 }
 
 fn parse_leading_file_range(body: &str) -> Option<(ReviewFindingFileRange, String)> {
-    let trimmed = body
-        .trim_start_matches(|ch: char| {
-            matches!(ch, '`' | '(' | '[' | '（' | '）')
+    let trimmed = body.trim_start();
+    let trimmed = if trimmed.starts_with('`') {
+        trimmed
+    } else {
+        trimmed
+            .trim_start_matches(|ch: char| {
+                matches!(ch, '`' | '(' | '[' | '（' | '）')
+            })
+            .trim_start()
+    };
+    let (token, description, quoted) = if let Some(quoted_body) = trimmed.strip_prefix('`') {
+        let end = quoted_body.find('`')?;
+        (&quoted_body[..end], &quoted_body[end + 1..], true)
+    } else {
+        let mut parts = trimmed.splitn(2, char::is_whitespace);
+        (parts.next()?, parts.next().unwrap_or_default(), false)
+    };
+    let token = if quoted {
+        token
+    } else {
+        token.trim_matches(|ch: char| {
+            matches!(ch, '`' | ',' | '.' | ')' | ']' | '（' | '）')
         })
-        .trim_start();
-    let mut parts = trimmed.splitn(2, char::is_whitespace);
-    let token = parts.next()?.trim_matches(|ch: char| {
-        matches!(ch, '`' | ',' | '.' | ')' | ']' | '（' | '）')
-    });
-    let description = parts
-        .next()
-        .unwrap_or_default()
+    };
+    let description = description
         .trim_start_matches(['-', ':'])
         .trim()
         .to_string();
@@ -53,28 +66,42 @@ fn parse_leading_file_range(body: &str) -> Option<(ReviewFindingFileRange, Strin
 }
 
 fn parse_embedded_file_range(body: &str) -> Option<ReviewFindingFileRange> {
-    body.split(char::is_whitespace)
-        .map(|token| {
-            if let Some(start) = token.find('`')
-                && let Some(relative_end) = token[start + 1..].find('`')
-            {
-                let end = start + 1 + relative_end;
-                return &token[start + 1..end];
+    for token in body.split(char::is_whitespace) {
+        let mut search_start = 0;
+        let mut found_span = false;
+        while let Some(relative_start) = token[search_start..].find('`') {
+            let start = search_start + relative_start + 1;
+            let Some(relative_end) = token[start..].find('`') else {
+                break;
+            };
+            found_span = true;
+            let end = start + relative_end;
+            if let Some((path, start)) = parse_file_reference_token(&token[start..end]) {
+                return Some(ReviewFindingFileRange {
+                    path,
+                    start,
+                    end: None,
+                });
             }
-            token.trim_matches(|ch: char| {
+            search_start = end + 1;
+        }
+        if !found_span {
+            let token = token.trim_matches(|ch: char| {
                 matches!(
                     ch,
                     '`' | '(' | ')' | '[' | ']' | ',' | '.' | ';' | '（' | '）'
                 )
-            })
-        })
-        .find_map(|token| {
-            parse_file_reference_token(token).map(|(path, start)| ReviewFindingFileRange {
-                path,
-                start,
-                end: None,
-            })
-        })
+            });
+            if let Some((path, start)) = parse_file_reference_token(token) {
+                return Some(ReviewFindingFileRange {
+                    path,
+                    start,
+                    end: None,
+                });
+            }
+        }
+    }
+    None
 }
 
 fn parse_file_reference_token(token: &str) -> Option<(String, u32)> {

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_generated.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_generated.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use csa_session::FindingsFile;
 
 use super::{
@@ -11,6 +13,19 @@ pub(in crate::review_cmd) fn generated_prose_finding_id(index: usize) -> String 
     format!("{GENERATED_PROSE_FINDING_ID_PREFIX}{index:03}")
 }
 
+pub(in crate::review_cmd) fn allocate_unique_generated_prose_finding_id(
+    used_ids: &mut HashSet<String>,
+    next_index: &mut usize,
+) -> String {
+    loop {
+        let id = generated_prose_finding_id(*next_index);
+        *next_index += 1;
+        if used_ids.insert(id.clone()) {
+            return id;
+        }
+    }
+}
+
 pub(in crate::review_cmd) fn is_generated_prose_finding_id(id: &str) -> bool {
     let Some(index) = id.strip_prefix(GENERATED_PROSE_FINDING_ID_PREFIX) else {
         return false;
@@ -22,6 +37,8 @@ pub(in crate::review_cmd) fn findings_file_from_explicit_findings_sections(
     text: &str,
 ) -> Option<FindingsFile> {
     let mut findings = Vec::new();
+    let mut used_ids = HashSet::new();
+    let mut next_generated_index = 1;
     for body in findings_section_bodies(text) {
         let parser_input = format!("Findings\n{}", body.as_str());
         for mut finding in extract_review_findings_from_prose_with_default(&parser_input, None) {
@@ -32,7 +49,12 @@ pub(in crate::review_cmd) fn findings_file_from_explicit_findings_sections(
                 continue;
             }
             if is_generated_prose_finding_id(&finding.id) {
-                finding.id = generated_prose_finding_id(findings.len() + 1);
+                finding.id = allocate_unique_generated_prose_finding_id(
+                    &mut used_ids,
+                    &mut next_generated_index,
+                );
+            } else {
+                used_ids.insert(finding.id.clone());
             }
             findings.push(finding);
         }

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_generated.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_generated.rs
@@ -1,0 +1,41 @@
+use csa_session::FindingsFile;
+
+use super::{
+    extract_review_findings_from_prose_with_default, findings_section_bodies,
+    review_finding_payload_eq,
+};
+
+const GENERATED_PROSE_FINDING_ID_PREFIX: &str = "prose-generated-";
+
+pub(in crate::review_cmd) fn generated_prose_finding_id(index: usize) -> String {
+    format!("{GENERATED_PROSE_FINDING_ID_PREFIX}{index:03}")
+}
+
+pub(in crate::review_cmd) fn is_generated_prose_finding_id(id: &str) -> bool {
+    let Some(index) = id.strip_prefix(GENERATED_PROSE_FINDING_ID_PREFIX) else {
+        return false;
+    };
+    !index.is_empty() && index.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+pub(in crate::review_cmd) fn findings_file_from_explicit_findings_sections(
+    text: &str,
+) -> Option<FindingsFile> {
+    let mut findings = Vec::new();
+    for body in findings_section_bodies(text) {
+        let parser_input = format!("Findings\n{}", body.as_str());
+        for mut finding in extract_review_findings_from_prose_with_default(&parser_input, None) {
+            if findings
+                .iter()
+                .any(|existing| review_finding_payload_eq(existing, &finding))
+            {
+                continue;
+            }
+            if is_generated_prose_finding_id(&finding.id) {
+                finding.id = generated_prose_finding_id(findings.len() + 1);
+            }
+            findings.push(finding);
+        }
+    }
+    (!findings.is_empty()).then_some(FindingsFile { findings })
+}

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
@@ -478,6 +478,32 @@ fn issue_3071_fullwidth_path_punctuation_survives_leading_and_embedded_parsing()
 }
 
 #[test]
+fn issue_3071_double_backtick_leading_location_preserves_file_range() {
+    let findings = extract_review_findings_from_prose(concat!(
+        "## Findings\n",
+        "1. [HIGH] leading double-backtick path\n",
+        "   Location: ``src/lib.rs:42``\n",
+    ));
+
+    assert_eq!(findings.len(), 1, "{findings:#?}");
+    assert_eq!(findings[0].file_ranges.len(), 1, "{findings:#?}");
+    assert_eq!(findings[0].file_ranges[0].path, "src/lib.rs");
+    assert_eq!(findings[0].file_ranges[0].start, 42);
+}
+
+#[test]
+fn issue_3071_double_backtick_embedded_location_preserves_file_range() {
+    let findings = extract_review_findings_from_prose(
+        "## Findings\n1. [HIGH] embedded double-backtick path ``src/lib.rs:42`` for context\n",
+    );
+
+    assert_eq!(findings.len(), 1, "{findings:#?}");
+    assert_eq!(findings[0].file_ranges.len(), 1, "{findings:#?}");
+    assert_eq!(findings[0].file_ranges[0].path, "src/lib.rs");
+    assert_eq!(findings[0].file_ranges[0].start, 42);
+}
+
+#[test]
 fn issue_3071_adjacent_backtick_spans_with_fullwidth_punctuation_preserve_later_path() {
     let findings = extract_review_findings_from_prose(concat!(
         "## Findings\n",

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
@@ -476,3 +476,35 @@ fn issue_3071_fullwidth_path_punctuation_survives_leading_and_embedded_parsing()
     );
     assert_eq!(embedded[0].file_ranges[0].start, 42);
 }
+
+#[test]
+fn issue_3071_adjacent_backtick_spans_with_fullwidth_punctuation_preserve_later_path() {
+    let findings = extract_review_findings_from_prose(concat!(
+        "## Findings\n",
+        "1. [HIGH] adjacent spans `--json`\u{ff0c}`src/lib.rs:42`\u{ff0e}\n",
+    ));
+
+    assert_eq!(findings.len(), 1, "{findings:#?}");
+    assert_eq!(findings[0].file_ranges.len(), 1, "{findings:#?}");
+    assert_eq!(findings[0].file_ranges[0].path, "src/lib.rs");
+    assert_eq!(findings[0].file_ranges[0].start, 42);
+}
+
+#[test]
+fn issue_3071_backtick_quoted_leading_fullwidth_parenthesis_preserves_path() {
+    let findings = extract_review_findings_from_prose(concat!(
+        "## Findings\n",
+        "1. [HIGH] leading quoted path\n",
+        "   Location: `\u{ff08}src/lib.rs:42`\n",
+        "2. [HIGH] second leading quoted path\n",
+        "   Location: `\u{ff09}src/lib.rs:43`\n",
+    ));
+
+    assert_eq!(findings.len(), 2, "{findings:#?}");
+    assert_eq!(findings[0].file_ranges.len(), 1, "{findings:#?}");
+    assert_eq!(findings[0].file_ranges[0].path, "\u{ff08}src/lib.rs");
+    assert_eq!(findings[0].file_ranges[0].start, 42);
+    assert_eq!(findings[1].file_ranges.len(), 1, "{findings:#?}");
+    assert_eq!(findings[1].file_ranges[0].path, "\u{ff09}src/lib.rs");
+    assert_eq!(findings[1].file_ranges[0].start, 43);
+}

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
@@ -339,7 +339,7 @@ fn issue_2664_cluster_parses_substantive_heading_and_location_variants() {
                 "1. [MODERATE][correctness/ordering] Latched limits can still be reclassified ",
                 "as cancellation ([lifecycle.rs](/project/rust-core/src/workflow_adk/lifecycle.rs:741), confidence 0.98).\n",
             ),
-            "prose-001",
+            "prose-generated-001",
             Severity::Medium,
             Some(("lifecycle.rs", 741)),
         ),
@@ -349,7 +349,7 @@ fn issue_2664_cluster_parses_substantive_heading_and_location_variants() {
                 "1. [P1][security] Deleted-file ownership tokens have an inode-reuse ABA window\n",
                 "`llm/coding/scripts/test-fix-target.sh:104`, confidence 0.96\n",
             ),
-            "prose-001",
+            "prose-generated-001",
             Severity::High,
             Some(("llm/coding/scripts/test-fix-target.sh", 104)),
         ),
@@ -436,4 +436,43 @@ fn issue_3071_linux_path_prefixes_survive_leading_and_embedded_parsing() {
         assert_eq!(finding.file_ranges[0].path, path);
         assert_eq!(finding.file_ranges[0].start, line);
     }
+}
+
+#[test]
+fn parser_generated_prose_ids_support_indices_above_999() {
+    let text = (1..=1000)
+        .map(|index| format!("{index}. [LOW] generated finding {index}\n"))
+        .collect::<String>();
+    let findings = extract_review_findings_from_prose(&format!("## Findings\n{text}"));
+
+    assert_eq!(findings.len(), 1000);
+    assert_eq!(findings[999].id, "prose-generated-1000");
+}
+
+#[test]
+fn issue_3071_fullwidth_path_punctuation_survives_leading_and_embedded_parsing() {
+    let leading = extract_review_findings_from_prose(concat!(
+        "## Findings\n",
+        "1. [HIGH] leading fullwidth path\n",
+        "   Location: ",
+        "\u{ff0c}report.rs:7\n",
+    ));
+    assert_eq!(leading.len(), 1, "{leading:#?}");
+    assert_eq!(leading[0].file_ranges.len(), 1, "{leading:#?}");
+    assert_eq!(leading[0].file_ranges[0].path, "\u{ff0c}report.rs");
+    assert_eq!(leading[0].file_ranges[0].start, 7);
+
+    let embedded = extract_review_findings_from_prose(concat!(
+        "## Findings\n",
+        "1. [HIGH] embedded fullwidth path (",
+        "`src/\u{62a5}\u{544a}\u{ff0c}\u{6700}\u{7ec8}.rs:42`)",
+        "\n",
+    ));
+    assert_eq!(embedded.len(), 1, "{embedded:#?}");
+    assert_eq!(embedded[0].file_ranges.len(), 1, "{embedded:#?}");
+    assert_eq!(
+        embedded[0].file_ranges[0].path,
+        "src/\u{62a5}\u{544a}\u{ff0c}\u{6700}\u{7ec8}.rs"
+    );
+    assert_eq!(embedded[0].file_ranges[0].start, 42);
 }

--- a/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_prose_findings_tests.rs
@@ -396,3 +396,44 @@ fn issue_2975_wrapped_finding_keeps_continuation_and_source() {
     assert_eq!(finding.file_ranges[0].path, "lifecycle.rs");
     assert_eq!(finding.file_ranges[0].start, 741);
 }
+
+#[test]
+fn issue_3071_linux_path_prefixes_survive_leading_and_embedded_parsing() {
+    let leading = extract_review_findings_from_prose(concat!(
+        "## Findings\n",
+        "1. [HIGH] absolute path regression\n",
+        "   Location: /workspace/src/lib.rs:42\n",
+        "2. [HIGH] generated path regression\n",
+        "   Location: _generated.rs:7\n",
+        "3. [HIGH] dashed path regression\n",
+        "   Location: -generated.rs:8\n",
+        "4. [HIGH] plus path regression\n",
+        "   Location: +generated.rs:9\n",
+    ));
+    let expected = [
+        ("/workspace/src/lib.rs", 42),
+        ("_generated.rs", 7),
+        ("-generated.rs", 8),
+        ("+generated.rs", 9),
+    ];
+    assert_eq!(leading.len(), expected.len(), "{leading:#?}");
+    for (finding, (path, line)) in leading.iter().zip(expected) {
+        assert_eq!(finding.file_ranges.len(), 1, "{finding:#?}");
+        assert_eq!(finding.file_ranges[0].path, path);
+        assert_eq!(finding.file_ranges[0].start, line);
+    }
+
+    let embedded = extract_review_findings_from_prose(concat!(
+        "## Findings\n",
+        "1. [HIGH] absolute path regression (/workspace/src/lib.rs:42)\n",
+        "2. [HIGH] generated path regression (_generated.rs:7)\n",
+        "3. [HIGH] dashed path regression (-generated.rs:8)\n",
+        "4. [HIGH] plus path regression (+generated.rs:9)\n",
+    ));
+    assert_eq!(embedded.len(), expected.len(), "{embedded:#?}");
+    for (finding, (path, line)) in embedded.iter().zip(expected) {
+        assert_eq!(finding.file_ranges.len(), 1, "{finding:#?}");
+        assert_eq!(finding.file_ranges[0].path, path);
+        assert_eq!(finding.file_ranges[0].start, line);
+    }
+}

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper_alias_race.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper_alias_race.rs
@@ -1,6 +1,9 @@
 use super::*;
 
 #[cfg(target_os = "linux")]
+use std::os::unix::fs::MetadataExt;
+
+#[cfg(target_os = "linux")]
 fn read_process_start_time_ticks(pid: u32) -> u64 {
     let stat_path = format!("/proc/{pid}/stat");
     let content = std::fs::read_to_string(stat_path).expect("read process stat");
@@ -28,18 +31,55 @@ fn daemon_pid_record(pid: u32) -> String {
 fn wait_until_wait_lock_is_held(session_dir: &std::path::Path) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
     loop {
-        match try_acquire_session_wait_lock(session_dir).expect("probe wait lock") {
-            Some(lock) => {
-                drop(lock);
-                assert!(
-                    std::time::Instant::now() < deadline,
-                    "session wait did not rebind to target wait lock at {}",
-                    session_dir.display()
-                );
-                std::thread::sleep(std::time::Duration::from_millis(10));
-            }
-            None => return,
+        if wait_lock_is_held(session_dir) {
+            return;
         }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "session wait did not rebind to target wait lock at {}",
+            session_dir.display()
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn wait_lock_is_held(session_dir: &std::path::Path) -> bool {
+    let Ok(inode) =
+        std::fs::metadata(session_dir.join(".wait.lock")).map(|metadata| metadata.ino())
+    else {
+        return false;
+    };
+    let expected_inode = inode.to_string();
+    std::fs::read_to_string("/proc/locks")
+        .ok()
+        .is_some_and(|locks| {
+            locks.lines().any(|line| {
+                let mut fields = line.split_whitespace();
+                let _record = fields.next();
+                let lock_type = fields.next();
+                let advisory = fields.next();
+                let access = fields.next();
+                let _pid = fields.next();
+                let device_inode = fields.next();
+                matches!(
+                    (lock_type, advisory, access),
+                    (Some("FLOCK"), Some("ADVISORY"), Some("WRITE"))
+                ) && device_inode
+                    .and_then(|value| value.rsplit_once(':'))
+                    .is_some_and(|(_, locked_inode)| locked_inode == expected_inode)
+            })
+        })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn wait_lock_is_held(session_dir: &std::path::Path) -> bool {
+    match try_acquire_session_wait_lock(session_dir).expect("probe wait lock") {
+        Some(lock) => {
+            drop(lock);
+            false
+        }
+        None => true,
     }
 }
 

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper_alias_race.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_resume_wrapper_alias_race.rs
@@ -45,31 +45,91 @@ fn wait_until_wait_lock_is_held(session_dir: &std::path::Path) {
 
 #[cfg(target_os = "linux")]
 fn wait_lock_is_held(session_dir: &std::path::Path) -> bool {
-    let Ok(inode) =
-        std::fs::metadata(session_dir.join(".wait.lock")).map(|metadata| metadata.ino())
-    else {
+    let lock_path = session_dir.join(".wait.lock");
+    let Ok(metadata) = std::fs::metadata(&lock_path) else {
         return false;
     };
-    let expected_inode = inode.to_string();
+    let Some(expected_device) = proc_locks_device_for_path(&lock_path) else {
+        return false;
+    };
     std::fs::read_to_string("/proc/locks")
         .ok()
         .is_some_and(|locks| {
             locks.lines().any(|line| {
-                let mut fields = line.split_whitespace();
-                let _record = fields.next();
-                let lock_type = fields.next();
-                let advisory = fields.next();
-                let access = fields.next();
-                let _pid = fields.next();
-                let device_inode = fields.next();
-                matches!(
-                    (lock_type, advisory, access),
-                    (Some("FLOCK"), Some("ADVISORY"), Some("WRITE"))
-                ) && device_inode
-                    .and_then(|value| value.rsplit_once(':'))
-                    .is_some_and(|(_, locked_inode)| locked_inode == expected_inode)
+                wait_lock_line_matches_target(line, expected_device, metadata.ino())
             })
         })
+}
+
+#[cfg(target_os = "linux")]
+fn wait_lock_line_matches_target(
+    line: &str,
+    expected_device: (u64, u64),
+    expected_inode: u64,
+) -> bool {
+    let mut fields = line.split_whitespace();
+    let _record = fields.next();
+    let lock_type = fields.next();
+    let advisory = fields.next();
+    let access = fields.next();
+    let _pid = fields.next();
+    let device_inode = fields.next();
+    matches!(
+        (lock_type, advisory, access),
+        (Some("FLOCK"), Some("ADVISORY"), Some("WRITE"))
+    ) && device_inode
+        .and_then(parse_proc_lock_device_inode)
+        .is_some_and(|(major, minor, locked_inode)| {
+            (major, minor) == expected_device && locked_inode == expected_inode
+        })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_proc_lock_device_inode(value: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = value.split(':');
+    let major = u64::from_str_radix(parts.next()?, 16).ok()?;
+    let minor = u64::from_str_radix(parts.next()?, 16).ok()?;
+    let inode = parts.next()?.parse().ok()?;
+    parts.next().is_none().then_some((major, minor, inode))
+}
+
+#[cfg(target_os = "linux")]
+fn proc_locks_device_for_path(path: &std::path::Path) -> Option<(u64, u64)> {
+    let canonical_path = std::fs::canonicalize(path).ok()?;
+    std::fs::read_to_string("/proc/self/mountinfo")
+        .ok()?
+        .lines()
+        .filter_map(|line| {
+            let fields: Vec<_> = line.split_whitespace().collect();
+            let (major, minor) = fields.get(2)?.split_once(':')?;
+            let major = major.parse().ok()?;
+            let minor = minor.parse().ok()?;
+            let mount_point = std::path::PathBuf::from(decode_mountinfo_path(fields.get(4)?));
+            canonical_path
+                .starts_with(&mount_point)
+                .then_some((mount_point.components().count(), (major, minor)))
+        })
+        .max_by_key(|(depth, _)| *depth)
+        .map(|(_, device)| device)
+}
+
+#[cfg(target_os = "linux")]
+fn decode_mountinfo_path(value: &str) -> String {
+    value
+        .replace("\\040", " ")
+        .replace("\\011", "\t")
+        .replace("\\134", "\\")
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn wait_lock_identity_rejects_same_inode_on_different_device() {
+    let same_inode = 4242;
+    assert!(!wait_lock_line_matches_target(
+        "1: FLOCK ADVISORY WRITE 1234 00:2b:4242 0 EOF",
+        (0, 0x2a),
+        same_inode,
+    ));
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/crates/cli-sub-agent/tests/run_blocked_cargo_target.rs
+++ b/crates/cli-sub-agent/tests/run_blocked_cargo_target.rs
@@ -215,6 +215,18 @@ fn output_with_deadline(
     description: &str,
     command_timeout: Duration,
 ) -> Output {
+    output_with_deadline_observing(command, description, command_timeout, || String::new())
+}
+
+fn output_with_deadline_observing<F>(
+    command: &mut Command,
+    description: &str,
+    command_timeout: Duration,
+    mut observe_before_cleanup: F,
+) -> Output
+where
+    F: FnMut() -> String,
+{
     command.process_group(0);
     let mut child = command
         .stdin(Stdio::null())
@@ -227,6 +239,7 @@ fn output_with_deadline(
     let mut child = ChildProcessGroupGuard::new(child);
     let deadline = Instant::now() + command_timeout;
     let status = loop {
+        let observation = observe_before_cleanup();
         match child.exited_without_reaping() {
             Ok(true) => {
                 let _ = child.fence_group_if_owned();
@@ -238,8 +251,8 @@ fn output_with_deadline(
             Ok(false) => {
                 child.cleanup();
                 panic!(
-                    "{description} did not finish within {} seconds",
-                    command_timeout.as_secs()
+                    "{description} did not finish within {} seconds; {observation}",
+                    command_timeout.as_secs(),
                 );
             }
             Err(error) => {
@@ -271,38 +284,60 @@ fn output_with_deadline(
 
 #[test]
 fn output_reaps_descendants_after_direct_child_exits_and_pipes_drain() {
+    let identity_dir = tempfile::tempdir().expect("create descendant identity directory");
+    let identity_path = identity_dir.path().join("descendant.identity");
+    let release_path = identity_dir.path().join("release");
     let mut command = Command::new("sh");
-    command.args([
-        "-c",
-        "sleep 300 </dev/null >/dev/null 2>&1 & descendant=$!; start_time=$(awk '{print $22}' \"/proc/$descendant/stat\"); printf '%s %s\\n' \"$descendant\" \"$start_time\"; exit 0",
-    ]);
+    let script = format!(
+        "sleep 300 </dev/null >/dev/null 2>&1 & descendant=$!; start_time=$(awk '{{print $22}}' \"/proc/$descendant/stat\"); printf '%s %s\\n' \"$descendant\" \"$start_time\" > \"{}\"; printf '%s %s\\n' \"$descendant\" \"$start_time\"; while [ ! -e \"{}\" ]; do sleep 0.01; done; exit 0",
+        identity_path.display(),
+        release_path.display(),
+    );
+    command.args(["-c", &script]);
     let started = Instant::now();
-    let output = output_with_deadline(
+    let mut descendant = None;
+    let output = output_with_deadline_observing(
         &mut command,
         "direct child exited but descendant survived with closed pipes",
         Duration::from_secs(5),
+        || {
+            if descendant.is_some() {
+                return String::from("captured descendant identity");
+            }
+            let Ok(identity_output) = std::fs::read_to_string(&identity_path) else {
+                return String::from("descendant identity has not been published");
+            };
+            let identity = identity_output.split_whitespace().collect::<Vec<_>>();
+            if identity.len() != 2 {
+                return format!("invalid descendant identity contents: {identity_output:?}");
+            }
+            let Ok(pid) = identity[0].parse::<u32>() else {
+                return format!("invalid descendant PID: {:?}", identity[0]);
+            };
+            let Ok(start_time) = identity[1].parse::<u64>() else {
+                return format!("invalid descendant start time: {:?}", identity[1]);
+            };
+            if let Some(captured) = ProcessIdentity::capture_with_start_time(pid, start_time) {
+                descendant = Some(captured);
+                std::fs::write(&release_path, "released").expect("release direct child");
+                return format!("captured descendant identity pid={pid} start_time={start_time}");
+            }
+            format!(
+                "published descendant identity pid={pid} start_time={start_time} no longer matches"
+            )
+        },
     );
-    let descendant_output = String::from_utf8(output.stdout).expect("descendant pid is utf-8");
-    let descendant_identity = descendant_output.split_whitespace().collect::<Vec<_>>();
-    assert_eq!(descendant_identity.len(), 2, "descendant identity fields");
-    let descendant_pid = descendant_identity[0]
-        .parse::<u32>()
-        .expect("parse descendant pid");
-    let descendant_start_time = descendant_identity[1]
-        .parse::<u64>()
-        .expect("parse descendant start time");
     let descendant =
-        ProcessIdentity::capture_with_start_time(descendant_pid, descendant_start_time)
-            .expect("capture the spawned descendant identity before checking cleanup");
-    let exited = wait_for_process_exit(descendant_pid);
+        descendant.expect("capture the spawned descendant identity before checking cleanup");
+    let exited = wait_for_process_exit(descendant.pid);
     if !exited {
-        // Keep the RED test hygienic: the unfixed helper intentionally leaks
-        // this descendant, so clean it up before asserting the failure.
+        // Keep the regression hygienic if cleanup regresses: signal only the
+        // descendant identity captured before the helper checked process exit.
         assert!(
             descendant.signal_direct_if_current(libc::SIGKILL),
             "cleanup must signal only the captured descendant identity"
         );
-        let _ = wait_for_process_exit(descendant_pid);
+        let _ = wait_for_process_exit(descendant.pid);
     }
 
     assert!(

--- a/crates/csa-process/src/daemon_tests.rs
+++ b/crates/csa-process/src/daemon_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
+use crate::ToolLiveness;
 use std::io::Read;
+use std::time::{Duration, Instant};
 
 fn write_executable_script(path: &Path, contents: &str) {
     let mut file = std::fs::OpenOptions::new()
@@ -57,6 +59,41 @@ fn test_spawn_config(session_id: &str, csa_binary: PathBuf) -> DaemonSpawnConfig
         subcommand: "plan run".to_string(),
         args: vec!["--flag".to_string(), "value".to_string()],
         env: HashMap::from([("CSA_TEST_ENV".to_string(), "1".to_string())]),
+    }
+}
+
+struct ReleaseMarker(PathBuf);
+
+impl Drop for ReleaseMarker {
+    fn drop(&mut self) {
+        let _ = std::fs::write(&self.0, b"release\n");
+    }
+}
+
+fn wait_for_spool_content(path: &Path, expected: &str) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if std::fs::read_to_string(path).is_ok_and(|contents| contents.contains(expected)) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "spool did not contain {expected:?} before readiness deadline: {}",
+            path.display()
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_daemon_exit(session_dir: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while ToolLiveness::daemon_pid_is_alive(session_dir) {
+        assert!(
+            Instant::now() < deadline,
+            "daemon did not exit after readiness release: {}",
+            session_dir.display()
+        );
+        std::thread::sleep(Duration::from_millis(10));
     }
 }
 
@@ -129,34 +166,41 @@ fn test_daemon_spawn_creates_spool_files() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let session_dir = tmp.path().join("session-test");
     let wrapper = write_wrapper_script(tmp.path(), "wrapper1.sh");
+    let release_marker = tmp.path().join("daemon-release");
+    let _release_guard = ReleaseMarker(release_marker.clone());
 
     let config = DaemonSpawnConfig {
-        session_id: "TEST001".to_string(),
+        session_id: "01M0KCV46DMV3TMJ0CAPA4FXZT".to_string(),
         session_dir: session_dir.clone(),
         csa_binary: wrapper,
         subcommand: "run".to_string(),
-        // After the injected flags, pass '--' then the real command.
-        args: vec!["--".to_string(), "echo hello".to_string()],
-        env: HashMap::new(),
+        // Keep the child alive until the parent observes durable spool output.
+        args: vec![
+            "--".to_string(),
+            "echo hello; while [ ! -e \"$CSA_TEST_RELEASE_MARKER\" ]; do sleep 0.01; done"
+                .to_string(),
+        ],
+        env: HashMap::from([(
+            "CSA_TEST_RELEASE_MARKER".to_string(),
+            release_marker.to_string_lossy().into_owned(),
+        )]),
     };
 
     let result = spawn_daemon(config).expect("spawn_daemon");
-    assert_eq!(result.session_id, "TEST001");
+    assert_eq!(result.session_id, "01M0KCV46DMV3TMJ0CAPA4FXZT");
     assert!(result.pid > 0);
-
-    // Give the child time to write and exit.
-    std::thread::sleep(std::time::Duration::from_millis(500));
 
     let stdout_path = session_dir.join("stdout.log");
     let stderr_path = session_dir.join("stderr.log");
     assert!(stdout_path.exists(), "stdout.log must exist");
     assert!(stderr_path.exists(), "stderr.log must exist");
+    wait_for_spool_content(&stdout_path, "hello");
 
-    let mut contents = String::new();
-    File::open(&stdout_path)
-        .expect("open stdout.log")
-        .read_to_string(&mut contents)
-        .expect("read stdout.log");
+    // Release the child only after the parent has observed the durable spool.
+    std::fs::write(&release_marker, b"release\n").expect("release daemon readiness barrier");
+    wait_for_daemon_exit(&session_dir);
+
+    let contents = std::fs::read_to_string(&stdout_path).expect("read stdout.log");
     assert!(
         contents.contains("hello"),
         "stdout.log should contain 'hello', got: {contents:?}"

--- a/crates/csa-process/src/lib_cancellation_tests.rs
+++ b/crates/csa-process/src/lib_cancellation_tests.rs
@@ -280,6 +280,8 @@ async fn idle_timeout_after_both_pipes_close_terminates_term_resistant_descendan
     let child = spawn_tool_with_options(command.into(), None, SpawnOptions::default())
         .await
         .expect("spawn fixture");
+    let process_group = i32::try_from(child.id().expect("fixture process group identity"))
+        .expect("fixture PID fits process-group ID");
     let pid = wait_for_fixture_pid(&pid_file).await;
     let result = tokio::time::timeout(
         Duration::from_secs(2),
@@ -299,4 +301,9 @@ async fn idle_timeout_after_both_pipes_close_terminates_term_resistant_descendan
     .expect("wait result");
     assert_eq!(result.exit_code, 137);
     assert_dead_or_zombie(pid).await;
+    assert!(
+        !crate::process_activity::process_group_has_live_members(process_group)
+            .expect("inspect cleaned process group"),
+        "timed-out cleanup must leave no live process-group members"
+    );
 }

--- a/crates/csa-process/src/lib_subprocess_helpers.rs
+++ b/crates/csa-process/src/lib_subprocess_helpers.rs
@@ -118,12 +118,21 @@ async fn wait_for_process_group_termination(process_group: i32) -> Result<()> {
     loop {
         match crate::process_activity::process_group_has_live_members(process_group) {
             Ok(false) => return Ok(()),
-            Ok(true) => {}
+            Ok(true) => {
+                // A descendant can fork between the initial group kill and
+                // this observation. Keep the kill fenced to the owned PGID
+                // until the scanner observes no live members.
+                signal_process_group(process_group, libc::SIGKILL)?;
+            }
             Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
-            Err(error) => return Err(error).context("failed to inspect child process group"),
+            Err(error) => {
+                return Err(error).context(format!(
+                    "failed to inspect child process group {process_group}"
+                ));
+            }
         }
         if tokio::time::Instant::now() >= deadline {
-            anyhow::bail!("timed out waiting for child process group to terminate");
+            anyhow::bail!("timed out waiting for child process group {process_group} to terminate");
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
@@ -145,7 +154,16 @@ pub async fn terminate_child_process_group(
             // PID anchors the PGID even when it exited on SIGTERM.
             signal_process_group(process_group, libc::SIGKILL)?;
             #[cfg(target_os = "linux")]
-            wait_for_process_group_termination(process_group).await?;
+            if let Err(group_error) = wait_for_process_group_termination(process_group).await {
+                return match wait_for_child_exit(child).await {
+                    Ok(_) => Err(group_error.context(format!(
+                        "child process was reaped but process group {process_group} cleanup failed"
+                    ))),
+                    Err(child_error) => Err(group_error.context(format!(
+                        "process group {process_group} cleanup failed and direct child reap also failed: {child_error:#}"
+                    ))),
+                };
+            }
             return wait_for_child_exit(child).await;
         }
     }

--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,10 @@ ignore = [
     # Transitive from rustls-webpki 0.101.7 (old agent-teams/cc-sdk reqwest 0.11 chain).
     # No non-breaking upgrade path exists on the 0.101 line.
     "RUSTSEC-2026-0104",
+    # Transitive from h2 0.3.27 (old agent-teams/cc-sdk reqwest 0.11 -> hyper 0.14 chain).
+    # Unbounded empty DATA frames DoS (low); patched only on h2 0.4 >=0.4.16, which this
+    # repo already uses. h2 0.3 line is archived with no non-breaking patch. Ignored 2026-08-18.
+    "RUSTSEC-2026-0258",
 ]
 
 [licenses]

--- a/justfile
+++ b/justfile
@@ -217,6 +217,11 @@ deny:
         exit "$status"; \
     fi
 
+# Update one lockfile package to a precise version (just-wrapped cargo).
+# Usage: just cargo-update-precise h2@0.4.14 0.4.16
+cargo-update-precise pkg precise:
+    {{_io_prefix}} {{_cargo}} update -p {{pkg}} --precise {{precise}}
+
 # ==============================================================================
 # 🧪 Testing
 # ==============================================================================

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1140"
-weave = "0.1.1140"
+csa = "0.1.1141"
+weave = "0.1.1141"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Fixes residual CSA prose/structured finding loss and inflation after PR #3070, plus Linux path/backtick range parsing. Successor commits also isolate wait-lock/daemon/resource fixtures and match wait locks by Linux device+inode.

Closes #3071

## Root Cause

Post-#3070 reconciliation still dropped or duplicated prose-derived findings, collided generated IDs, and sliced Linux/fullwidth/backtick locations incorrectly. Follow-on exact-HEAD review then found wait-lock readiness compared inode only.

## Fix

- Preserve canonical prose findings, authored IDs, and post-prose audit rows; derive `severity_counts` from that set.
- Parse Linux path prefixes, fullwidth quotes, and backtick spans without invalid slicing.
- Match `/proc/locks` wait readiness by device major/minor and inode at both wrapper and fix-session sites.
- Isolate hostile fixture process-group/descendant capture without weakening production retry/deadline semantics.

## How to Verify

1. Exact-HEAD `just pre-push` on `10aa6e1b56cbfc334fe3aec3b317e740e5f97392`: `7603 tests run: 7603 passed, 7 skipped`, `GATE_EXIT=0`.
2. Focused selectors: `issue_3071_single_review_preserves_post_prose_audit_finding`, `wait_lock_identity_rejects_same_inode_on_different_device`.
3. Native clean-room report: `/home/obj/project/github/RyderFreeman4Logos/drafts/cli-sub-agent/3071-native-review-10aa6e1b.md` (`sha256 780599b79ffd49e4b671715908bff74113bcf0aa45b3d9f3213095a2038d902f`), `VERDICT: PASS`, 0 findings.

## Review / publication note

CSA Tier-4 session `01M0N7K9XF1RAXH81FWYVYJBEV` returned infrastructure `UNCERTAIN` because `--context` lived outside the strict workspace (`#2704`). Native exact-HEAD fallback PASS is the content review for this SHA. Pre-push used the documented `CSA_SKIP_REVIEW_CHECK=1` review-check-only bypass; other hooks remained enabled.

## Out of scope

- OPEN #3084 hostile-ambient Git fixture flake
- OPEN #3082 post-exec temp-index staging flake
- OPEN #2704 CSA `--context` sandbox readability

## Test Plan

- [x] Added/kept regression tests for #3071 parser/reconciliation and wait-lock identity
- [x] Exact-HEAD local gate passed (`7603/7603`)
- [x] Native clean-room review PASS, 0 findings

## Risk Assessment

Medium — parser/reconciliation changes affect review artifacts. Range-local tests and exact-HEAD suite cover the residual classes; production retry/deadline semantics were not weakened.
