### PR TITLE
fix(csa-acp): bound timeout test waits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1157"
+version = "0.1.1158"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1157"
+version = "0.1.1158"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-acp/src/connection_initial_response_tests.rs
+++ b/crates/csa-acp/src/connection_initial_response_tests.rs
@@ -164,6 +164,15 @@ impl Drop for TestConnectionGuard {
     }
 }
 
+async fn wait_for_test_future<F, T>(label: &str, timeout: Duration, future: F) -> Result<T, String>
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::time::timeout(timeout, future)
+        .await
+        .map_err(|_| format!("{label} timed out after {timeout:?}"))
+}
+
 #[cfg(target_os = "linux")]
 struct CpuBoundChildFixture {
     _temp_dir: tempfile::TempDir,
@@ -200,10 +209,14 @@ impl CpuBoundChildFixture {
             .expect("release CPU-bound child into its load loop");
 
         let mut started = [0];
-        tokio::time::timeout(Duration::from_secs(5), control.read_exact(&mut started))
-            .await
-            .expect("CPU-bound child did not begin its load loop")
-            .expect("read CPU-bound child load-loop acknowledgement");
+        wait_for_test_future(
+            "CPU-bound child load-loop acknowledgement",
+            Duration::from_secs(5),
+            control.read_exact(&mut started),
+        )
+        .await
+        .expect("CPU-bound child did not begin its load loop")
+        .expect("read CPU-bound child load-loop acknowledgement");
         assert_eq!(started, [1], "unexpected CPU-bound child load-loop acknowledgement");
     }
 }
@@ -234,11 +247,15 @@ with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as control:
 
 #[cfg(target_os = "linux")]
 async fn wait_for_cpu_fixture_connection(listener: &UnixListener) -> UnixStream {
-    tokio::time::timeout(Duration::from_secs(5), listener.accept())
-        .await
-        .expect("CPU-bound child did not reach its control handshake")
-        .expect("accept CPU-bound child control connection")
-        .0
+    wait_for_test_future(
+        "CPU-bound child control handshake",
+        Duration::from_secs(5),
+        listener.accept(),
+    )
+    .await
+    .expect("CPU-bound child did not reach its control handshake")
+    .expect("accept CPU-bound child control connection")
+    .0
 }
 
 fn append_test_stderr_tail(stderr_buf: &mut String, chunk: &str) {
@@ -369,6 +386,19 @@ async fn build_test_connection(
             ..AcpConnectionOptions::default()
         },
     }))
+}
+
+#[tokio::test]
+async fn bounded_test_wait_returns_success_before_deadline() {
+    assert_eq!(wait_for_test_future("successful fixture", Duration::ZERO, async { 7 }).await.unwrap(), 7);
+}
+
+#[tokio::test]
+async fn bounded_test_wait_reports_context_on_timeout() {
+    let error = wait_for_test_future("stalled fixture", Duration::ZERO, std::future::pending::<()>())
+        .await
+        .unwrap_err();
+    assert_eq!(error, "stalled fixture timed out after 0ns");
 }
 
 #[test]
@@ -605,16 +635,20 @@ async fn idle_timeout_still_fires_for_alive_child_with_no_cpu_progress() {
         .await
         .expect("new session");
 
-    let result = connection
-        .prompt_with_io(
+    let result = wait_for_test_future(
+        "idle-timeout ACP prompt",
+        Duration::from_secs(10),
+        connection.prompt_with_io(
             &session_id,
             "ping",
             Duration::from_millis(150),
             None,
             PromptIoOptions::default(),
-        )
-        .await
-        .expect("prompt returns timeout result");
+        ),
+    )
+    .await
+    .expect("idle-timeout ACP prompt must finish")
+    .expect("prompt returns timeout result");
 
     assert!(result.timed_out, "sleeping child must remain killable");
     assert_eq!(result.exit_reason.as_deref(), Some("idle_timeout"));
@@ -636,16 +670,20 @@ async fn initial_response_timeout_fires_when_only_protocol_notifications() {
         .await
         .expect("new session");
 
-    let result = connection
-        .prompt_with_io(
+    let result = wait_for_test_future(
+        "initial-response protocol-only ACP prompt",
+        Duration::from_secs(10),
+        connection.prompt_with_io(
             &session_id,
             "ping",
             Duration::from_secs(5),
             Some(Duration::from_millis(150)),
             PromptIoOptions::default(),
-        )
-        .await
-        .expect("prompt result");
+        ),
+    )
+    .await
+    .expect("initial-response protocol-only ACP prompt must finish")
+    .expect("prompt result");
 
     assert!(result.timed_out, "protocol-only chatter must trip the watchdog");
     assert_eq!(

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1157"
-weave = "0.1.1157"
+csa = "0.1.1158"
+weave = "0.1.1158"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
Bound ACP timeout tests so they fail closed instead of hanging the suite.

## Why
Exact-head gates on unrelated branches failed in `csa-acp` timeout tests under aggregate load. Focused selectors passed. This isolates the ACP timeout pair only.

## Changes
- Bound wait in ACP initial-response and idle-timeout tests
- Version/lockfile sync

## Test plan
- `just quality-gates` on `51dad838`: 7642 passed, 7 skipped
- CSA review `01M0YF271DTTRPBR4S4740HF6Q`: PASS (`main...HEAD`)

Addresses #3115 (ACP timeout pair only; git-guard and descendant-reap remain open).
