### PR TITLE
fix(review): ignore placeholder findings.toml on clean prose (#3114)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1154"
+version = "0.1.1156"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1154"
+version = "0.1.1156"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -15,7 +15,6 @@ pub(super) fn detect_prose_clean_conclusion(text: &str) -> bool {
         "no issues found",
         "no issues were found",
         "no actionable findings",
-        "findings: 0",
         "ship-ready",
         "ship ready",
         "\u{672a}\u{53d1}\u{73b0}\u{9700}\u{8981}\u{963b}\u{585e}\u{5408}\u{5e76}",
@@ -23,6 +22,7 @@ pub(super) fn detect_prose_clean_conclusion(text: &str) -> bool {
     ]
     .iter()
     .any(|phrase| lower.contains(phrase))
+        || contains_bounded_zero_findings(&lower)
         || (lower.contains("no correctness")
             && [
                 "issue", "issues", "problem", "problems", "finding", "findings",
@@ -30,6 +30,20 @@ pub(super) fn detect_prose_clean_conclusion(text: &str) -> bool {
             .iter()
             .any(|noun| lower.contains(noun)))
         || verdict_tokens::verdict_token_pass_or_clean(&current_prose)
+}
+
+fn contains_bounded_zero_findings(lower: &str) -> bool {
+    lower.lines().any(|line| {
+        let Some((_, count)) = line.split_once("findings:") else {
+            return false;
+        };
+        let Some(tail) = count.trim_start().strip_prefix('0') else {
+            return false;
+        };
+        let tail = tail.trim_start().as_bytes();
+        matches!(tail, [] | [b'.' | b'!' | b'?'])
+            || matches!(tail, [b'.' | b'!' | b'?', next, ..] if next.is_ascii_whitespace())
+    })
 }
 
 fn current_reviewer_prose_without_quoted_repro(text: &str) -> String {

--- a/crates/cli-sub-agent/src/review_cmd_output_clean.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_clean.rs
@@ -15,6 +15,7 @@ pub(super) fn detect_prose_clean_conclusion(text: &str) -> bool {
         "no issues found",
         "no issues were found",
         "no actionable findings",
+        "findings: 0",
         "ship-ready",
         "ship ready",
         "\u{672a}\u{53d1}\u{73b0}\u{9700}\u{8981}\u{963b}\u{585e}\u{5408}\u{5e76}",

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -214,22 +214,11 @@ pub(super) fn enforce_final_verdict_consistency(
     let resume_to_fix_blocks_clean_recovery = resume_to_fix
         && !artifact_failure_reason_is_placeholder(artifact.failure_reason.as_deref())
         && !placeholder_findings_only;
-    let empty_fail_placeholder_allows_clean_recovery = artifact
-        .failure_reason
-        .as_deref()
-        .is_some_and(|reason| reason.trim() == EMPTY_FAIL_FINDINGS_ARTIFACT_REASON)
-        || (placeholder_findings_only
-            && findings_file.findings.first().is_some_and(|finding| {
-                finding
-                    .description
-                    .contains(EMPTY_FAIL_FINDINGS_ARTIFACT_REASON)
-            }));
-
     if clean_review_can_recover_to_pass(
         artifact,
         CleanReviewRecoverySignals {
             artifact_counts_clean: severity_counts_are_zero(&artifact.severity_counts)
-                || empty_fail_placeholder_allows_clean_recovery,
+                || placeholder_findings_only,
             has_structured_findings,
             has_prose_failure_evidence: has_hard_prose_failure_evidence,
             resume_to_fix: resume_to_fix_blocks_clean_recovery,

--- a/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_consistency.rs
@@ -214,11 +214,32 @@ pub(super) fn enforce_final_verdict_consistency(
     let resume_to_fix_blocks_clean_recovery = resume_to_fix
         && !artifact_failure_reason_is_placeholder(artifact.failure_reason.as_deref())
         && !placeholder_findings_only;
+    let synthetic_placeholder_count = artifact.severity_counts.get(&Severity::Medium) == Some(&1)
+        && artifact
+            .severity_counts
+            .iter()
+            .all(|(severity, count)| *count == 0 || (*severity == Severity::Medium && *count == 1));
+    let empty_findings_failure_reason = artifact
+        .failure_reason
+        .as_deref()
+        .is_some_and(|reason| reason.trim() == EMPTY_FAIL_FINDINGS_ARTIFACT_REASON);
+    let placeholder_failure_reason = artifact.failure_reason.as_deref().is_some_and(|reason| {
+        matches!(
+            reason.trim(),
+            EMPTY_FAIL_FINDINGS_ARTIFACT_REASON | PROSE_FINDINGS_UNPARSED_REASON
+        )
+    }) || findings_file.findings.first().is_some_and(|finding| {
+        finding
+            .description
+            .contains(EMPTY_FAIL_FINDINGS_ARTIFACT_REASON)
+    });
     if clean_review_can_recover_to_pass(
         artifact,
         CleanReviewRecoverySignals {
             artifact_counts_clean: severity_counts_are_zero(&artifact.severity_counts)
-                || placeholder_findings_only,
+                || (synthetic_placeholder_count
+                    && ((findings_file.findings.is_empty() && empty_findings_failure_reason)
+                        || (placeholder_findings_only && placeholder_failure_reason))),
             has_structured_findings,
             has_prose_failure_evidence: has_hard_prose_failure_evidence,
             resume_to_fix: resume_to_fix_blocks_clean_recovery,

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_clean_3114_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_clean_3114_tests.rs
@@ -33,6 +33,39 @@ fn repairs_prose_unparsed_placeholder_when_review_is_clean() {
 }
 
 #[test]
+fn unresolved_continuation_after_zero_fixed_stays_fail_closed() {
+    let session_id = "01TEST3114UNRESOLVED00000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-3114-zero-fixed-unresolved", session_id);
+    write_fail_meta(&session_dir, session_id);
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nFindings: 0 fixed; one unresolved item remains.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist unresolved review");
+    write_empty_fail_placeholder_artifacts(&session_dir, session_id);
+    let mut verdict = read_output_verdict(&session_dir);
+    verdict.failure_reason = Some("prose_findings_present_but_unparsed".to_string());
+    csa_session::write_review_verdict(&session_dir, &verdict).expect("write prose fail verdict");
+
+    assert!(
+        !super::super::super::consistency::repair_clean_empty_fail_review_verdict(&session_dir)
+            .expect("repair verdict"),
+        "zero fixed must not mean zero unresolved findings"
+    );
+
+    let verdict = read_output_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(
+        verdict.failure_reason.as_deref(),
+        Some("prose_findings_present_but_unparsed")
+    );
+    assert_eq!(read_output_findings(&session_dir).findings.len(), 1);
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
 fn concrete_findings_dominate_prose_clean_summary() {
     let session_id = "01TESTFINDINGSDOMINATE000000";
     let (_env_lock, project_root, session_dir) =

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_clean_3114_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_clean_3114_tests.rs
@@ -1,0 +1,74 @@
+use super::*;
+
+#[test]
+fn repairs_prose_unparsed_placeholder_when_review_is_clean() {
+    let session_id = "01TEST3114PROSECLEAN000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("issue-3114-prose-unparsed-clean", session_id);
+    write_fail_meta(&session_dir, session_id);
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nFindings: 0. Overall risk: Low. The prior HIGH finding is closed; no unresolved findings remain.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist clean review");
+    write_empty_fail_placeholder_artifacts(&session_dir, session_id);
+    let mut verdict = read_output_verdict(&session_dir);
+    verdict.failure_reason = Some("prose_findings_present_but_unparsed".to_string());
+    csa_session::write_review_verdict(&session_dir, &verdict).expect("write prose fail verdict");
+
+    assert!(
+        super::super::super::consistency::repair_clean_empty_fail_review_verdict(&session_dir)
+            .expect("repair verdict"),
+        "placeholder-only findings must not override conclusive clean prose"
+    );
+
+    let verdict = read_output_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Pass);
+    assert_eq!(verdict.verdict_legacy, "CLEAN");
+    assert_eq!(verdict.failure_reason, None);
+    assert!(verdict.severity_counts.values().all(|count| *count == 0));
+    assert!(read_output_findings(&session_dir).findings.is_empty());
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}
+
+#[test]
+fn concrete_findings_dominate_prose_clean_summary() {
+    let session_id = "01TESTFINDINGSDOMINATE000000";
+    let (_env_lock, project_root, session_dir) =
+        lock_test_session("persist-review-verdict-findings-dominate", session_id);
+    let findings = vec![make_finding(Severity::High, "blocking-high")];
+    let artifact = json!({
+        "findings": findings,
+        "severity_summary": SeveritySummary {
+            critical: 0,
+            high: 1,
+            medium: 0,
+            low: 0,
+        },
+        "overall_risk": "low"
+    });
+    fs::write(
+        session_dir.join("review-findings.json"),
+        serde_json::to_vec_pretty(&artifact).expect("serialize findings"),
+    )
+    .expect("write findings artifact");
+    csa_session::persist_structured_output(
+        &session_dir,
+        "<!-- CSA:SECTION:summary -->\nNo blocking issues found.\n<!-- CSA:SECTION:summary:END -->\n",
+    )
+    .expect("persist summary");
+
+    let meta = make_review_meta(session_id);
+    persist_review_verdict(&project_root, &meta, &[], Vec::new());
+
+    let verdict = read_output_verdict(&session_dir);
+    assert_eq!(verdict.decision, ReviewDecision::Fail);
+    assert_eq!(verdict.verdict_legacy, "HAS_ISSUES");
+    assert_eq!(verdict.severity_counts.get(&Severity::High), Some(&1));
+    let findings = read_output_findings(&session_dir);
+    assert_eq!(findings.findings.len(), 1);
+    assert_eq!(findings.findings[0].severity, Severity::High);
+
+    fs::remove_dir_all(project_root).expect("remove temp project root");
+}

--- a/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_prose_clean_tests.rs
@@ -472,47 +472,6 @@ fn persist_review_verdict_uncertain_meta_without_pass_prose_fails_closed() {
 }
 
 #[test]
-fn persist_review_verdict_findings_dominate_prose_clean_summary() {
-    let session_id = "01TESTFINDINGSDOMINATE000000";
-    let (_env_lock, project_root, session_dir) =
-        lock_test_session("persist-review-verdict-findings-dominate", session_id);
-    let findings = vec![make_finding(Severity::High, "blocking-high")];
-    let artifact = json!({
-        "findings": findings,
-        "severity_summary": SeveritySummary {
-            critical: 0,
-            high: 1,
-            medium: 0,
-            low: 0,
-        },
-        "overall_risk": "low"
-    });
-    fs::write(
-        session_dir.join("review-findings.json"),
-        serde_json::to_vec_pretty(&artifact).expect("serialize findings"),
-    )
-    .expect("write findings artifact");
-    csa_session::persist_structured_output(
-        &session_dir,
-        "<!-- CSA:SECTION:summary -->\nNo blocking issues found.\n<!-- CSA:SECTION:summary:END -->\n",
-    )
-    .expect("persist summary");
-
-    let meta = make_review_meta(session_id);
-    persist_review_verdict(&project_root, &meta, &[], Vec::new());
-
-    let verdict_path = session_dir.join("output").join("review-verdict.json");
-    let artifact: ReviewVerdictArtifact =
-        serde_json::from_str(&fs::read_to_string(&verdict_path).expect("read verdict"))
-            .expect("parse verdict");
-    assert_eq!(artifact.decision, ReviewDecision::Fail);
-    assert_eq!(artifact.verdict_legacy, "HAS_ISSUES");
-    assert_eq!(artifact.severity_counts.get(&Severity::High), Some(&1));
-
-    fs::remove_dir_all(project_root).expect("remove temp project root");
-}
-
-#[test]
 fn persist_review_verdict_prose_clean_summary_respects_high_overall_risk_fail_closed() {
     let session_id = "01TESTPROSECLEANRISK0000000";
     let (_env_lock, project_root, session_dir) =
@@ -549,3 +508,6 @@ fn persist_review_verdict_prose_clean_summary_respects_high_overall_risk_fail_cl
 
 #[path = "review_cmd_output_prose_clean_2425_tests.rs"]
 mod issue_2425;
+
+#[path = "review_cmd_output_prose_clean_3114_tests.rs"]
+mod issue_3114;

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1154"
-weave = "0.1.1154"
+csa = "0.1.1156"
+weave = "0.1.1156"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Bug Description

Clean reviewer prose plus a placeholder-only `artifact-generation-001` findings.toml was classified as `prose_findings_present_but_unparsed` FAIL. That blocked otherwise-clean reviews.

Closes #3114

## Root Cause

Placeholder-only artifact-generation failures were treated as structured findings. A later recovery also matched `findings: 0` as an arbitrary substring, so text like `Findings: 0 fixed; one unresolved item remains.` could recover to PASS.

## Fix

- Ignore a sole placeholder `artifact-generation-001` row when reviewer prose is clean.
- Recover that exact synthetic one-medium placeholder shape only.
- Bound zero-findings grammar so `0` must end the line or be followed by sentence punctuation.
- Keep concrete unresolved findings and #2425 blocking-count wait summaries fail-closed.
- Keep the #2425 repaired-empty-findings observability refresh on the success path.

## How to Verify

1. `just test-f issue_3114`
2. Negative: unresolved continuation after `Findings: 0 fixed` stays FAIL.
3. Existing #2425 refresh and blocking-count wait-summary regressions.
4. Exact-HEAD `just pre-push` at `edc1f9bed18679911393327151246cc8787f930a` (`GATE_EXIT=0`).

## Test Plan

- [x] Added/updated #3114 regressions, including the bounded zero-findings negative case
- [x] Existing #2425 tests still pass
- [x] Exact-HEAD local gate green at the frozen SHA

## Review / publication

CSA Codex review was unavailable: host-memory admission refused before provider launch. This is a **native fallback review PASS**, not a CSA or Tier-4 verdict.

- HEAD: `edc1f9bed18679911393327151246cc8787f930a`
- tree: `0f8d5ab0443606236399d2029526d524ad642667`
- range: `main...HEAD`
- native report: `/home/obj/project/github/RyderFreeman4Logos/drafts/cli-sub-agent/issue-3114/native-review-edc1f9be.md`
- report sha256: `1bc835a28250bd8909b72657a4100de63efb9f70861303b864af4a7733091ee0`
- exact-gate log: `/home/obj/project/github/RyderFreeman4Logos/drafts/cli-sub-agent/issue-3114/exact-gate-edc1f9be-20260825T170120Z.log`
- gate log sha256: `9d6ca400406be684c25acd6bd6037b203e81ca2a9da5bbe7696f1aaee0ea215f`

Pre-push uses the documented `CSA_SKIP_REVIEW_CHECK=1` review-check-only bypass. Other hooks remain enabled. `--no-verify` was not used.

Unrelated exact-HEAD suite flakes under load are tracked in #3115 and do not block this leaf.

## Risk Assessment

Medium — review recovery is fail-closed by design. The risk is a false PASS on unresolved prose; the bounded grammar and negative fixture are the guard.
