### PR TITLE
fix: terminalize Codex config parse failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1180"
+version = "0.1.1181"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1183"
+version = "0.1.1184"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1185"
+version = "0.1.1186"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1187"
+version = "0.1.1188"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1181"
+version = "0.1.1182"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1176"
+version = "0.1.1177"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1179"
+version = "0.1.1180"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1178"
+version = "0.1.1179"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1182"
+version = "0.1.1183"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1177"
+version = "0.1.1178"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1188"
+version = "0.1.1189"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1184"
+version = "0.1.1185"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1186"
+version = "0.1.1187"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1175"
+version = "0.1.1176"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1176"
+version = "0.1.1177"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1188"
+version = "0.1.1189"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1178"
+version = "0.1.1179"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1185"
+version = "0.1.1186"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1186"
+version = "0.1.1187"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1181"
+version = "0.1.1182"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1179"
+version = "0.1.1180"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1177"
+version = "0.1.1178"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1183"
+version = "0.1.1184"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1187"
+version = "0.1.1188"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1175"
+version = "0.1.1176"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1182"
+version = "0.1.1183"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1180"
+version = "0.1.1181"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1184"
+version = "0.1.1185"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/Cargo.toml
+++ b/crates/cli-sub-agent/Cargo.toml
@@ -54,6 +54,7 @@ tree-sitter-rust.workspace = true
 xurl-core.workspace = true
 
 [dev-dependencies]
+csa-executor = { workspace = true, features = ["codex-acp"] }
 proptest = "1"
 serial_test = "3.4"
 

--- a/crates/cli-sub-agent/src/debate_cmd_execute.rs
+++ b/crates/cli-sub-agent/src/debate_cmd_execute.rs
@@ -8,7 +8,9 @@ use tracing::{debug, error, warn};
 
 use crate::cli::DebateArgs;
 use crate::debate_cmd_output::DebateOutputHeader;
-use crate::debate_errors::{DebateErrorKind, classify_execution_error, classify_execution_outcome};
+use crate::debate_errors::{
+    DebateErrorKind, classify_execution_error, classify_execution_outcome_for_tool,
+};
 use crate::run_resource_overrides::RunResourceOverrides;
 use crate::startup_env::StartupSubtreeEnv;
 use crate::tier_model_fallback::{self, TierAttemptFailure};
@@ -334,10 +336,11 @@ pub(crate) async fn execute_debate(request: DebateExecutionRequest<'_>) -> Resul
                 csa_session::get_session_dir(request.project_root, &executed.meta_session_id)?;
             let session_state =
                 csa_session::load_session(request.project_root, &executed.meta_session_id).ok();
-            match classify_execution_outcome(
+            match classify_execution_outcome_for_tool(
                 &executed.execution,
                 session_state.as_ref(),
                 &session_dir,
+                Some(attempt_tool.as_str()),
             ) {
                 DebateErrorKind::StillWorking => {
                     wait_for_still_working_backoff().await;

--- a/crates/cli-sub-agent/src/debate_errors.rs
+++ b/crates/cli-sub-agent/src/debate_errors.rs
@@ -7,6 +7,7 @@ pub(crate) const EMPTY_DEBATE_QUESTION_ERROR: &str = concat!(
     "debate question is empty (stdin is not available to the detached daemon - ",
     "pass a positional QUESTION, use --question-file QUESTION.md, or pair --context with a QUESTION)"
 );
+const CODEX_CONFIG_PARSE_ERROR_MARKER: &str = "Error loading config.toml";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DebateErrorKind {
@@ -22,6 +23,12 @@ pub(crate) fn classify_execution_outcome(
 ) -> DebateErrorKind {
     if has_persisted_pre_exec_failure(session_dir) {
         return DebateErrorKind::Deterministic("persisted pre-exec failure".to_string());
+    }
+
+    if is_codex_config_parse_failure(&execution.summary)
+        || is_codex_config_parse_failure(&execution.stderr_output)
+    {
+        return DebateErrorKind::Deterministic("Codex config.toml parse failure".to_string());
     }
 
     if ToolLiveness::is_alive(session_dir) {
@@ -84,9 +91,9 @@ pub(crate) fn classify_execution_outcome(
     DebateErrorKind::Deterministic(format!("exit code {}", execution.exit_code))
 }
 
-/// A pre-exec failure result is terminal evidence for this attempt. Its diagnostic
-/// lock may retain the launching test/process PID after release, so it must win
-/// over lock-based liveness and prevent an endless StillWorking retry.
+/// A persisted terminal failure is evidence for this attempt. Its diagnostic lock
+/// may retain the launching test/process PID after release, so it must win over
+/// lock-based liveness and prevent an endless StillWorking retry.
 fn has_persisted_pre_exec_failure(session_dir: &Path) -> bool {
     let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
     let Ok(contents) = std::fs::read_to_string(result_path) else {
@@ -95,7 +102,13 @@ fn has_persisted_pre_exec_failure(session_dir: &Path) -> bool {
     let Ok(result) = toml::from_str::<csa_session::SessionResult>(&contents) else {
         return false;
     };
-    result.status == "failure" && result.summary.trim_start().starts_with("pre-exec:")
+    result.status == "failure"
+        && (result.summary.trim_start().starts_with("pre-exec:")
+            || is_codex_config_parse_failure(&result.summary))
+}
+
+pub(crate) fn is_codex_config_parse_failure(text: &str) -> bool {
+    text.contains(CODEX_CONFIG_PARSE_ERROR_MARKER)
 }
 
 pub(crate) fn classify_execution_error(
@@ -103,6 +116,10 @@ pub(crate) fn classify_execution_error(
     session_dir: Option<&Path>,
 ) -> DebateErrorKind {
     if session_dir.is_some_and(has_persisted_pre_exec_failure) {
+        return DebateErrorKind::Deterministic(error.to_string());
+    }
+
+    if is_codex_config_parse_failure(&error.to_string()) {
         return DebateErrorKind::Deterministic(error.to_string());
     }
 

--- a/crates/cli-sub-agent/src/debate_errors.rs
+++ b/crates/cli-sub-agent/src/debate_errors.rs
@@ -16,33 +16,39 @@ pub(crate) enum DebateErrorKind {
     StillWorking,
 }
 
+#[allow(dead_code)]
 pub(crate) fn classify_execution_outcome(
     execution: &ExecutionResult,
     session_state: Option<&MetaSessionState>,
     session_dir: &Path,
 ) -> DebateErrorKind {
-    if has_persisted_pre_exec_failure(session_dir) {
-        return DebateErrorKind::Deterministic("persisted pre-exec failure".to_string());
-    }
+    classify_execution_outcome_for_tool(execution, session_state, session_dir, None)
+}
 
-    if is_codex_config_parse_failure(&execution.summary)
-        || is_codex_config_parse_failure(&execution.stderr_output)
-    {
-        return DebateErrorKind::Deterministic("Codex config.toml parse failure".to_string());
-    }
-
-    if ToolLiveness::is_alive(session_dir) {
-        return DebateErrorKind::StillWorking;
-    }
-
+pub(crate) fn classify_execution_outcome_for_tool(
+    execution: &ExecutionResult,
+    session_state: Option<&MetaSessionState>,
+    session_dir: &Path,
+    tool: Option<&str>,
+) -> DebateErrorKind {
     let termination_reason = session_state.and_then(|s| s.termination_reason.as_deref());
     let sandbox_memory_limit = session_state
         .and_then(|s| s.sandbox_info.as_ref())
         .and_then(|s| s.memory_max_mb);
+    let codex_config_parse_failure =
+        is_codex_config_parse_failure_for_tool(tool, execution.exit_code, &execution.summary)
+            || is_codex_config_parse_failure_for_tool(
+                tool,
+                execution.exit_code,
+                &execution.stderr_output,
+            );
 
     if execution.exit_code == 137 {
         if matches!(termination_reason, Some("sigkill" | "sigterm"))
             || sandbox_memory_limit.is_some()
+            || (tool.is_some_and(|tool| tool.eq_ignore_ascii_case("codex"))
+                && (is_codex_config_parse_failure(&execution.summary)
+                    || is_codex_config_parse_failure(&execution.stderr_output)))
         {
             return DebateErrorKind::Transient(format!(
                 "exit 137 (termination_reason={termination_reason:?}, sandbox_memory_max_mb={sandbox_memory_limit:?})"
@@ -60,23 +66,24 @@ pub(crate) fn classify_execution_outcome(
         ));
     }
 
-    // Catch-all: valid signal-based exit codes (128+signal) are transient.
-    // Valid Unix signals: 1-31 (standard) + 32-64 (real-time), so exit
-    // codes 129-192.  128 (signal 0) and 193+ (signal > 64) are not real
-    // signal exits — treat those as deterministic.
-    // CSA only sends SIGTERM(15) and SIGKILL(9); other signals come from
-    // external sources (systemd scope cleanup, kernel OOM, etc.).
     if execution.exit_code >= 129 && execution.exit_code <= 192 {
         let signal_num = execution.exit_code - 128;
-        tracing::warn!(
-            exit_code = execution.exit_code,
-            signal = signal_num,
-            "process killed by unexpected signal; classifying as transient"
-        );
         return DebateErrorKind::Transient(format!(
             "process killed by signal {} (exit_code={})",
             signal_num, execution.exit_code,
         ));
+    }
+
+    if has_persisted_pre_exec_failure(session_dir) {
+        return DebateErrorKind::Deterministic("persisted pre-exec failure".to_string());
+    }
+
+    if has_persisted_codex_config_parse_failure(session_dir) || codex_config_parse_failure {
+        return DebateErrorKind::Deterministic("Codex config.toml parse failure".to_string());
+    }
+
+    if ToolLiveness::is_alive(session_dir) {
+        return DebateErrorKind::StillWorking;
     }
 
     let stderr_lower = execution.stderr_output.to_ascii_lowercase();
@@ -102,9 +109,37 @@ fn has_persisted_pre_exec_failure(session_dir: &Path) -> bool {
     let Ok(result) = toml::from_str::<csa_session::SessionResult>(&contents) else {
         return false;
     };
+    result.status == "failure" && result.summary.trim_start().starts_with("pre-exec:")
+}
+
+fn has_persisted_codex_config_parse_failure(session_dir: &Path) -> bool {
+    let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
+    let Ok(contents) = std::fs::read_to_string(result_path) else {
+        return false;
+    };
+    let Ok(result) = toml::from_str::<csa_session::SessionResult>(&contents) else {
+        return false;
+    };
+    is_codex_config_parse_result(&result)
+}
+
+pub(crate) fn is_codex_config_parse_failure_for_tool(
+    tool: Option<&str>,
+    exit_code: i32,
+    text: &str,
+) -> bool {
+    exit_code == 1
+        && tool.is_some_and(|tool| tool.eq_ignore_ascii_case("codex"))
+        && is_codex_config_parse_failure(text)
+}
+
+pub(crate) fn is_codex_config_parse_result(result: &csa_session::SessionResult) -> bool {
     result.status == "failure"
-        && (result.summary.trim_start().starts_with("pre-exec:")
-            || is_codex_config_parse_failure(&result.summary))
+        && is_codex_config_parse_failure_for_tool(
+            Some(result.tool.as_str()),
+            result.exit_code,
+            &result.summary,
+        )
 }
 
 pub(crate) fn is_codex_config_parse_failure(text: &str) -> bool {
@@ -116,10 +151,6 @@ pub(crate) fn classify_execution_error(
     session_dir: Option<&Path>,
 ) -> DebateErrorKind {
     if session_dir.is_some_and(has_persisted_pre_exec_failure) {
-        return DebateErrorKind::Deterministic(error.to_string());
-    }
-
-    if is_codex_config_parse_failure(&error.to_string()) {
         return DebateErrorKind::Deterministic(error.to_string());
     }
 

--- a/crates/cli-sub-agent/src/debate_errors.rs
+++ b/crates/cli-sub-agent/src/debate_errors.rs
@@ -16,7 +16,7 @@ pub(crate) enum DebateErrorKind {
     StillWorking,
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 pub(crate) fn classify_execution_outcome(
     execution: &ExecutionResult,
     session_state: Option<&MetaSessionState>,
@@ -151,27 +151,34 @@ pub(crate) fn classify_execution_error(
     session_dir: Option<&Path>,
 ) -> DebateErrorKind {
     if session_dir.is_some_and(has_persisted_pre_exec_failure) {
-        return DebateErrorKind::Deterministic(error.to_string());
+        return DebateErrorKind::Deterministic(csa_session::redact_text_content(
+            &error.to_string(),
+        ));
+    }
+
+    if session_dir.is_some_and(has_persisted_codex_config_parse_failure) {
+        return DebateErrorKind::Deterministic("Codex config.toml parse failure".to_string());
     }
 
     if session_dir.is_some_and(ToolLiveness::is_alive) {
         return DebateErrorKind::StillWorking;
     }
 
-    let message = error.to_string().to_ascii_lowercase();
+    let error_text = csa_session::redact_text_content(&error.to_string());
+    let message = error_text.to_ascii_lowercase();
     if message.contains("oom")
         || message.contains("signal")
         || message.contains("killed")
         || message.contains("temporarily unavailable")
     {
-        return DebateErrorKind::Transient(error.to_string());
+        return DebateErrorKind::Transient(error_text);
     }
 
     if message.contains("permission denied") {
         return DebateErrorKind::Deterministic("permission error".to_string());
     }
 
-    DebateErrorKind::Deterministic(error.to_string())
+    DebateErrorKind::Deterministic(error_text)
 }
 
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/debate_errors_tests.rs
+++ b/crates/cli-sub-agent/src/debate_errors_tests.rs
@@ -288,3 +288,24 @@ fn classify_exit_2_still_deterministic() {
         "exit 2 should remain deterministic, got: {classified:?}"
     );
 }
+
+#[test]
+fn classify_codex_config_parse_error_before_live_lock_as_deterministic() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let locks_dir = tmp.path().join("locks");
+    std::fs::create_dir_all(&locks_dir).expect("create locks");
+    let lock_path = locks_dir.join("codex.lock");
+    std::fs::write(&lock_path, format!("{{\"pid\": {}}}", std::process::id())).expect("write");
+
+    let execution = ExecutionResult {
+        stderr_output: "Error loading config.toml:\n/path/config.toml:21:1: duplicate key".into(),
+        summary: "Error loading config.toml: /path/config.toml:21:1: duplicate key".into(),
+        exit_code: 1,
+        ..Default::default()
+    };
+    let classified = classify_execution_outcome(&execution, None, tmp.path());
+    assert!(
+        matches!(classified, DebateErrorKind::Deterministic(ref message) if message.contains("config.toml")),
+        "Codex config parse failure must not become StillWorking: {classified:?}"
+    );
+}

--- a/crates/cli-sub-agent/src/debate_errors_tests.rs
+++ b/crates/cli-sub-agent/src/debate_errors_tests.rs
@@ -303,9 +303,44 @@ fn classify_codex_config_parse_error_before_live_lock_as_deterministic() {
         exit_code: 1,
         ..Default::default()
     };
-    let classified = classify_execution_outcome(&execution, None, tmp.path());
+    let classified =
+        classify_execution_outcome_for_tool(&execution, None, tmp.path(), Some("codex"));
     assert!(
         matches!(classified, DebateErrorKind::Deterministic(ref message) if message.contains("config.toml")),
         "Codex config parse failure must not become StillWorking: {classified:?}"
+    );
+}
+
+#[test]
+fn classify_config_marker_from_non_codex_is_not_codex_terminal() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let execution = ExecutionResult {
+        stderr_output: "Error loading config.toml: duplicate key".into(),
+        summary: "Error loading config.toml: duplicate key".into(),
+        exit_code: 1,
+        ..Default::default()
+    };
+    let classified =
+        classify_execution_outcome_for_tool(&execution, None, tmp.path(), Some("claude"));
+    assert_eq!(
+        classified,
+        DebateErrorKind::Deterministic("argument error (exit code 1)".to_string())
+    );
+}
+
+#[test]
+fn classify_codex_config_marker_with_sigkill_exit_is_transient() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let execution = ExecutionResult {
+        stderr_output: "Error loading config.toml: duplicate key".into(),
+        summary: "Error loading config.toml: duplicate key".into(),
+        exit_code: 137,
+        ..Default::default()
+    };
+    let classified =
+        classify_execution_outcome_for_tool(&execution, None, tmp.path(), Some("codex"));
+    assert!(
+        matches!(classified, DebateErrorKind::Transient(_)),
+        "signal/OOM evidence must precede Codex marker: {classified:?}"
     );
 }

--- a/crates/cli-sub-agent/src/pipeline_execute.rs
+++ b/crates/cli-sub-agent/src/pipeline_execute.rs
@@ -262,7 +262,7 @@ pub(crate) async fn execute_transport_with_signal(
                 .chain()
                 .find_map(|cause| cause.downcast_ref::<PeakMemoryContext>())
                 .and_then(|ctx| ctx.0);
-            let error_summary = csa_session::redact_text_content(&format!("transport: {e}"));
+            let error_summary = csa_session::redact_text_content(&format!("transport: {e:#}"));
             // The anyhow error chain is the provider/transport error channel for
             // a failed turn (the agent's reviewed stdout is discarded on Err), so
             // it is the correct — and only — source for a permanent quota verdict

--- a/crates/cli-sub-agent/src/pipeline_execute.rs
+++ b/crates/cli-sub-agent/src/pipeline_execute.rs
@@ -262,7 +262,7 @@ pub(crate) async fn execute_transport_with_signal(
                 .chain()
                 .find_map(|cause| cause.downcast_ref::<PeakMemoryContext>())
                 .and_then(|ctx| ctx.0);
-            let error_summary = format!("transport: {e}");
+            let error_summary = csa_session::redact_text_content(&format!("transport: {e}"));
             // The anyhow error chain is the provider/transport error channel for
             // a failed turn (the agent's reviewed stdout is discarded on Err), so
             // it is the correct — and only — source for a permanent quota verdict
@@ -334,7 +334,10 @@ pub(crate) async fn execute_transport_with_signal(
             if let Some(cg) = cleanup_guard {
                 cg.defuse();
             }
-            Err(e).context("Failed to execute tool via transport")
+            Err(
+                anyhow::anyhow!(csa_session::redact_text_content(&format!("{e:#}")))
+                    .context("Failed to execute tool via transport"),
+            )
         }
     }
 }

--- a/crates/cli-sub-agent/src/pipeline_execute_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_execute_tests.rs
@@ -46,6 +46,87 @@ async fn cancelled_transport_cleanup_error_preserves_target_admission() {
 
 #[cfg(unix)]
 #[tokio::test]
+async fn acp_initialize_codex_config_error_is_terminal_and_redacted() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let fake_codex = temp.path().join("codex-acp");
+    std::fs::write(
+        &fake_codex,
+        "#!/bin/sh\nprintf '%s\\n' 'Error loading config.toml: duplicate key' 'OPENAI_API_KEY=providerfixture12345' >&2\nexit 1\n",
+    )
+    .expect("write fake codex ACP");
+    let mut permissions = std::fs::metadata(&fake_codex)
+        .expect("fake codex metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_codex, permissions).expect("make fake codex executable");
+
+    let mut session = csa_session::MetaSessionState::default();
+    session.meta_session_id = ulid::Ulid::new().to_string();
+    session.project_path = temp.path().display().to_string();
+    session.task_context.task_type = Some("debate".to_string());
+    let executor = csa_executor::Executor::Codex {
+        model_override: None,
+        thinking_budget: None,
+        runtime_metadata: csa_executor::CodexRuntimeMetadata::from_transport(
+            csa_executor::CodexTransport::Acp,
+        ),
+    };
+    let path = std::env::var("PATH").unwrap_or_default();
+    let extra_env = std::collections::HashMap::from([(
+        "PATH".to_string(),
+        format!("{}:{path}", temp.path().display()),
+    )]);
+    let options = csa_executor::ExecuteOptions::new(csa_process::StreamMode::BufferOnly, 1)
+        .with_acp_init_timeout_seconds(2)
+        .with_acp_crash_max_attempts(1);
+
+    let error = execute_transport_with_signal(
+        &executor,
+        "prompt",
+        None,
+        &session,
+        Some(&extra_env),
+        options,
+        None,
+        temp.path(),
+        &mut None,
+        chrono::Utc::now(),
+        None,
+    )
+    .await
+    .expect_err("ACP initialize failure must return an error");
+
+    let session_dir = csa_session::manager::get_session_dir(temp.path(), &session.meta_session_id)
+        .expect("session directory");
+    let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
+    let result_contents = std::fs::read_to_string(&result_path).expect("persisted result");
+    let result: csa_session::SessionResult = toml::from_str(&result_contents).expect("result TOML");
+    assert_eq!(result.status, "failure");
+    assert_eq!(result.tool, "codex");
+    assert_eq!(result.exit_code, 1);
+    assert!(result.summary.contains("Error loading config.toml"));
+    assert!(!result.summary.contains("providerfixture12345"));
+    assert!(result.summary.contains("[REDACTED]"));
+    let error_chain = format!("{error:#}");
+    assert!(!error_chain.contains("providerfixture12345"));
+    assert!(error_chain.contains("[REDACTED]"));
+
+    let lock_path = session_dir.join("locks/codex.lock");
+    std::fs::create_dir_all(lock_path.parent().expect("lock parent")).expect("create locks");
+    std::fs::write(&lock_path, format!("{{\"pid\": {}}}", std::process::id()))
+        .expect("write live diagnostic lock");
+    assert_eq!(
+        crate::debate_errors::classify_execution_error(&error, Some(&session_dir)),
+        crate::debate_errors::DebateErrorKind::Deterministic(
+            "Codex config.toml parse failure".to_string()
+        )
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
 async fn cancelled_transport_cleanup_timeout_preserves_admission_with_term_resistant_descendant() {
     let temp = tempfile::tempdir().expect("tempdir");
     let descendant_pid_file = temp.path().join("descendant.pid");

--- a/crates/cli-sub-agent/src/pipeline_session_exec_bootstrap.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_bootstrap.rs
@@ -190,6 +190,23 @@ pub(super) async fn bootstrap_session(
         && std::env::var("CSA_DAEMON_SESSION_ID").ok().as_deref() == Some(wrapper_session_id)
         && wrapper_session_id != session.meta_session_id
     {
+        // The alias makes target artifacts visible to wrapper waiters, so the
+        // previous attempt's terminal result must be invalidated first.
+        let target_session_dir =
+            csa_session::get_session_dir(project_root, &session.meta_session_id)?;
+        let stale_result_path = target_session_dir.join(csa_session::result::RESULT_FILE_NAME);
+        match std::fs::remove_file(&stale_result_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to invalidate stale resume result before publishing alias: {}",
+                        stale_result_path.display()
+                    )
+                });
+            }
+        }
         csa_session::write_resume_target(
             project_root,
             wrapper_session_id,
@@ -285,12 +302,18 @@ fn inherited_parent_session_id_for_new_session(startup_env: &StartupSubtreeEnv) 
 
 #[cfg(test)]
 mod tests {
-    use super::inherited_parent_session_id_for_new_session;
+    use super::{bootstrap_session, inherited_parent_session_id_for_new_session};
+    use crate::pipeline::{ParentSessionSource, SessionCreationMode};
+    use crate::session_cmds_daemon::{
+        WaitBehavior, WaitLoopTiming, WaitReconciliationOutcome, handle_session_wait_with_hooks,
+    };
     use crate::startup_env::StartupSubtreeEnv;
     use crate::test_env_lock::{ScopedEnvVarRestore, TEST_ENV_LOCK};
+    use crate::test_session_sandbox::ScopedSessionSandbox;
     use csa_core::env::{
         CSA_PARENT_SESSION_ENV_KEY, CSA_SESSION_DIR_ENV_KEY, CSA_SESSION_ID_ENV_KEY,
     };
+    use csa_core::types::ToolName;
     use std::collections::HashMap;
 
     #[test]
@@ -351,6 +374,119 @@ mod tests {
         assert_eq!(
             inherited_parent_session_id_for_new_session(&startup_env),
             Some("01PARENT")
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_alias_does_not_expose_previous_attempt_config_failure() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _sandbox = ScopedSessionSandbox::new(&temp).await;
+        let project = temp.path();
+        let target =
+            csa_session::create_session_fresh(project, Some("resume target"), None, Some("codex"))
+                .expect("create target");
+        let target_id = target.meta_session_id.clone();
+        let target_dir = csa_session::get_session_dir(project, &target_id).expect("target dir");
+        let previous_result = csa_session::SessionResult {
+            status: "failure".to_string(),
+            exit_code: 1,
+            summary: "Error loading config.toml: previous attempt".to_string(),
+            tool: "codex".to_string(),
+            ..Default::default()
+        };
+        csa_session::save_result(project, &target_id, &previous_result)
+            .expect("save previous result");
+        let _diagnostic_lock =
+            csa_lock::acquire_lock(&target_dir, "codex", "previous attempt diagnostic")
+                .expect("acquire live diagnostic lock");
+
+        let wrapper =
+            csa_session::create_session_fresh(project, Some("resume wrapper"), None, Some("codex"))
+                .expect("create wrapper");
+        let wrapper_id = wrapper.meta_session_id;
+        // SAFETY: ScopedSessionSandbox owns TEST_ENV_LOCK for the test lifetime.
+        unsafe { std::env::set_var("CSA_DAEMON_SESSION_ID", &wrapper_id) };
+        let startup_env = StartupSubtreeEnv::from_values(HashMap::from([(
+            CSA_SESSION_ID_ENV_KEY,
+            wrapper_id.clone(),
+        )]));
+
+        bootstrap_session(
+            &ToolName::Codex,
+            "resume target",
+            Some(&target_id),
+            false,
+            None,
+            None,
+            project,
+            None,
+            None,
+            Some("run"),
+            None,
+            ParentSessionSource::ExplicitOrEnv,
+            SessionCreationMode::DaemonManaged,
+            &startup_env,
+        )
+        .await
+        .expect("bootstrap resumed target");
+        assert!(
+            !target_dir.join("result.toml").exists(),
+            "alias publication must invalidate the previous result first"
+        );
+        let mut completion = None;
+        let wait_behavior = WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming {
+                poll_interval: std::time::Duration::from_millis(1),
+                memory_sample_interval: std::time::Duration::from_secs(15),
+            },
+        };
+        let first_exit = handle_session_wait_with_hooks(
+            wrapper_id.clone(),
+            Some(project.to_string_lossy().into_owned()),
+            wait_behavior,
+            |_project_root, _current_session_id, _trigger| {
+                Ok(WaitReconciliationOutcome {
+                    result_became_available: false,
+                    synthetic: false,
+                })
+            },
+            |_sid: &str, status: &str, exit_code, _synthetic, _mirror_to_stdout| {
+                completion = Some((status.to_string(), exit_code));
+            },
+        )
+        .expect("wait before current result");
+        assert_eq!(first_exit, 0);
+        assert_eq!(completion, None, "wait must reject the previous result");
+
+        let current_result = csa_session::SessionResult {
+            summary: "Error loading config.toml: current attempt".to_string(),
+            ..previous_result
+        };
+        csa_session::save_result(project, &target_id, &current_result)
+            .expect("save current result");
+
+        let second_exit = handle_session_wait_with_hooks(
+            wrapper_id,
+            Some(project.to_string_lossy().into_owned()),
+            wait_behavior,
+            |_project_root, _current_session_id, _trigger| {
+                panic!("current config failure must not reconcile")
+            },
+            |_sid: &str, status: &str, exit_code, _synthetic, _mirror_to_stdout| {
+                completion = Some((status.to_string(), exit_code));
+            },
+        )
+        .expect("wait should accept the current attempt result");
+        assert_eq!(second_exit, 1);
+        assert_eq!(completion, Some(("failure".to_string(), 1)));
+        assert_eq!(
+            csa_session::load_result(project, &target_id)
+                .expect("load result")
+                .expect("current result")
+                .summary,
+            "Error loading config.toml: current attempt"
         );
     }
 }

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait.rs
@@ -47,7 +47,7 @@ pub(crate) use result_loader::expected_in_flight_turn_result_artifact_path_for_t
 #[cfg(test)]
 pub(crate) use result_loader::parse_output_result_artifact_for_test;
 use result_loader::{
-    load_completed_daemon_result_with_fallback, refresh_result_for_wait,
+    load_completed_daemon_result_with_fallback, load_live_result_for_wait, refresh_result_for_wait,
     suppress_pending_tier_failover_result,
 };
 #[cfg(test)]

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -22,8 +22,9 @@ use super::target::resolve_wait_target;
 pub(crate) use super::types::WaitEmitters;
 use super::types::{WaitExecutionOptions, WaitReconciliationOutcome};
 use super::{
-    emit_wait_terminal_output, load_completed_daemon_result_with_fallback, refresh_result_for_wait,
-    suppress_pending_tier_failover_result, try_acquire_session_wait_lock_with_caller,
+    emit_wait_terminal_output, load_completed_daemon_result_with_fallback,
+    load_live_result_for_wait, refresh_result_for_wait, suppress_pending_tier_failover_result,
+    try_acquire_session_wait_lock_with_caller,
 };
 use crate::session_cmds::resolve_session_prefix_with_global_fallback;
 use crate::session_cmds_daemon::{
@@ -336,17 +337,20 @@ pub(crate) fn handle_session_wait_with_emitters(
             }
         }
 
-        let completed_result = load_completed_daemon_result_with_fallback(
-            effective_root,
-            result_session_id,
-            result_session_dir,
-            result_uses_direct_session_dir,
-        )?;
         let completed_result = if session_live {
-            completed_result.filter(|result| {
-                result.status == "failure"
-                    && crate::debate_errors::is_codex_config_parse_failure(&result.summary)
+            load_live_result_for_wait(result_session_dir)?.and_then(|result| {
+                suppress_pending_tier_failover_result(result_session_id, result_session_dir, result)
             })
+        } else {
+            load_completed_daemon_result_with_fallback(
+                effective_root,
+                result_session_id,
+                result_session_dir,
+                result_uses_direct_session_dir,
+            )?
+        };
+        let completed_result = if session_live {
+            completed_result.filter(crate::debate_errors::is_codex_config_parse_result)
         } else {
             completed_result
         };

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_core.rs
@@ -336,15 +336,19 @@ pub(crate) fn handle_session_wait_with_emitters(
             }
         }
 
+        let completed_result = load_completed_daemon_result_with_fallback(
+            effective_root,
+            result_session_id,
+            result_session_dir,
+            result_uses_direct_session_dir,
+        )?;
         let completed_result = if session_live {
-            None
+            completed_result.filter(|result| {
+                result.status == "failure"
+                    && crate::debate_errors::is_codex_config_parse_failure(&result.summary)
+            })
         } else {
-            load_completed_daemon_result_with_fallback(
-                effective_root,
-                result_session_id,
-                result_session_dir,
-                result_uses_direct_session_dir,
-            )?
+            completed_result
         };
         if let Some(mut result) = completed_result {
             super::summary::reconcile_repaired_review_pass_result_status(

--- a/crates/cli-sub-agent/src/session_cmds_daemon_wait_result.rs
+++ b/crates/cli-sub-agent/src/session_cmds_daemon_wait_result.rs
@@ -23,6 +23,28 @@ pub(super) fn suppress_pending_tier_failover_result(
     }
 }
 
+/// Read the current result without invoking refresh-and-repair, which may rewrite
+/// an artifact while the live daemon is still publishing it.
+pub(crate) fn load_live_result_for_wait(
+    session_dir: &Path,
+) -> Result<Option<csa_session::SessionResult>> {
+    let result_path = session_dir.join(csa_session::result::RESULT_FILE_NAME);
+    let Ok(contents) = fs::read_to_string(&result_path) else {
+        return Ok(None);
+    };
+    match toml::from_str(&contents) {
+        Ok(result) => Ok(Some(result)),
+        Err(err) => {
+            tracing::debug!(
+                path = %result_path.display(),
+                error = %err,
+                "Ignoring incomplete live result artifact"
+            );
+            Ok(None)
+        }
+    }
+}
+
 fn load_completed_daemon_result(
     project_root: &Path,
     session_id: &str,
@@ -369,4 +391,32 @@ pub(super) fn load_completed_daemon_result_with_fallback(
     }
 
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn live_result_loader_does_not_rewrite_interleaved_result() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let result_path = temp.path().join(csa_session::result::RESULT_FILE_NAME);
+        let result = csa_session::SessionResult {
+            status: "failure".to_string(),
+            exit_code: 1,
+            summary: "Error loading config.toml: duplicate key".to_string(),
+            tool: "codex".to_string(),
+            ..Default::default()
+        };
+        let before = toml::to_string_pretty(&result).expect("serialize result");
+        std::fs::write(&result_path, &before).expect("write result");
+
+        let loaded = load_live_result_for_wait(temp.path())
+            .expect("load live result")
+            .expect("result");
+        let after = std::fs::read_to_string(&result_path).expect("read result");
+
+        assert_eq!(loaded.summary, result.summary);
+        assert_eq!(after, before);
+    }
 }

--- a/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
+++ b/crates/cli-sub-agent/src/session_cmds_tests_tail_wait_lock.rs
@@ -328,6 +328,63 @@ fn handle_session_wait_rejects_duplicate_wait_before_entering_loop() {
 }
 
 #[test]
+fn handle_session_wait_terminalizes_codex_config_parse_failure_while_live() {
+    let td = tempdir().expect("tempdir");
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
+    let state_home = td.path().join("xdg-state");
+    std::fs::create_dir_all(&state_home).expect("create state home");
+    let _home_guard = EnvVarGuard::set("HOME", td.path());
+    let _state_guard = EnvVarGuard::set("XDG_STATE_HOME", &state_home);
+    let project = td.path();
+    let session = create_session(
+        project,
+        Some("wait-codex-config-parse-failure"),
+        None,
+        Some("codex"),
+    )
+    .expect("create session");
+    let session_id = session.meta_session_id.clone();
+    let now = chrono::Utc::now();
+    save_result(
+        project,
+        &session_id,
+        &csa_session::SessionResult {
+            status: "failure".to_string(),
+            exit_code: 1,
+            summary: "Error loading config.toml: /path/config.toml:21:1: duplicate key".to_string(),
+            tool: "codex".to_string(),
+            started_at: now,
+            completed_at: now,
+            ..Default::default()
+        },
+    )
+    .expect("save config parse failure result");
+
+    let mut emitted_completion = None;
+    let exit_code = handle_session_wait_with_hooks_at(
+        session_id,
+        Some(project.to_string_lossy().into_owned()),
+        WaitBehavior {
+            wait_timeout_secs: 0,
+            memory_warn_mb: None,
+            timing: WaitLoopTiming::default(),
+        },
+        now,
+        Some(true),
+        |_project_root, _current_session_id, _trigger| {
+            panic!("persisted config parse failure must not reconcile as live")
+        },
+        |_sid: &str, status: &str, code, _synthetic, _mirror_to_stdout| {
+            emitted_completion = Some((status.to_string(), code));
+        },
+    )
+    .expect("wait should return terminal config parse failure");
+
+    assert_eq!(exit_code, 1);
+    assert_eq!(emitted_completion, Some(("failure".to_string(), 1)));
+}
+
+#[test]
 fn handle_session_wait_continues_stale_session_with_live_worktree_lock() {
     let td = tempdir().expect("tempdir");
     let _env_lock = TEST_ENV_LOCK.blocking_lock();

--- a/crates/cli-sub-agent/tests/run_blocked_cargo_target.rs
+++ b/crates/cli-sub-agent/tests/run_blocked_cargo_target.rs
@@ -306,7 +306,9 @@ fn output_reaps_descendants_after_direct_child_exits_and_pipes_drain() {
     let release_path = identity_dir.path().join("release");
     let mut command = Command::new("sh");
     let script = format!(
-        "sleep 300 </dev/null >/dev/null 2>&1 & descendant=$!; start_time=$(awk '{{print $22}}' \"/proc/$descendant/stat\"); printf '%s %s\\n' \"$descendant\" \"$start_time\" > \"{}\"; printf '%s %s\\n' \"$descendant\" \"$start_time\"; while [ ! -e \"{}\" ]; do sleep 0.01; done; exit 0",
+        // Keep publication to shell builtins: an extra `awk` child can miss
+        // this test's bounded handshake when the full suite is scheduling.
+        "sleep 300 </dev/null >/dev/null 2>&1 & descendant=$!; printf '%s\\n' \"$descendant\" > \"{}\"; printf '%s\\n' \"$descendant\"; while [ ! -e \"{}\" ]; do sleep 0.01; done; exit 0",
         identity_path.display(),
         release_path.display(),
     );
@@ -325,23 +327,19 @@ fn output_reaps_descendants_after_direct_child_exits_and_pipes_drain() {
                 return String::from("descendant identity has not been published");
             };
             let identity = identity_output.split_whitespace().collect::<Vec<_>>();
-            if identity.len() != 2 {
+            if identity.len() != 1 {
                 return format!("invalid descendant identity contents: {identity_output:?}");
             }
             let Ok(pid) = identity[0].parse::<u32>() else {
                 return format!("invalid descendant PID: {:?}", identity[0]);
             };
-            let Ok(start_time) = identity[1].parse::<u64>() else {
-                return format!("invalid descendant start time: {:?}", identity[1]);
-            };
-            if let Some(captured) = ProcessIdentity::capture_with_start_time(pid, start_time) {
+            if let Some(captured) = ProcessIdentity::capture(pid) {
+                let start_time = captured.start_time;
                 descendant = Some(captured);
                 std::fs::write(&release_path, "released").expect("release direct child");
                 return format!("captured descendant identity pid={pid} start_time={start_time}");
             }
-            format!(
-                "published descendant identity pid={pid} start_time={start_time} no longer matches"
-            )
+            format!("published descendant PID {pid} no longer matches")
         },
     );
     let descendant =

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -71,6 +71,7 @@ pub struct AcpConnection {
     last_meaningful_activity: SharedActivity,
     tool_output_compactor: SharedToolOutputCompactor,
     stderr_buf: Rc<RefCell<String>>,
+    stderr_closed: Rc<std::cell::Cell<bool>>,
     default_working_dir: PathBuf,
     init_timeout: Duration,
     termination_grace_period: Duration,
@@ -95,6 +96,7 @@ impl AcpConnection {
             last_meaningful_activity: parts.last_meaningful_activity,
             tool_output_compactor: parts.tool_output_compactor,
             stderr_buf: parts.stderr_buf,
+            stderr_closed: parts.stderr_closed,
             default_working_dir: parts.default_working_dir,
             init_timeout: parts.options.init_timeout,
             termination_grace_period: parts.options.termination_grace_period,
@@ -513,8 +515,13 @@ impl AcpConnection {
     }
 
     async fn drain_stderr_tail(&self) {
-        self.local_set
-            .run_until(tokio::time::sleep(Duration::from_millis(10)))
+        let _ = self
+            .local_set
+            .run_until(tokio::time::timeout(Duration::from_millis(10), async {
+                while !self.stderr_closed.get() {
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                }
+            }))
             .await;
     }
 

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -120,7 +120,8 @@ impl AcpConnection {
         match result {
             Some(Ok(_response)) => Ok(()),
             Some(Err(err)) => {
-                self.drain_stderr_tail().await;
+                self.kill().await?;
+                self.drain_stderr_until_closed().await;
                 let stderr = self.stderr();
                 Err(AcpError::InitializationFailed(format!(
                     "{err}{}",
@@ -522,6 +523,17 @@ impl AcpConnection {
                     tokio::time::sleep(Duration::from_millis(1)).await;
                 }
             }))
+            .await;
+    }
+
+    /// Drives the local stderr reader after the owned child has closed its pipe.
+    async fn drain_stderr_until_closed(&self) {
+        self.local_set
+            .run_until(async {
+                while !self.stderr_closed.get() {
+                    tokio::task::yield_now().await;
+                }
+            })
             .await;
     }
 

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -118,6 +118,7 @@ impl AcpConnection {
         match result {
             Some(Ok(_response)) => Ok(()),
             Some(Err(err)) => {
+                self.drain_stderr_tail().await;
                 let stderr = self.stderr();
                 Err(AcpError::InitializationFailed(format!(
                     "{err}{}",
@@ -166,6 +167,7 @@ impl AcpConnection {
         match result {
             Some(Ok(response)) => Ok(response.session_id.0.to_string()),
             Some(Err(err)) => {
+                self.drain_stderr_tail().await;
                 let stderr = self.stderr();
                 Err(AcpError::SessionFailed(format!(
                     "{err}{}",
@@ -209,6 +211,7 @@ impl AcpConnection {
         match result {
             Some(Ok(_response)) => Ok(session_id.to_string()),
             Some(Err(err)) => {
+                self.drain_stderr_tail().await;
                 let stderr = self.stderr();
                 Err(AcpError::SessionFailed(format!(
                     "{err}{}",
@@ -430,6 +433,7 @@ impl AcpConnection {
                 metadata,
             }),
             PromptOutcome::Completed(Err(err)) => {
+                self.drain_stderr_tail().await;
                 let stderr_detail = format_stderr(&self.stderr());
                 Err(AcpError::PromptFailed(format!("{err}{stderr_detail}")))
             }

--- a/crates/csa-acp/src/connection.rs
+++ b/crates/csa-acp/src/connection.rs
@@ -121,7 +121,7 @@ impl AcpConnection {
             Some(Ok(_response)) => Ok(()),
             Some(Err(err)) => {
                 self.kill().await?;
-                self.drain_stderr_until_closed().await;
+                self.drain_stderr_tail().await;
                 let stderr = self.stderr();
                 Err(AcpError::InitializationFailed(format!(
                     "{err}{}",
@@ -523,17 +523,6 @@ impl AcpConnection {
                     tokio::time::sleep(Duration::from_millis(1)).await;
                 }
             }))
-            .await;
-    }
-
-    /// Drives the local stderr reader after the owned child has closed its pipe.
-    async fn drain_stderr_until_closed(&self) {
-        self.local_set
-            .run_until(async {
-                while !self.stderr_closed.get() {
-                    tokio::task::yield_now().await;
-                }
-            })
             .await;
     }
 

--- a/crates/csa-acp/src/connection_initial_response_tests.rs
+++ b/crates/csa-acp/src/connection_initial_response_tests.rs
@@ -101,18 +101,20 @@ fn spawn_test_child(shell_script: &str) -> Child {
     cmd.spawn().expect("spawn test child")
 }
 
+fn hanging_child() -> Child {
+    spawn_test_child("python3 -c 'import signal;signal.pause()'")
+}
+
 fn configure_test_child(cmd: &mut Command) {
     cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
-        // The test connection owns the child. Ensure an assertion panic cannot
-        // leave its direct child behind while the nextest worker stays alive.
+        // Keep panic cleanup from leaving a child for the nextest worker.
         .kill_on_drop(true);
 
     #[cfg(unix)]
     {
-        // AcpConnection::kill targets -PID, so fixtures must be process-group
-        // leaders for descendant cleanup to be meaningful.
+        // Kill targets -PID; make fixtures process-group leaders.
         cmd.process_group(0);
     }
 }
@@ -515,7 +517,7 @@ async fn initial_response_timeout_stays_alive_for_stderr_only() {
 #[tokio::test]
 async fn initial_response_timeout_fires_when_stderr_also_silent() {
     let connection = build_test_connection(
-        spawn_test_child("sleep 5"),
+        hanging_child(),
         Duration::from_secs(5),
         PromptBehavior::Silent,
     )
@@ -623,7 +625,7 @@ async fn initial_response_timeout_fires_while_child_process_tree_consumes_cpu() 
 #[tokio::test]
 async fn idle_timeout_still_fires_for_alive_child_with_no_cpu_progress() {
     let connection = build_test_connection(
-        spawn_test_child("sleep 5"),
+        hanging_child(),
         Duration::from_secs(5),
         PromptBehavior::Silent,
     )
@@ -658,7 +660,7 @@ async fn idle_timeout_still_fires_for_alive_child_with_no_cpu_progress() {
 #[tokio::test]
 async fn initial_response_timeout_fires_when_only_protocol_notifications() {
     let connection = build_test_connection(
-        spawn_test_child("sleep 5"),
+        hanging_child(),
         Duration::from_secs(5),
         PromptBehavior::ProtocolOnly,
     )
@@ -696,7 +698,7 @@ async fn initial_response_timeout_fires_when_only_protocol_notifications() {
 #[tokio::test]
 async fn initial_response_timeout_stays_alive_for_eligible_event_stream() {
     let connection = build_test_connection(
-        spawn_test_child("sleep 5"),
+        hanging_child(),
         Duration::from_millis(220),
         PromptBehavior::EligibleEventStream,
     )

--- a/crates/csa-acp/src/connection_initial_response_tests.rs
+++ b/crates/csa-acp/src/connection_initial_response_tests.rs
@@ -380,6 +380,7 @@ async fn build_test_connection(
         last_meaningful_activity,
         tool_output_compactor: Rc::new(RefCell::new(None)),
         stderr_buf,
+        stderr_closed: Rc::new(std::cell::Cell::new(true)),
         default_working_dir: std::env::current_dir().expect("cwd"),
         options: AcpConnectionOptions {
             termination_grace_period: Duration::ZERO,

--- a/crates/csa-acp/src/connection_parts.rs
+++ b/crates/csa-acp/src/connection_parts.rs
@@ -9,6 +9,7 @@ pub(crate) struct AcpConnectionParts {
     pub(crate) last_meaningful_activity: SharedActivity,
     pub(crate) tool_output_compactor: SharedToolOutputCompactor,
     pub(crate) stderr_buf: Rc<RefCell<String>>,
+    pub(crate) stderr_closed: Rc<std::cell::Cell<bool>>,
     pub(crate) default_working_dir: PathBuf,
     pub(crate) options: AcpConnectionOptions,
 }

--- a/crates/csa-acp/src/connection_spawn.rs
+++ b/crates/csa-acp/src/connection_spawn.rs
@@ -517,6 +517,7 @@ impl AcpConnection {
             tool_output_compactor.clone(),
         );
         let stderr_buf = Rc::new(RefCell::new(String::new()));
+        let stderr_closed = Rc::new(std::cell::Cell::new(false));
 
         let connection = local_set
             .run_until(async {
@@ -538,6 +539,7 @@ impl AcpConnection {
                 });
 
                 let stderr_buf_clone = stderr_buf.clone();
+                let stderr_closed_clone = stderr_closed.clone();
                 let activity_clone = last_activity.clone();
                 let meaningful_activity_clone = last_meaningful_activity.clone();
                 tokio::task::spawn_local(async move {
@@ -559,6 +561,7 @@ impl AcpConnection {
                             }
                         }
                     }
+                    stderr_closed_clone.set(true);
                 });
 
                 conn
@@ -574,6 +577,7 @@ impl AcpConnection {
             last_meaningful_activity,
             tool_output_compactor,
             stderr_buf,
+            stderr_closed,
             default_working_dir: working_dir.to_path_buf(),
             options,
         }))

--- a/crates/csa-acp/src/transport.rs
+++ b/crates/csa-acp/src/transport.rs
@@ -454,7 +454,7 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn acp_process_fixture(pid_file: &Path, ready_file: &Path, prompt_error: bool) -> String {
+    fn acp_process_fixture(pid_file: &Path, prompt_error: bool) -> String {
         let prompt_response = if prompt_error {
             r#"printf '{"jsonrpc":"2.0","id":%s,"error":{"code":-32000,"message":"prompt failed"}}\n' "$id""#
         } else {
@@ -462,7 +462,8 @@ mod tests {
         };
         r#"
 trap '' TERM
-python3 -c 'import signal;signal.signal(15,1);signal.pause()' & echo $! > "__PID__"; : > "__READY__"
+python3 -c 'import os,signal;signal.signal(15,signal.SIG_IGN);open("__PID__","w").write(str(os.getpid()));signal.pause()' &
+while [ ! -s "__PID__" ]; do sleep .01; done
 while IFS= read -r line; do
   id=$(printf '%s\n' "$line" | sed -n 's/.*"id":[ ]*\([0-9][0-9]*\).*/\1/p')
   case "$line" in
@@ -482,7 +483,6 @@ while IFS= read -r line; do
 done
 "#
         .replace("__PID__", &pid_file.display().to_string())
-        .replace("__READY__", &ready_file.display().to_string())
         .replace("__PROMPT_RESPONSE__", prompt_response)
     }
 
@@ -496,10 +496,9 @@ done
         ] {
             let temp = tempfile::tempdir().expect("tempdir");
             let pid_file = temp.path().join(format!("{name}.pid"));
-            let ready_file = temp.path().join(format!("{name}.ready"));
             let args = vec![
                 "-c".to_string(),
-                acp_process_fixture(&pid_file, &ready_file, prompt_error),
+                acp_process_fixture(&pid_file, prompt_error),
             ];
             let result = tokio::time::timeout(
                 Duration::from_secs(3),
@@ -550,8 +549,9 @@ done
         let args = vec![
             "-c".to_string(),
             format!(
-                "trap '' TERM; python3 -c 'import signal;signal.signal(15,1);signal.pause()' & echo $! > \"{}\"; printf 'not-json\\n'; exec 1>&- 2>&-; while IFS= read -r _; do :; done",
-                pid_file.display()
+                "trap '' TERM; python3 -c 'import os,signal;signal.signal(15,signal.SIG_IGN);open(\"{}\",\"w\").write(str(os.getpid()));signal.pause()' & while [ ! -s \"{}\" ]; do sleep .01; done; printf 'not-json\\n'; exec 1>&- 2>&-; while IFS= read -r _; do :; done",
+                pid_file.display(),
+                pid_file.display(),
             ),
         ];
         let result = tokio::time::timeout(

--- a/crates/csa-acp/src/transport.rs
+++ b/crates/csa-acp/src/transport.rs
@@ -462,8 +462,7 @@ mod tests {
         };
         r#"
 trap '' TERM
-sh -c 'trap "" TERM; echo $$ > "__PID__"; : > "__READY__"; while :; do sleep 1; done' &
-while [ ! -e "__READY__" ]; do sleep 0.01; done
+python3 -c 'import signal;signal.signal(15,1);signal.pause()' & echo $! > "__PID__"; : > "__READY__"
 while IFS= read -r line; do
   id=$(printf '%s\n' "$line" | sed -n 's/.*"id":[ ]*\([0-9][0-9]*\).*/\1/p')
   case "$line" in
@@ -551,8 +550,7 @@ done
         let args = vec![
             "-c".to_string(),
             format!(
-                "trap '' TERM; sh -c 'trap \"\" TERM; echo $$ > \"{}\"; while :; do sleep 1; done' & while [ ! -s \"{}\" ]; do sleep 0.01; done; printf 'not-json\\n'; exec 1>&- 2>&-; while :; do sleep 1; done",
-                pid_file.display(),
+                "trap '' TERM; python3 -c 'import signal;signal.signal(15,1);signal.pause()' & echo $! > \"{}\"; printf 'not-json\\n'; exec 1>&- 2>&-; while IFS= read -r _; do :; done",
                 pid_file.display()
             ),
         ];

--- a/crates/csa-executor/src/transport_acp_sandbox.rs
+++ b/crates/csa-executor/src/transport_acp_sandbox.rs
@@ -315,6 +315,10 @@ pub(super) fn build_summary(stdout: &str, stderr: &str, exit_code: i32) -> Strin
         return truncate_line(last_non_empty_line(stdout), SUMMARY_MAX_CHARS);
     }
 
+    if let Some(summary) = codex_config_parse_summary(stderr) {
+        return summary;
+    }
+
     let stdout_line = last_non_empty_line(stdout);
     if !stdout_line.is_empty() {
         return truncate_line(stdout_line, SUMMARY_MAX_CHARS);
@@ -326,6 +330,22 @@ pub(super) fn build_summary(stdout: &str, stderr: &str, exit_code: i32) -> Strin
     }
 
     format!("exit code {exit_code}")
+}
+
+fn codex_config_parse_summary(stderr: &str) -> Option<String> {
+    let lines: Vec<_> = stderr
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    let start = lines
+        .iter()
+        .position(|line| line.contains("Error loading config.toml"))?;
+    let end = (start + 4).min(lines.len());
+    Some(truncate_line(
+        &lines[start..end].join(" "),
+        SUMMARY_MAX_CHARS,
+    ))
 }
 
 fn last_non_empty_line(output: &str) -> &str {

--- a/crates/csa-executor/src/transport_acp_sandbox.rs
+++ b/crates/csa-executor/src/transport_acp_sandbox.rs
@@ -342,8 +342,9 @@ fn codex_config_parse_summary(stderr: &str) -> Option<String> {
         .iter()
         .position(|line| line.contains("Error loading config.toml"))?;
     let end = (start + 4).min(lines.len());
+    let summary = lines[start..end].join(" ");
     Some(truncate_line(
-        &lines[start..end].join(" "),
+        &csa_session::redact_text_content(&summary),
         SUMMARY_MAX_CHARS,
     ))
 }

--- a/crates/csa-executor/src/transport_tests_codex_config.rs
+++ b/crates/csa-executor/src/transport_tests_codex_config.rs
@@ -5,3 +5,12 @@ fn test_build_summary_preserves_codex_config_parse_diagnostic() {
     assert!(summary.contains("Error loading config.toml"), "summary: {summary}");
     assert!(summary.contains("duplicate key"), "summary: {summary}");
 }
+
+#[test]
+fn test_build_summary_redacts_secret_bearing_codex_config_diagnostic() {
+    let stderr = "Error loading config.toml:\nOPENAI_API_KEY=providerfixture12345\n";
+    let summary = super::build_summary("", stderr, 1);
+    assert!(summary.contains("Error loading config.toml"), "summary: {summary}");
+    assert!(summary.contains("[REDACTED]"), "summary: {summary}");
+    assert!(!summary.contains("providerfixture12345"), "summary: {summary}");
+}

--- a/crates/csa-executor/src/transport_tests_codex_config.rs
+++ b/crates/csa-executor/src/transport_tests_codex_config.rs
@@ -1,0 +1,7 @@
+#[test]
+fn test_build_summary_preserves_codex_config_parse_diagnostic() {
+    let stderr = "Error loading config.toml:\n/home/obj/.codex/config.toml:21:1: duplicate key\n21 | service_tier = \"default\"\n   | ^^^^^^^^^^^^\n";
+    let summary = super::build_summary("21 | service_tier = \"default\"\n", stderr, 1);
+    assert!(summary.contains("Error loading config.toml"), "summary: {summary}");
+    assert!(summary.contains("duplicate key"), "summary: {summary}");
+}

--- a/crates/csa-executor/src/transport_tests_mod.rs
+++ b/crates/csa-executor/src/transport_tests_mod.rs
@@ -11,6 +11,7 @@ include!("transport_tests_gemini_init_classification.rs");
 include!("transport_tests_gemini_acp_mcp_retry.rs");
 include!("transport_tests_gemini_oauth_prompt.rs");
 include!("transport_tests_extra.rs");
+include!("transport_tests_codex_config.rs");
 include!("transport_tests_codex_acp_stall.rs");
 include!("transport_tests_capabilities.rs");
 

--- a/crates/csa-process/src/daemon.rs
+++ b/crates/csa-process/src/daemon.rs
@@ -23,6 +23,7 @@ use cleanup::{
 use cleanup::{observe_before_final_group_signal_for_test, stop_systemd_scope_with_timeout};
 
 const DAEMON_INDEPENDENT_SCOPE_ENV: &str = "CSA_DAEMON_INDEPENDENT_SCOPE";
+const DAEMON_RESULT_FILE: &str = "result.toml";
 
 /// Configuration for spawning a daemonized child process.
 pub struct DaemonSpawnConfig {
@@ -291,6 +292,11 @@ where
     }
 
     let mut cmd = build_daemon_command_with_systemd_run(&config, &spawn_mode, systemd_run);
+
+    // A resumed daemon supersedes any prior attempt. Remove its terminal
+    // result before publishing the new daemon PID, so wait cannot consume a
+    // stale result while this process is live.
+    remove_file_if_exists(&config.session_dir.join(DAEMON_RESULT_FILE))?;
 
     cmd.stdin(Stdio::null());
     cmd.stdout(stdout_file);

--- a/crates/csa-process/src/daemon_tests.rs
+++ b/crates/csa-process/src/daemon_tests.rs
@@ -186,9 +186,16 @@ fn test_daemon_spawn_creates_spool_files() {
         )]),
     };
 
+    std::fs::create_dir_all(&session_dir).expect("create session dir");
+    std::fs::write(session_dir.join("result.toml"), "status = \"failure\"\n")
+        .expect("write stale result");
     let result = spawn_daemon(config).expect("spawn_daemon");
     assert_eq!(result.session_id, "01M0KCV46DMV3TMJ0CAPA4FXZT");
     assert!(result.pid > 0);
+    assert!(
+        !session_dir.join("result.toml").exists(),
+        "new daemon liveness must not expose a stale terminal result"
+    );
 
     let stdout_path = session_dir.join("stdout.log");
     let stderr_path = session_dir.join("stderr.log");

--- a/crates/csa-process/src/daemon_tests.rs
+++ b/crates/csa-process/src/daemon_tests.rs
@@ -282,6 +282,8 @@ fn test_daemon_spawn_falls_back_to_direct_when_scope_spawn_fails() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let session_dir = tmp.path().join("session-fallback");
     let wrapper = write_wrapper_script(tmp.path(), "wrapper-fallback.sh");
+    let release_marker = tmp.path().join("daemon-release");
+    let _release_guard = ReleaseMarker(release_marker.clone());
 
     let missing_systemd_run = tmp.path().join("missing-systemd-run");
 
@@ -290,8 +292,18 @@ fn test_daemon_spawn_falls_back_to_direct_when_scope_spawn_fails() {
         session_dir: session_dir.clone(),
         csa_binary: wrapper,
         subcommand: "run".to_string(),
-        args: vec!["--".to_string(), "echo scope-fallback-ok".to_string()],
-        env: HashMap::new(),
+        // Keep the child alive through spawn_daemon's post-fallback waitid
+        // inspection. Unique-gate load made a bare `echo` exit before that
+        // check (`wait code 1 status 0`).
+        args: vec![
+            "--".to_string(),
+            "echo scope-fallback-ok; while [ ! -e \"$CSA_TEST_RELEASE_MARKER\" ]; do sleep 0.01; done"
+                .to_string(),
+        ],
+        env: HashMap::from([(
+            "CSA_TEST_RELEASE_MARKER".to_string(),
+            release_marker.to_string_lossy().into_owned(),
+        )]),
     };
 
     let result = spawn_daemon_with_systemd_run(config, &missing_systemd_run);
@@ -299,10 +311,13 @@ fn test_daemon_spawn_falls_back_to_direct_when_scope_spawn_fails() {
     let result = result.expect("spawn_daemon should succeed via direct fallback");
     assert!(result.pid > 0);
 
-    std::thread::sleep(std::time::Duration::from_millis(500));
+    let stdout_path = session_dir.join("stdout.log");
+    wait_for_spool_content(&stdout_path, "scope-fallback-ok");
+    std::fs::write(&release_marker, b"release\n").expect("release daemon readiness barrier");
+    wait_for_daemon_exit(&session_dir);
 
-    let contents = std::fs::read_to_string(session_dir.join("stdout.log"))
-        .expect("stdout.log must exist after daemon spawn");
+    let contents =
+        std::fs::read_to_string(stdout_path).expect("stdout.log must exist after daemon spawn");
     assert!(
         contents.contains("scope-fallback-ok"),
         "expected 'scope-fallback-ok' in stdout (direct fallback output), got: {contents:?}"

--- a/scripts/tests/check-env-dependent-tests.sh
+++ b/scripts/tests/check-env-dependent-tests.sh
@@ -3,12 +3,18 @@ set -euo pipefail
 
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 CHECKER="${ROOT_DIR}/scripts/hooks/check-env-dependent-tests.sh"
-TMP_ROOT="$(mktemp -d)"
+if [[ -n "${CSA_SESSION_DIR:-}" ]]; then
+    fixture_root="${CSA_SESSION_DIR}/git-fixtures"
+    mkdir -p "${fixture_root}"
+    TMP_ROOT="$(mktemp -d "${fixture_root}/check-env-dependent-tests.XXXXXX")"
+else
+    TMP_ROOT="$(mktemp -d)"
+fi
 trap 'rm -rf "${TMP_ROOT}"' EXIT
 
 repo_dir="${TMP_ROOT}/fixture"
 mkdir -p "${repo_dir}/crates/demo/src" "${repo_dir}/crates/demo/tests"
-git init -q "${repo_dir}"
+(cd "${repo_dir}" && git init -q)
 
 cat >"${repo_dir}/crates/demo/src/lib.rs" <<'RS'
 fn production_only() {

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1185"
-weave = "0.1.1185"
+csa = "0.1.1186"
+weave = "0.1.1186"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1183"
-weave = "0.1.1183"
+csa = "0.1.1184"
+weave = "0.1.1184"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1177"
-weave = "0.1.1177"
+csa = "0.1.1178"
+weave = "0.1.1178"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1179"
-weave = "0.1.1179"
+csa = "0.1.1180"
+weave = "0.1.1180"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1182"
-weave = "0.1.1182"
+csa = "0.1.1183"
+weave = "0.1.1183"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1175"
-weave = "0.1.1175"
+csa = "0.1.1177"
+weave = "0.1.1177"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1187"
-weave = "0.1.1187"
+csa = "0.1.1188"
+weave = "0.1.1188"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1188"
-weave = "0.1.1188"
+csa = "0.1.1189"
+weave = "0.1.1189"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1184"
-weave = "0.1.1184"
+csa = "0.1.1185"
+weave = "0.1.1185"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1181"
-weave = "0.1.1181"
+csa = "0.1.1182"
+weave = "0.1.1182"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1178"
-weave = "0.1.1178"
+csa = "0.1.1179"
+weave = "0.1.1179"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1180"
-weave = "0.1.1180"
+csa = "0.1.1181"
+weave = "0.1.1181"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1186"
-weave = "0.1.1186"
+csa = "0.1.1187"
+weave = "0.1.1187"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary

Terminalize immediate Codex `config.toml` parse failures instead of waiting until the 1800s wall-clock timeout. Preserve a sanitized `Error loading config.toml` summary, bind live `session wait` results to the current attempt, and keep ACP init cleanup bounded.

Also lands unique-gate fixture repairs needed to publish this leaf:
- descendant-reap handshake (`Refs #3115`)
- daemon spawn fallback keep-alive (`Closes #3168`)

## Test plan

- Unique exact-tree `just quality-gates` on `57bcffb32d86dd135528b5fcc9022d3def571997`: default-features 7671 passed, all-features 7701 passed.
- Receipt: `/home/obj/project/github/RyderFreeman4Logos/drafts/cli-sub-agent/gates/57bcffb32d86dd135528b5fcc9022d3def571997-quality-gates.receipt`
- Log sha256: `56b8185180f05755ecd098b7519dc04f6ccf8608c0f31d701bfd2383b6e5572f`
- CSA review `01M1F7C6EKWSX31ACFBVJAB6ZM` PASS/CLEAN for `main...HEAD` at `57bcffb32d8`
- Verdict sha256: `85a86921358115cf5f2cd77e514746eeac131b4c0b074c147e6948f694e711f1`

## Not closed

- #3115 git-guard hook fingerprint remains OPEN.
- #3169 local pre-push `/tmp` wrapper friction remains OPEN.

Closes #3152
Closes #3168
Refs #3115
