### PR TITLE
fix(csa): keep writable dests writable when extra-readable aliases them (#3101)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1149"
+version = "0.1.1150"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1149"
+version = "0.1.1150"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -206,9 +206,10 @@ impl BwrapCommandBuilder {
     }
 
     fn is_covered_by_writable_path(&self, readable_path: &Path) -> bool {
+        let readable_dest = effective_mount_destination(readable_path);
         self.writable_paths.iter().any(|writable_path| {
-            let writable_path = writable_path.as_path();
-            readable_path == writable_path || readable_path.starts_with(writable_path)
+            let writable_dest = effective_mount_destination(writable_path);
+            readable_dest == writable_dest || readable_dest.starts_with(writable_dest)
         })
     }
 
@@ -293,6 +294,16 @@ pub fn from_isolation_plan(
     }
 
     Some(builder.build())
+}
+
+/// Resolve the destination used for a bind mount. Fresh virtual filesystems
+/// keep their logical paths because their resolved host paths are hidden.
+fn effective_mount_destination(path: &Path) -> PathBuf {
+    if fresh_writable_mount_root(path).is_some() {
+        path.to_path_buf()
+    } else {
+        resolve_for_bind(path)
+    }
 }
 
 /// Resolve a bind source path by following symlinks. bwrap operates in the

--- a/crates/csa-resource/src/bwrap_tests_paths.rs
+++ b/crates/csa-resource/src/bwrap_tests_paths.rs
@@ -237,6 +237,53 @@ fn from_isolation_plan_keeps_tmp_symlink_logical_readable_destination() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn from_isolation_plan_does_not_remount_writable_canonical_child_readonly_through_alias() {
+    use std::os::unix::fs::symlink;
+
+    let base = tempfile::Builder::new()
+        .prefix("bwrap-3101-")
+        .tempdir_in("/var/tmp")
+        .expect("tempdir");
+    let writable_tree = base.path().join("project");
+    let canonical_file = writable_tree.join("file");
+    std::fs::create_dir_all(&writable_tree).expect("create writable tree");
+    std::fs::write(&canonical_file, "{}").expect("write canonical file");
+
+    let alias_root = base.path().join("read-alias");
+    symlink(&writable_tree, &alias_root).expect("create readable alias");
+    let readable_alias = alias_root.join("file");
+
+    let plan = IsolationPlan {
+        resource: ResourceCapability::None,
+        filesystem: FilesystemCapability::Bwrap,
+        writable_paths: vec![writable_tree],
+        readable_paths: vec![readable_alias],
+        env_overrides: HashMap::new(),
+        degraded_reasons: Vec::new(),
+        memory_max_mb: None,
+        memory_swap_max_mb: None,
+        pids_max: None,
+        readonly_project_root: false,
+        project_root: None,
+        soft_limit_percent: None,
+        memory_monitor_interval_seconds: None,
+        user_daemon_ipc: false,
+    };
+    let args = command_args(
+        &from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("bwrap isolation plan"),
+    );
+    let canonical = canonical_file.to_string_lossy();
+
+    assert!(
+        !args.windows(3).any(|window| {
+            window[0] == "--ro-bind" && window[1] == canonical && window[2] == canonical
+        }),
+        "writable canonical child must not be remounted read-only through an alias; args: {args:?}"
+    );
+}
+
 #[test]
 fn test_bwrap_readable_path_binds_resolved_dest_when_logical_parents_missing() {
     // Repro for #3075: on autofs/logical worktrees the logical path's parent

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1149"
-weave = "0.1.1149"
+csa = "0.1.1150"
+weave = "0.1.1150"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
Writable bind destinations stay writable when an extra-readable symlink aliases them. Canonical writable children are no longer remounted `--ro-bind`.

## Test plan
- `just test-f from_isolation_plan_does_not_remount_writable_canonical_child_readonly_through_alias`
- `just pre-push` (7615 passed)
- CSA Tier-4 `main...HEAD` PASS/CLEAN
  - session `01M0TV6PPQQ18795WV9E4T6850`
  - HEAD `7fbba87e81f6d7b6dfa8e29d323389d2e5850506`

Closes #3101
