### PR TITLE
fix(pr-bot): skip redundant push for existing reviewed PR

### DIFF
--- a/patterns/pr-bot/PATTERN.md
+++ b/patterns/pr-bot/PATTERN.md
@@ -252,15 +252,7 @@ if [ -z "${PR_TITLE}" ]; then
   PR_TITLE="$(derive_default_pr_title)"
   echo "INFO: PR_TITLE unset; using derived title: ${PR_TITLE}" >&2
 fi
-# --- Early-push detection: warn if branch was already pushed before review ---
-if git ls-remote --heads "${REMOTE_NAME}" "${WORKFLOW_BRANCH}" 2>/dev/null | grep -q .; then
-  echo "WARNING: Branch '${WORKFLOW_BRANCH}' was already pushed to remote before this skill ran."
-  echo "Unreviewed code may have been visible to CI/reviewers. Continuing with force-push of reviewed code."
-fi
-
-CSA_SKIP_REVIEW_CHECK=1 \
-CSA_SKIP_REVIEW_CHECK_REASON="pr-bot initial branch push for CI/review" \
-  git push --force-with-lease -u "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+REVIEWED_SHA="$(git rev-parse HEAD)"
 ORIGIN_URL="$(git remote get-url --push "${REMOTE_NAME}")"
 SOURCE_OWNER="$(
   printf '%s\n' "${ORIGIN_URL}" | sed -nE \
@@ -271,12 +263,34 @@ SOURCE_OWNER="$(
 if [ -z "${SOURCE_OWNER}" ]; then
   SOURCE_OWNER="$(gh repo view "${REPO_SLUG}" --json owner -q '.owner.login')"
 fi
+EXISTING_PR_SHA="$(
+  gh pr view "${WORKFLOW_BRANCH}" \
+    --repo "${REPO_SLUG}" \
+    --json baseRefName,headRefName,headRepositoryOwner,headRefOid 2>/dev/null \
+  | jq -r \
+      --arg base "${DEFAULT_BRANCH}" --arg branch "${WORKFLOW_BRANCH}" --arg owner "${SOURCE_OWNER}" \
+      'select(.baseRefName == $base and .headRefName == $branch and .headRepositoryOwner.login == $owner) | .headRefOid // empty' \
+    2>/dev/null || true
+ )"
+if [ "${EXISTING_PR_SHA}" = "${REVIEWED_SHA}" ]; then
+  echo "Using existing PR at reviewed SHA ${REVIEWED_SHA}; skipping redundant push."
+else
+  # --- Early-push detection: warn if branch was already pushed before review ---
+  if git ls-remote --heads "${REMOTE_NAME}" "${WORKFLOW_BRANCH}" 2>/dev/null | grep -q .; then
+    echo "WARNING: Branch '${WORKFLOW_BRANCH}' was already pushed to remote before this skill ran."
+    echo "Unreviewed code may have been visible to CI/reviewers. Continuing with force-push of reviewed code."
+  fi
+
+  CSA_SKIP_REVIEW_CHECK=1 \
+  CSA_SKIP_REVIEW_CHECK_REASON="pr-bot initial branch push for CI/review" \
+    git push --force-with-lease -u "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+fi
 resolve_branch_pr_record() {
   local lookup status pr_num pr_state pr_merged_at
   lookup="$(
     gh pr view "${WORKFLOW_BRANCH}" \
       --repo "${REPO_SLUG}" \
-      --json number,baseRefName,headRefName,headRepositoryOwner,state,mergedAt \
+      --json number,baseRefName,headRefName,headRepositoryOwner,state,mergedAt,headRefOid \
       2>/dev/null \
     | jq -r \
         --arg base "${DEFAULT_BRANCH}" \
@@ -302,7 +316,7 @@ resolve_branch_pr_record() {
       --base "${DEFAULT_BRANCH}" \
       --state all \
       --head "${WORKFLOW_BRANCH}" \
-      --json number,baseRefName,headRefName,headRepositoryOwner,state,mergedAt \
+      --json number,baseRefName,headRefName,headRepositoryOwner,state,mergedAt,headRefOid \
       2>/dev/null \
     | jq -r \
         --arg base "${DEFAULT_BRANCH}" \

--- a/patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
+++ b/patterns/pr-bot/scripts/tests/_stubs/gh-stub.sh
@@ -52,7 +52,7 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "list" ]; then
     echo "unexpected --state: ${state_arg}" >&2
     exit 1
   fi
-  if [ "${json_arg}" != "number,baseRefName,headRefName,headRepositoryOwner,state,mergedAt" ]; then
+  if [ "${json_arg}" != "number,baseRefName,headRefName,headRepositoryOwner,state,mergedAt,headRefOid" ]; then
     echo "unexpected --json: ${json_arg}" >&2
     exit 1
   fi
@@ -117,7 +117,7 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "view" ]; then
     echo "unexpected pr view branch: ${branch_arg}" >&2
     exit 1
   fi
-  if [ "${json_arg}" != "number,baseRefName,headRefName,headRepositoryOwner,state,mergedAt" ]; then
+  if [ "${json_arg}" != "number,baseRefName,headRefName,headRepositoryOwner,state,mergedAt,headRefOid" ] && [ "${json_arg}" != "baseRefName,headRefName,headRepositoryOwner,headRefOid" ]; then
     echo "unexpected pr view --json: ${json_arg}" >&2
     exit 1
   fi
@@ -125,23 +125,23 @@ if [ "${1:-}" = "pr" ] && [ "${2:-}" = "view" ]; then
   view_call="$(count_call pr-view)"
   case "${scenario}" in
     preexisting)
-      printf '{"number":202,"baseRefName":"main","headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"},"state":"OPEN","mergedAt":null}\n'
+      printf '{"number":202,"baseRefName":"main","headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"},"state":"OPEN","mergedAt":null,"headRefOid":"reviewed-sha"}\n'
       ;;
     merged)
-      printf '{"number":909,"baseRefName":"main","headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"},"state":"MERGED","mergedAt":"2026-05-22T21:19:08Z"}\n'
+      printf '{"number":909,"baseRefName":"main","headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"},"state":"MERGED","mergedAt":"2026-05-22T21:19:08Z","headRefOid":"old-sha"}\n'
       ;;
     closed)
-      printf '{"number":410,"baseRefName":"main","headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"},"state":"CLOSED","mergedAt":null}\n'
+      printf '{"number":410,"baseRefName":"main","headRefName":"fix/1171","headRepositoryOwner":{"login":"test-owner"},"state":"CLOSED","mergedAt":null,"headRefOid":"old-sha"}\n'
       ;;
     create-success)
       if [ -f "${state_dir}/pr-create-count" ] && [ "${view_call}" -ge 2 ]; then
-        printf '{"number":101,"baseRefName":"main","headRefName":"%s","headRepositoryOwner":{"login":"test-owner"},"state":"OPEN","mergedAt":null}\n' "${expected_list_head}"
+        printf '{"number":101,"baseRefName":"main","headRefName":"%s","headRepositoryOwner":{"login":"test-owner"},"state":"OPEN","mergedAt":null,"headRefOid":"reviewed-sha"}\n' "${expected_list_head}"
       else
         exit 1
       fi
       ;;
     quoted-branch)
-      printf '{"number":707,"baseRefName":"main","headRefName":"feat/has\\"quote","headRepositoryOwner":{"login":"test-owner"},"state":"OPEN","mergedAt":null}\n'
+      printf '{"number":707,"baseRefName":"main","headRefName":"feat/has\\"quote","headRepositoryOwner":{"login":"test-owner"},"state":"OPEN","mergedAt":null,"headRefOid":"old-sha"}\n'
       ;;
     *)
       exit 1

--- a/patterns/pr-bot/scripts/tests/_stubs/git-stub.sh
+++ b/patterns/pr-bot/scripts/tests/_stubs/git-stub.sh
@@ -23,6 +23,11 @@ if [ "${1:-}" = "push" ]; then
   exit 0
 fi
 
+if [ "${1:-}" = "rev-parse" ] && [ "${2:-}" = "HEAD" ]; then
+  printf '%s\n' "${GIT_STUB_HEAD_SHA-reviewed-sha}"
+  exit 0
+fi
+
 if [ "${1:-}" = "log" ] && [ "${2:-}" = "-1" ] && [ "${3:-}" = "--pretty=%s" ]; then
   printf '%s\n' "${GIT_STUB_HEAD_SUBJECT-Fix 1171}"
   exit 0

--- a/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
+++ b/patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
@@ -52,6 +52,7 @@ run_case() {
   local pr_title_mode="${12:-set}"
   local git_head_subject="${13-Fix 1171}"
   local pr_body_mode="${14:-set}"
+  local expected_pushes="${15:-1}"
   local case_dir="${TMP_ROOT}/${case_name}"
   local bin_dir="${case_dir}/bin"
   local stdout_file="${case_dir}/stdout.txt"
@@ -70,6 +71,7 @@ run_case() {
     export GIT_STUB_STATE_DIR="${case_dir}"
     export GIT_STUB_BRANCH_PUSHED="${branch_pushed}"
     export GIT_STUB_SOURCE_OWNER="test-owner"
+    export GIT_STUB_HEAD_SHA="reviewed-sha"
     export GIT_STUB_HEAD_SUBJECT="${git_head_subject}"
     export GH_STUB_STATE_DIR="${case_dir}"
     export GH_STUB_SCENARIO="${scenario}"
@@ -106,7 +108,7 @@ run_case() {
     exit 1
   fi
 
-  assert_file_value "${case_dir}/push-count" "1"
+  assert_file_value "${case_dir}/push-count" "${expected_pushes}"
   assert_file_value "${case_dir}/pr-create-count" "${expected_creates}"
 
   if [ "${expected_rc}" = "0" ]; then
@@ -122,7 +124,7 @@ run_case() {
 
 run_case "branch-unpushed-create" "false" "create-success" "0" "101" "1"
 run_case "branch-pushed-create" "true" "create-success" "0" "101" "1"
-run_case "lookup-hits-reuse" "true" "preexisting" "0" "202" "0"
+run_case "lookup-hits-reuse" "true" "preexisting" "0" "202" "0" "" "fix/1171" "fix/1171" "test-owner:fix/1171" "Fix 1171" "set" "Fix 1171" "set" "0"
 run_case "lookup-hits-merged-noop" "true" "merged" "0" "909" "0"
 run_case "cross-owner-create" "true" "cross-owner" "0" "101" "1"
 run_case "unset-title-derives-head" "true" "create-success" "0" "101" "1" "PR_TITLE unset; using derived title: fix(pr-bot): derive title" "fix/1171" "fix/1171" "test-owner:fix/1171" "fix(pr-bot): derive title" "unset" "fix(pr-bot): derive title"

--- a/patterns/pr-bot/workflow.toml
+++ b/patterns/pr-bot/workflow.toml
@@ -740,15 +740,7 @@ if [ -z "${PR_TITLE}" ]; then
   PR_TITLE="$(derive_default_pr_title)"
   echo "INFO: PR_TITLE unset; using derived title: ${PR_TITLE}" >&2
 fi
-# --- Early-push detection: warn if branch was already pushed before review ---
-if git ls-remote --heads "${REMOTE_NAME}" "${WORKFLOW_BRANCH}" 2>/dev/null | grep -q .; then
-  echo "WARNING: Branch '${WORKFLOW_BRANCH}' was already pushed to remote before this skill ran."
-  echo "Unreviewed code may have been visible to CI/reviewers. Continuing with force-push of reviewed code."
-fi
-
-CSA_SKIP_REVIEW_CHECK=1 \
-CSA_SKIP_REVIEW_CHECK_REASON="pr-bot initial branch push for CI/review" \
-  git push --force-with-lease -u "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+REVIEWED_SHA="$(git rev-parse HEAD)"
 ORIGIN_URL="$(git remote get-url --push "${REMOTE_NAME}")"
 SOURCE_OWNER="$(
   printf '%s\n' "${ORIGIN_URL}" | sed -nE \
@@ -759,12 +751,34 @@ SOURCE_OWNER="$(
 if [ -z "${SOURCE_OWNER}" ]; then
   SOURCE_OWNER="$(gh repo view "${REPO_SLUG}" --json owner -q '.owner.login')"
 fi
+EXISTING_PR_SHA="$(
+  gh pr view "${WORKFLOW_BRANCH}" \
+    --repo "${REPO_SLUG}" \
+    --json baseRefName,headRefName,headRepositoryOwner,headRefOid 2>/dev/null \
+  | jq -r \
+      --arg base "${DEFAULT_BRANCH}" --arg branch "${WORKFLOW_BRANCH}" --arg owner "${SOURCE_OWNER}" \
+      'select(.baseRefName == $base and .headRefName == $branch and .headRepositoryOwner.login == $owner) | .headRefOid // empty' \
+    2>/dev/null || true
+ )"
+if [ "${EXISTING_PR_SHA}" = "${REVIEWED_SHA}" ]; then
+  echo "Using existing PR at reviewed SHA ${REVIEWED_SHA}; skipping redundant push."
+else
+  # --- Early-push detection: warn if branch was already pushed before review ---
+  if git ls-remote --heads "${REMOTE_NAME}" "${WORKFLOW_BRANCH}" 2>/dev/null | grep -q .; then
+    echo "WARNING: Branch '${WORKFLOW_BRANCH}' was already pushed to remote before this skill ran."
+    echo "Unreviewed code may have been visible to CI/reviewers. Continuing with force-push of reviewed code."
+  fi
+
+  CSA_SKIP_REVIEW_CHECK=1 \
+  CSA_SKIP_REVIEW_CHECK_REASON="pr-bot initial branch push for CI/review" \
+    git push --force-with-lease -u "${REMOTE_NAME}" "${WORKFLOW_BRANCH}"
+fi
 resolve_branch_pr_record() {
   local lookup status pr_num pr_state pr_merged_at
   lookup="$(
     gh pr view "${WORKFLOW_BRANCH}" \
       --repo "${REPO_SLUG}" \
-      --json number,baseRefName,headRefName,headRepositoryOwner,state,mergedAt \
+      --json number,baseRefName,headRefName,headRepositoryOwner,state,mergedAt,headRefOid \
       2>/dev/null \
     | jq -r \
         --arg base "${DEFAULT_BRANCH}" \
@@ -790,7 +804,7 @@ resolve_branch_pr_record() {
       --base "${DEFAULT_BRANCH}" \
       --state all \
       --head "${WORKFLOW_BRANCH}" \
-      --json number,baseRefName,headRefName,headRepositoryOwner,state,mergedAt \
+      --json number,baseRefName,headRefName,headRepositoryOwner,state,mergedAt,headRefOid \
       2>/dev/null \
     | jq -r \
         --arg base "${DEFAULT_BRANCH}" \


### PR DESCRIPTION
Fix pr-bot Step 5 when the parent already pushed the reviewed SHA and opened the PR.

Changes:
- Check the owner-aware existing PR headRefOid before the initial push.
- Skip the push only when it exactly matches the reviewed HEAD.
- Cover the reviewed-SHA reuse path in the shell tests and keep PATTERN.md synchronized with workflow.toml.

Test plan:
- patterns/pr-bot/scripts/tests/ensure-pr-step5-tests.sh
- All patterns/pr-bot/scripts/tests/*.sh

Closes #3123