### PR TITLE
fix(hooks): allow read-only git diff-tree in CSA git-guard (#3068)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1153"
+version = "0.1.1154"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1153"
+version = "0.1.1154"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-hooks/src/git_guard.rs
+++ b/crates/csa-hooks/src/git_guard.rs
@@ -390,7 +390,7 @@ is_head_ref() {
 
 is_safe_local_command() {
   case "${1}" in
-    ""|add|am|annotate|apply|bisect|blame|branch|cat-file|check-attr|check-ignore|check-mailmap|check-ref-format|checkout|cherry|cherry-pick|clean|commit|config|count-objects|describe|diff|difftool|fast-export|fast-import|format-patch|fsck|gc|grep|hash-object|log|ls-files|ls-tree|merge|merge-base|merge-file|merge-index|merge-tree|mv|name-rev|notes|pack-objects|prune|read-tree|rebase|reflog|reset|restore|rev-list|rev-parse|rm|show|show-branch|sparse-checkout|stash|status|switch|symbolic-ref|tag|update-index|update-ref|verify-commit|verify-pack|verify-tag|worktree|write-tree)
+    ""|add|am|annotate|apply|bisect|blame|branch|cat-file|check-attr|check-ignore|check-mailmap|check-ref-format|checkout|cherry|cherry-pick|clean|commit|config|count-objects|describe|diff|diff-tree|difftool|fast-export|fast-import|format-patch|fsck|gc|grep|hash-object|log|ls-files|ls-tree|merge|merge-base|merge-file|merge-index|merge-tree|mv|name-rev|notes|pack-objects|prune|read-tree|rebase|reflog|reset|restore|rev-list|rev-parse|rm|show|show-branch|sparse-checkout|stash|status|switch|symbolic-ref|tag|update-index|update-ref|verify-commit|verify-pack|verify-tag|worktree|write-tree)
       return 0
       ;;
     *) return 1 ;;

--- a/crates/csa-hooks/src/git_guard_tests.rs
+++ b/crates/csa-hooks/src/git_guard_tests.rs
@@ -633,6 +633,7 @@ fn wrapper_allows_leading_dash_after_file_option() {
 }
 
 include!("git_guard_tests_local_grammar.rs");
+include!("git_guard_tests_readonly_diff_tree.rs");
 
 #[cfg(unix)]
 #[test]

--- a/crates/csa-hooks/src/git_guard_tests_readonly_diff_tree.rs
+++ b/crates/csa-hooks/src/git_guard_tests_readonly_diff_tree.rs
@@ -1,0 +1,87 @@
+#[cfg(unix)]
+#[test]
+fn wrapper_allows_readonly_git_diff_tree_commit_path_audits() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let fake_git = temp.path().join("real-git");
+    write_executable(
+        &fake_git,
+        "#!/usr/bin/env bash\nif [ \"${1:-}\" = --exec-path ]; then exec /usr/bin/git --exec-path; fi\nprintf '%s\\n' \"$*\"\n",
+    );
+
+    let cases: &[&[&str]] = &[
+        &["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
+        &["diff-tree", "--no-commit-id", "--name-status", "-r", "HEAD"],
+    ];
+
+    for args in cases {
+        let output = std::process::Command::new(&wrapper)
+            .args(*args)
+            .env("CSA_REAL_GIT", &fake_git)
+            .env_remove("CSA_SESSION_DIR")
+            .env_remove("CSA_GIT_PUSH_ALLOWED")
+            .output_with_timeout()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{}: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            args.join(" ")
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn wrapper_still_blocks_network_push_without_git_fixtures() {
+    let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+    let temp = tempfile::tempdir().unwrap();
+    let wrapper = temp.path().join("git");
+    write_executable(&wrapper, git_wrapper_script());
+
+    let marker = temp.path().join("fake-git-reached");
+    let fake_git = temp.path().join("real-git");
+    write_executable(
+        &fake_git,
+        r#"#!/usr/bin/env bash
+if [ "${1:-}" = --exec-path ]; then exec /usr/bin/git --exec-path; fi
+printf reached > "$FAKE_GIT_MARKER"
+printf '%s\n' "$*"
+"#,
+    );
+
+    let output = std::process::Command::new(&wrapper)
+        .args([
+            "push",
+            "https://example.invalid/publication.git",
+            "HEAD:main",
+        ])
+        .env("CSA_REAL_GIT", &fake_git)
+        .env("FAKE_GIT_MARKER", &marker)
+        .env_remove("CSA_SESSION_DIR")
+        .env_remove("CSA_GIT_PUSH_ALLOWED")
+        .output_with_timeout()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(128));
+    assert!(!marker.exists(), "fake Git reached for network push");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("CSA git-guard: blocked command: git"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("hermetic local bare fixture"), "{stderr}");
+    assert!(
+        !stderr.contains("example.invalid"),
+        "destination leaked in {stderr}"
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+}

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1153"
-weave = "0.1.1153"
+csa = "0.1.1154"
+weave = "0.1.1154"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Allow CSA git-guard to execute safe read-only `git diff-tree` commit-path audits.

`git diff-tree --no-commit-id --name-only -r HEAD` (and the `--name-status` sibling) is local plumbing and does not write the index or worktree. It was rejected as an unknown command. This adds `diff-tree` to the existing `is_safe_local_command` list.

Network `git push`, alias overrides, and `git -C` still fail closed. The push block still runs before the unknown-command gate.

Closes #3068.

## Test plan

- Focused GREEN: `wrapper_allows_readonly_git_diff_tree_commit_path_audits`
- Focused GREEN: `wrapper_still_blocks_network_push_without_git_fixtures`
- Exact local gate: `just pre-push` — 7618 passed

## Review

CSA transport is unavailable (#3109). Isolated native children produced no verdict (provider 403). Same-scope shared-host native fallback reviewed frozen HEAD `21fc7d6437b2d16a22e7bf9a5f05e1fc27a911b8` / tree `96a67c1e62694c97af97968f616c34810357f374` and reported `VERDICT: PASS`. This is not a CSA or Tier-4 verdict.

Push used hook-scoped `CSA_SKIP_REVIEW_CHECK=1` only; `--no-verify` was not used.
