### PR TITLE
fix: keep caller-guard summaries from discarding review results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1171"
+version = "0.1.1172"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1173"
+version = "0.1.1174"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1169"
+version = "0.1.1170"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1170"
+version = "0.1.1171"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1168"
+version = "0.1.1169"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1172"
+version = "0.1.1173"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1166"
+version = "0.1.1167"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1167"
+version = "0.1.1168"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1171"
+version = "0.1.1172"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1169"
+version = "0.1.1170"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1167"
+version = "0.1.1168"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1166"
+version = "0.1.1167"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1172"
+version = "0.1.1173"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1173"
+version = "0.1.1174"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1170"
+version = "0.1.1171"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1168"
+version = "0.1.1169"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -88,6 +88,17 @@ pub(crate) async fn process_execution_result(
                 result.terminal_reason.as_deref(),
             ],
         )
+        .or_else(|| {
+            crate::pipeline::prompt_guard::caller_guard_failure_summary(
+                ctx.executor.tool_name(),
+                &result.summary,
+                &result.output,
+                [
+                    Some(result.stderr_output.as_str()),
+                    result.terminal_reason.as_deref(),
+                ],
+            )
+        })
     {
         result.summary = summary;
     }

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -77,6 +77,19 @@ pub(crate) async fn process_execution_result(
     session: &mut MetaSessionState,
     result: &mut csa_process::ExecutionResult,
 ) -> anyhow::Result<()> {
+    if ctx.sa_mode
+        && result.exit_code != 0
+        && let Some(summary) = crate::pipeline::prompt_guard::caller_guard_failure_summary(
+            ctx.executor.tool_name(),
+            &result.output,
+            [
+                Some(result.stderr_output.as_str()),
+                result.terminal_reason.as_deref(),
+            ],
+        )
+    {
+        result.summary = summary;
+    }
     let token_usage = parse_token_usage(&result.output);
 
     // Update session tool state

--- a/crates/cli-sub-agent/src/pipeline_post_exec.rs
+++ b/crates/cli-sub-agent/src/pipeline_post_exec.rs
@@ -82,6 +82,7 @@ pub(crate) async fn process_execution_result(
         && let Some(summary) = crate::pipeline::prompt_guard::caller_guard_failure_summary(
             ctx.executor.tool_name(),
             &result.output,
+            &result.summary,
             [
                 Some(result.stderr_output.as_str()),
                 result.terminal_reason.as_deref(),

--- a/crates/cli-sub-agent/src/pipeline_prompt_guard.rs
+++ b/crates/cli-sub-agent/src/pipeline_prompt_guard.rs
@@ -138,9 +138,10 @@ Decisions MUST be based on result.toml reports, not direct code inspection.
 pub(crate) fn caller_guard_failure_summary<'a>(
     tool: &str,
     output: &str,
+    selected_summary: &str,
     diagnostics: impl IntoIterator<Item = Option<&'a str>>,
 ) -> Option<String> {
-    if !is_caller_guard_only_output(output) {
+    if !is_caller_guard_only_output(output) && !is_caller_guard_only_output(selected_summary) {
         return None;
     }
 

--- a/crates/cli-sub-agent/src/pipeline_prompt_guard.rs
+++ b/crates/cli-sub-agent/src/pipeline_prompt_guard.rs
@@ -138,10 +138,10 @@ Decisions MUST be based on result.toml reports, not direct code inspection.
 pub(crate) fn caller_guard_failure_summary<'a>(
     tool: &str,
     output: &str,
-    selected_summary: &str,
+    _selected_summary: &str,
     diagnostics: impl IntoIterator<Item = Option<&'a str>>,
 ) -> Option<String> {
-    if !is_caller_guard_only_output(output) && !is_caller_guard_only_output(selected_summary) {
+    if !is_caller_guard_only_output(output) {
         return None;
     }
 

--- a/crates/cli-sub-agent/src/pipeline_prompt_guard.rs
+++ b/crates/cli-sub-agent/src/pipeline_prompt_guard.rs
@@ -2,6 +2,9 @@ pub(crate) const PROMPT_GUARD_CALLER_INJECTION_ENV: &str = "CSA_EMIT_CALLER_GUAR
 pub(crate) const COMPACT_SA_GUARD_ENV: &str = "CSA_SAY_COMPACT";
 const SA_GUARD_TIER_ENV: &str = "CSA_SA_GUARD_TIER";
 const SA_GUARD_TOOL_ENV: &str = "CSA_SA_GUARD_TOOL";
+const CALLER_SA_GUARD_OPEN: &str = "<csa-caller-sa-guard>";
+const CALLER_SA_GUARD_CLOSE: &str = "</csa-caller-sa-guard>";
+const CALLER_GUARD_FAILURE_SUMMARY_MAX_CHARS: usize = 240;
 
 pub(super) fn should_emit_prompt_guard_to_caller(current_depth: u32) -> bool {
     // Prompt-guard reverse injection is only for the top-level caller.
@@ -131,6 +134,56 @@ ALLOWED:
 ALL implementation work MUST be delegated to CSA sub-agents.
 Decisions MUST be based on result.toml reports, not direct code inspection.
 </csa-caller-sa-guard>";
+
+pub(crate) fn caller_guard_failure_summary<'a>(
+    tool: &str,
+    output: &str,
+    diagnostics: impl IntoIterator<Item = Option<&'a str>>,
+) -> Option<String> {
+    if !is_caller_guard_only_output(output) {
+        return None;
+    }
+
+    let detail = diagnostics
+        .into_iter()
+        .flatten()
+        .find(|text| !text.trim().is_empty() && !is_caller_guard_only_output(text))
+        .unwrap_or("caller guard emitted without a substantive result");
+    let summary = format!("{tool} tool failure: {}", detail.trim().replace('\n', " "));
+    Some(
+        summary
+            .chars()
+            .take(CALLER_GUARD_FAILURE_SUMMARY_MAX_CHARS)
+            .collect(),
+    )
+}
+
+fn is_caller_guard_only_output(output: &str) -> bool {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let full_guard = SA_MODE_CALLER_GUARD.trim();
+    let mut remainder = trimmed;
+    let mut full_guard_count = 0;
+    while let Some(after_guard) = remainder.strip_prefix(full_guard) {
+        full_guard_count += 1;
+        remainder = after_guard.trim();
+    }
+    if full_guard_count > 0 {
+        return remainder.is_empty();
+    }
+
+    trimmed
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .all(|line| {
+            matches!(line, CALLER_SA_GUARD_OPEN | CALLER_SA_GUARD_CLOSE)
+                || line.starts_with("<csa-caller-sa-guard:compact")
+        })
+}
 
 pub(crate) fn set_sa_mode_caller_guard_context(tier: Option<&str>, tool: Option<&str>) {
     set_optional_env(SA_GUARD_TIER_ENV, tier);

--- a/crates/cli-sub-agent/src/review_cmd_handle.rs
+++ b/crates/cli-sub-agent/src/review_cmd_handle.rs
@@ -449,7 +449,12 @@ async fn handle_review_inner(
         );
         let effective_exit_code = persisted_verdict_exit_code.unwrap_or(effective_exit_code);
         if let Some(session_id) = result.persistable_session_id.as_deref() {
-            persist_review_result_exit_code(&project_root, session_id, effective_exit_code);
+            persist_review_result_exit_code(
+                &project_root,
+                session_id,
+                effective_exit_code,
+                resolved.caller_guard_failure.then_some(sanitized.as_str()),
+            );
             diff_size::persist_review_diff_size_headers(&project_root, session_id, diff.as_ref());
         }
         if verdict != CLEAN {

--- a/crates/cli-sub-agent/src/review_cmd_output_exit.rs
+++ b/crates/cli-sub-agent/src/review_cmd_output_exit.rs
@@ -52,6 +52,7 @@ pub(in crate::review_cmd) fn persist_review_result_exit_code(
     project_root: &Path,
     session_id: &str,
     exit_code: i32,
+    caller_guard_summary: Option<&str>,
 ) {
     let mut result = match csa_session::load_result(project_root, session_id) {
         Ok(Some(result)) => result,
@@ -65,19 +66,67 @@ pub(in crate::review_cmd) fn persist_review_result_exit_code(
             return;
         }
     };
+    let summary = caller_guard_summary
+        .and_then(|summary| summary.lines().map(str::trim).find(|line| !line.is_empty()))
+        .map(|summary| summary.chars().take(200).collect::<String>());
     if result.exit_code == exit_code
         && result.status == csa_session::SessionResult::status_from_exit_code(exit_code)
+        && summary.is_none()
     {
         return;
     }
 
     result.exit_code = exit_code;
     result.status = csa_session::SessionResult::status_from_exit_code(exit_code);
+    if let Some(summary) = summary {
+        result.summary = summary;
+    }
     if let Err(error) = csa_session::save_result(project_root, session_id, &result) {
         warn!(
             session_id,
             error = %error,
             "Failed to persist review result.toml verdict exit-code alignment"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn caller_guard_failure_replaces_persisted_guard_summary() {
+        let project = tempfile::tempdir().expect("temp project");
+        let session = csa_session::create_session(
+            project.path(),
+            Some("caller guard persistence"),
+            None,
+            Some("codex"),
+        )
+        .expect("create session");
+        let result = csa_session::SessionResult {
+            status: csa_session::SessionResult::status_from_exit_code(1),
+            exit_code: 1,
+            summary: "</csa-caller-sa-guard>".to_string(),
+            tool: "codex".to_string(),
+            ..Default::default()
+        };
+        csa_session::save_result(project.path(), &session.meta_session_id, &result)
+            .expect("save guard result");
+
+        persist_review_result_exit_code(
+            project.path(),
+            &session.meta_session_id,
+            1,
+            Some("Review unavailable: codex tool failure: executable not found\n"),
+        );
+
+        let persisted = csa_session::load_result(project.path(), &session.meta_session_id)
+            .expect("load result")
+            .expect("persisted result");
+        assert_eq!(
+            persisted.summary,
+            "Review unavailable: codex tool failure: executable not found"
         );
     }
 }

--- a/crates/cli-sub-agent/src/review_cmd_result.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result.rs
@@ -45,8 +45,6 @@ const REVIEW_UNAVAILABLE_FAILURE_PATTERNS: &[&str] = &[
     "invalid api key",
     "authentication required",
 ];
-const CALLER_SA_GUARD_OPEN: &str = "<csa-caller-sa-guard>";
-const CALLER_SA_GUARD_CLOSE: &str = "</csa-caller-sa-guard>";
 
 fn verdict_from_decision(decision: ReviewDecision) -> &'static str {
     match decision {
@@ -211,54 +209,17 @@ pub(super) fn resolve_single_review_result(
 }
 
 fn caller_guard_failure_reason(result: &ReviewExecutionOutcome, tool: ToolName) -> Option<String> {
-    let output = &result.execution.execution.output;
-    if !is_caller_guard_only_output(output) {
-        return None;
-    }
-
-    let diagnostic = [
-        result.failure_reason.as_deref(),
-        result.primary_failure.as_deref(),
-        Some(result.execution.execution.stderr_output.as_str()),
-        Some(result.execution.execution.summary.as_str()),
-        result.status_reason.as_deref(),
-    ]
-    .into_iter()
-    .flatten()
-    .find(|text| !text.trim().is_empty() && !is_caller_guard_only_output(text))
-    .map(|text| truncate_single_line(text, 240))
-    .unwrap_or_else(|| "caller guard emitted without a review result".to_string());
-
-    Some(format!("{} tool failure: {diagnostic}", tool.as_str()))
-}
-
-fn is_caller_guard_only_output(output: &str) -> bool {
-    let trimmed = output.trim();
-    if trimmed.is_empty() {
-        return false;
-    }
-
-    let full_guard = crate::pipeline::prompt_guard::SA_MODE_CALLER_GUARD.trim();
-    let mut remainder = trimmed;
-    let mut full_guard_count = 0;
-    while let Some(after_guard) = remainder.strip_prefix(full_guard) {
-        full_guard_count += 1;
-        remainder = after_guard.trim();
-    }
-    if full_guard_count > 0 {
-        return remainder.is_empty();
-    }
-
-    trimmed
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .all(is_caller_guard_line)
-}
-
-fn is_caller_guard_line(line: &str) -> bool {
-    matches!(line, CALLER_SA_GUARD_OPEN | CALLER_SA_GUARD_CLOSE)
-        || line.starts_with("<csa-caller-sa-guard:compact")
+    crate::pipeline::prompt_guard::caller_guard_failure_summary(
+        tool.as_str(),
+        &result.execution.execution.output,
+        [
+            result.failure_reason.as_deref(),
+            result.primary_failure.as_deref(),
+            Some(result.execution.execution.stderr_output.as_str()),
+            Some(result.execution.execution.summary.as_str()),
+            result.status_reason.as_deref(),
+        ],
+    )
 }
 
 pub(super) fn build_reviewer_outcome(

--- a/crates/cli-sub-agent/src/review_cmd_result.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result.rs
@@ -45,6 +45,8 @@ const REVIEW_UNAVAILABLE_FAILURE_PATTERNS: &[&str] = &[
     "invalid api key",
     "authentication required",
 ];
+const CALLER_SA_GUARD_OPEN: &str = "<csa-caller-sa-guard>";
+const CALLER_SA_GUARD_CLOSE: &str = "</csa-caller-sa-guard>";
 
 fn verdict_from_decision(decision: ReviewDecision) -> &'static str {
     match decision {
@@ -88,6 +90,7 @@ pub(super) struct SingleReviewResolution {
     pub effective_exit_code: i32,
     pub auth_prompt_failure: bool,
     pub failure_reason: Option<String>,
+    pub caller_guard_failure: bool,
 }
 
 pub(super) fn resolve_single_review_result(
@@ -101,6 +104,7 @@ pub(super) fn resolve_single_review_result(
     let forced_unavailable = matches!(result.forced_decision, Some(ReviewDecision::Unavailable));
     let terminal_tool_error = terminal_tool_error_reason(&result.execution.execution.output);
     let tool_unavailable_reason = tool_unavailable_failure_reason(result, tool);
+    let caller_guard_reason = caller_guard_failure_reason(result, tool);
     let opaque_total_exhaustion = opaque_total_exhaustion_message(
         result.primary_failure.as_deref(),
         result.failure_reason.as_deref(),
@@ -125,6 +129,8 @@ pub(super) fn resolve_single_review_result(
         )
     } else if let Some(reason) = tool_unavailable_reason.as_deref() {
         format!("{REVIEW_UNAVAILABLE_PREFIX}{reason}\n")
+    } else if let Some(reason) = caller_guard_reason.as_deref() {
+        format!("{REVIEW_UNAVAILABLE_PREFIX}{reason}\n")
     } else {
         sanitize_review_output(&result.execution.execution.output)
     };
@@ -132,6 +138,7 @@ pub(super) fn resolve_single_review_result(
         && !forced_unavailable
         && terminal_tool_error.is_none()
         && tool_unavailable_reason.is_none()
+        && caller_guard_reason.is_none()
         && is_review_output_empty(&result.execution.execution.output);
     let tool_diagnostic = if opaque_total_exhaustion.is_some() {
         None
@@ -161,7 +168,7 @@ pub(super) fn resolve_single_review_result(
         load_summary_fallback(project_root, &result.execution.meta_session_id).as_deref(),
     );
 
-    let decision = if terminal_tool_error.is_some() {
+    let decision = if caller_guard_reason.is_some() || terminal_tool_error.is_some() {
         ReviewDecision::Unavailable
     } else if reviewer_killed_before_completion(
         &result.execution.execution.output,
@@ -188,6 +195,7 @@ pub(super) fn resolve_single_review_result(
     let effective_exit_code = crate::verdict_exit_code::exit_code_from_review_decision(decision);
     let failure_reason = terminal_tool_error
         .clone()
+        .or_else(|| caller_guard_reason.clone())
         .or_else(|| result.failure_reason.clone());
 
     SingleReviewResolution {
@@ -198,7 +206,59 @@ pub(super) fn resolve_single_review_result(
         effective_exit_code,
         auth_prompt_failure,
         failure_reason,
+        caller_guard_failure: caller_guard_reason.is_some(),
     }
+}
+
+fn caller_guard_failure_reason(result: &ReviewExecutionOutcome, tool: ToolName) -> Option<String> {
+    let output = &result.execution.execution.output;
+    if !is_caller_guard_only_output(output) {
+        return None;
+    }
+
+    let diagnostic = [
+        result.failure_reason.as_deref(),
+        result.primary_failure.as_deref(),
+        Some(result.execution.execution.stderr_output.as_str()),
+        Some(result.execution.execution.summary.as_str()),
+        result.status_reason.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .find(|text| !text.trim().is_empty() && !is_caller_guard_only_output(text))
+    .map(|text| truncate_single_line(text, 240))
+    .unwrap_or_else(|| "caller guard emitted without a review result".to_string());
+
+    Some(format!("{} tool failure: {diagnostic}", tool.as_str()))
+}
+
+fn is_caller_guard_only_output(output: &str) -> bool {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let full_guard = crate::pipeline::prompt_guard::SA_MODE_CALLER_GUARD.trim();
+    let mut remainder = trimmed;
+    let mut full_guard_count = 0;
+    while let Some(after_guard) = remainder.strip_prefix(full_guard) {
+        full_guard_count += 1;
+        remainder = after_guard.trim();
+    }
+    if full_guard_count > 0 {
+        return remainder.is_empty();
+    }
+
+    trimmed
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .all(is_caller_guard_line)
+}
+
+fn is_caller_guard_line(line: &str) -> bool {
+    matches!(line, CALLER_SA_GUARD_OPEN | CALLER_SA_GUARD_CLOSE)
+        || line.starts_with("<csa-caller-sa-guard:compact")
 }
 
 pub(super) fn build_reviewer_outcome(
@@ -215,6 +275,7 @@ pub(super) fn build_reviewer_outcome(
     );
     let terminal_tool_error = terminal_tool_error_reason(&result.execution.output);
     let tool_unavailable_reason = tool_unavailable_failure_reason(session_result, reviewer_tool);
+    let caller_guard_reason = caller_guard_failure_reason(session_result, reviewer_tool);
     let opaque_total_exhaustion = opaque_total_exhaustion_message(
         session_result.primary_failure.as_deref(),
         session_result.failure_reason.as_deref(),
@@ -223,6 +284,7 @@ pub(super) fn build_reviewer_outcome(
         && !forced_unavailable
         && terminal_tool_error.is_none()
         && tool_unavailable_reason.is_none()
+        && caller_guard_reason.is_none()
         && is_review_output_empty(&result.execution.output);
     let diagnostic =
         detect_tool_diagnostic(&result.execution.output, &result.execution.stderr_output);
@@ -240,7 +302,7 @@ pub(super) fn build_reviewer_outcome(
         result.execution.exit_code,
         None,
     );
-    let decision = if terminal_tool_error.is_some() {
+    let decision = if caller_guard_reason.is_some() || terminal_tool_error.is_some() {
         ReviewDecision::Unavailable
     } else if reviewer_killed_before_completion(
         &result.execution.output,
@@ -292,6 +354,8 @@ pub(super) fn build_reviewer_outcome(
             )
         } else if let Some(reason) = tool_unavailable_reason.as_deref() {
             format!("{REVIEW_UNAVAILABLE_PREFIX}{reason}\n")
+        } else if let Some(reason) = caller_guard_reason.as_deref() {
+            format!("{REVIEW_UNAVAILABLE_PREFIX}{reason}\n")
         } else {
             sanitize_review_output(&result.execution.output)
         },
@@ -302,6 +366,7 @@ pub(super) fn build_reviewer_outcome(
             diagnostic
                 .or_else(|| auth_prompt_failure.then(|| AUTH_PROMPT_DIAGNOSTIC.to_string()))
                 .or_else(|| terminal_tool_error.clone())
+                .or_else(|| caller_guard_reason.clone())
                 .or_else(|| tool_unavailable_reason.clone())
         },
     })
@@ -422,3 +487,7 @@ mod tests;
 #[cfg(test)]
 #[path = "review_cmd_result_memory_soft_limit_tests.rs"]
 mod memory_soft_limit_tests;
+
+#[cfg(test)]
+#[path = "review_cmd_result_caller_guard_tests.rs"]
+mod caller_guard_tests;

--- a/crates/cli-sub-agent/src/review_cmd_result.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result.rs
@@ -212,6 +212,7 @@ fn caller_guard_failure_reason(result: &ReviewExecutionOutcome, tool: ToolName) 
     crate::pipeline::prompt_guard::caller_guard_failure_summary(
         tool.as_str(),
         &result.execution.execution.output,
+        &result.execution.execution.summary,
         [
             result.failure_reason.as_deref(),
             result.primary_failure.as_deref(),

--- a/crates/cli-sub-agent/src/review_cmd_result_caller_guard_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_caller_guard_tests.rs
@@ -67,3 +67,28 @@ fn literal_caller_guard_text_in_provider_output_remains_data() {
     assert_eq!(resolved.decision, ReviewDecision::Pass);
     assert!(resolved.sanitized.contains("</csa-caller-sa-guard>"));
 }
+
+#[test]
+fn substantive_review_output_overrides_guard_only_selected_summary() {
+    let output = "<!-- CSA:SECTION:summary -->\nPASS\n<!-- CSA:SECTION:summary:END -->\n\
+        <!-- CSA:SECTION:details -->\nNo blocking issues found.\n<!-- CSA:SECTION:details:END -->";
+    let mut result = outcome(output, 0);
+    result.execution.execution.summary = "</csa-caller-sa-guard>".to_string();
+
+    let resolved =
+        resolve_single_review_result(&result, ToolName::Codex, "uncommitted", Path::new("."));
+
+    assert_eq!(resolved.decision, ReviewDecision::Pass);
+    assert_eq!(resolved.verdict, CLEAN);
+    assert!(resolved.sanitized.contains("No blocking issues found."));
+    assert!(!resolved.caller_guard_failure);
+    assert!(
+        crate::pipeline::prompt_guard::caller_guard_failure_summary(
+            ToolName::Codex.as_str(),
+            output,
+            &result.execution.execution.summary,
+            [None],
+        )
+        .is_none()
+    );
+}

--- a/crates/cli-sub-agent/src/review_cmd_result_caller_guard_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_caller_guard_tests.rs
@@ -1,0 +1,69 @@
+use super::tests::outcome;
+use super::*;
+use std::path::Path;
+
+#[test]
+fn resolve_single_review_result_rejects_caller_guard_as_review_result() {
+    let mut result = outcome("</csa-caller-sa-guard>", 1);
+    result.execution.execution.summary = "</csa-caller-sa-guard>".to_string();
+    result.failure_reason = Some("reviewer failed to start: executable not found".to_string());
+
+    let resolved =
+        resolve_single_review_result(&result, ToolName::Codex, "uncommitted", Path::new("."));
+
+    assert_eq!(resolved.decision, ReviewDecision::Unavailable);
+    assert_eq!(resolved.verdict, UNAVAILABLE);
+    assert_eq!(resolved.effective_exit_code, 1);
+    assert!(!resolved.sanitized.contains("csa-caller-sa-guard"));
+    assert!(resolved.sanitized.contains("reviewer failed to start"));
+}
+
+#[test]
+fn build_reviewer_outcome_rejects_caller_guard_as_review_result() {
+    let mut result = outcome("<csa-caller-sa-guard>\n</csa-caller-sa-guard>", 1);
+    result.primary_failure =
+        Some("reviewer startup failed: process exited before provider".to_string());
+
+    let reviewer = build_reviewer_outcome(0, ToolName::Codex, &result).expect("reviewer outcome");
+
+    assert_eq!(reviewer.verdict, UNAVAILABLE);
+    assert_eq!(reviewer.exit_code, 1);
+    assert!(!reviewer.output.contains("csa-caller-sa-guard"));
+    assert!(
+        reviewer
+            .diagnostic
+            .as_deref()
+            .is_some_and(|diagnostic| diagnostic.contains("reviewer startup failed"))
+    );
+}
+
+#[test]
+fn resolve_single_review_result_fails_closed_for_truncated_caller_guard() {
+    let result = outcome("<csa-caller-sa-guard:compact tier=codex", 1);
+    let resolved =
+        resolve_single_review_result(&result, ToolName::Codex, "uncommitted", Path::new("."));
+
+    assert_eq!(resolved.decision, ReviewDecision::Unavailable);
+    assert_eq!(resolved.verdict, UNAVAILABLE);
+    assert!(!resolved.sanitized.contains("csa-caller-sa-guard"));
+    assert!(
+        resolved
+            .failure_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("caller guard"))
+    );
+}
+
+#[test]
+fn literal_caller_guard_text_in_provider_output_remains_data() {
+    let output = "<csa-caller-sa-guard>\n<!-- CSA:SECTION:summary -->\nPASS — documented literal </csa-caller-sa-guard>\n<!-- CSA:SECTION:summary:END -->";
+    let resolved = resolve_single_review_result(
+        &outcome(output, 0),
+        ToolName::Codex,
+        "uncommitted",
+        Path::new("."),
+    );
+
+    assert_eq!(resolved.decision, ReviewDecision::Pass);
+    assert!(resolved.sanitized.contains("</csa-caller-sa-guard>"));
+}

--- a/crates/cli-sub-agent/src/review_cmd_result_tests.rs
+++ b/crates/cli-sub-agent/src/review_cmd_result_tests.rs
@@ -4,7 +4,7 @@ use csa_core::env::{CSA_SESSION_DIR_ENV_KEY, CSA_SESSION_ID_ENV_KEY};
 use csa_process::ExecutionResult;
 use std::{collections::HashMap, fs, path::Path};
 
-fn outcome(output: &str, exit_code: i32) -> ReviewExecutionOutcome {
+pub(super) fn outcome(output: &str, exit_code: i32) -> ReviewExecutionOutcome {
     ReviewExecutionOutcome {
         execution: SessionExecutionResult {
             execution: ExecutionResult {

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate.rs
@@ -18,7 +18,7 @@ use crate::run_cmd_post_exec_gate_capture::{
 #[path = "run_cmd_execute_post_exec_gate_index.rs"]
 mod gate_index;
 
-use gate_index::post_exec_gate_env_with_temp_index;
+use gate_index::{post_exec_gate_env_with_temp_index, strip_inherited_env};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct PostExecGateCommandOutcome {
@@ -286,17 +286,6 @@ fn classify_post_exec_gate_worktree(
     }
 }
 
-fn strip_inherited_csa_env(cmd: &mut Command) {
-    for var in csa_executor::CHILD_PROCESS_STRIPPED_ENV_VARS {
-        cmd.env_remove(var);
-    }
-    for (key, _) in std::env::vars_os() {
-        if key.to_string_lossy().starts_with("CSA_") {
-            cmd.env_remove(key);
-        }
-    }
-}
-
 pub(super) fn execute_post_exec_gate_command(
     command: &str,
     project_root: &Path,
@@ -311,15 +300,13 @@ pub(super) fn execute_post_exec_gate_command(
         cmd.arg("-c")
             .arg(&command)
             .current_dir(&project_root)
-            // Capture stdout/stderr so a failure can be surfaced structurally
-            // (#1726); the tee tasks below re-emit every chunk to the parent's
-            // stdout/stderr, so the raw transcript (`full.md`) is unchanged.
+            // Capture output for structured failure reporting (#1726).
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        strip_inherited_env(&mut cmd);
         if let Some(extra_env) = extra_env {
             cmd.envs(extra_env);
         }
-        strip_inherited_csa_env(&mut cmd);
 
         #[cfg(unix)]
         {

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate_index.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_gate_index.rs
@@ -12,8 +12,59 @@ pub(super) struct TempGateIndex {
 type GateEnv = Option<HashMap<String, String>>;
 type GateEnvWithIndex = (GateEnv, Option<TempGateIndex>);
 
+pub(super) fn is_git_routing_env(name: &str) -> bool {
+    matches!(
+        name,
+        "GIT_CONFIG"
+            | "GIT_DIR"
+            | "GIT_WORK_TREE"
+            | "GIT_COMMON_DIR"
+            | "GIT_NAMESPACE"
+            | "GIT_CEILING_DIRECTORIES"
+            | "GIT_DISCOVERY_ACROSS_FILESYSTEM"
+            | "GIT_TEMPLATE_DIR"
+            | "GIT_INDEX_FILE"
+            | "GIT_OBJECT_DIRECTORY"
+            | "GIT_ALTERNATE_OBJECT_DIRECTORIES"
+    ) || name.starts_with("GIT_CONFIG_")
+}
+
+pub(super) fn strip_inherited_env(command: &mut tokio::process::Command) {
+    for var in csa_executor::CHILD_PROCESS_STRIPPED_ENV_VARS {
+        command.env_remove(var);
+    }
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("CSA_") || is_git_routing_env(&key.to_string_lossy()) {
+            command.env_remove(key);
+        }
+    }
+}
+
+fn clear_git_routing_env(command: &mut std::process::Command) {
+    for (key, _) in std::env::vars_os() {
+        if is_git_routing_env(&key.to_string_lossy()) {
+            command.env_remove(key);
+        }
+    }
+}
+
+fn is_git_worktree(project_root: &Path) -> bool {
+    let mut command = std::process::Command::new("git");
+    clear_git_routing_env(&mut command);
+    command
+        .arg("-C")
+        .arg(project_root)
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+        .is_ok_and(|output| {
+            output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true"
+        })
+}
+
 fn git_index_path(project_root: &Path) -> Result<PathBuf> {
-    let output = std::process::Command::new("git")
+    let mut command = std::process::Command::new("git");
+    clear_git_routing_env(&mut command);
+    let output = command
         .arg("-C")
         .arg(project_root)
         .args(["rev-parse", "--git-path", "index"])
@@ -83,7 +134,9 @@ fn temp_index_contains_path(
     temp_index: &Path,
     changed_path: &str,
 ) -> Result<bool> {
-    let output = std::process::Command::new("git")
+    let mut command = std::process::Command::new("git");
+    clear_git_routing_env(&mut command);
+    let output = command
         .arg("-C")
         .arg(project_root)
         .args(["ls-files", "--stage", "--"])
@@ -107,7 +160,9 @@ fn temp_index_contains_path(
 }
 
 fn stage_changed_path(project_root: &Path, temp_index: &Path, changed_path: &str) -> Result<()> {
-    let output = std::process::Command::new("git")
+    let mut command = std::process::Command::new("git");
+    clear_git_routing_env(&mut command);
+    let output = command
         .arg("-C")
         .arg(project_root)
         .args(["add", "--all", "--"])
@@ -138,12 +193,13 @@ pub(super) fn post_exec_gate_env_with_temp_index(
     let Some(changed_paths) = changed_paths.filter(|paths| !paths.is_empty()) else {
         return Ok((extra_env, None));
     };
-    if !crate::run_cmd::is_git_worktree(project_root) {
+    if !is_git_worktree(project_root) {
         return Ok((extra_env, None));
     }
 
     let temp_index = build_temp_gate_index(project_root, changed_paths)?;
     let mut env = extra_env.unwrap_or_default();
+    env.retain(|name, _| !is_git_routing_env(name));
     env.insert(
         "GIT_INDEX_FILE".to_string(),
         temp_index.path.to_string_lossy().into_owned(),

--- a/crates/cli-sub-agent/src/run_cmd_execute_post_exec_staged_gate_tests.rs
+++ b/crates/cli-sub-agent/src/run_cmd_execute_post_exec_staged_gate_tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    PostExecGateCommandOutcome, PostExecGateOutcome, maybe_run_post_exec_gate_with_runner,
+    PostExecGateCommandOutcome, PostExecGateOutcome, execute_post_exec_gate_command,
+    maybe_run_post_exec_gate_with_runner,
 };
 use crate::test_env_lock::ScopedEnvVarRestore;
 use crate::test_session_sandbox::ScopedSessionSandbox;
@@ -413,4 +414,43 @@ async fn post_exec_gate_tolerates_deleted_never_tracked_changed_paths() {
         "",
         "post-exec gate must not stage deleted never-tracked paths in the real index"
     );
+}
+
+#[tokio::test]
+async fn post_exec_gate_ignores_inherited_git_work_tree_routing() {
+    let project_dir = tempdir().unwrap();
+    let wrong_work_tree = tempdir().unwrap();
+    let _sandbox = ScopedSessionSandbox::new(&project_dir).await;
+    init_clean_git_repo(project_dir.path());
+    init_clean_git_repo(wrong_work_tree.path());
+    std::fs::write(project_dir.path().join("tracked.txt"), "changed\n").unwrap();
+    let _work_tree = ScopedEnvVarRestore::set("GIT_WORK_TREE", wrong_work_tree.path());
+
+    let mut gate = PostExecGateConfig::default();
+    gate.command = "git diff --cached --name-only".to_string();
+    let config = project_config_with_gate(gate);
+    let changed_paths = vec!["tracked.txt".to_string()];
+    let outcome = maybe_run_post_exec_gate_with_runner(
+        project_dir.path(),
+        "Modify tracked.txt",
+        Some("01TESTPOSTEXECGATEGITROUTE0"),
+        Some(&config),
+        Some(&changed_paths),
+        None,
+        |command, cwd, timeout_seconds, extra_env| {
+            let cwd = cwd.to_path_buf();
+            let command = command.to_string();
+            Box::pin(async move {
+                let result =
+                    execute_post_exec_gate_command(&command, &cwd, timeout_seconds, extra_env)
+                        .await?;
+                assert_eq!(result.captured_output, "tracked.txt\n");
+                Ok(result)
+            })
+        },
+    )
+    .await
+    .expect("gate should pass");
+
+    assert_eq!(outcome, PostExecGateOutcome::Passed);
 }

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_guard_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_guard_summary_tests.rs
@@ -3,7 +3,7 @@ use crate::pipeline_post_exec::{PostExecContext, process_execution_result};
 use crate::test_session_sandbox::ScopedSessionSandbox;
 
 #[tokio::test]
-async fn guard_only_sa_failure_is_sanitized_before_generic_session_persistence() {
+async fn selected_guard_summary_in_mixed_output_is_sanitized_before_persistence() {
     let temp = tempfile::tempdir().expect("tempdir");
     let _sandbox = ScopedSessionSandbox::new(&temp).await;
     let project_root = temp.path();
@@ -51,7 +51,8 @@ async fn guard_only_sa_failure_is_sanitized_before_generic_session_persistence()
     };
     let guard = "</csa-caller-sa-guard>";
     let mut execution = csa_process::ExecutionResult {
-        output: guard.to_string(),
+        output: format!("wrapper control prelude\n<csa-caller-sa-guard>\n{guard}\n"),
+        stderr_output: "fixture codex startup rejected".to_string(),
         summary: guard.to_string(),
         exit_code: 1,
         model_completed: Some(false),
@@ -72,6 +73,7 @@ async fn guard_only_sa_failure_is_sanitized_before_generic_session_persistence()
     assert_eq!(execution.summary, persisted.summary);
     assert!(!persisted.summary.contains("csa-caller-sa-guard"));
     assert!(persisted.summary.contains("codex tool failure"));
+    assert!(persisted.summary.contains("fixture codex startup rejected"));
     assert!(persisted.summary.chars().count() <= 240);
 
     let wait = render_wait_result_summary(&session_dir, &session.meta_session_id, &persisted);

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_guard_summary_tests.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_guard_summary_tests.rs
@@ -1,0 +1,82 @@
+use super::*;
+use crate::pipeline_post_exec::{PostExecContext, process_execution_result};
+use crate::test_session_sandbox::ScopedSessionSandbox;
+
+#[tokio::test]
+async fn guard_only_sa_failure_is_sanitized_before_generic_session_persistence() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let _sandbox = ScopedSessionSandbox::new(&temp).await;
+    let project_root = temp.path();
+    let mut session = csa_session::create_session(
+        project_root,
+        Some("pre-provider review failure"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    session.task_context.task_type = Some("review".to_string());
+    let session_dir =
+        csa_session::get_session_dir(project_root, &session.meta_session_id).expect("session dir");
+    let executor = csa_executor::Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: csa_executor::codex_runtime::codex_runtime_metadata(),
+    };
+    let hooks_config = csa_hooks::HooksConfig::default();
+    let ctx = PostExecContext {
+        executor: &executor,
+        prompt: "review main...HEAD",
+        effective_prompt: "review main...HEAD",
+        task_type: Some("review"),
+        readonly_project_root: true,
+        project_root,
+        config: None,
+        global_config: None,
+        session_dir: session_dir.clone(),
+        sessions_root: "test-root".to_string(),
+        execution_start_time: chrono::Utc::now() - chrono::Duration::seconds(1),
+        hooks_config: &hooks_config,
+        memory_project_key: None,
+        provider_session_id: None,
+        events_count: 0,
+        transcript_artifacts: vec![],
+        changed_paths: vec![],
+        pre_exec_snapshot: None,
+        timeout_diagnostics: None,
+        has_tool_calls: false,
+        turn_count: 0,
+        output_tokens: None,
+        sa_mode: true,
+        original_exit_code: Some(1),
+    };
+    let guard = "</csa-caller-sa-guard>";
+    let mut execution = csa_process::ExecutionResult {
+        output: guard.to_string(),
+        summary: guard.to_string(),
+        exit_code: 1,
+        model_completed: Some(false),
+        ..Default::default()
+    };
+
+    process_execution_result(ctx, &mut session, &mut execution)
+        .await
+        .expect("process generic session result");
+
+    let persisted: csa_session::SessionResult = toml::from_str(
+        &std::fs::read_to_string(session_dir.join(csa_session::result::RESULT_FILE_NAME))
+            .expect("read persisted result"),
+    )
+    .expect("parse persisted result");
+    assert_eq!(persisted.status, "failure");
+    assert_eq!(persisted.exit_code, 1);
+    assert_eq!(execution.summary, persisted.summary);
+    assert!(!persisted.summary.contains("csa-caller-sa-guard"));
+    assert!(persisted.summary.contains("codex tool failure"));
+    assert!(persisted.summary.chars().count() <= 240);
+
+    let wait = render_wait_result_summary(&session_dir, &session.meta_session_id, &persisted);
+    assert!(wait.contains(&format!("Summary: {}", persisted.summary)));
+    assert!(!wait.contains("csa-caller-sa-guard"));
+    assert!(!wait.contains("Review verdict: PASS"));
+    assert!(!wait.contains("Review verdict: FAIL"));
+}

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_summary.rs
@@ -641,6 +641,9 @@ fn render_wait_output_log(raw: &[u8], truncated: bool) -> Option<String> {
 }
 
 #[cfg(test)]
+#[path = "session_cmds_daemon_wait_guard_summary_tests.rs"]
+mod guard_summary_tests;
+#[cfg(test)]
 #[path = "session_cmds_daemon_wait_summary_2425.rs"]
 mod session_cmds_daemon_wait_summary_2425;
 #[cfg(test)]

--- a/crates/cli-sub-agent/tests/caller_guard_result_toml.rs
+++ b/crates/cli-sub-agent/tests/caller_guard_result_toml.rs
@@ -1,0 +1,266 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::Duration;
+
+#[path = "../src/test_bounded_command.rs"]
+#[expect(
+    dead_code,
+    reason = "the integration test captures command output with a deadline"
+)]
+mod test_bounded_command;
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+const GIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn csa_cmd(home: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_csa"));
+    scrub_inherited_csa_env(&mut command);
+    command
+        .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+        .env("HOME", home)
+        .env("XDG_STATE_HOME", home.join(".local/state"))
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("TOKIO_WORKER_THREADS", "1")
+        .env("CSA_DAEMON_INDEPENDENT_SCOPE", "0")
+        .env("CSA_TEST_SKIP_HOST_MEMORY_ADMISSION", "1");
+    command
+}
+
+fn scrub_inherited_csa_env(command: &mut Command) {
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("CSA_") {
+            command.env_remove(key);
+        }
+    }
+}
+
+fn run_git(project: &Path, args: &[&str]) {
+    let mut command = Command::new("/usr/bin/git");
+    command
+        .env_clear()
+        .args([
+            "-c",
+            "commit.gpgSign=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "init.templateDir=",
+        ])
+        .args(args)
+        .current_dir(project)
+        .env("PATH", "/usr/local/bin:/usr/bin:/bin")
+        .env("HOME", project)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("XDG_CONFIG_HOME", "/dev/null")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "test@test.com")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "test@test.com");
+    let output = test_bounded_command::output_with_timeout(command, GIT_TIMEOUT);
+    assert!(
+        output.status.success(),
+        "fixture git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_project(project: &Path) {
+    fs::create_dir_all(project.join(".csa")).expect("create fixture config directory");
+    fs::write(project.join("README.md"), "# fixture\n").expect("write fixture readme");
+    fs::write(project.join("lefthook.yml"), "pre-commit:\n").expect("write fixture hooks");
+    fs::write(
+        project.join(".csa/config.toml"),
+        r#"schema_version = 1
+
+[resources]
+min_free_memory_mb = 0
+memory_max_mb = 9000
+soft_limit_percent = 100
+
+[filesystem_sandbox]
+enforcement_mode = "off"
+
+[tools.codex]
+enabled = true
+transport = "cli"
+default_model = "gpt-5.4-mini"
+
+[run.post_exec_gate]
+enabled = false
+"#,
+    )
+    .expect("write fixture config");
+    run_git(project, &["-c", "init.defaultBranch=main", "init"]);
+    run_git(project, &["config", "user.email", "test@example.com"]);
+    run_git(project, &["config", "user.name", "Test User"]);
+    run_git(project, &["add", "."]);
+    run_git(project, &["commit", "-m", "initial"]);
+    run_git(project, &["checkout", "-b", "fix/caller-guard-summary"]);
+}
+
+#[cfg(unix)]
+fn install_fake_codex(home: &Path) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let bin = home.join("bin");
+    fs::create_dir_all(&bin).expect("create fake tool directory");
+    let codex = bin.join("codex");
+    fs::write(
+        &codex,
+        r#"#!/bin/sh
+printf '%s\n' 'wrapper control prelude' '<csa-caller-sa-guard>' '</csa-caller-sa-guard>'
+printf '%s\n' '{"type":"turn.failed","error":{"message":"fixture codex startup rejected"}}' >&2
+exit 86
+"#,
+    )
+    .expect("write fake codex");
+    let mut permissions = fs::metadata(&codex)
+        .expect("fake codex metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&codex, permissions).expect("make fake codex executable");
+
+    let which = bin.join("which");
+    fs::write(
+        &which,
+        "#!/bin/sh\nif [ \"${1:-}\" = bwrap ]; then exit 1; fi\nexec /usr/bin/which \"$@\"\n",
+    )
+    .expect("write fake which");
+    let mut permissions = fs::metadata(&which)
+        .expect("fake which metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&which, permissions).expect("make fake which executable");
+    bin
+}
+
+fn session_dir(home: &Path, project: &Path, session_id: &str) -> PathBuf {
+    let canonical = project
+        .canonicalize()
+        .unwrap_or_else(|_| project.to_path_buf());
+    let normalized = canonical
+        .to_string_lossy()
+        .trim_start_matches('/')
+        .replace('/', std::path::MAIN_SEPARATOR_STR);
+    home.join(".local/state/cli-sub-agent")
+        .join(normalized)
+        .join("sessions")
+        .join(session_id)
+}
+
+fn output_diagnostic(output: &Output) -> String {
+    format!(
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[cfg(unix)]
+#[test]
+fn daemon_run_persists_causal_summary_when_selected_summary_is_caller_guard() {
+    let home = tempfile::tempdir().expect("temporary home");
+    let fake_bin = install_fake_codex(home.path());
+    let project = home.path().join("project");
+    init_project(&project);
+    let global_config = home.path().join(".config/cli-sub-agent/config.toml");
+    fs::create_dir_all(global_config.parent().expect("global config parent"))
+        .expect("create global config directory");
+    fs::write(
+        &global_config,
+        format!(
+            "[kv_cache.provider_ttls]\nfixture = 30\n\n[tools.codex.env]\nPATH = \"{}\"\n",
+            fake_bin.display()
+        ),
+    )
+    .expect("write global config");
+
+    let launch = test_bounded_command::output_with_timeout(
+        {
+            let mut command = csa_cmd(home.path());
+            command.current_dir(&project).args([
+                "run",
+                "--sa-mode",
+                "true",
+                "--no-post-exec-gate",
+                "--tool",
+                "codex",
+                "--min-free-memory-mb",
+                "0",
+                "fixture failure",
+            ]);
+            command
+        },
+        COMMAND_TIMEOUT,
+    );
+    assert!(
+        launch.status.success(),
+        "daemon launch failed: {}",
+        output_diagnostic(&launch)
+    );
+    let session_id = String::from_utf8_lossy(&launch.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .last()
+        .expect("daemon launcher must end stdout with its session ID")
+        .to_string();
+    assert_eq!(
+        session_id.len(),
+        26,
+        "unexpected daemon session ID: {session_id}"
+    );
+    assert!(
+        String::from_utf8_lossy(&launch.stderr).contains("CSA:SESSION_STARTED"),
+        "daemon launch did not publish a session marker: {}",
+        output_diagnostic(&launch)
+    );
+
+    let wait = test_bounded_command::output_with_timeout(
+        {
+            let mut command = csa_cmd(home.path());
+            command.current_dir(&project).args([
+                "session",
+                "wait",
+                "--session",
+                &session_id,
+                "--model-provider",
+                "fixture",
+                "--cd",
+                project.to_str().expect("UTF-8 fixture path"),
+            ]);
+            command
+        },
+        COMMAND_TIMEOUT,
+    );
+    assert!(
+        !wait.status.success(),
+        "failed tool session unexpectedly succeeded"
+    );
+
+    let result_path =
+        session_dir(home.path(), &project, &session_id).join(csa_session::result::RESULT_FILE_NAME);
+    assert!(
+        result_path.exists(),
+        "wait did not publish {}: {}",
+        result_path.display(),
+        output_diagnostic(&wait)
+    );
+    let result: csa_session::SessionResult =
+        toml::from_str(&fs::read_to_string(&result_path).expect("read published result.toml"))
+            .expect("parse durable result.toml");
+    assert_eq!(result.status, "failure");
+    assert_ne!(result.exit_code, 0);
+    assert!(!result.summary.contains("csa-caller-sa-guard"));
+    assert!(
+        result.summary.contains("codex tool failure"),
+        "expected causal caller-guard summary, got {:?}",
+        result.summary
+    );
+    assert!(result.summary.contains("fixture codex startup rejected"));
+    assert!(result.summary.chars().count() <= 240);
+}

--- a/crates/cli-sub-agent/tests/mcp_hub_e2e.rs
+++ b/crates/cli-sub-agent/tests/mcp_hub_e2e.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -70,13 +70,38 @@ args = ["{}"]
     Ok(())
 }
 
-fn wait_for_socket(socket_path: &Path, timeout: Duration) -> Result<()> {
+fn wait_for_socket(
+    child: &mut Child,
+    socket_path: &Path,
+    stderr_path: &Path,
+    timeout: Duration,
+) -> Result<()> {
+    let pid = child.id();
+    let child_exit_error = |status| {
+        let startup_stderr = fs::File::open(stderr_path)
+            .and_then(|file| {
+                let mut bytes = Vec::new();
+                file.take(16 * 1024).read_to_end(&mut bytes)?;
+                Ok(String::from_utf8_lossy(&bytes).into_owned())
+            })
+            .unwrap_or_else(|error| format!("<unable to read startup stderr: {error}>"));
+        anyhow::anyhow!(
+            "hub child {pid} exited before socket readiness with status {status}; startup stderr:\n{startup_stderr}"
+        )
+    };
+
     let start = Instant::now();
     while start.elapsed() < timeout {
-        if socket_path.exists() && std::os::unix::net::UnixStream::connect(socket_path).is_ok() {
+        if std::os::unix::net::UnixStream::connect(socket_path).is_ok() {
             return Ok(());
         }
+        if let Some(status) = child.try_wait()? {
+            return Err(child_exit_error(status));
+        }
         std::thread::sleep(Duration::from_millis(50));
+    }
+    if let Some(status) = child.try_wait()? {
+        return Err(child_exit_error(status));
     }
     bail!("timed out waiting for socket {}", socket_path.display())
 }
@@ -154,12 +179,9 @@ fn reserve_local_port() -> Result<u16> {
     Ok(port)
 }
 
-// macOS CI: hub spawns the mock MCP backend but sh/sed differences prevent
-// the backend from registering tools.  Hub itself is Linux-first (UDS + systemd),
-// so restrict the E2E test to Linux.  Unit tests still cover logic on all platforms.
 #[test]
 #[cfg_attr(not(target_os = "linux"), ignore)]
-fn hub_forwards_requests_and_proxy_latency_budget_is_within_environment_budget() -> Result<()> {
+fn hub_startup_failure_is_reported_before_socket_timeout() -> Result<()> {
     let temp = tempfile::tempdir()?;
     let home = temp.path().join("home");
     let config_home = home.join(".config");
@@ -170,7 +192,10 @@ fn hub_forwards_requests_and_proxy_latency_budget_is_within_environment_budget()
     let script_path = write_mock_mcp_script(temp.path())?;
     write_global_config(&config_home, &script_path)?;
 
-    let socket_path = runtime_dir.join("mcp-hub.sock");
+    let blocked_runtime = temp.path().join("blocked-runtime");
+    fs::write(&blocked_runtime, b"not a directory")?;
+    let socket_path = blocked_runtime.join("mcp-hub.sock");
+    let stderr_file = tempfile::NamedTempFile::new()?;
 
     let mut hub_command = Command::new(env!("CARGO_BIN_EXE_csa"));
     scrub_inherited_csa_env(&mut hub_command);
@@ -188,12 +213,93 @@ fn hub_forwards_requests_and_proxy_latency_budget_is_within_environment_budget()
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_RUNTIME_DIR", &runtime_dir)
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::from(stderr_file.reopen()?))
+        .spawn()
+        .context("spawn hub")?;
+    let hub_pid = hub.id();
+
+    let readiness_error = wait_for_socket(
+        &mut hub,
+        &socket_path,
+        stderr_file.path(),
+        Duration::from_secs(1),
+    )
+    .expect_err("invalid socket parent should fail readiness");
+    let status = hub.wait()?;
+    let startup_stderr = fs::read_to_string(stderr_file.path())?;
+
+    assert!(!status.success(), "hub unexpectedly succeeded: {status}");
+    assert!(!socket_path.exists(), "hub socket unexpectedly exists");
+    let readiness_error = readiness_error.to_string();
+    assert!(
+        readiness_error.contains("exited before socket readiness"),
+        "readiness error should report early child exit: {readiness_error}"
+    );
+    assert!(
+        readiness_error.contains(&hub_pid.to_string()),
+        "readiness error should report child PID: {readiness_error}"
+    );
+    assert!(
+        readiness_error.contains(&status.to_string()),
+        "readiness error should report child status: {readiness_error}"
+    );
+    assert!(
+        !startup_stderr.trim().is_empty(),
+        "hub stderr should be captured"
+    );
+    assert!(
+        readiness_error.contains(startup_stderr.trim()),
+        "readiness error should preserve startup stderr: {readiness_error}"
+    );
+    Ok(())
+}
+
+// macOS CI: hub spawns the mock MCP backend but sh/sed differences prevent
+// the backend from registering tools.  Hub itself is Linux-first (UDS + systemd),
+// so restrict the E2E test to Linux.  Unit tests still cover logic on all platforms.
+#[test]
+#[cfg_attr(not(target_os = "linux"), ignore)]
+fn hub_forwards_requests_and_proxy_latency_budget_is_within_environment_budget() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let home = temp.path().join("home");
+    let config_home = home.join(".config");
+    let runtime_dir = temp.path().join("runtime");
+    fs::create_dir_all(&config_home)?;
+    fs::create_dir_all(&runtime_dir)?;
+
+    let script_path = write_mock_mcp_script(temp.path())?;
+    write_global_config(&config_home, &script_path)?;
+
+    let socket_path = runtime_dir.join("mcp-hub.sock");
+    let stderr_file = tempfile::NamedTempFile::new()?;
+
+    let mut hub_command = Command::new(env!("CARGO_BIN_EXE_csa"));
+    scrub_inherited_csa_env(&mut hub_command);
+    let mut hub = hub_command
+        .args([
+            "mcp-hub",
+            "serve",
+            "--foreground",
+            "--socket",
+            socket_path
+                .to_str()
+                .context("socket path should be valid UTF-8")?,
+        ])
+        .env("HOME", &home)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_RUNTIME_DIR", &runtime_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr_file.reopen()?))
         .spawn()
         .context("spawn hub")?;
 
     let test_result = (|| -> Result<()> {
-        wait_for_socket(&socket_path, Duration::from_secs(5))?;
+        wait_for_socket(
+            &mut hub,
+            &socket_path,
+            stderr_file.path(),
+            Duration::from_secs(5),
+        )?;
 
         // Retry tools/list until the hub has connected its MCP backend.
         // On macOS CI runners the hub socket is ready before backends register.
@@ -362,6 +468,7 @@ fn hub_http_streamable_transport_forwards_requests() -> Result<()> {
     write_global_config(&config_home, &script_path)?;
 
     let socket_path = runtime_dir.join("mcp-hub.sock");
+    let stderr_file = tempfile::NamedTempFile::new()?;
     let http_port = reserve_local_port()?;
 
     let mut hub_command = Command::new(env!("CARGO_BIN_EXE_csa"));
@@ -384,12 +491,17 @@ fn hub_http_streamable_transport_forwards_requests() -> Result<()> {
         .env("XDG_CONFIG_HOME", &config_home)
         .env("XDG_RUNTIME_DIR", &runtime_dir)
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::from(stderr_file.reopen()?))
         .spawn()
         .context("spawn hub")?;
 
     let test_result = (|| -> Result<()> {
-        wait_for_socket(&socket_path, Duration::from_secs(5))?;
+        wait_for_socket(
+            &mut hub,
+            &socket_path,
+            stderr_file.path(),
+            Duration::from_secs(5),
+        )?;
 
         let mcp_url = format!("http://127.0.0.1:{http_port}/mcp");
 

--- a/crates/csa-executor/src/transport_tests_gemini_fixture.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_fixture.rs
@@ -2,6 +2,12 @@ fn configure_fake_gemini_cache(
     temp: &tempfile::TempDir,
     env: &mut HashMap<String, String>,
 ) {
+    let home = temp.path().join("home");
+    std::fs::create_dir_all(home.join(".gemini")).expect("create fake Gemini home");
+    env.insert(
+        "HOME".to_string(),
+        home.to_string_lossy().into_owned(),
+    );
     let cache_home = temp.path().join("xdg-cache");
     std::fs::create_dir(&cache_home).expect("create fake Gemini cache home");
     env.insert(

--- a/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
+++ b/crates/csa-executor/src/transport_tests_gemini_init_classification.rs
@@ -454,6 +454,66 @@ exit 1
     );
 }
 
+#[tokio::test]
+async fn test_gemini_isolates_poisoned_home_extensions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let _env_lock = GEMINI_INIT_ENV_LOCK.lock().await;
+    let poisoned_home = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(
+        poisoned_home
+            .path()
+            .join(".gemini/extensions/gemini-cli-security"),
+    )
+    .unwrap();
+    let _home = GeminiInitScopedEnvVar::set(
+        "HOME",
+        poisoned_home.path().to_str().unwrap(),
+    );
+
+    let (temp, mut env, _) = setup_fake_gemini_environment(1);
+    let script_path = temp.path().join("gemini");
+    std::fs::write(
+        &script_path,
+        r#"#!/usr/bin/env bash
+runtime_home="${GEMINI_CLI_HOME:-$HOME/.gemini}"
+extension_dir="$runtime_home/.gemini/extensions/gemini-cli-security"
+if [ -d "$extension_dir" ]; then
+  printf 'spawn %s/mcp-server ENOENT\n' "$extension_dir" >&2
+  exit 1
+fi
+printf 'fake Gemini child exited before ACP handshake\n' >&2
+exit 1
+"#,
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script_path, perms).unwrap();
+    env.insert(
+        "CSA_GEMINI_ALLOW_DEGRADED_MCP".to_string(),
+        "0".to_string(),
+    );
+
+    let error = AcpTransport::new("gemini-cli", None)
+        .execute_in(
+            "test poisoned home isolation",
+            temp.path(),
+            Some(&env),
+            None,
+            false,
+            StreamMode::BufferOnly,
+            30,
+            super::ResolvedTimeout(None),
+        )
+        .await
+        .expect_err("fake Gemini should fail before ACP handshake");
+    let error_text = format!("{error:#}");
+    assert!(error_text.contains("gemini_acp_init_handshake_timeout"));
+    assert!(error_text.contains("fake Gemini child exited before ACP handshake"));
+    assert!(!error_text.contains("gemini-cli-security/mcp-server ENOENT"));
+}
+
 fn write_fake_gemini_startup_script(script_path: &std::path::Path) {
     use std::os::unix::fs::PermissionsExt;
 

--- a/scripts/build-exact-head-binaries.sh
+++ b/scripts/build-exact-head-binaries.sh
@@ -9,8 +9,8 @@ Usage: build-exact-head-binaries.sh --repo <path> --head <commit> --output-dir <
 Build csa and weave from a git-archive snapshot of one commit. The build runs
 with an isolated Cargo home/target directory and a whitelist environment so
 live-checkout ignored files, dotenv values, Cargo wrappers, and Rust flags
-cannot affect the produced binaries. The output directory must resolve to
-<repo>/target/exact-head/<head-commit>.
+cannot affect the produced binaries. The output directory must lexically
+normalize to <repo>/target/exact-head/<head-commit>.
 EOF
 }
 
@@ -60,11 +60,33 @@ case "${output_dir}" in
   /*) ;;
   *) output_dir="${repo}/${output_dir}" ;;
 esac
-output_root="$(realpath -m -- "${repo}/target/exact-head")"
-output_dir="$(realpath -m -- "${output_dir}")"
+lexical_path() {
+  realpath -ms -- "$1"
+}
+
+target_root="${repo}/target"
+if [ -L "${target_root}" ]; then
+  target_link="$(readlink -- "${target_root}")"
+  case "${target_link}" in
+    /*) target_root="${target_link}" ;;
+    *) target_root="${repo}/${target_link}" ;;
+  esac
+fi
+output_root="$(lexical_path "${target_root}/exact-head")"
+checkout_output_root="$(lexical_path "${repo}/target/exact-head")"
+output_dir="$(lexical_path "${output_dir}")"
+case "${output_dir}" in
+  "${checkout_output_root}"/*)
+    output_dir="${output_root}${output_dir#"${checkout_output_root}"}"
+    ;;
+esac
 expected_output_dir="${output_root}/${head}"
 if [ "${output_dir}" != "${expected_output_dir}" ]; then
-  echo "ERROR: --output-dir must resolve to the exact commit output path ${expected_output_dir}." >&2
+  echo "ERROR: --output-dir must normalize to the exact commit output path ${expected_output_dir}." >&2
+  exit 2
+fi
+if [ -L "${output_root}" ]; then
+  echo "ERROR: exact-build output root must not be a symbolic link: ${output_root}." >&2
   exit 2
 fi
 

--- a/scripts/tests/build-exact-head-binaries-tests.sh
+++ b/scripts/tests/build-exact-head-binaries-tests.sh
@@ -110,7 +110,13 @@ env -u RUSTC_WRAPPER \
 git -C "${fixture}" add .
 git -C "${fixture}" commit -qm "fixture"
 head="$(git -C "${fixture}" rev-parse HEAD)"
-output="${fixture}/target/exact-head/${head}"
+target_backing="${tmp}/target-backing"
+lexical_target="${tmp}/lexical-target"
+mkdir -p "${target_backing}"
+ln -s "${target_backing}" "${lexical_target}"
+ln -s "${lexical_target}" "${fixture}/target"
+output="${lexical_target}/exact-head/${head}"
+requested_output="${fixture}/target/exact-head/${head}"
 
 rename_source="${tmp}/rename-source"
 rename_destination="${tmp}/rename-destination"
@@ -136,8 +142,22 @@ rmdir "${rename_destination}"
 rm -rf "${rename_destination}"
 
 victim="${tmp}/victim"
-mkdir -p "${victim}" "${fixture}/target/exact-head"
+mkdir -p "${victim}"
 printf 'keep\n' >"${victim}/sentinel"
+ln -s "${victim}" "${fixture}/target/exact-head"
+if "${builder}" \
+  --repo "${fixture}" \
+  --head "${head}" \
+  --output-dir "${requested_output}" \
+  >"${tmp}/symlinked-root.stdout" 2>"${tmp}/symlinked-root.stderr"; then
+  echo "ERROR: accepted symlinked exact-build output root" >&2
+  exit 1
+fi
+grep -q 'exact-build output root must not be a symbolic link' \
+  "${tmp}/symlinked-root.stderr"
+[ "$(cat "${victim}/sentinel")" = "keep" ]
+rm "${fixture}/target/exact-head"
+mkdir -p "${fixture}/target/exact-head"
 ln -s "${victim}" "${fixture}/target/exact-head/escape"
 for dangerous_output in \
   "${HOME}" \
@@ -154,7 +174,7 @@ for dangerous_output in \
     echo "ERROR: accepted dangerous exact-build output path: ${dangerous_output}" >&2
     exit 1
   fi
-  grep -q 'must resolve to the exact commit output path' "${tmp}/dangerous-output.stderr"
+  grep -q 'must normalize to the exact commit output path' "${tmp}/dangerous-output.stderr"
   [ "$(cat "${victim}/sentinel")" = "keep" ]
 done
 
@@ -232,11 +252,22 @@ CARGO_ENCODED_RUSTFLAGS='--cfgcontaminated_encoded' \
 RUSTC_BOOTSTRAP=1 \
 CARGO_PROFILE_RELEASE_OPT_LEVEL=0 \
 CARGO_HOME="${fixture}/.cargo" \
-  "${builder}" --repo "${fixture}" --head "${head}" --output-dir "${output}"
+  "${builder}" \
+    --repo "${fixture}" \
+    --head "${head}" \
+    --output-dir "${requested_output}" \
+    >"${tmp}/lexical-output.stdout"
 
 [ "$(cat "${output}/SOURCE_COMMIT")" = "${head}" ]
 [ "$("${output}/csa")" = "exact archive binary: csa" ]
 [ "$("${output}/weave")" = "exact archive binary: weave" ]
+if ! grep -Fxq \
+  "Built exact-head binaries from ${head} at ${output}" \
+  "${tmp}/lexical-output.stdout"; then
+  echo "ERROR: exact builder did not preserve lexical target identity ${output}" >&2
+  cat "${tmp}/lexical-output.stdout" >&2
+  exit 1
+fi
 "${builder}" --repo "${fixture}" --head "${head}" --output-dir "${output}"
 [ "$(cat "${output}/SOURCE_COMMIT")" = "${head}" ]
 printf 'PASS: exact-head archive build rejects unsafe output paths, live checkout, and environment contamination\n'

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1166"
-weave = "0.1.1166"
+csa = "0.1.1167"
+weave = "0.1.1167"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1169"
-weave = "0.1.1169"
+csa = "0.1.1170"
+weave = "0.1.1170"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1170"
-weave = "0.1.1170"
+csa = "0.1.1171"
+weave = "0.1.1171"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1168"
-weave = "0.1.1168"
+csa = "0.1.1169"
+weave = "0.1.1169"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1171"
-weave = "0.1.1171"
+csa = "0.1.1172"
+weave = "0.1.1172"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1172"
-weave = "0.1.1172"
+csa = "0.1.1173"
+weave = "0.1.1173"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1167"
-weave = "0.1.1167"
+csa = "0.1.1168"
+weave = "0.1.1168"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1173"
-weave = "0.1.1173"
+csa = "0.1.1174"
+weave = "0.1.1174"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Keep caller-guard tags out of persisted/review summaries without discarding a substantive review result. Also isolate post-exec Git routing, fake Gemini HOME extensions, MCP hub startup-exit diagnostics, and lexical exact-build target paths.

## Test plan

- Exact-tree `just quality-gates` PASS on `34de477c` (`7661`/`7691` passed, 8 skipped)
- Frozen native Tier-4 `VERDICT: PASS` for `main...HEAD`
- Regression: substantive review output + exit 0 + guard-only selected summary remains PASS

## Notes

Native exact-head review was used because installed `csa` is `0.1.1156` while the candidate is `0.1.1174`. Pre-push `review-check` used the documented review-check-only bypass; other hooks remained enabled. Unrelated pre-push flake: #3156.

Closes #3145
Closes #3143
Closes #3082
Closes #3095
Closes #3155
Refs #3156
