### PR TITLE
fix(csa): allow git var and hook-local git -C probes (#3069)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1148"
+version = "0.1.1149"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1148"
+version = "0.1.1149"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -9,6 +9,9 @@ use std::sync::{LazyLock, Mutex};
 
 use anyhow::{Context, Result};
 
+#[path = "git_guard_env.rs"]
+mod git_guard_env;
+
 const FALLBACK_GUARD_DIR_NAME: &str = "guards";
 const SESSION_GUARD_DIR_NAME: &str = "bin";
 const CSA_SESSION_DIR_ENV: &str = "CSA_SESSION_DIR";
@@ -458,6 +461,7 @@ if [ "${CSA_GIT_PUSH_ALLOWED:-}" != "true" ]; then
     reset_hermetic_git_environment || block_untrusted_git_command "$@"
   elif ! is_exact_git_version_grammar "$@" \
     && ! is_exact_git_init_grammar "$@" \
+    && ! is_exact_git_var_identity_grammar "$@" \
     && ! is_safe_local_command "${COMMAND}"; then
     block_untrusted_git_command "$@"
   fi
@@ -684,7 +688,7 @@ pub fn inject_git_guard_env(env: &mut HashMap<String, String>) {
         }
     };
 
-    let real_git = real_git_binary(&guard_dir);
+    let real_git = git_guard_env::real_git_binary(&guard_dir);
     if let Some(real_git) = real_git {
         env.insert(
             "CSA_REAL_GIT".to_string(),
@@ -692,41 +696,7 @@ pub fn inject_git_guard_env(env: &mut HashMap<String, String>) {
         );
     }
 
-    prepend_guard_dir(env, &guard_dir);
-}
-
-fn real_git_binary(guard_dir: &Path) -> Option<PathBuf> {
-    // The guard's child environment is attacker-controlled. Resolve a known
-    // host Git rather than inheriting an ambient CSA_REAL_GIT override; this
-    // is the trust anchor used to pin the projected transfer's libexec path.
-    let guard_dir_str = guard_dir.to_string_lossy();
-    let is_not_guard = |path: &Path| !path.to_string_lossy().starts_with(guard_dir_str.as_ref());
-
-    ["/usr/bin/git", "/usr/local/bin/git", "/bin/git"]
-        .into_iter()
-        .map(PathBuf::from)
-        .find(|path| path.is_file() && is_not_guard(path))
-        .or_else(|| which::which("git").ok().filter(|path| is_not_guard(path)))
-}
-
-fn prepend_guard_dir(env: &mut HashMap<String, String>, guard_dir: &Path) {
-    let guard_dir_str = guard_dir.to_string_lossy().into_owned();
-    let current_path = env
-        .get("PATH")
-        .cloned()
-        .or_else(|| std::env::var("PATH").ok())
-        .unwrap_or_default();
-    let filtered = current_path
-        .split(':')
-        .filter(|entry| !entry.is_empty() && *entry != guard_dir_str)
-        .collect::<Vec<_>>()
-        .join(":");
-    let new_path = if filtered.is_empty() {
-        guard_dir_str
-    } else {
-        format!("{guard_dir_str}:{filtered}")
-    };
-    env.insert("PATH".to_string(), new_path);
+    git_guard_env::prepend_guard_dir(env, &guard_dir);
 }
 
 #[must_use]

--- a/crates/csa-hooks/src/git_guard_env.rs
+++ b/crates/csa-hooks/src/git_guard_env.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+pub(super) fn real_git_binary(guard_dir: &Path) -> Option<PathBuf> {
+    // The guard's child environment is attacker-controlled. Resolve a known
+    // host Git rather than inheriting an ambient CSA_REAL_GIT override; this
+    // is the trust anchor used to pin the projected transfer's libexec path.
+    let guard_dir_str = guard_dir.to_string_lossy();
+    let is_not_guard = |path: &Path| !path.to_string_lossy().starts_with(guard_dir_str.as_ref());
+
+    ["/usr/bin/git", "/usr/local/bin/git", "/bin/git"]
+        .into_iter()
+        .map(PathBuf::from)
+        .find(|path| path.is_file() && is_not_guard(path))
+        .or_else(|| which::which("git").ok().filter(|path| is_not_guard(path)))
+}
+
+pub(super) fn prepend_guard_dir(env: &mut HashMap<String, String>, guard_dir: &Path) {
+    let guard_dir_str = guard_dir.to_string_lossy().into_owned();
+    let current_path = env
+        .get("PATH")
+        .cloned()
+        .or_else(|| std::env::var("PATH").ok())
+        .unwrap_or_default();
+    let filtered = current_path
+        .split(':')
+        .filter(|entry| !entry.is_empty() && *entry != guard_dir_str)
+        .collect::<Vec<_>>()
+        .join(":");
+    let new_path = if filtered.is_empty() {
+        guard_dir_str
+    } else {
+        format!("{guard_dir_str}:{filtered}")
+    };
+    env.insert("PATH".to_string(), new_path);
+}

--- a/crates/csa-hooks/src/git_guard_exact_grammars.sh
+++ b/crates/csa-hooks/src/git_guard_exact_grammars.sh
@@ -19,6 +19,15 @@ is_exact_git_init_grammar() {
   return 1
 }
 
+is_exact_git_var_identity_grammar() {
+  [ "$#" -eq 2 ] || return 1
+  [ "${1}" = "var" ] || return 1
+  case "${2}" in
+    GIT_AUTHOR_IDENT|GIT_COMMITTER_IDENT) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 is_exact_git_c_local_grammar() {
   [ "$#" -ge 3 ] || return 1
   [ "${1}" = "-C" ] || return 1
@@ -30,7 +39,7 @@ is_exact_git_c_local_grammar() {
   git_c_command="${3}"
   shift 3
   case "${git_c_command}" in
-    init|config|add|commit|status|diff|rev-parse|log|show|checkout) ;;
+    init|config|add|commit|status|diff|diff-tree|rev-parse|log|show|checkout) ;;
     *) return 1 ;;
   esac
   for fixture_arg do
@@ -82,6 +91,13 @@ is_exact_git_c_local_grammar() {
         1) [ "${1}" = "--quiet" ] || return 1 ;;
         *) return 1 ;;
       esac
+      ;;
+    diff-tree)
+      [ "$#" -eq 4 ] \
+        && [ "${1}" = "--no-commit-id" ] \
+        && [ "${2}" = "--name-only" ] \
+        && [ "${3}" = "-r" ] \
+        && [ "${4}" = "HEAD" ] || return 1
       ;;
     rev-parse)
       case "$#" in

--- a/crates/csa-hooks/src/git_guard_tests_local_grammar.rs
+++ b/crates/csa-hooks/src/git_guard_tests_local_grammar.rs
@@ -68,6 +68,36 @@ fn wrapper_allows_exact_git_init_grammar() {
 
 #[cfg(unix)]
 #[test]
+fn wrapper_allows_git_var_identity_preflight() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(&fake_git, "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\"\n");
+
+    for ident in ["GIT_AUTHOR_IDENT", "GIT_COMMITTER_IDENT"] {
+        let output = std::process::Command::new(&wrapper)
+            .args(["var", ident])
+            .env("CSA_REAL_GIT", &fake_git)
+            .output_with_timeout()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "git var {ident}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            format!("var {ident}")
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
 fn wrapper_allows_git_c_existing_local_fixture_commands() {
     let _lock = ENV_LOCK.lock().expect("env lock poisoned");
     let temp = tempfile::tempdir().unwrap();
@@ -94,6 +124,7 @@ fn wrapper_allows_git_c_existing_local_fixture_commands() {
         &["diff", "--quiet"],
         &["rev-parse", "HEAD"],
         &["log", "-1", "--format=%H"],
+        &["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
         &["show", "HEAD:fixture.txt"],
         &["checkout", "-b", "fixture-branch"],
     ];
@@ -262,82 +293,7 @@ fn wrapper_allows_exact_show_ref_attestation() {
     );
 }
 
-#[cfg(unix)]
-#[test]
-fn wrapper_allows_exact_ls_remote_attestation_with_pinned_upload_pack() {
-    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
-    let temp = tempfile::tempdir().unwrap();
-    let wrapper = temp.path().join("git");
-    write_executable(&wrapper, git_wrapper_script());
-
-    let repo = temp.path().join("repo");
-    init_worktree_repo(&repo);
-    let remote = temp.path().join("remote.git");
-    init_bare_repo(temp.path(), &remote);
-    run_git(
-        &repo,
-        &[
-            "push",
-            remote.to_str().expect("UTF-8 remote path"),
-            "HEAD:refs/heads/main",
-        ],
-    );
-    run_git(
-        &repo,
-        &[
-            "remote",
-            "add",
-            "origin",
-            remote.to_str().expect("UTF-8 remote path"),
-        ],
-    );
-
-    let hostile_upload_pack = temp.path().join("hostile-upload-pack");
-    let hostile_marker = temp.path().join("hostile-upload-pack-ran");
-    write_executable(
-        &hostile_upload_pack,
-        "#!/usr/bin/env bash\nprintf reached > \"$HOSTILE_UPLOAD_PACK_MARKER\"\nexit 99\n",
-    );
-    run_git(
-        &repo,
-        &[
-            "config",
-            "remote.origin.uploadpack",
-            hostile_upload_pack
-                .to_str()
-                .expect("UTF-8 hostile upload-pack path"),
-        ],
-    );
-
-    let output = std::process::Command::new(&wrapper)
-        .args([
-            "ls-remote",
-            "--heads",
-            "origin",
-            "refs/heads/main",
-            "refs/heads/feat/comp-003-closed-operators",
-        ])
-        .current_dir(&repo)
-        .env("CSA_REAL_GIT", "/usr/bin/git")
-        .env("HOSTILE_UPLOAD_PACK_MARKER", &hostile_marker)
-        .output_with_timeout()
-        .unwrap();
-
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        String::from_utf8_lossy(&output.stdout).contains("refs/heads/main"),
-        "{}",
-        String::from_utf8_lossy(&output.stdout)
-    );
-    assert!(
-        !hostile_marker.exists(),
-        "named remote upload-pack override escaped the guard"
-    );
-}
+include!("git_guard_tests_local_grammar_attestation.rs");
 
 #[cfg(unix)]
 #[test]

--- a/crates/csa-hooks/src/git_guard_tests_local_grammar_attestation.rs
+++ b/crates/csa-hooks/src/git_guard_tests_local_grammar_attestation.rs
@@ -1,0 +1,76 @@
+#[cfg(unix)]
+#[test]
+fn wrapper_allows_exact_ls_remote_attestation_with_pinned_upload_pack() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let repo = temp.path().join("repo");
+    init_worktree_repo(&repo);
+    let remote = temp.path().join("remote.git");
+    init_bare_repo(temp.path(), &remote);
+    run_git(
+        &repo,
+        &[
+            "push",
+            remote.to_str().expect("UTF-8 remote path"),
+            "HEAD:refs/heads/main",
+        ],
+    );
+    run_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            remote.to_str().expect("UTF-8 remote path"),
+        ],
+    );
+
+    let hostile_upload_pack = temp.path().join("hostile-upload-pack");
+    let hostile_marker = temp.path().join("hostile-upload-pack-ran");
+    write_executable(
+        &hostile_upload_pack,
+        "#!/usr/bin/env bash\nprintf reached > \"$HOSTILE_UPLOAD_PACK_MARKER\"\nexit 99\n",
+    );
+    run_git(
+        &repo,
+        &[
+            "config",
+            "remote.origin.uploadpack",
+            hostile_upload_pack
+                .to_str()
+                .expect("UTF-8 hostile upload-pack path"),
+        ],
+    );
+
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "ls-remote",
+            "--heads",
+            "origin",
+            "refs/heads/main",
+            "refs/heads/feat/comp-003-closed-operators",
+        ])
+        .current_dir(&repo)
+        .env("CSA_REAL_GIT", "/usr/bin/git")
+        .env("HOSTILE_UPLOAD_PACK_MARKER", &hostile_marker)
+        .output_with_timeout()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("refs/heads/main"),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        !hostile_marker.exists(),
+        "named remote upload-pack override escaped the guard"
+    );
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1148"
-weave = "0.1.1148"
+csa = "0.1.1149"
+weave = "0.1.1149"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

- Allow exact `git var GIT_AUTHOR_IDENT` / `GIT_COMMITTER_IDENT` identity probes.
- Allow the hook-required local `git -C … diff-tree` probe.
- Keep real remote-push denial closed.
- Split `git_guard` source/tests to stay under the monolith token cap.
- Bump workspace/lock versions to `0.1.1149`.

Closes #3069

## Test plan

- [x] Focused GREEN: `wrapper_allows_git_var_identity_preflight`
- [x] Exact-HEAD `just pre-push` on `17cae0ba` (7614 passed, 7 skipped)
- [x] Hook-enabled push reused the quality-gate receipt and passed review-check + version-check
- [x] Tier-4 CSA Codex review PASS/CLEAN: session `01M0TPCJGR8X25SCHA8C9TKGJP`, range `main...HEAD`

## Review receipt

- Session: `01M0TPCJGR8X25SCHA8C9TKGJP`
- HEAD: `17cae0baf304beee3e774e0292c3c9865601bf57`
- Tree: `cef6a3819957659582ec60fff5b5b258578263a3`
- Verdict: PASS / CLEAN, findings = []
