### PR TITLE
fix(isolation): pin readable-symlink bind source after validation (#3102)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1151"
+version = "0.1.1152"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1151"
+version = "0.1.1152"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
@@ -17,11 +17,11 @@ fn comparable_test_path(path: &Path) -> PathBuf {
         .unwrap_or_else(|_| path.to_path_buf())
 }
 
-fn contains_equivalent_path(paths: &[PathBuf], expected: &Path) -> bool {
+fn contains_equivalent_path<P: AsRef<Path>>(paths: &[P], expected: &Path) -> bool {
     let expected = comparable_test_path(expected);
     paths
         .iter()
-        .any(|path| comparable_test_path(path) == expected)
+        .any(|path| comparable_test_path(path.as_ref()) == expected)
 }
 
 struct CurrentDirGuard {
@@ -605,7 +605,13 @@ enforcement_mode = "off"
     assert!(!plan.user_daemon_ipc);
     assert!(plan.degraded_reasons.is_empty());
     assert!(plan.env_overrides.is_empty());
-    assert_eq!(plan.readable_paths, vec![evidence.canonicalize().unwrap()]);
+    assert_eq!(
+        plan.readable_paths
+            .iter()
+            .map(|path| path.requested().to_path_buf())
+            .collect::<Vec<_>>(),
+        vec![evidence.canonicalize().unwrap()]
+    );
     assert_eq!(
         plan.writable_paths,
         vec![

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests_tail.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests_tail.rs
@@ -436,8 +436,16 @@ enforcement_mode = "best-effort"
         2,
         "expected two readable paths in the isolation plan"
     );
-    assert!(sandbox.isolation_plan.readable_paths.contains(&first));
-    assert!(sandbox.isolation_plan.readable_paths.contains(&second));
+    assert!(sandbox
+        .isolation_plan
+        .readable_paths
+        .iter()
+        .any(|path| path == &first));
+    assert!(sandbox
+        .isolation_plan
+        .readable_paths
+        .iter()
+        .any(|path| path == &second));
 }
 
 #[test]

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -14,7 +14,7 @@ pub struct BwrapCommandBuilder {
     tool_binary: String,
     tool_args: Vec<String>,
     writable_paths: Vec<PathBuf>,
-    readable_paths: Vec<PathBuf>,
+    readable_paths: Vec<crate::isolation_plan::ReadablePath>,
     ro_binds: Vec<(PathBuf, PathBuf)>,
     env_vars: Vec<(String, String)>,
 }
@@ -39,22 +39,29 @@ impl BwrapCommandBuilder {
     }
 
     /// Add a path that the sandboxed process may read (bind-mounted ro).
-    pub fn with_readable_path(&mut self, path: &Path) -> &mut Self {
+    ///
+    /// A [`crate::isolation_plan::ReadablePath`] keeps its validated bind
+    /// source. A bare path is pinned at this call.
+    pub fn with_readable_path(
+        &mut self,
+        path: impl Into<crate::isolation_plan::ReadablePath>,
+    ) -> &mut Self {
+        let path = path.into();
         assert!(
-            path.is_absolute(),
+            path.requested().is_absolute(),
             "readable sandbox path must be absolute: {}",
-            path.display()
+            path.requested().display()
         );
         assert!(
-            path != Path::new("/tmp"),
+            path.requested() != Path::new("/tmp"),
             "readable sandbox path must not be /tmp itself; expose a specific sub-path instead"
         );
         assert!(
-            path.exists(),
+            path.requested().exists() || path.bind_source().exists(),
             "readable sandbox path must exist: {}",
-            path.display()
+            path.requested().display()
         );
-        self.readable_paths.push(path.to_path_buf());
+        self.readable_paths.push(path);
         self
     }
 
@@ -140,10 +147,12 @@ impl BwrapCommandBuilder {
             if self.is_covered_by_writable_path(path) {
                 continue;
             }
-            let resolved = resolve_for_bind(path);
+            // Use the bind source pinned at validation/add time. Re-resolving
+            // here would reopen the #3102 TOCTOU after a symlink replacement.
+            let resolved = path.bind_source();
             let s = resolved.to_string_lossy();
             assert!(
-                path != tmp_prefix,
+                path.requested() != tmp_prefix,
                 "readable sandbox path must not be /tmp itself; expose a specific sub-path instead"
             );
             // Under a fresh virtual filesystem (/tmp) the resolved destination
@@ -151,10 +160,10 @@ impl BwrapCommandBuilder {
             // create its parents explicitly. Elsewhere bind at the resolved
             // destination: creating the logical parent can fail when it is a
             // symlink into an autofs-backed CSA session-state root (#3075).
-            let dest_path = if fresh_writable_mount_root(path).is_some() {
-                path.as_path()
+            let dest_path = if fresh_writable_mount_root(path.requested()).is_some() {
+                path.requested()
             } else {
-                resolved.as_path()
+                resolved
             };
             if let Some(parent) = dest_path.parent()
                 && parent != tmp_prefix
@@ -205,11 +214,18 @@ impl BwrapCommandBuilder {
         cmd
     }
 
-    fn is_covered_by_writable_path(&self, readable_path: &Path) -> bool {
-        let readable_dest = effective_mount_destination(readable_path);
+    fn is_covered_by_writable_path(
+        &self,
+        readable_path: &crate::isolation_plan::ReadablePath,
+    ) -> bool {
+        let readable_dest = if fresh_writable_mount_root(readable_path.requested()).is_some() {
+            readable_path.requested().to_path_buf()
+        } else {
+            readable_path.bind_source().to_path_buf()
+        };
         self.writable_paths.iter().any(|writable_path| {
             let writable_dest = effective_mount_destination(writable_path);
-            readable_dest == writable_dest || readable_dest.starts_with(writable_dest)
+            readable_dest == writable_dest || readable_dest.starts_with(&writable_dest)
         })
     }
 
@@ -283,7 +299,7 @@ pub fn from_isolation_plan(
     }
 
     for path in &plan.readable_paths {
-        builder.with_readable_path(path);
+        builder.with_readable_path(path.clone());
     }
 
     let mut env_overrides = plan.env_overrides.clone();

--- a/crates/csa-resource/src/bwrap_tests_paths.rs
+++ b/crates/csa-resource/src/bwrap_tests_paths.rs
@@ -205,7 +205,13 @@ fn from_isolation_plan_keeps_tmp_symlink_logical_readable_destination() {
         temp.path(),
     )
     .expect("/tmp symlink should be accepted after canonical source validation");
-    assert_eq!(readable_paths, vec![logical_destination.clone()]);
+    assert_eq!(
+        readable_paths
+            .iter()
+            .map(|path| path.requested().to_path_buf())
+            .collect::<Vec<_>>(),
+        vec![logical_destination.clone()]
+    );
 
     let plan = IsolationPlan {
         resource: ResourceCapability::None,
@@ -259,7 +265,7 @@ fn from_isolation_plan_does_not_remount_writable_canonical_child_readonly_throug
         resource: ResourceCapability::None,
         filesystem: FilesystemCapability::Bwrap,
         writable_paths: vec![writable_tree],
-        readable_paths: vec![readable_alias],
+        readable_paths: vec![readable_alias.into()],
         env_overrides: HashMap::new(),
         degraded_reasons: Vec::new(),
         memory_max_mb: None,
@@ -345,5 +351,78 @@ fn test_bwrap_readable_path_binds_resolved_dest_when_logical_parents_missing() {
             && window[1] == logical_str
             && window[2] == logical_str),
         "readable bind must not target the logical dest; args: {args:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn from_isolation_plan_pins_validated_readable_symlink_bind_source() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let validated_target = temp.path().join("validated-target.json");
+    let replaced_target = temp.path().join("replaced-target.json");
+    let readable_symlink = temp.path().join("readable-link.json");
+    std::fs::write(&validated_target, "validated").expect("write validated target");
+    std::fs::write(&replaced_target, "replaced").expect("write replaced target");
+    symlink(&validated_target, &readable_symlink).expect("create readable symlink");
+
+    let readable_paths = crate::isolation_plan::validate_readable_paths(
+        std::slice::from_ref(&readable_symlink),
+        temp.path(),
+    )
+    .expect("readable symlink should validate against its canonical target");
+    assert_eq!(
+        readable_paths
+            .iter()
+            .map(|path| path.requested().to_path_buf())
+            .collect::<Vec<_>>(),
+        vec![readable_symlink.clone()]
+    );
+    assert_eq!(
+        readable_paths[0].bind_source(),
+        validated_target
+            .canonicalize()
+            .expect("canonical validated target")
+            .as_path()
+    );
+
+    std::fs::remove_file(&readable_symlink).expect("remove symlink for replacement");
+    symlink(&replaced_target, &readable_symlink).expect("replace readable symlink");
+
+    let plan = IsolationPlan {
+        resource: ResourceCapability::None,
+        filesystem: FilesystemCapability::Bwrap,
+        writable_paths: Vec::new(),
+        readable_paths,
+        env_overrides: HashMap::new(),
+        degraded_reasons: Vec::new(),
+        memory_max_mb: None,
+        memory_swap_max_mb: None,
+        pids_max: None,
+        readonly_project_root: false,
+        project_root: None,
+        soft_limit_percent: None,
+        memory_monitor_interval_seconds: None,
+        user_daemon_ipc: false,
+    };
+    let args = command_args(
+        &from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("bwrap isolation plan"),
+    );
+    let validated = validated_target.to_string_lossy();
+    let replaced = replaced_target.to_string_lossy();
+    let dest = readable_symlink.to_string_lossy();
+
+    assert!(
+        args.windows(3).any(|window| {
+            window[0] == "--ro-bind" && window[1] == validated && window[2] == dest
+        }),
+        "bind source must stay the validated target after symlink replacement; args: {args:?}"
+    );
+    assert!(
+        !args
+            .windows(3)
+            .any(|window| window[0] == "--ro-bind" && window[1] == replaced),
+        "replaced symlink target must not become the bind source; args: {args:?}"
     );
 }

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -12,12 +12,15 @@ pub const DEFAULT_SANDBOX_TMPDIR: &str = "/tmp";
 mod claude_paths;
 #[path = "isolation_plan_codex.rs"]
 mod codex_paths;
+#[path = "isolation_plan_readable.rs"]
+mod readable;
 #[path = "isolation_plan_runtime_path.rs"]
 mod runtime_path;
 #[path = "isolation_plan_rust_env.rs"]
 mod rust_env;
 #[path = "isolation_plan_validation.rs"]
 mod validation;
+pub use readable::ReadablePath;
 #[cfg(test)]
 use runtime_path::is_xdg_runtime_child_path;
 use runtime_path::{detect_superproject_root, home_dir, is_sensitive_system_path};
@@ -55,7 +58,7 @@ pub struct IsolationPlan {
     /// Paths the sandboxed process is allowed to write to.
     pub writable_paths: Vec<PathBuf>,
     /// Paths the sandboxed process may read via read-only bind mounts.
-    pub readable_paths: Vec<PathBuf>,
+    pub readable_paths: Vec<ReadablePath>,
     /// Extra environment variables injected into the child process.
     pub env_overrides: HashMap<String, String>,
     /// Human-readable reasons when capabilities were downgraded.
@@ -117,7 +120,7 @@ pub struct IsolationPlanBuilder {
     resource: ResourceCapability,
     filesystem: FilesystemCapability,
     writable_paths: Vec<PathBuf>,
-    readable_paths: Vec<PathBuf>,
+    readable_paths: Vec<ReadablePath>,
     env_overrides: HashMap<String, String>,
     degraded_reasons: Vec<String>,
     memory_max_mb: Option<u64>,
@@ -174,8 +177,8 @@ impl IsolationPlanBuilder {
     }
 
     /// Add a single read-only readable path to the plan.
-    pub fn with_readable_path(mut self, path: PathBuf) -> Self {
-        self.readable_paths.push(path);
+    pub fn with_readable_path(mut self, path: impl Into<ReadablePath>) -> Self {
+        self.readable_paths.push(path.into());
         self
     }
 
@@ -505,7 +508,12 @@ impl IsolationPlanBuilder {
             self.writable_paths.extend([common_dir, git_dir]);
         }
 
-        self.add_runtime_daemon_socket_readable_paths();
+        readable::push_runtime_daemon_socket_readable_paths(
+            self.filesystem,
+            self.user_daemon_ipc,
+            &self.writable_paths,
+            &mut self.readable_paths,
+        );
 
         codex_paths::validate_required_writable_dirs(
             self.filesystem,
@@ -531,43 +539,12 @@ impl IsolationPlanBuilder {
         })
     }
 
-    fn add_runtime_daemon_socket_readable_paths(&mut self) {
-        if self.filesystem != FilesystemCapability::Bwrap {
-            return;
-        }
-        // #2404: D-Bus socket exposure is now an explicit named capability,
-        // not an implicit side-effect of having writable runtime children.
-        if !self.user_daemon_ipc {
-            return;
-        }
-        let Some(runtime_root) = runtime_path::xdg_runtime_root() else {
-            return;
-        };
-
-        for socket_path in runtime_path::runtime_daemon_socket_paths(&runtime_root) {
-            if !socket_path.exists() || self.path_already_exposed(&socket_path) {
-                continue;
-            }
-            self.readable_paths.push(socket_path);
-        }
-    }
-
     #[allow(dead_code)]
     fn has_writable_runtime_child(&self, runtime_root: &Path) -> bool {
         self.writable_paths.iter().any(|path| {
             let comparable = runtime_path::canonicalize_or_fallback(path);
             comparable.starts_with(runtime_root) && comparable != runtime_root
         })
-    }
-
-    fn path_already_exposed(&self, path: &Path) -> bool {
-        self.readable_paths
-            .iter()
-            .any(|candidate| path == candidate)
-            || self
-                .writable_paths
-                .iter()
-                .any(|candidate| path.starts_with(candidate))
     }
 }
 

--- a/crates/csa-resource/src/isolation_plan_path_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_path_tests.rs
@@ -87,11 +87,15 @@ fn test_validate_readable_paths_accepts_project_local_relative_path() {
         .expect("create .csa dir");
     std::fs::write(&context_file, "context").expect("write context file");
 
-    let resolved = validate_readable_paths(&[PathBuf::from(".csa/review-context.md")], &project).expect(
+    let resolved = validate_readable_paths(&[PathBuf::from(".csa/review-context.md")], &project)
+        .expect(
         "project-local relative readable path should resolve against project root and be accepted",
     );
     assert_eq!(
-        resolved,
+        resolved
+            .iter()
+            .map(|path| path.requested().to_path_buf())
+            .collect::<Vec<_>>(),
         vec![context_file.canonicalize().expect("canonical context file")],
         "readable paths must be returned resolved to project-root absolute form"
     );
@@ -284,8 +288,12 @@ fn test_user_daemon_ipc_exposes_daemon_sockets_readonly() {
         .build()
         .expect("runtime child scope with user_daemon_ipc should build");
 
-    assert!(plan.readable_paths.contains(&bus_socket));
-    assert!(plan.readable_paths.contains(&systemd_socket));
+    assert!(plan.readable_paths.iter().any(|path| path == &bus_socket));
+    assert!(
+        plan.readable_paths
+            .iter()
+            .any(|path| path == &systemd_socket)
+    );
 }
 
 #[test]
@@ -303,7 +311,7 @@ fn test_daemon_sockets_not_exposed_without_user_daemon_ipc() {
         .build()
         .expect("plan should build without runtime scope");
 
-    assert!(!plan.readable_paths.contains(&bus_socket));
+    assert!(!plan.readable_paths.iter().any(|path| path == &bus_socket));
 }
 
 #[cfg(unix)]

--- a/crates/csa-resource/src/isolation_plan_readable.rs
+++ b/crates/csa-resource/src/isolation_plan_readable.rs
@@ -1,0 +1,125 @@
+use std::path::{Path, PathBuf};
+
+use crate::filesystem_sandbox::FilesystemCapability;
+
+use super::runtime_path;
+
+/// Validated readable bind: requested destination plus the source pinned at
+/// validation time so later symlink replacement cannot change the bind (#3102).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadablePath {
+    requested: PathBuf,
+    bind_source: PathBuf,
+}
+
+impl ReadablePath {
+    /// Requested destination stored for the sandbox mount.
+    pub fn requested(&self) -> &Path {
+        &self.requested
+    }
+
+    /// Bind source pinned when the path was validated or first added.
+    pub fn bind_source(&self) -> &Path {
+        &self.bind_source
+    }
+
+    pub(crate) fn pinned(requested: PathBuf, bind_source: PathBuf) -> Self {
+        Self {
+            requested,
+            bind_source,
+        }
+    }
+}
+
+impl From<PathBuf> for ReadablePath {
+    fn from(requested: PathBuf) -> Self {
+        let bind_source = runtime_path::canonicalize_or_fallback(&requested);
+        Self::pinned(requested, bind_source)
+    }
+}
+
+impl From<&Path> for ReadablePath {
+    fn from(requested: &Path) -> Self {
+        requested.to_path_buf().into()
+    }
+}
+
+impl From<&PathBuf> for ReadablePath {
+    fn from(requested: &PathBuf) -> Self {
+        requested.as_path().into()
+    }
+}
+
+impl AsRef<Path> for ReadablePath {
+    fn as_ref(&self) -> &Path {
+        &self.requested
+    }
+}
+
+impl std::ops::Deref for ReadablePath {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        &self.requested
+    }
+}
+
+impl PartialEq<PathBuf> for ReadablePath {
+    fn eq(&self, other: &PathBuf) -> bool {
+        self.requested == *other
+    }
+}
+
+impl PartialEq<Path> for ReadablePath {
+    fn eq(&self, other: &Path) -> bool {
+        self.requested == other
+    }
+}
+
+impl PartialEq<ReadablePath> for PathBuf {
+    fn eq(&self, other: &ReadablePath) -> bool {
+        *self == other.requested
+    }
+}
+
+impl PartialEq<ReadablePath> for Path {
+    fn eq(&self, other: &ReadablePath) -> bool {
+        self == other.requested
+    }
+}
+
+pub(super) fn push_runtime_daemon_socket_readable_paths(
+    filesystem: FilesystemCapability,
+    user_daemon_ipc: bool,
+    writable_paths: &[PathBuf],
+    readable_paths: &mut Vec<ReadablePath>,
+) {
+    if filesystem != FilesystemCapability::Bwrap || !user_daemon_ipc {
+        return;
+    }
+    let Some(runtime_root) = runtime_path::xdg_runtime_root() else {
+        return;
+    };
+
+    for socket_path in runtime_path::runtime_daemon_socket_paths(&runtime_root) {
+        if !socket_path.exists()
+            || path_already_exposed(readable_paths, writable_paths, &socket_path)
+        {
+            continue;
+        }
+        readable_paths.push(socket_path.into());
+    }
+}
+
+fn path_already_exposed(
+    readable_paths: &[ReadablePath],
+    writable_paths: &[PathBuf],
+    path: &Path,
+) -> bool {
+    readable_paths
+        .iter()
+        .any(|candidate| path == candidate.requested())
+        || writable_paths
+            .iter()
+            .any(|candidate| path.starts_with(candidate))
+}

--- a/crates/csa-resource/src/isolation_plan_validation.rs
+++ b/crates/csa-resource/src/isolation_plan_validation.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 
+use super::readable::ReadablePath;
 use super::runtime_path::{
     canonicalize_or_fallback, home_dir, is_sensitive_system_path, is_xdg_runtime_child_path,
     normalize_path_components, xdg_runtime_root,
@@ -41,13 +42,13 @@ fn resolve_writable_paths_impl(
             canonicalize_for_allowlist: true,
             allow_requested_path_for_allowlist: true,
             allow_outside_default_roots,
-            preserve_requested_path: false,
         },
         &[],
     )
+    .map(|paths| paths.into_iter().map(|path| path.resolved).collect())
 }
 
-/// Validate readable paths and return normalized absolute requested paths.
+/// Validate readable paths and pin each bind source at validation time.
 ///
 /// Read-only binds are stricter than writable paths: every path must exist on
 /// disk, `/tmp` itself is forbidden, and symlinked paths are validated against
@@ -55,9 +56,9 @@ fn resolve_writable_paths_impl(
 /// resolves somewhere outside the allowlist.
 ///
 /// Project-local relative paths are resolved against `project_root` before
-/// validation, so every returned path is absolute. Symlink targets remain
-/// canonicalized for validation, but the requested path is stored in an
-/// `IsolationPlan` so Bwrap preserves logical `/tmp` destinations (#3074).
+/// validation, so every returned destination is absolute. The requested path
+/// remains the mount destination so Bwrap can preserve logical `/tmp` paths
+/// (#3074), while `bind_source` stays the validated target (#3102).
 ///
 /// # Errors
 ///
@@ -67,7 +68,7 @@ fn resolve_writable_paths_impl(
 pub fn validate_readable_paths(
     paths: &[PathBuf],
     project_root: &Path,
-) -> anyhow::Result<Vec<PathBuf>> {
+) -> anyhow::Result<Vec<ReadablePath>> {
     let mirror_roots = default_ssd_mirror_roots();
     validate_readable_paths_with_mirror_roots(paths, project_root, &mirror_roots)
 }
@@ -76,13 +77,16 @@ pub(super) fn validate_readable_paths_with_mirror_roots(
     paths: &[PathBuf],
     project_root: &Path,
     mirror_roots: &[PathBuf],
-) -> anyhow::Result<Vec<PathBuf>> {
-    validate_sandbox_paths(
+) -> anyhow::Result<Vec<ReadablePath>> {
+    Ok(validate_sandbox_paths(
         paths,
         project_root,
         readable_path_validation_options(),
         mirror_roots,
-    )
+    )?
+    .into_iter()
+    .map(|path| ReadablePath::pinned(path.requested, path.resolved))
+    .collect())
 }
 
 fn readable_path_validation_options() -> PathValidationOptions<'static> {
@@ -94,7 +98,6 @@ fn readable_path_validation_options() -> PathValidationOptions<'static> {
         canonicalize_for_allowlist: true,
         allow_requested_path_for_allowlist: false,
         allow_outside_default_roots: false,
-        preserve_requested_path: true,
     }
 }
 
@@ -167,7 +170,6 @@ struct PathValidationOptions<'a> {
     canonicalize_for_allowlist: bool,
     allow_requested_path_for_allowlist: bool,
     allow_outside_default_roots: bool,
-    preserve_requested_path: bool,
 }
 
 fn default_ssd_mirror_roots() -> [PathBuf; 1] {
@@ -179,7 +181,7 @@ fn validate_sandbox_paths(
     project_root: &Path,
     options: PathValidationOptions<'_>,
     mirror_roots: &[PathBuf],
-) -> anyhow::Result<Vec<PathBuf>> {
+) -> anyhow::Result<Vec<ValidatedPath>> {
     let home = home_dir().unwrap_or_else(|| PathBuf::from("/nonexistent"));
     let lexical_allowed_roots = [
         normalize_path_components(project_root.to_path_buf()),
@@ -250,11 +252,7 @@ fn validate_sandbox_paths(
             ));
             continue;
         }
-        resolved_paths.push(if options.preserve_requested_path {
-            validated.requested
-        } else {
-            validated.resolved
-        });
+        resolved_paths.push(validated);
     }
 
     if rejected.is_empty() {

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1151"
-weave = "0.1.1151"
+csa = "0.1.1152"
+weave = "0.1.1152"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Bug Description

Readable symlink validation checked the canonical target, then `IsolationPlan` kept only the requested path and `bwrap` resolved again. A concurrent replacement could change the bind source (TOCTOU).

Closes #3102
Refs #3109

## Root Cause

Validation and bind construction resolved the symlink at different times.

## Fix

- `ReadablePath` now carries a `bind_source` pinned at validation.
- `bwrap` binds that pinned source and does not re-resolve readable paths.
- Class-swept sibling production resolve sites.
- Extracted `isolation_plan_readable.rs` so `isolation_plan.rs` stays under the monolith cap.

## Review / gate evidence

- Exact HEAD: `088eeaa67ffd4a6f3733cf2ee0f0943c8abb43a0`
- Tree: `36c848448e09aaf172a4e597fc032d590d9405e2`
- Range: `main...HEAD`
- Exact-HEAD `just pre-push`: GREEN, 7616 passed
- Native clean-room review: `VERDICT: PASS`
  - report sha256: `ae6e1f1ff66ae8cf40756495ad3dec161a1ed4529ae2a0c17c06964f507642b8`
- CSA review unavailable (`#3109`). Pre-push used documented `CSA_SKIP_REVIEW_CHECK=1` after native PASS. Other hooks stayed enabled.

## Test Plan

- [x] RED/GREEN TOCTOU regression `from_isolation_plan_pins_validated_readable_symlink_bind_source`
- [x] Sibling focused tests: `from_isolation_plan`, `validate_readable_paths`, `test_bwrap_readable`, `extra_readable`
- [x] Exact-HEAD local gate passed (7616)
- [x] Native exact-HEAD review PASS

## Risk Assessment

Low — fail-closed isolation pin only. Writable/`ro_bind` pathname-bind behavior on `main` is unchanged.