### PR TITLE
fix(review): fail-closed review --context admission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1158"
+version = "0.1.1159"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1158"
+version = "0.1.1159"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -527,9 +527,11 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
             memory_cmd::handle_memory_command(command).await?;
         }
         Commands::Review(args) => {
-            if !args.daemon_child && args.session_id.is_none() {
-                review_cmd::preflight::validate_before_session(&args, &startup_env)?;
-            }
+            let admitted_context = if !args.daemon_child && args.session_id.is_none() {
+                review_cmd::preflight::validate_before_session(&args, &startup_env)?
+            } else {
+                None
+            };
             let wait_hint_provider =
                 daemon_caller_hints::explicit_wait_provider_from_launch_routing(
                     args.model_spec.as_deref(),
@@ -541,7 +543,7 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
                     args.prompt_file.as_deref(),
                 )
             } else {
-                run_cmd_daemon::DaemonSpawnOptions::default()
+                run_cmd_daemon::DaemonSpawnOptions::for_review(admitted_context)
             }
             .with_wait_hint_provider(wait_hint_provider);
             let mut daemon_guard = run_cmd_daemon::check_daemon_flags(

--- a/crates/cli-sub-agent/src/main.rs
+++ b/crates/cli-sub-agent/src/main.rs
@@ -543,7 +543,7 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
                     args.prompt_file.as_deref(),
                 )
             } else {
-                run_cmd_daemon::DaemonSpawnOptions::for_review(admitted_context)
+                run_cmd_daemon::DaemonSpawnOptions::for_review(admitted_context.clone())
             }
             .with_wait_hint_provider(wait_hint_provider);
             let mut daemon_guard = run_cmd_daemon::check_daemon_flags(
@@ -555,7 +555,13 @@ async fn run(wait_caller_identity: session_cmds::WaitCallerIdentity) -> Result<(
                 &mut startup_env,
                 review_daemon_options,
             )?;
-            let result = review_cmd::handle_review(args, current_depth, &startup_env).await;
+            let result = review_cmd::handle_review_with_admitted_context(
+                args,
+                current_depth,
+                &startup_env,
+                admitted_context,
+            )
+            .await;
             let exit_code = report_daemon_error_or_exit_code(result, &mut daemon_guard);
             crate::pipeline::prompt_guard::emit_sa_mode_caller_guard(
                 sa_mode_active,

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -132,7 +132,9 @@ pub(crate) use execute::compute_diff_fingerprint as compute_review_diff_fingerpr
 
 #[path = "review_cmd_handle.rs"]
 mod handle;
+#[cfg(test)]
 pub(crate) use handle::handle_review;
+pub(crate) use handle::handle_review_with_admitted_context;
 
 #[cfg(test)]
 #[path = "review_cmd_tests_barrel.rs"]

--- a/crates/cli-sub-agent/src/review_cmd.rs
+++ b/crates/cli-sub-agent/src/review_cmd.rs
@@ -7,9 +7,9 @@ use crate::review_consensus::CLEAN;
 use crate::review_consensus::{consensus_strategy_label, parse_consensus_strategy};
 #[cfg(test)]
 use crate::review_context::discover_review_context_for_branch;
+use crate::review_context::resolve_review_context_for_args;
 #[cfg(test)]
-use crate::review_context::{ResolvedReviewContext, ResolvedReviewContextKind};
-use crate::review_context::{resolve_review_context, validate_review_prompt_file};
+use crate::review_context::{ResolvedReviewContextKind, resolve_review_context};
 #[cfg(test)]
 use crate::review_routing::ReviewRoutingMetadata;
 use crate::startup_env::StartupSubtreeEnv;

--- a/crates/cli-sub-agent/src/review_cmd_handle.rs
+++ b/crates/cli-sub-agent/src/review_cmd_handle.rs
@@ -4,6 +4,7 @@ async fn handle_review_inner(
     mut args: ReviewArgs,
     current_depth: u32,
     startup_env: &StartupSubtreeEnv,
+    admitted_context: Option<crate::review_context::ResolvedReviewContext>,
 ) -> Result<i32> {
     let project_root = crate::pipeline::determine_project_root(args.cd.as_deref())?;
     if args.check_verdict {
@@ -111,7 +112,12 @@ async fn handle_review_inner(
         args.effective_security_mode_for(review_mode)
     };
     let auto_discover_context = review_scope_allows_auto_discovery(&args);
-    let context = resolve_review_context_for_args(&args, &project_root, auto_discover_context)?;
+    let context = resolve_review_context_for_args(
+        &args,
+        &project_root,
+        auto_discover_context,
+        admitted_context,
+    )?;
 
     debug!(
         scope = %scope,
@@ -604,4 +610,6 @@ async fn handle_review_inner(
 
 #[path = "review_cmd_handle_outer.rs"]
 mod outer;
+#[cfg(test)]
 pub(crate) use outer::handle_review;
+pub(crate) use outer::handle_review_with_admitted_context;

--- a/crates/cli-sub-agent/src/review_cmd_handle.rs
+++ b/crates/cli-sub-agent/src/review_cmd_handle.rs
@@ -16,7 +16,7 @@ async fn handle_review_inner(
     if args.converge && !args.discovery_only && !args.execute_completion {
         return review_convergence::emit_report_only(args.range.as_deref());
     }
-    validate_review_prompt_file(args.prompt_file.as_deref())?;
+
     if let Some(commit) = args.commit.as_deref() {
         super::resolve::validate_single_parent_commit_scope(&project_root, commit)?;
     }
@@ -111,13 +111,7 @@ async fn handle_review_inner(
         args.effective_security_mode_for(review_mode)
     };
     let auto_discover_context = review_scope_allows_auto_discovery(&args);
-    let prompt_file_path = args.prompt_file.as_ref().map(|p| p.display().to_string());
-    let explicit_context = args
-        .spec
-        .as_deref()
-        .or(args.context.as_deref())
-        .or(prompt_file_path.as_deref());
-    let context = resolve_review_context(explicit_context, &project_root, auto_discover_context)?;
+    let context = resolve_review_context_for_args(&args, &project_root, auto_discover_context)?;
 
     debug!(
         scope = %scope,

--- a/crates/cli-sub-agent/src/review_cmd_handle_outer.rs
+++ b/crates/cli-sub-agent/src/review_cmd_handle_outer.rs
@@ -1,13 +1,23 @@
 use super::*;
 
+#[cfg(test)]
 pub(crate) async fn handle_review(
     args: ReviewArgs,
     current_depth: u32,
     startup_env: &StartupSubtreeEnv,
 ) -> Result<i32> {
+    handle_review_with_admitted_context(args, current_depth, startup_env, None).await
+}
+
+pub(crate) async fn handle_review_with_admitted_context(
+    args: ReviewArgs,
+    current_depth: u32,
+    startup_env: &StartupSubtreeEnv,
+    admitted_context: Option<crate::review_context::ResolvedReviewContext>,
+) -> Result<i32> {
     let convergence = args.converge;
     let execute_completion = args.execute_completion;
-    match handle_review_inner(args, current_depth, startup_env).await {
+    match handle_review_inner(args, current_depth, startup_env, admitted_context).await {
         Ok(exit_code) => Ok(exit_code),
         Err(error) if convergence && execute_completion => {
             review_convergence::emit_completion_setup_block("execution_setup_failure", &error)

--- a/crates/cli-sub-agent/src/review_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_preflight.rs
@@ -33,6 +33,8 @@ fn validate_before_session_with_argv(
         return validate_fix_finding_resources_before_session(args, argv);
     }
     super::validate_review_prompt_file(args.prompt_file.as_deref())?;
+    let project_root = crate::pipeline::determine_project_root(args.cd.as_deref())?;
+    crate::review_context::resolve_review_context(args.context.as_deref(), &project_root, false)?;
     validate_review_routing_before_session(args, startup_env, argv)
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_preflight.rs
@@ -32,9 +32,8 @@ fn validate_before_session_with_argv(
     if args.fix_finding {
         return validate_fix_finding_resources_before_session(args, argv);
     }
-    super::validate_review_prompt_file(args.prompt_file.as_deref())?;
     let project_root = crate::pipeline::determine_project_root(args.cd.as_deref())?;
-    crate::review_context::resolve_review_context(args.context.as_deref(), &project_root, false)?;
+    crate::review_context::resolve_review_context_for_args(args, &project_root, false)?;
     validate_review_routing_before_session(args, startup_env, argv)
 }
 

--- a/crates/cli-sub-agent/src/review_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_preflight.rs
@@ -36,7 +36,7 @@ fn validate_before_session_with_argv(
     }
     let project_root = crate::pipeline::determine_project_root(args.cd.as_deref())?;
     let context =
-        crate::review_context::resolve_review_context_for_args(args, &project_root, false)?;
+        crate::review_context::resolve_review_context_for_args(args, &project_root, false, None)?;
     validate_review_routing_before_session(args, startup_env, argv)?;
     Ok(context)
 }

--- a/crates/cli-sub-agent/src/review_cmd_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_preflight.rs
@@ -4,6 +4,7 @@ use csa_core::types::ToolName;
 use csa_resource::{ResourceGuard, ResourceLimits};
 
 use crate::cli::ReviewArgs;
+use crate::review_context::ResolvedReviewContext;
 use crate::run_resource_overrides::RunResourceOverrides;
 use crate::startup_env::StartupSubtreeEnv;
 
@@ -13,7 +14,7 @@ const REVIEWER_SUB_SESSION_TASK_TYPE: &str = "reviewer_sub_session";
 pub(crate) fn validate_before_session(
     args: &ReviewArgs,
     startup_env: &StartupSubtreeEnv,
-) -> Result<()> {
+) -> Result<Option<ResolvedReviewContext>> {
     let argv: Vec<String> = std::env::args().collect();
     validate_before_session_with_argv(args, startup_env, &argv)
 }
@@ -22,19 +23,22 @@ fn validate_before_session_with_argv(
     args: &ReviewArgs,
     startup_env: &StartupSubtreeEnv,
     argv: &[String],
-) -> Result<()> {
+) -> Result<Option<ResolvedReviewContext>> {
     if args.check_verdict {
-        return Ok(());
+        return Ok(None);
     }
 
     super::session_fix::validate_session_fix_before_daemon(args)?;
     super::fix_finding::validate_fix_finding_before_daemon(args)?;
     if args.fix_finding {
-        return validate_fix_finding_resources_before_session(args, argv);
+        validate_fix_finding_resources_before_session(args, argv)?;
+        return Ok(None);
     }
     let project_root = crate::pipeline::determine_project_root(args.cd.as_deref())?;
-    crate::review_context::resolve_review_context_for_args(args, &project_root, false)?;
-    validate_review_routing_before_session(args, startup_env, argv)
+    let context =
+        crate::review_context::resolve_review_context_for_args(args, &project_root, false)?;
+    validate_review_routing_before_session(args, startup_env, argv)?;
+    Ok(context)
 }
 
 fn validate_fix_finding_resources_before_session(args: &ReviewArgs, argv: &[String]) -> Result<()> {

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -395,15 +395,25 @@ fn build_review_instruction_without_design_anchor(
         "\nUNAVAILABLE means infrastructure/tool failure (for example quota/auth/network), not low confidence; use UNCERTAIN for insufficient context. Legacy aliases accepted: CLEAN → PASS, HAS_ISSUES → FAIL.",
     );
     if let Some(ctx) = context {
-        instruction.push_str(&format!(" context_digest={}", ctx.digest));
+        instruction.push_str(&format!(
+            " context_digest={} context_kind={}",
+            ctx.digest,
+            ctx.kind.tag()
+        ));
         instruction.push_str("\n<review-context-snapshot>\n");
         instruction.push_str(ctx.snapshot());
         instruction.push_str("\n</review-context-snapshot>");
-        if let ResolvedReviewContextKind::SpecToml { spec } = &ctx.kind {
-            instruction.push_str(
-                "\nSpec alignment context (parsed from spec.toml; use this criteria set directly):\n",
-            );
-            instruction.push_str(&render_spec_review_context(spec));
+        match &ctx.kind {
+            ResolvedReviewContextKind::TodoMarkdown => instruction.push_str(
+                "\nTODO/plan alignment (trusted inline Markdown context; the original path is intentionally omitted):\nCheck task completion, design drift, scope creep, and risk coverage against the snapshot above.",
+            ),
+            ResolvedReviewContextKind::SpecToml { spec } => {
+                instruction.push_str(
+                    "\nSpec alignment context (parsed from spec.toml; use this criteria set directly):\n",
+                );
+                instruction.push_str(&render_spec_review_context(spec));
+            }
+            ResolvedReviewContextKind::Passthrough => {}
         }
     }
     if let (Some(project_root), Some(pattern)) = (project_root, pattern) {

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -395,7 +395,10 @@ fn build_review_instruction_without_design_anchor(
         "\nUNAVAILABLE means infrastructure/tool failure (for example quota/auth/network), not low confidence; use UNCERTAIN for insufficient context. Legacy aliases accepted: CLEAN → PASS, HAS_ISSUES → FAIL.",
     );
     if let Some(ctx) = context {
-        instruction.push_str(&format!(" context={}", ctx.path));
+        instruction.push_str(&format!(
+            " context={} context_digest={}",
+            ctx.path, ctx.digest
+        ));
         if let ResolvedReviewContextKind::SpecToml { spec } = &ctx.kind {
             instruction.push_str(
                 "\nSpec alignment context (parsed from spec.toml; use this criteria set directly):\n",

--- a/crates/cli-sub-agent/src/review_cmd_resolve.rs
+++ b/crates/cli-sub-agent/src/review_cmd_resolve.rs
@@ -395,10 +395,10 @@ fn build_review_instruction_without_design_anchor(
         "\nUNAVAILABLE means infrastructure/tool failure (for example quota/auth/network), not low confidence; use UNCERTAIN for insufficient context. Legacy aliases accepted: CLEAN → PASS, HAS_ISSUES → FAIL.",
     );
     if let Some(ctx) = context {
-        instruction.push_str(&format!(
-            " context={} context_digest={}",
-            ctx.path, ctx.digest
-        ));
+        instruction.push_str(&format!(" context_digest={}", ctx.digest));
+        instruction.push_str("\n<review-context-snapshot>\n");
+        instruction.push_str(ctx.snapshot());
+        instruction.push_str("\n</review-context-snapshot>");
         if let ResolvedReviewContextKind::SpecToml { spec } = &ctx.kind {
             instruction.push_str(
                 "\nSpec alignment context (parsed from spec.toml; use this criteria set directly):\n",

--- a/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
@@ -117,6 +117,32 @@ fn review_invalid_tier_is_rejected_before_session_creation() {
 }
 
 #[test]
+fn review_context_outside_workspace_is_rejected_before_session_creation() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let outside_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    write_project_config(project_dir.path(), &project_config_with_quality_tier());
+    let context_path = outside_dir.path().join("context.md");
+    std::fs::write(&context_path, "mandatory context").unwrap();
+    let args = parse_review_args(
+        project_dir.path(),
+        &["--context", context_path.to_str().unwrap()],
+    );
+
+    let error = super::validate_before_session(&args, &StartupSubtreeEnv::default())
+        .expect_err("outside review context must fail before provider launch");
+
+    assert!(format!("{error:#}").contains("outside the project workspace"));
+    assert!(
+        csa_session::list_sessions(project_dir.path(), None)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
 fn review_host_memory_admission_is_rejected_before_session_creation() {
     let project_dir = tempfile::tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);

--- a/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
@@ -143,6 +143,31 @@ fn review_context_outside_workspace_is_rejected_before_session_creation() {
 }
 
 #[test]
+fn oversized_review_context_is_rejected_before_session_creation() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    write_project_config(project_dir.path(), &project_config_with_quality_tier());
+    let context_path = project_dir.path().join("context.md");
+    std::fs::write(&context_path, vec![b'x'; 10 * 1024 * 1024 + 1]).unwrap();
+    let args = parse_review_args(
+        project_dir.path(),
+        &["--context", context_path.to_str().unwrap()],
+    );
+
+    let error = super::validate_before_session(&args, &StartupSubtreeEnv::default())
+        .expect_err("oversized review context must fail before provider launch");
+
+    assert!(format!("{error:#}").contains("exceeds the 10485760 byte limit"));
+    assert!(
+        csa_session::list_sessions(project_dir.path(), None)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
 fn review_spec_outside_workspace_is_rejected_before_session_creation() {
     let project_dir = tempfile::tempdir().unwrap();
     let outside_dir = tempfile::tempdir().unwrap();

--- a/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
@@ -221,6 +221,43 @@ fn review_prompt_file_outside_workspace_is_rejected_before_session_creation() {
 }
 
 #[test]
+fn foreground_no_daemon_review_uses_admitted_context_after_source_replacement() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let context_path = project_dir.path().join("context.md");
+    std::fs::write(&context_path, "admitted foreground context").unwrap();
+    let args = parse_review_args(
+        project_dir.path(),
+        &["--no-daemon", "--context", context_path.to_str().unwrap()],
+    );
+    let admitted = crate::review_context::resolve_review_context_for_args(
+        &args,
+        project_dir.path(),
+        false,
+        None,
+    )
+    .unwrap();
+
+    std::fs::write(&context_path, "replacement foreground context").unwrap();
+    let context = crate::review_context::resolve_review_context_for_args(
+        &args,
+        project_dir.path(),
+        false,
+        admitted,
+    )
+    .unwrap();
+    let prompt = super::super::build_review_instruction(
+        "uncommitted",
+        "review-only",
+        "auto",
+        crate::cli::ReviewMode::Standard,
+        context.as_ref(),
+    );
+
+    assert!(prompt.contains("admitted foreground context"));
+    assert!(!prompt.contains("replacement foreground context"));
+}
+
+#[test]
 fn review_spec_precedence_ignores_outside_context_before_session_creation() {
     let project_dir = tempfile::tempdir().unwrap();
     let outside_dir = tempfile::tempdir().unwrap();

--- a/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_preflight.rs
@@ -143,6 +143,98 @@ fn review_context_outside_workspace_is_rejected_before_session_creation() {
 }
 
 #[test]
+fn review_spec_outside_workspace_is_rejected_before_session_creation() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let outside_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    write_project_config(project_dir.path(), &project_config_with_quality_tier());
+    let spec_path = outside_dir.path().join("context.toml");
+    std::fs::write(
+        &spec_path,
+        "plan_ulid = \"01JTESTPLAN0000000000000000\"\nsummary = \"x\"\n",
+    )
+    .unwrap();
+    let args = parse_review_args(project_dir.path(), &["--spec", spec_path.to_str().unwrap()]);
+
+    let error = super::validate_before_session(&args, &StartupSubtreeEnv::default())
+        .expect_err("outside review spec must fail before provider launch");
+
+    assert!(format!("{error:#}").contains("outside the project workspace"));
+    assert!(
+        csa_session::list_sessions(project_dir.path(), None)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn review_prompt_file_outside_workspace_is_rejected_before_session_creation() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let outside_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    write_project_config(project_dir.path(), &project_config_with_quality_tier());
+    let prompt_path = outside_dir.path().join("context.md");
+    std::fs::write(&prompt_path, "mandatory context").unwrap();
+    let args = parse_review_args(
+        project_dir.path(),
+        &["--prompt-file", prompt_path.to_str().unwrap()],
+    );
+
+    let error = super::validate_before_session(&args, &StartupSubtreeEnv::default())
+        .expect_err("outside review prompt file must fail before provider launch");
+
+    assert!(format!("{error:#}").contains("outside the project workspace"));
+    assert!(
+        csa_session::list_sessions(project_dir.path(), None)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn review_spec_precedence_ignores_outside_context_before_session_creation() {
+    let project_dir = tempfile::tempdir().unwrap();
+    let outside_dir = tempfile::tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);
+    let _config_home =
+        ScopedEnvVarRestore::set("XDG_CONFIG_HOME", project_dir.path().join("xdg-config"));
+    write_project_config(project_dir.path(), &project_config_with_quality_tier());
+    let spec_path = project_dir.path().join("context.toml");
+    std::fs::write(
+        &spec_path,
+        "plan_ulid = \"01JTESTPLAN0000000000000000\"\nsummary = \"x\"\n",
+    )
+    .unwrap();
+    let outside_context = outside_dir.path().join("context.md");
+    std::fs::write(&outside_context, "ignored context").unwrap();
+    let args = parse_review_args(
+        project_dir.path(),
+        &[
+            "--spec",
+            spec_path.to_str().unwrap(),
+            "--context",
+            outside_context.to_str().unwrap(),
+            "--tier",
+            "missing-tier",
+        ],
+    );
+
+    let error = super::validate_before_session(&args, &StartupSubtreeEnv::default())
+        .expect_err("preflight must continue past an ignored outside context");
+
+    assert!(format!("{error:#}").contains("Tier selector 'missing-tier' not found"));
+    assert!(
+        csa_session::list_sessions(project_dir.path(), None)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
 fn review_host_memory_admission_is_rejected_before_session_creation() {
     let project_dir = tempfile::tempdir().unwrap();
     let _sandbox = ScopedSessionSandbox::new_blocking(&project_dir);

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -350,6 +350,8 @@ fn test_build_review_instruction_with_context() {
     );
     assert!(result.contains("scope=range:main...HEAD"));
     assert!(result.contains("context_digest=sha256:"));
+    assert!(result.contains("context_kind=todo-markdown"));
+    assert!(result.contains("TODO/plan alignment"));
     assert!(result.contains("context snapshot"));
     assert!(!result.contains(&path.display().to_string()));
 }
@@ -373,6 +375,8 @@ fn test_build_review_instruction_uses_context_snapshot_not_path() {
     );
 
     assert!(result.contains("snapshot context"));
+    assert!(result.contains("context_kind=todo-markdown"));
+    assert!(result.contains("TODO/plan alignment"));
     assert!(!result.contains("replacement context"));
     assert!(!result.contains(&path.display().to_string()));
 }

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -335,11 +335,12 @@ fn test_build_review_instruction_basic() {
 
 #[test]
 fn test_build_review_instruction_with_context() {
-    let context = ResolvedReviewContext {
-        path: "/path/to/TODO.md".to_string(),
-        digest: "sha256:1234".to_string(),
-        kind: ResolvedReviewContextKind::TodoMarkdown,
-    };
+    let project = tempdir().unwrap();
+    let path = project.path().join("TODO.md");
+    std::fs::write(&path, "context snapshot").unwrap();
+    let context = resolve_review_context(Some(path.to_str().unwrap()), project.path(), false)
+        .unwrap()
+        .unwrap();
     let result = build_review_instruction(
         "range:main...HEAD",
         "review-only",
@@ -348,7 +349,32 @@ fn test_build_review_instruction_with_context() {
         Some(&context),
     );
     assert!(result.contains("scope=range:main...HEAD"));
-    assert!(result.contains("context=/path/to/TODO.md"));
+    assert!(result.contains("context_digest=sha256:"));
+    assert!(result.contains("context snapshot"));
+    assert!(!result.contains(&path.display().to_string()));
+}
+
+#[test]
+fn test_build_review_instruction_uses_context_snapshot_not_path() {
+    let project = tempdir().unwrap();
+    let path = project.path().join("TODO.md");
+    std::fs::write(&path, "snapshot context").unwrap();
+    let context = resolve_review_context(Some(path.to_str().unwrap()), project.path(), false)
+        .unwrap()
+        .unwrap();
+    std::fs::write(&path, "replacement context").unwrap();
+
+    let result = build_review_instruction(
+        "range:main...HEAD",
+        "review-only",
+        "on",
+        ReviewMode::Standard,
+        Some(&context),
+    );
+
+    assert!(result.contains("snapshot context"));
+    assert!(!result.contains("replacement context"));
+    assert!(!result.contains(&path.display().to_string()));
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail.rs
@@ -337,6 +337,7 @@ fn test_build_review_instruction_basic() {
 fn test_build_review_instruction_with_context() {
     let context = ResolvedReviewContext {
         path: "/path/to/TODO.md".to_string(),
+        digest: "sha256:1234".to_string(),
         kind: ResolvedReviewContextKind::TodoMarkdown,
     };
     let result = build_review_instruction(

--- a/crates/cli-sub-agent/src/review_cmd_tests_tail_part2.rs
+++ b/crates/cli-sub-agent/src/review_cmd_tests_tail_part2.rs
@@ -28,11 +28,14 @@ fn resolve_review_context_parses_spec_toml() {
 
 #[test]
 fn resolve_review_context_keeps_markdown_path_behavior() {
-    let context = resolve_review_context(Some("/tmp/TODO.md"), std::path::Path::new("/tmp"), false)
+    let project = tempdir().unwrap();
+    let path = project.path().join("TODO.md");
+    std::fs::write(&path, "context").unwrap();
+    let context = resolve_review_context(Some(path.to_str().unwrap()), project.path(), false)
         .unwrap()
         .unwrap();
 
-    assert_eq!(context.path, "/tmp/TODO.md");
+    assert_eq!(context.path, path.display().to_string());
     assert!(matches!(
         context.kind,
         ResolvedReviewContextKind::TodoMarkdown

--- a/crates/cli-sub-agent/src/review_context.rs
+++ b/crates/cli-sub-agent/src/review_context.rs
@@ -16,6 +16,7 @@ use tracing::warn;
 use crate::review_session_findings::read_session_findings_or_fall_back;
 
 const REVIEW_CONTEXT_MAX_BYTES: usize = 10 * 1024 * 1024;
+pub(crate) const DAEMON_REVIEW_CONTEXT_DIGEST_ENV_KEY: &str = "CSA_DAEMON_REVIEW_CONTEXT_DIGEST";
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) enum ResolvedReviewContextKind {

--- a/crates/cli-sub-agent/src/review_context.rs
+++ b/crates/cli-sub-agent/src/review_context.rs
@@ -1,8 +1,11 @@
-use std::path::Path;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use csa_session::{Finding, ReviewSessionMeta, Severity};
 use csa_todo::{CriterionKind, CriterionStatus, SpecDocument, TodoManager};
+use sha2::{Digest, Sha256};
 use tracing::warn;
 
 use crate::review_session_findings::read_session_findings_or_fall_back;
@@ -17,6 +20,7 @@ pub(crate) enum ResolvedReviewContextKind {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ResolvedReviewContext {
     pub(crate) path: String,
+    pub(crate) digest: String,
     pub(crate) kind: ResolvedReviewContextKind,
 }
 
@@ -26,7 +30,7 @@ pub(crate) fn resolve_review_context(
     allow_auto_discovery: bool,
 ) -> Result<Option<ResolvedReviewContext>> {
     match requested_context {
-        Some(path) => Ok(Some(resolve_explicit_review_context(path)?)),
+        Some(path) => Ok(Some(resolve_explicit_review_context(path, project_root)?)),
         None if allow_auto_discovery => Ok(auto_discover_review_context(project_root)),
         None => Ok(None),
     }
@@ -42,25 +46,59 @@ pub(crate) fn validate_review_prompt_file(path: Option<&Path>) -> Result<()> {
     Ok(())
 }
 
-fn resolve_explicit_review_context(path: &str) -> Result<ResolvedReviewContext> {
-    let path_ref = Path::new(path);
+fn resolve_explicit_review_context(
+    path: &str,
+    project_root: &Path,
+) -> Result<ResolvedReviewContext> {
+    let (path_ref, digest) = admit_review_context(Path::new(path), project_root)?;
 
-    match csa_core::spec_validate::validate_spec(path_ref) {
-        Ok(spec_path) => return load_spec_review_context(&spec_path),
+    match csa_core::spec_validate::validate_spec(&path_ref) {
+        Ok(spec_path) => return load_spec_review_context(&spec_path, digest),
         Err(csa_core::spec_validate::SpecValidationError::InvalidExtension { .. }) => {}
         Err(error) => return Err(error.into()),
     }
 
-    let kind = if has_extension(path_ref, "md") {
+    let kind = if has_extension(&path_ref, "md") {
         ResolvedReviewContextKind::TodoMarkdown
     } else {
         ResolvedReviewContextKind::Passthrough
     };
 
     Ok(ResolvedReviewContext {
-        path: path.to_string(),
+        path: path_ref.display().to_string(),
+        digest,
         kind,
     })
+}
+
+fn admit_review_context(path: &Path, project_root: &Path) -> Result<(PathBuf, String)> {
+    let project_root = project_root
+        .canonicalize()
+        .context("--context: failed to resolve project root")?;
+    let requested = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        project_root.join(path)
+    };
+    let metadata = std::fs::symlink_metadata(&requested)
+        .with_context(|| format!("--context: failed to inspect '{}'", path.display()))?;
+    if !metadata.file_type().is_file() {
+        anyhow::bail!(
+            "--context: '{}' must be a regular, non-symlink file",
+            path.display()
+        );
+    }
+    let resolved = requested
+        .canonicalize()
+        .with_context(|| format!("--context: failed to resolve '{}'", path.display()))?;
+    if !resolved.starts_with(&project_root) {
+        anyhow::bail!(
+            "--context: '{}' is outside the project workspace; copy it into the project and retry",
+            path.display()
+        );
+    }
+
+    Ok((resolved.clone(), digest_review_context_file(&resolved)?))
 }
 
 fn auto_discover_review_context(project_root: &Path) -> Option<ResolvedReviewContext> {
@@ -99,10 +137,10 @@ pub(crate) fn discover_review_context_for_branch(
         return Ok(None);
     }
 
-    load_spec_review_context(&spec_path).map(Some)
+    load_spec_review_context(&spec_path, digest_review_context_file(&spec_path)?).map(Some)
 }
 
-fn load_spec_review_context(path: &Path) -> Result<ResolvedReviewContext> {
+fn load_spec_review_context(path: &Path, digest: String) -> Result<ResolvedReviewContext> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read spec context: {}", path.display()))?;
     let spec: SpecDocument = toml::from_str(&content)
@@ -110,8 +148,26 @@ fn load_spec_review_context(path: &Path) -> Result<ResolvedReviewContext> {
 
     Ok(ResolvedReviewContext {
         path: path.display().to_string(),
+        digest,
         kind: ResolvedReviewContextKind::SpecToml { spec },
     })
+}
+
+fn digest_review_context_file(path: &Path) -> Result<String> {
+    let mut file = File::open(path)
+        .with_context(|| format!("--context: failed to read '{}'", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let count = file
+            .read(&mut buffer)
+            .with_context(|| format!("--context: failed to read '{}'", path.display()))?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(format!("sha256:{:x}", hasher.finalize()))
 }
 
 fn current_git_branch(project_root: &Path) -> Option<String> {

--- a/crates/cli-sub-agent/src/review_context.rs
+++ b/crates/cli-sub-agent/src/review_context.rs
@@ -15,6 +15,8 @@ use tracing::warn;
 
 use crate::review_session_findings::read_session_findings_or_fall_back;
 
+const REVIEW_CONTEXT_MAX_BYTES: usize = 10 * 1024 * 1024;
+
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) enum ResolvedReviewContextKind {
     TodoMarkdown,
@@ -39,6 +41,9 @@ pub(crate) struct ResolvedReviewContext {
     pub(crate) kind: ResolvedReviewContextKind,
     snapshot: String,
 }
+
+#[path = "review_context_daemon_snapshot.rs"]
+mod daemon_snapshot;
 
 impl fmt::Debug for ResolvedReviewContext {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -79,6 +84,12 @@ pub(crate) fn resolve_review_context_for_args(
     project_root: &Path,
     allow_auto_discovery: bool,
 ) -> Result<Option<ResolvedReviewContext>> {
+    if let (true, Some(session_id)) = (args.daemon_child, args.session_id.as_deref()) {
+        let session_dir = csa_session::get_session_dir(project_root, session_id)?;
+        if let Some(context) = ResolvedReviewContext::load_daemon_snapshot(&session_dir)? {
+            return Ok(Some(context));
+        }
+    }
     let explicit = args
         .spec
         .as_deref()
@@ -148,7 +159,10 @@ fn admit_review_context(
     } else {
         path.to_path_buf()
     };
-    let components: Vec<_> = relative.components().collect();
+    let components: Vec<_> = relative
+        .components()
+        .filter(|component| !matches!(component, Component::CurDir))
+        .collect();
     if components.is_empty()
         || components
             .iter()
@@ -196,7 +210,7 @@ fn read_beneath_root_snapshot(
         Some(Component::Normal(name)) => name,
         _ => anyhow::bail!("{label}: context path must name a file beneath the project workspace"),
     };
-    let mut file = openat_file(
+    let file = openat_file(
         directory.as_raw_fd(),
         name,
         libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
@@ -214,8 +228,14 @@ fn read_beneath_root_snapshot(
         );
     }
     let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes)
+    file.take(REVIEW_CONTEXT_MAX_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
         .with_context(|| format!("{label}: failed to read '{}'", resolved.display()))?;
+    anyhow::ensure!(
+        bytes.len() <= REVIEW_CONTEXT_MAX_BYTES,
+        "{label}: '{}' exceeds the {REVIEW_CONTEXT_MAX_BYTES} byte limit",
+        resolved.display()
+    );
     String::from_utf8(bytes)
         .with_context(|| format!("{label}: '{}' must be valid UTF-8", resolved.display()))
 }
@@ -578,6 +598,9 @@ fn criterion_status_label(status: CriterionStatus) -> &'static str {
     }
 }
 
+#[cfg(test)]
+#[path = "review_context_admission_tests.rs"]
+mod admission_tests;
 #[cfg(test)]
 #[path = "review_context_tests.rs"]
 mod tests;

--- a/crates/cli-sub-agent/src/review_context.rs
+++ b/crates/cli-sub-agent/src/review_context.rs
@@ -1,6 +1,11 @@
-use std::fs::File;
+use std::ffi::CString;
+use std::fmt;
+use std::fs::{File, OpenOptions};
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, Result};
 use csa_session::{Finding, ReviewSessionMeta, Severity};
@@ -10,56 +15,109 @@ use tracing::warn;
 
 use crate::review_session_findings::read_session_findings_or_fall_back;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) enum ResolvedReviewContextKind {
     TodoMarkdown,
     Passthrough,
     SpecToml { spec: SpecDocument },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+impl fmt::Debug for ResolvedReviewContextKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::TodoMarkdown => "TodoMarkdown",
+            Self::Passthrough => "Passthrough",
+            Self::SpecToml { .. } => "SpecToml",
+        })
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct ResolvedReviewContext {
     pub(crate) path: String,
     pub(crate) digest: String,
     pub(crate) kind: ResolvedReviewContextKind,
+    snapshot: String,
 }
 
+impl fmt::Debug for ResolvedReviewContext {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ResolvedReviewContext")
+            .field("path", &self.path)
+            .field("digest", &self.digest)
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ResolvedReviewContext {
+    pub(crate) fn snapshot(&self) -> &str {
+        &self.snapshot
+    }
+}
+
+#[cfg(test)]
 pub(crate) fn resolve_review_context(
     requested_context: Option<&str>,
     project_root: &Path,
     allow_auto_discovery: bool,
 ) -> Result<Option<ResolvedReviewContext>> {
     match requested_context {
-        Some(path) => Ok(Some(resolve_explicit_review_context(path, project_root)?)),
+        Some(path) => Ok(Some(resolve_explicit_review_context(
+            Path::new(path),
+            project_root,
+            "--context",
+        )?)),
         None if allow_auto_discovery => Ok(auto_discover_review_context(project_root)),
         None => Ok(None),
     }
 }
 
-pub(crate) fn validate_review_prompt_file(path: Option<&Path>) -> Result<()> {
-    let Some(path) = path else {
-        return Ok(());
-    };
-
-    std::fs::read_to_string(path)
-        .with_context(|| format!("--prompt-file: failed to read '{}'", path.display()))?;
-    Ok(())
+pub(crate) fn resolve_review_context_for_args(
+    args: &crate::cli::ReviewArgs,
+    project_root: &Path,
+    allow_auto_discovery: bool,
+) -> Result<Option<ResolvedReviewContext>> {
+    let explicit = args
+        .spec
+        .as_deref()
+        .map(|path| (Path::new(path), "--spec"))
+        .or_else(|| {
+            args.context
+                .as_deref()
+                .map(|path| (Path::new(path), "--context"))
+        })
+        .or_else(|| {
+            args.prompt_file
+                .as_deref()
+                .map(|path| (path, "--prompt-file"))
+        });
+    match explicit {
+        Some((path, label)) => Ok(Some(resolve_explicit_review_context(
+            path,
+            project_root,
+            label,
+        )?)),
+        None if allow_auto_discovery => Ok(auto_discover_review_context(project_root)),
+        None => Ok(None),
+    }
 }
 
 fn resolve_explicit_review_context(
-    path: &str,
+    path: &Path,
     project_root: &Path,
+    label: &str,
 ) -> Result<ResolvedReviewContext> {
-    let (path_ref, digest) = admit_review_context(Path::new(path), project_root)?;
-
-    match csa_core::spec_validate::validate_spec(&path_ref) {
-        Ok(spec_path) => return load_spec_review_context(&spec_path, digest),
-        Err(csa_core::spec_validate::SpecValidationError::InvalidExtension { .. }) => {}
-        Err(error) => return Err(error.into()),
-    }
+    let (path_ref, snapshot) = admit_review_context(path, project_root, label)?;
+    let digest = digest_review_context(&snapshot);
 
     let kind = if has_extension(&path_ref, "md") {
         ResolvedReviewContextKind::TodoMarkdown
+    } else if has_extension(&path_ref, "toml") || has_extension(&path_ref, "spec") {
+        let spec: SpecDocument = toml::from_str(&snapshot)
+            .with_context(|| format!("Failed to parse spec context: {}", path_ref.display()))?;
+        ResolvedReviewContextKind::SpecToml { spec }
     } else {
         ResolvedReviewContextKind::Passthrough
     };
@@ -68,37 +126,119 @@ fn resolve_explicit_review_context(
         path: path_ref.display().to_string(),
         digest,
         kind,
+        snapshot,
     })
 }
 
-fn admit_review_context(path: &Path, project_root: &Path) -> Result<(PathBuf, String)> {
+fn admit_review_context(
+    path: &Path,
+    project_root: &Path,
+    label: &str,
+) -> Result<(PathBuf, String)> {
     let project_root = project_root
         .canonicalize()
-        .context("--context: failed to resolve project root")?;
-    let requested = if path.is_absolute() {
-        path.to_path_buf()
+        .with_context(|| format!("{label}: failed to resolve project root"))?;
+    let relative = if path.is_absolute() {
+        path.strip_prefix(&project_root).map(Path::to_path_buf).map_err(|_| {
+            anyhow::anyhow!(
+                "{label}: '{}' is outside the project workspace; copy it into the project and retry",
+                path.display()
+            )
+        })?
     } else {
-        project_root.join(path)
+        path.to_path_buf()
     };
-    let metadata = std::fs::symlink_metadata(&requested)
-        .with_context(|| format!("--context: failed to inspect '{}'", path.display()))?;
-    if !metadata.file_type().is_file() {
+    let components: Vec<_> = relative.components().collect();
+    if components.is_empty()
+        || components
+            .iter()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
         anyhow::bail!(
-            "--context: '{}' must be a regular, non-symlink file",
+            "{label}: '{}' must be a file beneath the project workspace",
             path.display()
         );
     }
-    let resolved = requested
-        .canonicalize()
-        .with_context(|| format!("--context: failed to resolve '{}'", path.display()))?;
-    if !resolved.starts_with(&project_root) {
-        anyhow::bail!(
-            "--context: '{}' is outside the project workspace; copy it into the project and retry",
-            path.display()
-        );
-    }
+    let resolved = project_root.join(&relative);
+    let snapshot = read_beneath_root_snapshot(&project_root, &components, &resolved, label)?;
+    Ok((resolved, snapshot))
+}
 
-    Ok((resolved.clone(), digest_review_context_file(&resolved)?))
+fn read_beneath_root_snapshot(
+    project_root: &Path,
+    components: &[Component<'_>],
+    resolved: &Path,
+    label: &str,
+) -> Result<String> {
+    let root = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(project_root)
+        .with_context(|| format!("{label}: failed to open project root"))?;
+    let mut directory = root;
+    for component in &components[..components.len() - 1] {
+        let name = match component {
+            Component::Normal(name) => name,
+            _ => anyhow::bail!("{label}: context path must stay beneath the project workspace"),
+        };
+        directory = openat_file(
+            directory.as_raw_fd(),
+            name,
+            libc::O_RDONLY
+                | libc::O_DIRECTORY
+                | libc::O_NOFOLLOW
+                | libc::O_CLOEXEC
+                | libc::O_NONBLOCK,
+        )
+        .with_context(|| format!("{label}: failed to open '{}'", resolved.display()))?;
+    }
+    let name = match components.last() {
+        Some(Component::Normal(name)) => name,
+        _ => anyhow::bail!("{label}: context path must name a file beneath the project workspace"),
+    };
+    let mut file = openat_file(
+        directory.as_raw_fd(),
+        name,
+        libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
+    )
+    .with_context(|| format!("{label}: failed to read '{}'", resolved.display()))?;
+    if !file
+        .metadata()
+        .with_context(|| format!("{label}: failed to inspect '{}'", resolved.display()))?
+        .file_type()
+        .is_file()
+    {
+        anyhow::bail!(
+            "{label}: '{}' must be a regular, non-symlink file",
+            resolved.display()
+        );
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .with_context(|| format!("{label}: failed to read '{}'", resolved.display()))?;
+    String::from_utf8(bytes)
+        .with_context(|| format!("{label}: '{}' must be valid UTF-8", resolved.display()))
+}
+
+fn openat_file(
+    directory_fd: std::os::fd::RawFd,
+    name: &std::ffi::OsStr,
+    flags: i32,
+) -> std::io::Result<File> {
+    let name = CString::new(name.as_bytes()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "context path contains a null byte",
+        )
+    })?;
+    // SAFETY: `directory_fd` is owned by a live `File`; `name` is NUL-terminated; a successful
+    // `openat` returns a new descriptor transferred immediately to the returned `File`.
+    let descriptor = unsafe { libc::openat(directory_fd, name.as_ptr(), flags, 0) };
+    if descriptor < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: `descriptor` is a successful, uniquely owned `openat` result.
+    Ok(unsafe { File::from_raw_fd(descriptor) })
 }
 
 fn auto_discover_review_context(project_root: &Path) -> Option<ResolvedReviewContext> {
@@ -137,37 +277,27 @@ pub(crate) fn discover_review_context_for_branch(
         return Ok(None);
     }
 
-    load_spec_review_context(&spec_path, digest_review_context_file(&spec_path)?).map(Some)
+    let snapshot = std::fs::read_to_string(&spec_path)
+        .with_context(|| format!("Failed to read spec context: {}", spec_path.display()))?;
+    load_spec_review_context(&spec_path, snapshot).map(Some)
 }
 
-fn load_spec_review_context(path: &Path, digest: String) -> Result<ResolvedReviewContext> {
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read spec context: {}", path.display()))?;
-    let spec: SpecDocument = toml::from_str(&content)
+fn load_spec_review_context(path: &Path, snapshot: String) -> Result<ResolvedReviewContext> {
+    let spec: SpecDocument = toml::from_str(&snapshot)
         .with_context(|| format!("Failed to parse spec context: {}", path.display()))?;
 
     Ok(ResolvedReviewContext {
         path: path.display().to_string(),
-        digest,
+        digest: digest_review_context(&snapshot),
         kind: ResolvedReviewContextKind::SpecToml { spec },
+        snapshot,
     })
 }
 
-fn digest_review_context_file(path: &Path) -> Result<String> {
-    let mut file = File::open(path)
-        .with_context(|| format!("--context: failed to read '{}'", path.display()))?;
+fn digest_review_context(snapshot: &str) -> String {
     let mut hasher = Sha256::new();
-    let mut buffer = [0_u8; 8192];
-    loop {
-        let count = file
-            .read(&mut buffer)
-            .with_context(|| format!("--context: failed to read '{}'", path.display()))?;
-        if count == 0 {
-            break;
-        }
-        hasher.update(&buffer[..count]);
-    }
-    Ok(format!("sha256:{:x}", hasher.finalize()))
+    hasher.update(snapshot.as_bytes());
+    format!("sha256:{:x}", hasher.finalize())
 }
 
 fn current_git_branch(project_root: &Path) -> Option<String> {

--- a/crates/cli-sub-agent/src/review_context.rs
+++ b/crates/cli-sub-agent/src/review_context.rs
@@ -83,7 +83,11 @@ pub(crate) fn resolve_review_context_for_args(
     args: &crate::cli::ReviewArgs,
     project_root: &Path,
     allow_auto_discovery: bool,
+    admitted_context: Option<ResolvedReviewContext>,
 ) -> Result<Option<ResolvedReviewContext>> {
+    if admitted_context.is_some() {
+        return Ok(admitted_context);
+    }
     if let (true, Some(session_id)) = (args.daemon_child, args.session_id.as_deref()) {
         let session_dir = csa_session::get_session_dir(project_root, session_id)?;
         if let Some(context) = ResolvedReviewContext::load_daemon_snapshot(&session_dir)? {

--- a/crates/cli-sub-agent/src/review_context.rs
+++ b/crates/cli-sub-agent/src/review_context.rs
@@ -88,12 +88,6 @@ pub(crate) fn resolve_review_context_for_args(
     if admitted_context.is_some() {
         return Ok(admitted_context);
     }
-    if let (true, Some(session_id)) = (args.daemon_child, args.session_id.as_deref()) {
-        let session_dir = csa_session::get_session_dir(project_root, session_id)?;
-        if let Some(context) = ResolvedReviewContext::load_daemon_snapshot(&session_dir)? {
-            return Ok(Some(context));
-        }
-    }
     let explicit = args
         .spec
         .as_deref()
@@ -108,6 +102,15 @@ pub(crate) fn resolve_review_context_for_args(
                 .as_deref()
                 .map(|path| (path, "--prompt-file"))
         });
+    if let (true, Some(session_id)) = (args.daemon_child, args.session_id.as_deref()) {
+        let session_dir = csa_session::get_session_dir(project_root, session_id)?;
+        if let Some(context) = ResolvedReviewContext::load_daemon_snapshot(&session_dir)? {
+            return Ok(Some(context));
+        }
+        if explicit.is_some() {
+            anyhow::bail!("missing admitted daemon review context snapshot")
+        }
+    }
     match explicit {
         Some((path, label)) => Ok(Some(resolve_explicit_review_context(
             path,

--- a/crates/cli-sub-agent/src/review_context.rs
+++ b/crates/cli-sub-agent/src/review_context.rs
@@ -25,6 +25,16 @@ pub(crate) enum ResolvedReviewContextKind {
     SpecToml { spec: SpecDocument },
 }
 
+impl ResolvedReviewContextKind {
+    pub(crate) fn tag(&self) -> &'static str {
+        match self {
+            Self::TodoMarkdown => "todo-markdown",
+            Self::Passthrough => "passthrough",
+            Self::SpecToml { .. } => "spec-toml",
+        }
+    }
+}
+
 impl fmt::Debug for ResolvedReviewContextKind {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(match self {
@@ -129,7 +139,6 @@ fn resolve_explicit_review_context(
     label: &str,
 ) -> Result<ResolvedReviewContext> {
     let (path_ref, snapshot) = admit_review_context(path, project_root, label)?;
-    let digest = digest_review_context(&snapshot);
 
     let kind = if has_extension(&path_ref, "md") {
         ResolvedReviewContextKind::TodoMarkdown
@@ -140,6 +149,7 @@ fn resolve_explicit_review_context(
     } else {
         ResolvedReviewContextKind::Passthrough
     };
+    let digest = digest_review_context(kind.tag(), &snapshot);
 
     Ok(ResolvedReviewContext {
         path: path_ref.display().to_string(),
@@ -192,10 +202,7 @@ fn read_beneath_root_snapshot(
     resolved: &Path,
     label: &str,
 ) -> Result<String> {
-    let root = OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-        .open(project_root)
+    let root = open_directory(project_root)
         .with_context(|| format!("{label}: failed to open project root"))?;
     let mut directory = root;
     for component in &components[..components.len() - 1] {
@@ -218,23 +225,8 @@ fn read_beneath_root_snapshot(
         Some(Component::Normal(name)) => name,
         _ => anyhow::bail!("{label}: context path must name a file beneath the project workspace"),
     };
-    let file = openat_file(
-        directory.as_raw_fd(),
-        name,
-        libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
-    )
-    .with_context(|| format!("{label}: failed to read '{}'", resolved.display()))?;
-    if !file
-        .metadata()
-        .with_context(|| format!("{label}: failed to inspect '{}'", resolved.display()))?
-        .file_type()
-        .is_file()
-    {
-        anyhow::bail!(
-            "{label}: '{}' must be a regular, non-symlink file",
-            resolved.display()
-        );
-    }
+    let file = open_regular_file_at(directory.as_raw_fd(), name)
+        .with_context(|| format!("{label}: failed to read '{}'", resolved.display()))?;
     let mut bytes = Vec::new();
     file.take(REVIEW_CONTEXT_MAX_BYTES as u64 + 1)
         .read_to_end(&mut bytes)
@@ -246,6 +238,31 @@ fn read_beneath_root_snapshot(
     );
     String::from_utf8(bytes)
         .with_context(|| format!("{label}: '{}' must be valid UTF-8", resolved.display()))
+}
+
+fn open_directory(path: &Path) -> std::io::Result<File> {
+    OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK)
+        .open(path)
+}
+
+fn open_regular_file_at(
+    directory_fd: std::os::fd::RawFd,
+    name: &std::ffi::OsStr,
+) -> std::io::Result<File> {
+    let file = openat_file(
+        directory_fd,
+        name,
+        libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
+    )?;
+    if !file.metadata()?.file_type().is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "not a regular file",
+        ));
+    }
+    Ok(file)
 }
 
 fn openat_file(
@@ -313,17 +330,21 @@ pub(crate) fn discover_review_context_for_branch(
 fn load_spec_review_context(path: &Path, snapshot: String) -> Result<ResolvedReviewContext> {
     let spec: SpecDocument = toml::from_str(&snapshot)
         .with_context(|| format!("Failed to parse spec context: {}", path.display()))?;
+    let kind = ResolvedReviewContextKind::SpecToml { spec };
 
     Ok(ResolvedReviewContext {
         path: path.display().to_string(),
-        digest: digest_review_context(&snapshot),
-        kind: ResolvedReviewContextKind::SpecToml { spec },
+        digest: digest_review_context(kind.tag(), &snapshot),
+        kind,
         snapshot,
     })
 }
 
-fn digest_review_context(snapshot: &str) -> String {
+fn digest_review_context(kind: &str, snapshot: &str) -> String {
     let mut hasher = Sha256::new();
+    hasher.update(b"csa-review-context-v1|");
+    hasher.update(kind.as_bytes());
+    hasher.update(b"|");
     hasher.update(snapshot.as_bytes());
     format!("sha256:{:x}", hasher.finalize())
 }

--- a/crates/cli-sub-agent/src/review_context_admission_tests.rs
+++ b/crates/cli-sub-agent/src/review_context_admission_tests.rs
@@ -39,6 +39,27 @@ fn daemon_review_context_snapshot_survives_source_replacement() {
 }
 
 #[test]
+fn daemon_snapshot_round_trips_max_escaped_context_without_source_path() {
+    let session = tempdir().unwrap();
+    let snapshot = "\0".repeat(REVIEW_CONTEXT_MAX_BYTES);
+    let parent = ResolvedReviewContext {
+        path: "x".repeat(16 * 1024),
+        digest: digest_review_context(&snapshot),
+        kind: ResolvedReviewContextKind::TodoMarkdown,
+        snapshot,
+    };
+
+    parent.persist_daemon_snapshot(session.path()).unwrap();
+    let child = ResolvedReviewContext::load_daemon_snapshot(session.path())
+        .unwrap()
+        .expect("daemon child should accept the maximum admitted context");
+
+    assert_eq!(child.snapshot(), parent.snapshot());
+    assert_eq!(child.digest, parent.digest);
+    assert!(child.path.is_empty());
+}
+
+#[test]
 fn resolve_review_context_accepts_dot_relative_explicit_paths() {
     let project = tempdir().unwrap();
     std::fs::write(project.path().join("TODO.md"), "todo context").unwrap();

--- a/crates/cli-sub-agent/src/review_context_admission_tests.rs
+++ b/crates/cli-sub-agent/src/review_context_admission_tests.rs
@@ -197,6 +197,8 @@ fn daemon_snapshot_fifo_fails_without_blocking() {
     std::fs::create_dir(&input_dir).unwrap();
     let fifo = input_dir.join("review-context.json");
     let fifo_name = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+    // SAFETY: `fifo_name` is NUL-free and remains alive for the call; the
+    // assertion checks `mkfifo`'s return status before the FIFO is used.
     assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
 
     let (sender, receiver) = std::sync::mpsc::channel();

--- a/crates/cli-sub-agent/src/review_context_admission_tests.rs
+++ b/crates/cli-sub-agent/src/review_context_admission_tests.rs
@@ -1,4 +1,5 @@
 use crate::cli::{Cli, Commands, validate_review_args};
+use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use clap::Parser;
 use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument};
 use tempfile::tempdir;
@@ -31,6 +32,10 @@ fn daemon_review_context_snapshot_survives_source_replacement() {
 
     parent.persist_daemon_snapshot(session.path()).unwrap();
     std::fs::write(&path, "replacement context").unwrap();
+    let lock = TEST_ENV_LOCK.clone();
+    let _lock = lock.blocking_lock();
+    let _launch_digest =
+        ScopedEnvVarRestore::set(DAEMON_REVIEW_CONTEXT_DIGEST_ENV_KEY, &parent.digest);
     let child = ResolvedReviewContext::load_daemon_snapshot(session.path())
         .unwrap()
         .expect("daemon child should receive the admitted snapshot");
@@ -38,6 +43,80 @@ fn daemon_review_context_snapshot_survives_source_replacement() {
     assert_eq!(child.snapshot(), "admitted context");
     assert_eq!(child.digest, parent.digest);
     assert_eq!(child.kind, parent.kind);
+}
+
+#[test]
+fn daemon_child_rejects_replacement_with_recomputed_digest_for_each_context_flag() {
+    let lock = TEST_ENV_LOCK.clone();
+    let _lock = lock.blocking_lock();
+    let project = tempdir().unwrap();
+    let session_id = "daemon-context-digest-binding";
+    let session_dir = csa_session::get_session_dir(project.path(), session_id).unwrap();
+
+    for (flag, file_name, admitted, replacement, kind) in [
+        (
+            "--spec",
+            "review.toml",
+            "plan_ulid = \"01JTESTPLAN0000000000000003\"\nsummary = \"admitted spec\"\n",
+            "plan_ulid = \"01JTESTPLAN0000000000000004\"\nsummary = \"replacement spec\"\n",
+            "SpecToml",
+        ),
+        (
+            "--context",
+            "context.md",
+            "admitted context",
+            "replacement context",
+            "TodoMarkdown",
+        ),
+        (
+            "--prompt-file",
+            "prompt.md",
+            "admitted prompt",
+            "replacement prompt",
+            "TodoMarkdown",
+        ),
+    ] {
+        let path = project.path().join(file_name);
+        std::fs::write(&path, admitted).unwrap();
+        let parent = parse_review_args(project.path(), &[flag, path.to_str().unwrap()]);
+        let admitted_context =
+            resolve_review_context_for_args(&parent, project.path(), false, None)
+                .unwrap()
+                .expect("parent should admit explicit context");
+        let _launch_digest = ScopedEnvVarRestore::set(
+            DAEMON_REVIEW_CONTEXT_DIGEST_ENV_KEY,
+            &admitted_context.digest,
+        );
+        admitted_context
+            .persist_daemon_snapshot(&session_dir)
+            .unwrap();
+
+        let replacement_digest = digest_review_context(replacement);
+        let replacement_snapshot = serde_json::json!({
+            "digest": replacement_digest,
+            "kind": kind,
+            "snapshot": replacement,
+        });
+        std::fs::write(
+            session_dir.join("input/review-context.json"),
+            serde_json::to_vec(&replacement_snapshot).unwrap(),
+        )
+        .unwrap();
+
+        let child = parse_review_args(
+            project.path(),
+            &[
+                "--daemon-child",
+                "--session-id",
+                session_id,
+                flag,
+                path.to_str().unwrap(),
+            ],
+        );
+        let error = resolve_review_context_for_args(&child, project.path(), false, None)
+            .expect_err("daemon child must reject a replacement snapshot");
+        assert!(format!("{error:#}").contains("admitted daemon review context digest mismatch"));
+    }
 }
 
 #[test]
@@ -52,6 +131,10 @@ fn daemon_snapshot_round_trips_max_escaped_context_without_source_path() {
     };
 
     parent.persist_daemon_snapshot(session.path()).unwrap();
+    let lock = TEST_ENV_LOCK.clone();
+    let _lock = lock.blocking_lock();
+    let _launch_digest =
+        ScopedEnvVarRestore::set(DAEMON_REVIEW_CONTEXT_DIGEST_ENV_KEY, &parent.digest);
     let child = ResolvedReviewContext::load_daemon_snapshot(session.path())
         .unwrap()
         .expect("daemon child should accept the maximum admitted context");

--- a/crates/cli-sub-agent/src/review_context_admission_tests.rs
+++ b/crates/cli-sub-agent/src/review_context_admission_tests.rs
@@ -1,0 +1,66 @@
+use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument};
+use tempfile::tempdir;
+
+use super::*;
+
+fn sample_spec_document(plan_ulid: &str, criterion_id: &str) -> SpecDocument {
+    SpecDocument {
+        schema_version: 1,
+        plan_ulid: plan_ulid.to_string(),
+        summary: format!("Spec summary for {plan_ulid}"),
+        criteria: vec![SpecCriterion {
+            kind: CriterionKind::Scenario,
+            id: criterion_id.to_string(),
+            description: format!("Criterion {criterion_id} must be satisfied."),
+            status: CriterionStatus::Pending,
+        }],
+    }
+}
+
+#[test]
+fn daemon_review_context_snapshot_survives_source_replacement() {
+    let project = tempdir().unwrap();
+    let session = tempdir().unwrap();
+    let path = project.path().join("TODO.md");
+    std::fs::write(&path, "admitted context").unwrap();
+    let parent = resolve_review_context(Some("TODO.md"), project.path(), false)
+        .unwrap()
+        .unwrap();
+
+    parent.persist_daemon_snapshot(session.path()).unwrap();
+    std::fs::write(&path, "replacement context").unwrap();
+    let child = ResolvedReviewContext::load_daemon_snapshot(session.path())
+        .unwrap()
+        .expect("daemon child should receive the admitted snapshot");
+
+    assert_eq!(child.snapshot(), "admitted context");
+    assert_eq!(child.digest, parent.digest);
+    assert_eq!(child.kind, parent.kind);
+}
+
+#[test]
+fn resolve_review_context_accepts_dot_relative_explicit_paths() {
+    let project = tempdir().unwrap();
+    std::fs::write(project.path().join("TODO.md"), "todo context").unwrap();
+    std::fs::write(
+        project.path().join("spec.toml"),
+        toml::to_string_pretty(&sample_spec_document(
+            "01JTESTPLAN0000000000000002",
+            "criterion-dot-relative",
+        ))
+        .unwrap(),
+    )
+    .unwrap();
+    std::fs::write(project.path().join("prompt.md"), "prompt context").unwrap();
+
+    for path in ["./TODO.md", "./spec.toml", "./prompt.md"] {
+        let context = resolve_review_context(Some(path), project.path(), false)
+            .unwrap_or_else(|error| panic!("{path} should be admitted: {error:#}"))
+            .expect("explicit path should resolve");
+        assert!(!context.snapshot().is_empty(), "{path}");
+    }
+
+    let parent = resolve_review_context(Some("../TODO.md"), project.path(), false)
+        .expect_err("parent traversal must stay rejected");
+    assert!(format!("{parent:#}").contains("must be a file beneath"));
+}

--- a/crates/cli-sub-agent/src/review_context_admission_tests.rs
+++ b/crates/cli-sub-agent/src/review_context_admission_tests.rs
@@ -2,6 +2,14 @@ use crate::cli::{Cli, Commands, validate_review_args};
 use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
 use clap::Parser;
 use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument};
+#[cfg(unix)]
+use std::ffi::CString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+#[cfg(unix)]
+use std::time::Duration;
 use tempfile::tempdir;
 
 use super::*;
@@ -91,7 +99,13 @@ fn daemon_child_rejects_replacement_with_recomputed_digest_for_each_context_flag
             .persist_daemon_snapshot(&session_dir)
             .unwrap();
 
-        let replacement_digest = digest_review_context(replacement);
+        let replacement_kind = match kind {
+            "SpecToml" => "spec-toml",
+            "TodoMarkdown" => "todo-markdown",
+            "Passthrough" => "passthrough",
+            _ => unreachable!("serialized daemon context kind"),
+        };
+        let replacement_digest = digest_review_context(replacement_kind, replacement);
         let replacement_snapshot = serde_json::json!({
             "digest": replacement_digest,
             "kind": kind,
@@ -120,12 +134,105 @@ fn daemon_child_rejects_replacement_with_recomputed_digest_for_each_context_flag
 }
 
 #[test]
+fn daemon_child_rejects_kind_tampering_for_each_context_flag() {
+    let lock = TEST_ENV_LOCK.clone();
+    let _lock = lock.blocking_lock();
+    let project = tempdir().unwrap();
+    let session_id = "daemon-context-kind-binding";
+    let session_dir = csa_session::get_session_dir(project.path(), session_id).unwrap();
+
+    for (flag, file_name, admitted) in [
+        (
+            "--spec",
+            "review.toml",
+            r#"plan_ulid = "01JTESTPLAN0000000000000003"
+summary = "admitted spec"
+"#,
+        ),
+        ("--context", "context.md", "admitted context"),
+        ("--prompt-file", "prompt.md", "admitted prompt"),
+    ] {
+        let path = project.path().join(file_name);
+        std::fs::write(&path, admitted).unwrap();
+        let parent = parse_review_args(project.path(), &[flag, path.to_str().unwrap()]);
+        let admitted_context =
+            resolve_review_context_for_args(&parent, project.path(), false, None)
+                .unwrap()
+                .expect("parent should admit explicit context");
+        let _launch_digest = ScopedEnvVarRestore::set(
+            DAEMON_REVIEW_CONTEXT_DIGEST_ENV_KEY,
+            &admitted_context.digest,
+        );
+        admitted_context
+            .persist_daemon_snapshot(&session_dir)
+            .unwrap();
+
+        let snapshot_path = session_dir.join("input/review-context.json");
+        let mut tampered: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&snapshot_path).unwrap()).unwrap();
+        tampered["kind"] = serde_json::Value::String("Passthrough".to_string());
+        std::fs::write(&snapshot_path, serde_json::to_vec(&tampered).unwrap()).unwrap();
+
+        let child = parse_review_args(
+            project.path(),
+            &[
+                "--daemon-child",
+                "--session-id",
+                session_id,
+                flag,
+                path.to_str().unwrap(),
+            ],
+        );
+        let error = resolve_review_context_for_args(&child, project.path(), false, None)
+            .expect_err("daemon child must reject kind tampering");
+        assert!(format!("{error:#}").contains("admitted daemon review context digest mismatch"));
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn daemon_snapshot_fifo_fails_without_blocking() {
+    let session = tempdir().unwrap();
+    let input_dir = session.path().join("input");
+    std::fs::create_dir(&input_dir).unwrap();
+    let fifo = input_dir.join("review-context.json");
+    let fifo_name = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+    assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
+
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let session_path = session.path().to_path_buf();
+    let worker = std::thread::spawn(move || {
+        sender
+            .send(ResolvedReviewContext::load_daemon_snapshot(&session_path))
+            .unwrap();
+    });
+    let finished = match receiver.recv_timeout(Duration::from_secs(1)) {
+        Ok(result) => {
+            let error = result.expect_err("FIFO snapshot must be rejected");
+            assert!(format!("{error:#}").contains("regular"));
+            true
+        }
+        Err(_) => {
+            let _writer = std::fs::OpenOptions::new()
+                .write(true)
+                .custom_flags(libc::O_NONBLOCK)
+                .open(&fifo)
+                .unwrap();
+            let _ = receiver.recv_timeout(Duration::from_secs(1));
+            false
+        }
+    };
+    worker.join().unwrap();
+    assert!(finished, "FIFO snapshot open exceeded the bounded deadline");
+}
+
+#[test]
 fn daemon_snapshot_round_trips_max_escaped_context_without_source_path() {
     let session = tempdir().unwrap();
     let snapshot = "\0".repeat(REVIEW_CONTEXT_MAX_BYTES);
     let parent = ResolvedReviewContext {
         path: "x".repeat(16 * 1024),
-        digest: digest_review_context(&snapshot),
+        digest: digest_review_context("todo-markdown", &snapshot),
         kind: ResolvedReviewContextKind::TodoMarkdown,
         snapshot,
     };

--- a/crates/cli-sub-agent/src/review_context_admission_tests.rs
+++ b/crates/cli-sub-agent/src/review_context_admission_tests.rs
@@ -1,3 +1,5 @@
+use crate::cli::{Cli, Commands, validate_review_args};
+use clap::Parser;
 use csa_todo::{CriterionKind, CriterionStatus, SpecCriterion, SpecDocument};
 use tempfile::tempdir;
 
@@ -57,6 +59,59 @@ fn daemon_snapshot_round_trips_max_escaped_context_without_source_path() {
     assert_eq!(child.snapshot(), parent.snapshot());
     assert_eq!(child.digest, parent.digest);
     assert!(child.path.is_empty());
+}
+
+#[test]
+fn daemon_child_rejects_missing_admitted_snapshot_for_explicit_context() {
+    let project = tempdir().unwrap();
+    let session_id = "daemon-context-snapshot";
+    let session_dir = csa_session::get_session_dir(project.path(), session_id).unwrap();
+
+    for (flag, file_name, admitted) in [
+        (
+            "--spec",
+            "review.toml",
+            "plan_ulid = \"01JTESTPLAN0000000000000003\"\nsummary = \"admitted spec\"\n",
+        ),
+        ("--context", "context.md", "admitted context"),
+        ("--prompt-file", "prompt.md", "admitted prompt"),
+    ] {
+        let path = project.path().join(file_name);
+        let path_arg = path.to_str().unwrap();
+        std::fs::write(&path, admitted).unwrap();
+        let parent = parse_review_args(project.path(), &[flag, path_arg]);
+        let admitted_context =
+            resolve_review_context_for_args(&parent, project.path(), false, None)
+                .unwrap()
+                .expect("parent should admit explicit context");
+        admitted_context
+            .persist_daemon_snapshot(&session_dir)
+            .unwrap();
+        std::fs::remove_file(session_dir.join("input/review-context.json")).unwrap();
+        std::fs::write(&path, "replacement context").unwrap();
+
+        let child = parse_review_args(
+            project.path(),
+            &["--daemon-child", "--session-id", session_id, flag, path_arg],
+        );
+        let error = resolve_review_context_for_args(&child, project.path(), false, None)
+            .expect_err("daemon child must reject a missing admitted snapshot");
+
+        assert!(format!("{error:#}").contains("missing admitted daemon review context"));
+    }
+}
+
+fn parse_review_args(project_root: &std::path::Path, extra: &[&str]) -> crate::cli::ReviewArgs {
+    let cd = project_root.display().to_string();
+    let mut argv = vec!["csa", "review", "--cd", cd.as_str(), "--diff"];
+    argv.extend_from_slice(extra);
+    match Cli::try_parse_from(argv).unwrap().command {
+        Commands::Review(args) => {
+            validate_review_args(&args).unwrap();
+            args
+        }
+        _ => unreachable!(),
+    }
 }
 
 #[test]

--- a/crates/cli-sub-agent/src/review_context_daemon_snapshot.rs
+++ b/crates/cli-sub-agent/src/review_context_daemon_snapshot.rs
@@ -7,12 +7,16 @@ use serde::{Deserialize, Serialize};
 
 use super::{ResolvedReviewContext, ResolvedReviewContextKind, digest_review_context};
 
-const DAEMON_REVIEW_CONTEXT_SNAPSHOT_MAX_BYTES: usize = super::REVIEW_CONTEXT_MAX_BYTES * 6 + 4096;
+const DAEMON_REVIEW_CONTEXT_SNAPSHOT_MAX_BYTES: usize = super::REVIEW_CONTEXT_MAX_BYTES * 6
+    + r#"{"digest":""#.len()
+    + "sha256:".len()
+    + 64
+    + r#"","kind":"TodoMarkdown","snapshot":""#.len()
+    + r#""}"#.len();
 const DAEMON_REVIEW_CONTEXT_SNAPSHOT_FILE: &str = "review-context.json";
 
 #[derive(Serialize, Deserialize)]
 struct DaemonReviewContextSnapshot {
-    path: String,
     digest: String,
     kind: DaemonReviewContextKind,
     snapshot: String,
@@ -33,7 +37,6 @@ impl ResolvedReviewContext {
             ResolvedReviewContextKind::SpecToml { .. } => DaemonReviewContextKind::SpecToml,
         };
         let encoded = serde_json::to_vec(&DaemonReviewContextSnapshot {
-            path: self.path.clone(),
             digest: self.digest.clone(),
             kind,
             snapshot: self.snapshot.clone(),
@@ -80,7 +83,7 @@ impl ResolvedReviewContext {
             },
         };
         Ok(Some(Self {
-            path: snapshot.path,
+            path: String::new(),
             digest: snapshot.digest,
             kind,
             snapshot: snapshot.snapshot,

--- a/crates/cli-sub-agent/src/review_context_daemon_snapshot.rs
+++ b/crates/cli-sub-agent/src/review_context_daemon_snapshot.rs
@@ -1,0 +1,89 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::{ResolvedReviewContext, ResolvedReviewContextKind, digest_review_context};
+
+const DAEMON_REVIEW_CONTEXT_SNAPSHOT_MAX_BYTES: usize = super::REVIEW_CONTEXT_MAX_BYTES * 6 + 4096;
+const DAEMON_REVIEW_CONTEXT_SNAPSHOT_FILE: &str = "review-context.json";
+
+#[derive(Serialize, Deserialize)]
+struct DaemonReviewContextSnapshot {
+    path: String,
+    digest: String,
+    kind: DaemonReviewContextKind,
+    snapshot: String,
+}
+
+#[derive(Serialize, Deserialize)]
+enum DaemonReviewContextKind {
+    TodoMarkdown,
+    Passthrough,
+    SpecToml,
+}
+
+impl ResolvedReviewContext {
+    pub(crate) fn persist_daemon_snapshot(&self, session_dir: &Path) -> Result<()> {
+        let kind = match &self.kind {
+            ResolvedReviewContextKind::TodoMarkdown => DaemonReviewContextKind::TodoMarkdown,
+            ResolvedReviewContextKind::Passthrough => DaemonReviewContextKind::Passthrough,
+            ResolvedReviewContextKind::SpecToml { .. } => DaemonReviewContextKind::SpecToml,
+        };
+        let encoded = serde_json::to_vec(&DaemonReviewContextSnapshot {
+            path: self.path.clone(),
+            digest: self.digest.clone(),
+            kind,
+            snapshot: self.snapshot.clone(),
+        })
+        .context("failed to encode admitted daemon review context")?;
+        let input_dir = session_dir.join("input");
+        std::fs::create_dir_all(&input_dir)
+            .context("failed to create admitted daemon review context input directory")?;
+        std::fs::write(input_dir.join(DAEMON_REVIEW_CONTEXT_SNAPSHOT_FILE), encoded)
+            .context("failed to persist admitted daemon review context")
+    }
+
+    pub(crate) fn load_daemon_snapshot(session_dir: &Path) -> Result<Option<Self>> {
+        let path = session_dir
+            .join("input")
+            .join(DAEMON_REVIEW_CONTEXT_SNAPSHOT_FILE);
+        let file = match File::open(&path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error).context("failed to read admitted daemon review context");
+            }
+        };
+        let mut encoded = Vec::new();
+        file.take(DAEMON_REVIEW_CONTEXT_SNAPSHOT_MAX_BYTES as u64 + 1)
+            .read_to_end(&mut encoded)
+            .context("failed to read admitted daemon review context")?;
+        anyhow::ensure!(
+            encoded.len() <= DAEMON_REVIEW_CONTEXT_SNAPSHOT_MAX_BYTES,
+            "admitted daemon review context exceeds the allowed size"
+        );
+        let snapshot: DaemonReviewContextSnapshot = serde_json::from_slice(&encoded)
+            .context("failed to decode admitted daemon review context")?;
+        anyhow::ensure!(
+            digest_review_context(&snapshot.snapshot) == snapshot.digest,
+            "admitted daemon review context digest mismatch"
+        );
+        let kind = match snapshot.kind {
+            DaemonReviewContextKind::TodoMarkdown => ResolvedReviewContextKind::TodoMarkdown,
+            DaemonReviewContextKind::Passthrough => ResolvedReviewContextKind::Passthrough,
+            DaemonReviewContextKind::SpecToml => ResolvedReviewContextKind::SpecToml {
+                spec: toml::from_str(&snapshot.snapshot)
+                    .context("failed to parse admitted daemon review spec context")?,
+            },
+        };
+        Ok(Some(Self {
+            path: snapshot.path,
+            digest: snapshot.digest,
+            kind,
+            snapshot: snapshot.snapshot,
+        }))
+    }
+}

--- a/crates/cli-sub-agent/src/review_context_daemon_snapshot.rs
+++ b/crates/cli-sub-agent/src/review_context_daemon_snapshot.rs
@@ -70,6 +70,12 @@ impl ResolvedReviewContext {
         );
         let snapshot: DaemonReviewContextSnapshot = serde_json::from_slice(&encoded)
             .context("failed to decode admitted daemon review context")?;
+        let expected_digest = std::env::var(super::DAEMON_REVIEW_CONTEXT_DIGEST_ENV_KEY)
+            .context("missing admitted daemon review context launch digest")?;
+        anyhow::ensure!(
+            expected_digest == snapshot.digest,
+            "admitted daemon review context digest mismatch"
+        );
         anyhow::ensure!(
             digest_review_context(&snapshot.snapshot) == snapshot.digest,
             "admitted daemon review context digest mismatch"

--- a/crates/cli-sub-agent/src/review_context_daemon_snapshot.rs
+++ b/crates/cli-sub-agent/src/review_context_daemon_snapshot.rs
@@ -1,5 +1,6 @@
-use std::fs::File;
+use std::ffi::OsStr;
 use std::io::Read;
+use std::os::fd::AsRawFd;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -50,10 +51,18 @@ impl ResolvedReviewContext {
     }
 
     pub(crate) fn load_daemon_snapshot(session_dir: &Path) -> Result<Option<Self>> {
-        let path = session_dir
-            .join("input")
-            .join(DAEMON_REVIEW_CONTEXT_SNAPSHOT_FILE);
-        let file = match File::open(&path) {
+        let input_dir = session_dir.join("input");
+        let directory = match super::open_directory(&input_dir) {
+            Ok(directory) => directory,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error).context("failed to read admitted daemon review context");
+            }
+        };
+        let file = match super::open_regular_file_at(
+            directory.as_raw_fd(),
+            OsStr::new(DAEMON_REVIEW_CONTEXT_SNAPSHOT_FILE),
+        ) {
             Ok(file) => file,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(error) => {
@@ -76,8 +85,13 @@ impl ResolvedReviewContext {
             expected_digest == snapshot.digest,
             "admitted daemon review context digest mismatch"
         );
+        let kind_tag = match &snapshot.kind {
+            DaemonReviewContextKind::TodoMarkdown => "todo-markdown",
+            DaemonReviewContextKind::Passthrough => "passthrough",
+            DaemonReviewContextKind::SpecToml => "spec-toml",
+        };
         anyhow::ensure!(
-            digest_review_context(&snapshot.snapshot) == snapshot.digest,
+            digest_review_context(kind_tag, &snapshot.snapshot) == snapshot.digest,
             "admitted daemon review context digest mismatch"
         );
         let kind = match snapshot.kind {

--- a/crates/cli-sub-agent/src/review_context_tests.rs
+++ b/crates/cli-sub-agent/src/review_context_tests.rs
@@ -144,6 +144,21 @@ fn resolve_review_context_explicit_spec_still_parses_when_auto_discovery_disable
     ));
 }
 
+#[cfg(unix)]
+#[test]
+fn resolve_review_context_rejects_symlinked_parent_directory() {
+    let project = tempdir().unwrap();
+    let source = project.path().join("source");
+    std::fs::create_dir(&source).unwrap();
+    std::fs::write(source.join("context.md"), "context").unwrap();
+    std::os::unix::fs::symlink(&source, project.path().join("alias")).unwrap();
+
+    let error = resolve_review_context(Some("alias/context.md"), project.path(), false)
+        .expect_err("context paths must not traverse symlinked directories");
+
+    assert!(format!("{error:#}").contains("failed to open"));
+}
+
 #[test]
 fn discover_review_checklist_returns_content_when_file_exists() {
     let temp = tempdir().unwrap();

--- a/crates/cli-sub-agent/src/review_context_tests.rs
+++ b/crates/cli-sub-agent/src/review_context_tests.rs
@@ -137,6 +137,7 @@ fn resolve_review_context_explicit_spec_still_parses_when_auto_discovery_disable
         .unwrap();
 
     assert_eq!(context.path, spec_path.display().to_string());
+    assert!(context.digest.starts_with("sha256:"));
     assert!(matches!(
         context.kind,
         ResolvedReviewContextKind::SpecToml { .. }

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -376,6 +376,12 @@ pub(crate) fn spawn_and_exit(
         project_root.display().to_string(),
     );
     startup_env.apply_to_child_env(&mut daemon_env);
+    if let Some(context) = spawn_options.review_context.as_ref() {
+        daemon_env.insert(
+            crate::review_context::DAEMON_REVIEW_CONTEXT_DIGEST_ENV_KEY.to_string(),
+            context.digest.clone(),
+        );
+    }
 
     let config = csa_process::daemon::DaemonSpawnConfig {
         session_id: sid.clone(),

--- a/crates/cli-sub-agent/src/run_cmd_daemon.rs
+++ b/crates/cli-sub-agent/src/run_cmd_daemon.rs
@@ -26,6 +26,7 @@ pub(crate) use tier_policy::{
 pub(crate) struct DaemonSpawnOptions {
     run_stdin_prompt: RunStdinPrompt,
     prompt_file_to_capture: Option<PathBuf>,
+    review_context: Option<crate::review_context::ResolvedReviewContext>,
     remove_prompt_file_arg: bool,
     prompt_file_forward_arg: PromptFileForwardArg,
     no_fs_sandbox: bool,
@@ -68,6 +69,15 @@ impl PromptFileForwardArg {
 }
 
 impl DaemonSpawnOptions {
+    pub(crate) fn for_review(
+        context: Option<crate::review_context::ResolvedReviewContext>,
+    ) -> Self {
+        Self {
+            review_context: context,
+            ..Default::default()
+        }
+    }
+
     pub(crate) fn with_wait_hint_provider(
         mut self,
         wait_hint_provider: Option<csa_config::ModelProvider>,
@@ -342,6 +352,7 @@ pub(crate) fn spawn_and_exit(
     let session_dir = session_root.join("sessions").join(&sid);
     let prompt_input = read_daemon_prompt_input_if_needed(&spawn_options)?;
     persist_daemon_placeholder_session(&project_root, &session_dir, &sid, subcommand)?;
+    write_daemon_review_context_if_needed(&session_dir, spawn_options.review_context.as_ref())?;
     let prompt_input_file = write_daemon_prompt_input_if_needed(&session_dir, prompt_input)?;
 
     // Forward args after the subcommand verb; spawn_daemon injects child/session flags.
@@ -577,6 +588,16 @@ fn write_daemon_prompt_input_if_needed(
         )
     })?;
     Ok(Some(prompt_path))
+}
+
+fn write_daemon_review_context_if_needed(
+    session_dir: &Path,
+    context: Option<&crate::review_context::ResolvedReviewContext>,
+) -> Result<()> {
+    if let Some(context) = context {
+        context.persist_daemon_snapshot(session_dir)?;
+    }
+    Ok(())
 }
 
 fn build_forwarded_args(

--- a/crates/csa-executor/src/executor_prompt_helpers.rs
+++ b/crates/csa-executor/src/executor_prompt_helpers.rs
@@ -22,6 +22,23 @@ impl Executor {
         )
     }
 
+    pub(crate) fn validate_prompt_for_execution(&self, prompt: &str) -> anyhow::Result<()> {
+        if !matches!(self, Self::Opencode { .. }) {
+            return Ok(());
+        }
+        if prompt.as_bytes().contains(&0) {
+            anyhow::bail!("OpenCode prompt contains an embedded NUL; refusing argv transport");
+        }
+        if prompt.len() > MAX_ARGV_PROMPT_LEN {
+            anyhow::bail!(
+                "OpenCode prompt length {} exceeds argv safety limit {}; refusing provider launch",
+                prompt.len(),
+                MAX_ARGV_PROMPT_LEN
+            );
+        }
+        Ok(())
+    }
+
     /// Append minimal prompt args for execute_in.
     pub(super) fn append_prompt_args(&self, cmd: &mut Command, prompt: &str) {
         self.append_prompt_args_with_transport(cmd, prompt, PromptTransport::Argv);

--- a/crates/csa-executor/src/executor_prompt_transport_tests.rs
+++ b/crates/csa-executor/src/executor_prompt_transport_tests.rs
@@ -262,3 +262,61 @@ fn test_build_command_long_prompt_opencode_emits_warning() {
     // warning output best-effort for observability.
     let _ = logs;
 }
+
+#[test]
+fn opencode_prompt_validation_rejects_argv_overflow_and_nul() {
+    let exec = Executor::Opencode {
+        model_override: None,
+        agent: None,
+        thinking_budget: None,
+    };
+
+    for (source, prompt) in [
+        ("--spec", "x".repeat(MAX_ARGV_PROMPT_LEN + 1)),
+        ("--context", "x".repeat(MAX_ARGV_PROMPT_LEN + 1)),
+        ("--prompt-file", "x".repeat(MAX_ARGV_PROMPT_LEN + 1)),
+        ("--context", "safe\0unsafe".to_string()),
+        ("--prompt-file", "safe\0unsafe".to_string()),
+    ] {
+        let error = exec
+            .validate_prompt_for_execution(&prompt)
+            .expect_err("OpenCode prompt must fail before argv construction");
+        assert!(
+            error.to_string().contains("refusing"),
+            "{source} should return a bounded validation error: {error:#}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn opencode_prompt_validation_runs_before_execute_in_spawn() {
+    let exec = Executor::Opencode {
+        model_override: None,
+        agent: None,
+        thinking_budget: None,
+    };
+    let temp = tempfile::tempdir().expect("tempdir");
+    for (prompt, expected) in [
+        ("x".repeat(MAX_ARGV_PROMPT_LEN + 1), "argv safety limit"),
+        ("safe\0unsafe".to_string(), "embedded NUL"),
+    ] {
+        let error = exec
+            .execute_in(
+                &prompt,
+                temp.path(),
+                None,
+                None,
+                false,
+                csa_process::StreamMode::BufferOnly,
+                1,
+                ResolvedTimeout(None),
+            )
+            .await
+            .expect_err("invalid OpenCode prompt must fail before provider launch");
+
+        assert!(
+            error.to_string().contains(expected),
+            "expected bounded {expected} validation error, got: {error:#}"
+        );
+    }
+}

--- a/crates/csa-executor/src/transport_legacy.rs
+++ b/crates/csa-executor/src/transport_legacy.rs
@@ -93,6 +93,9 @@ impl LegacyTransport {
         &self,
         request: ExecuteInAttempt<'_>,
     ) -> Result<TransportResult> {
+        request
+            .executor
+            .validate_prompt_for_execution(request.prompt)?;
         // Stage the antigravity-cli `model` field in
         // `~/.gemini/antigravity-cli/settings.json` before spawning `agy`,
         // and hold the RAII guard so the original contents are restored
@@ -167,6 +170,7 @@ impl LegacyTransport {
         attempt_env: LegacyAttemptEnv<'_>,
         options: TransportOptions<'_>,
     ) -> Result<TransportResult> {
+        executor.validate_prompt_for_execution(prompt)?;
         // Shared attempt boundary: degraded-MCP / OAuth / initial-stall retries
         // all re-enter here. Fail closed if the owning execution was cancelled
         // after the previous attempt returned.

--- a/patterns/csa-review/skills/csa-review/references/review-protocol.md
+++ b/patterns/csa-review/skills/csa-review/references/review-protocol.md
@@ -140,11 +140,18 @@ When `consistency_scope=touched-files`, extend only the consistency scan:
 
 ## Step 2.5: Plan / Spec Alignment (when context is provided)
 
-Context: {context}
+Context may be absent or supplied as a trusted inline snapshot. When present, the
+instruction includes `context_kind` metadata and the original filesystem path is
+not part of the review input:
 
-When a context path is provided, detect its type and verify implementation alignment:
+- `context_kind=todo-markdown`: treat the inline snapshot as the TODO/plan and verify
+  task completion, design drift, scope creep, and risk coverage.
+- `context_kind=spec-toml`: use the embedded parsed SpecDocument criteria below the
+  snapshot instead of attempting to rediscover a path.
+- `context_kind=passthrough`: use the inline snapshot as background only; skip plan
+  and spec alignment checks.
 
-### If `context` points to `TODO.md`
+### If `context_kind=todo-markdown`
 
 1. **Task completion**: Are all `[ ]` tasks from the plan addressed in the diff?
 2. **Design drift**: Does the implementation deviate from key decisions documented in the plan?
@@ -153,7 +160,7 @@ When a context path is provided, detect its type and verify implementation align
 
 Flag deviations as findings with `finding_type: "plan-deviation"` at P2 priority.
 
-### If `context` points to `spec.toml`
+### If `context_kind=spec-toml`
 
 1. Parse the TOML as `SpecDocument`, unless the initial prompt already embeds a parsed
    "Spec alignment context" block. If both are present, prefer the embedded block because
@@ -172,7 +179,7 @@ Flag deviations as findings with `finding_type: "plan-deviation"` at P2 priority
 Spec alignment findings should normally be P2, escalating to P1 when the criterion covers
 correctness, security, tenancy, data loss, or an AGENTS.md MUST/FORBIDDEN rule.
 
-If no context path is provided, skip this step entirely.
+If no `context_kind` is provided, skip this step entirely.
 
 ## Step 2.6: Project Profile Routing
 

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1158"
-weave = "0.1.1158"
+csa = "0.1.1159"
+weave = "0.1.1159"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Fail-closed `csa review` context admission for `#2704`.

- Shared precedence `--spec > --context > --prompt-file` for preflight and runtime.
- One UTF-8 snapshot for digest, parse, and reviewer prompt. Original pathname is not sent to the reviewer.
- Daemon and foreground consume the admitted snapshot. Missing snapshot fail-closes; they do not reopen the source.
- Snapshot envelope is bound (bytes, digest, kind). FIFO/non-regular snapshot files are rejected without blocking.
- Markdown snapshots keep plan-alignment via a trusted kind, not a path.
- OpenCode argv-only tools fail closed before provider launch on overflow or NUL.

## Test plan

- Focused function-name regressions for snapshot, FIFO, kind tampering, and OpenCode argv/NUL.
- Exact-head `just quality-gates`: `GATE_EXIT=0`, `7669 passed / 7 skipped` on `7695a1cbb08ed83807fabc2782c0968445d54b1e`.
- CSA session `01M145JB573AZ4NZB64SSZPQCV` PASS/CLEAN for `main...HEAD`.

Closes #2704
