### PR TITLE
fix(review): honor tools.openai-compat.default_model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1141"
+version = "0.1.1142"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1141"
+version = "0.1.1142"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline.rs
+++ b/crates/cli-sub-agent/src/pipeline.rs
@@ -362,6 +362,7 @@ pub(crate) async fn build_and_validate_executor(
     force_override_user_config: bool,
     apply_tool_defaults: bool,
 ) -> Result<AdmittedExecutor> {
+    let apply_tool_defaults = apply_tool_defaults || *tool == ToolName::OpenaiCompat;
     let shipped_catalog;
     let model_catalog = if let Some(catalog) = configs.model_catalog {
         catalog

--- a/crates/cli-sub-agent/src/pipeline_tests_thinking.rs
+++ b/crates/cli-sub-agent/src/pipeline_tests_thinking.rs
@@ -115,6 +115,75 @@ async fn build_and_validate_executor_accepts_global_openai_compat_env() {
 }
 
 #[tokio::test]
+async fn openai_compat_default_model_is_admitted_for_review_without_model_env() {
+    let _lock = crate::test_env_lock::TEST_ENV_LOCK
+        .clone()
+        .lock_owned()
+        .await;
+    let _base = crate::test_env_lock::ScopedEnvVarRestore::unset("OPENAI_COMPAT_BASE_URL");
+    let _key = crate::test_env_lock::ScopedEnvVarRestore::unset("OPENAI_COMPAT_API_KEY");
+    let _model = crate::test_env_lock::ScopedEnvVarRestore::unset("OPENAI_COMPAT_MODEL");
+    let mut cfg = config_with_single_tier_model(
+        "tier-3-complex",
+        "openai-compat",
+        "openai-compat/openai/gpt-5/high",
+    );
+    let tool = cfg
+        .tools
+        .get_mut("openai-compat")
+        .expect("openai-compat test tool config exists");
+    tool.base_url = Some("http://localhost:8317".to_string());
+    tool.api_key = Some("test-key".to_string());
+    tool.default_model = Some("configured-default".to_string());
+
+    let default_executor = build_and_validate_executor(
+        &ToolName::OpenaiCompat,
+        None,
+        None,
+        None,
+        ConfigRefs {
+            project: Some(&cfg),
+            global: None,
+            model_catalog: None,
+        },
+        false,
+        false,
+        false,
+    )
+    .await
+    .expect("review admission should use the configured default model");
+    match &*default_executor {
+        csa_executor::Executor::OpenaiCompat { model_override, .. } => {
+            assert_eq!(model_override.as_deref(), Some("configured-default"));
+        }
+        other => panic!("expected openai-compat executor, got {other:?}"),
+    }
+
+    let cli_executor = build_and_validate_executor(
+        &ToolName::OpenaiCompat,
+        None,
+        Some("cli-model"),
+        None,
+        ConfigRefs {
+            project: Some(&cfg),
+            global: None,
+            model_catalog: None,
+        },
+        false,
+        false,
+        false,
+    )
+    .await
+    .expect("explicit model should be admitted");
+    match &*cli_executor {
+        csa_executor::Executor::OpenaiCompat { model_override, .. } => {
+            assert_eq!(model_override.as_deref(), Some("cli-model"));
+        }
+        other => panic!("expected openai-compat executor, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn openai_compat_model_spec_overrides_project_default_model() {
     let _lock = crate::test_env_lock::TEST_ENV_LOCK
         .clone()

--- a/crates/csa-executor/src/transport_openai_compat.rs
+++ b/crates/csa-executor/src/transport_openai_compat.rs
@@ -325,6 +325,23 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_config_model_env_overrides_default() {
+        let transport = OpenaiCompatTransport::new(Some("configured-default".to_string()));
+        let mut env = HashMap::new();
+        env.insert(
+            ENV_BASE_URL.to_string(),
+            "http://localhost:8317".to_string(),
+        );
+        env.insert(ENV_API_KEY.to_string(), "test-key".to_string());
+        env.insert(ENV_MODEL.to_string(), "env-model".to_string());
+
+        let config = transport
+            .resolve_config(Some(&env))
+            .expect("environment model should resolve");
+        assert_eq!(config.model, "env-model");
+    }
+
+    #[test]
     fn test_resolve_config_missing_base_url_errors() {
         let transport = OpenaiCompatTransport::new(Some("gemini-flash".to_string()));
         let env = HashMap::new();


### PR DESCRIPTION
## Bug Description

`csa review --tool openai-compat` failed pre-provider even when `[tools.openai-compat].default_model` was set, env had no `OPENAI_COMPAT_MODEL`, and the launch did not pass `--model`.

Closes #3083

## Root Cause

Review/debate callers constructed the OpenAI-compat executor with `apply_tool_defaults=false`, so the configured `default_model` never reached transport resolution. The error text asked operators to set `default_model`, which was already present.

## Fix

- Honor `tools.openai-compat.default_model` at the shared executor construction boundary even when callers skip tool defaults.
- Keep explicit `--model` / `model_spec` and `OPENAI_COMPAT_MODEL` precedence.
- Add regression coverage for configured default, CLI model, model spec, and env override.
- Bump workspace version `0.1.1141` → `0.1.1142`.

The later openai-compat tools-unavailable class (session `01M0N1Q19S3N5M0YEFXYVS9M08`) remains OPEN and is out of this slice.

## How to Verify

1. Configured `default_model` with no env model and no `--model` resolves.
2. Explicit `--model` still wins.
3. `OPENAI_COMPAT_MODEL` still wins over the constructed default.

## Test Plan

- [x] Focused regression tests in the landed commit
- [x] Exact-HEAD `just pre-push`: `7605 tests run: 7605 passed, 7 skipped`, `GATE_EXIT=0`
- [x] CSA T4 `01M0NF6HPBCWR8EB5E0KH3B3EV` PASS/CLEAN, 0 findings, `--check-verdict` green for `3e4b5933` `main...HEAD`

## Risk Assessment

Low — shared construction-boundary default only; explicit model and env overrides unchanged.
