### PR TITLE
fix(run): keep wait success after reaped child cleanup timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1174"
+version = "0.1.1175"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1174"
+version = "0.1.1175"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/csa-process/src/lib_subprocess_helpers.rs
+++ b/crates/csa-process/src/lib_subprocess_helpers.rs
@@ -2,7 +2,13 @@ use anyhow::{Context, Result};
 use std::{process::ExitStatus, time::Duration};
 use tokio::process::Command;
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicI32, Ordering};
+
 const CHILD_REAP_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[cfg(test)]
+static FORCE_GROUP_CLEANUP_TIMEOUT_FOR: AtomicI32 = AtomicI32::new(0);
 
 #[derive(Debug)]
 pub enum ChildWaitState {
@@ -114,6 +120,11 @@ async fn wait_for_child_exit(child: &mut tokio::process::Child) -> Result<ExitSt
 
 #[cfg(target_os = "linux")]
 async fn wait_for_process_group_termination(process_group: i32) -> Result<()> {
+    #[cfg(test)]
+    if FORCE_GROUP_CLEANUP_TIMEOUT_FOR.swap(0, Ordering::SeqCst) == process_group {
+        anyhow::bail!("forced process-group cleanup timeout");
+    }
+
     let deadline = tokio::time::Instant::now() + CHILD_REAP_TIMEOUT;
     loop {
         match crate::process_activity::process_group_has_live_members(process_group) {
@@ -156,9 +167,17 @@ pub async fn terminate_child_process_group(
             #[cfg(target_os = "linux")]
             if let Err(group_error) = wait_for_process_group_termination(process_group).await {
                 return match wait_for_child_exit(child).await {
-                    Ok(_) => Err(group_error.context(format!(
-                        "child process was reaped but process group {process_group} cleanup failed"
-                    ))),
+                    Ok(status) => match crate::process_activity::process_group_has_live_members(
+                        process_group,
+                    ) {
+                        Ok(false) => Ok(status),
+                        Ok(true) => Err(group_error.context(format!(
+                            "child process was reaped but process group {process_group} cleanup failed"
+                        ))),
+                        Err(liveness_error) => Err(group_error.context(format!(
+                            "child process was reaped but process group {process_group} cleanup failed; final liveness check failed: {liveness_error:#}"
+                        ))),
+                    },
                     Err(child_error) => Err(group_error.context(format!(
                         "process group {process_group} cleanup failed and direct child reap also failed: {child_error:#}"
                     ))),
@@ -190,4 +209,44 @@ pub async fn check_tool_installed(executable: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn reaped_child_and_gone_group_ignore_cleanup_timeout() {
+        let mut child = Command::new("sh")
+            .args(["-c", "exit 0"])
+            .process_group(0)
+            .spawn()
+            .expect("spawn child");
+        let process_group = i32::try_from(child.id().expect("child PID")).expect("pid_t range");
+        let observed_status = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                match inspect_child_without_reaping(&mut child).expect("inspect child") {
+                    ChildWaitState::Running => tokio::task::yield_now().await,
+                    ChildWaitState::Exited(status) => break status,
+                }
+            }
+        })
+        .await
+        .expect("child exits before cleanup");
+        assert!(
+            observed_status.success(),
+            "expected the child to exit successfully"
+        );
+        FORCE_GROUP_CLEANUP_TIMEOUT_FOR.store(process_group, Ordering::SeqCst);
+
+        let status = terminate_child_process_group(&mut child, Duration::ZERO)
+            .await
+            .expect("a reaped child with no live group members is complete");
+        assert!(status.success(), "expected the child to exit successfully");
+        assert_eq!(
+            FORCE_GROUP_CLEANUP_TIMEOUT_FOR.load(Ordering::SeqCst),
+            0,
+            "cleanup-timeout injection must be consumed by the cleanup seam",
+        );
+    }
 }

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1174"
-weave = "0.1.1174"
+csa = "0.1.1175"
+weave = "0.1.1175"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Bug

`csa session wait` could exit 1 with `Failed to terminate completed command process group` after the owned child was already reaped and the process group was gone.

Closes #3159

## Fix

`terminate_child_process_group` keeps the observed child status when cleanup times out **and** `process_group_has_live_members` is `Ok(false)`. Live members still fail closed. No timeout growth, retry, or broader kill.

## Test plan

- [x] Focused Linux unit test at the cleanup-timeout seam
- [x] Exact-tree `just quality-gates` PASS (`7662/7692 passed, 8 skipped`)
- [x] Frozen native Tier-4 `VERDICT: PASS` (report SHA-256 `1bbb45ee18cbfb7f5115f5cac545dc19fc7e642f03eb5c217985f000e271fb5f`)

Refs #2681 (umbrella remains open)
