### PR TITLE
fix(hooks): allow intentional local artifacts in quality-gate receipts (#3092)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1152"
+version = "0.1.1153"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1152"
+version = "0.1.1153"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/scripts/hooks/quality-gate-contract-tests.sh
+++ b/scripts/hooks/quality-gate-contract-tests.sh
@@ -42,9 +42,10 @@ run_contract_suite() {
 }
 
 run_quality_gate_contract_suites() {
-  # Exact ratchet: 46 core + 8 hostile + 19 isolation + 8 pre-push + 2
-  # dev2merge runtime contracts = 83 independently named PASS cases.
+  # Exact ratchet: 46 core + 1 intentional-local + 8 hostile + 19 isolation + 8
+  # pre-push + 2 dev2merge runtime contracts = 84 independently named PASS cases.
   run_contract_suite scripts/tests/quality-gate-receipt-tests.sh 46
+  run_contract_suite scripts/tests/quality-gate-receipt-intentional-local-tests.sh 1
   run_contract_suite scripts/tests/quality-gate-receipt-hostile-tests.sh 8
   run_contract_suite scripts/tests/quality-gate-isolation-tests.sh 19
   run_contract_suite scripts/tests/pre-push-quality-gates-tests.sh 8

--- a/scripts/quality_gate_host_attestation.py
+++ b/scripts/quality_gate_host_attestation.py
@@ -22,12 +22,21 @@ from pathlib import Path
 
 __all__ = (
     "IsolationError",
+    "classified_untracked_listing",
     "host_clean_state",
     "run_git",
     "safe_git_environment",
 )
 
 GIT = Path("/usr/bin/git")
+# Exact checkout-relative names. Lefthook local overrides and a Hermes TUI
+# session sidecar are operator-owned; they must not block reusable receipts.
+INTENTIONAL_LOCAL_OPERATIONAL_ARTIFACTS = frozenset(
+    (
+        b".lefthook-local.yml",
+        b"hermes-tui-active-session-dllg3s3s.json",
+    )
+)
 
 
 class IsolationError(RuntimeError):
@@ -43,6 +52,19 @@ def safe_git_environment() -> dict[str, str]:
         "LC_ALL": "C",
         "PATH": "/usr/bin:/bin",
     }
+
+
+def classified_untracked_listing(untracked: bytes) -> bytes:
+    """Drop exact intentional local operational artifacts from a NUL listing."""
+
+    kept = [
+        path
+        for path in untracked.split(b"\0")
+        if path and path not in INTENTIONAL_LOCAL_OPERATIONAL_ARTIFACTS
+    ]
+    if not kept:
+        return b""
+    return b"\0".join(kept) + b"\0"
 
 
 def run_git(repo: Path, *arguments: str) -> bytes:
@@ -165,7 +187,9 @@ def host_clean_state(repo: Path) -> tuple[str, str, str, str]:
         tracked_clean = str(
             refreshed.returncode == 0 and compared.returncode == 0
         ).lower()
-    untracked = run_git(repo, "ls-files", "--others", "--exclude-standard", "-z")
+    untracked = classified_untracked_listing(
+        run_git(repo, "ls-files", "--others", "--exclude-standard", "-z")
+    )
     return (
         index_clean,
         tracked_clean,

--- a/scripts/quality_gate_sandbox.py
+++ b/scripts/quality_gate_sandbox.py
@@ -21,6 +21,7 @@ from quality_gate_toolchain import (
 from quality_gate_host_attestation import (
     GIT,
     IsolationError,
+    classified_untracked_listing as _classified_untracked_listing,
     host_clean_state as _host_clean_state,
     run_git as _run_git,
 )
@@ -100,7 +101,9 @@ def _source_fingerprint(
     digest = hashlib.sha256()
     digest.update(_run_git(repo, "rev-parse", "HEAD").strip())
     digest.update(_run_git(repo, "ls-files", "--stage", "-z"))
-    untracked = _run_git(repo, "ls-files", "--others", "--exclude-standard", "-z")
+    untracked = _classified_untracked_listing(
+        _run_git(repo, "ls-files", "--others", "--exclude-standard", "-z")
+    )
     if excluded_prefix is not None:
         prefix = os.fsencode(excluded_prefix)
         untracked = b"\0".join(

--- a/scripts/tests/pre-push-quality-gates-tests.sh
+++ b/scripts/tests/pre-push-quality-gates-tests.sh
@@ -287,6 +287,7 @@ require_source_contract() {
   assert_not_matches source-contract-deny-not-static 'just deny' "$static_source"
   for suite in \
     quality-gate-receipt-tests.sh \
+    quality-gate-receipt-intentional-local-tests.sh \
     quality-gate-receipt-hostile-tests.sh \
     quality-gate-isolation-tests.sh \
     pre-push-quality-gates-tests.sh \

--- a/scripts/tests/quality-gate-receipt-intentional-local-tests.sh
+++ b/scripts/tests/quality-gate-receipt-intentional-local-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+source "$repo_root/scripts/tests/quality-gate-receipt-tests.sh"
+receipt_contract_install_failure_trap quality-gate-receipt-intentional-local-tests.sh
+
+run_intentional_local_artifacts_receipt() {
+  local fixture counter runner output identity second manifest
+  fixture="$(new_fixture)"
+  runner="${fixture}/scripts/hooks/quality-gate-receipt.sh"
+  counter="${fixture}/target/quality-gate-test-state/gate-counter"
+  printf 'local-hooks\n' >"$fixture/.lefthook-local.yml"
+  printf '{}\n' >"$fixture/hermes-tui-active-session-dllg3s3s.json"
+  output="$(cd "$fixture" && "$runner" -- scripts/hooks/fake-quality-gate.sh "$counter")"
+  identity="$(printf '%s' "$output" | json_field receipt_identity)"
+  assert_eq intentional-local-artifacts-status executed \
+    "$(printf '%s' "$output" | json_field status)"
+  assert_eq intentional-local-artifacts-reason receipt_missing \
+    "$(printf '%s' "$output" | json_field rejection_reason)"
+  assert_eq intentional-local-artifacts-gate-runs 1 "$(wc -c <"$counter")"
+  assert_path_exists intentional-local-artifacts-receipt \
+    "$fixture/.csa/state/quality-gate-receipts/${identity}.json"
+  manifest="$(receipt_manifest "$fixture")"
+  assert_contains intentional-local-artifacts-head \
+    "head_oid=$(git -C "$fixture" rev-parse HEAD)" "$manifest"
+  assert_contains intentional-local-artifacts-tree \
+    "tree_oid=$(git -C "$fixture" rev-parse 'HEAD^{tree}')" "$manifest"
+  assert_contains intentional-local-artifacts-empty-untracked \
+    "untracked_worktree_digest=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" \
+    "$manifest"
+  second="$(cd "$fixture" && "$runner" -- scripts/hooks/fake-quality-gate.sh "$counter")"
+  assert_eq intentional-local-artifacts-reuse reused \
+    "$(printf '%s' "$second" | json_field status)"
+  assert_eq intentional-local-artifacts-reuse-runs 1 "$(wc -c <"$counter")"
+  printf 'unrelated\n' >"$fixture/unrelated-untracked"
+  output="$(cd "$fixture" && "$runner" -- scripts/hooks/fake-quality-gate.sh "$counter")"
+  assert_eq intentional-local-unrelated-reason dirty_state \
+    "$(printf '%s' "$output" | json_field rejection_reason)"
+  assert_eq intentional-local-unrelated-runs 2 "$(wc -c <"$counter")"
+  echo "PASS intentional-local-artifacts"
+}
+
+receipt_contract_set_case intentional-local-artifacts
+run_intentional_local_artifacts_receipt

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1152"
-weave = "0.1.1152"
+csa = "0.1.1153"
+weave = "0.1.1153"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Bug Description

A successful canonical `just pre-push` run could not publish a reusable quality-gate receipt when two intentional local operational artifacts remained untracked.

Closes #3092

## Root Cause

Host untracked provenance hashed checkout-root names `.lefthook-local.yml` and `hermes-tui-active-session-dllg3s3s.json` into `untracked_worktree_digest`, so an otherwise clean HEAD was classified `dirty_state`.

## Fix

Shared host-attestation classifier drops only those two exact NUL-record names before digesting. Unrelated untracked files still fail closed. The files are not opened, staged, deleted, or broadly ignored.

## How to Verify

1. Focused: `bash scripts/tests/quality-gate-receipt-intentional-local-tests.sh`
2. Exact-HEAD `just pre-push` at `e73e2f44e7fbf7ac08693d575c5049f0c626387c`: 7616 passed, 7 skipped.
3. Native clean-room review `VERDICT: PASS` (CSA unavailable; see #3109).

## Test Plan

- [x] Added focused receipt contract for intentional local artifacts vs unrelated untracked
- [x] Exact-HEAD local gate GREEN
- [x] Native clean-room exact-HEAD review PASS

## Risk Assessment

Low — classifier is name-exact and fail-closed for all other dirty-state paths.

## Review fallback

CSA final review is unavailable (#3109). Native clean-room report:

`/home/obj/project/github/RyderFreeman4Logos/drafts/cli-sub-agent/issue-3092/native-review-e73e2f44.md`

sha256 `0942bd091d731eae9f330fa59fbdf2589356783e95ef662681759d5beaee60ea`

Push used hook-scoped `CSA_SKIP_REVIEW_CHECK=1` only; `--no-verify` was not used.
