### PR TITLE
fix(sandbox): fail closed on unpinned read-only binds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-sub-agent"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "chrono",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "csa-acp"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "csa-config"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "chrono",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "csa-core"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "agent-teams",
  "chrono",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "csa-eval"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "chrono",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "csa-executor"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "agent-teams",
  "anyhow",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "csa-hooks"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "chrono",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "csa-lock"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "chrono",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "csa-mcp-hub"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "axum",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csa-memory"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "csa-process"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "chrono",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "csa-resource"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "csa-core",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "csa-scheduler"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "chrono",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "csa-session"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "chrono",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "csa-todo"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "weave"
-version = "0.1.1230"
+version = "0.1.1231"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1230"
+version = "0.1.1231"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/crates/cli-sub-agent/src/cargo_env_normalize_script_tests.rs
+++ b/crates/cli-sub-agent/src/cargo_env_normalize_script_tests.rs
@@ -224,6 +224,7 @@ printf '%s\n' "$@" >"${CSA_CAPTURE_ARGS:?}"
         .current_dir(repo.path())
         .env("CSA_CAPTURE_ARGS", &capture)
         .env("CSA_CARGO_TARGET_LEASE", &lease)
+        .env("CARGO_INSTALL_ROOT", repo.path().join("cargo-install-root"))
         .output()
         .expect("normalizer should execute lease helper");
 
@@ -235,6 +236,41 @@ printf '%s\n' "$@" >"${CSA_CAPTURE_ARGS:?}"
     assert_eq!(
         fs::read_to_string(capture).unwrap(),
         "--\ncargo\nmetadata\n"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn cargo_env_normalize_delegates_default_install_root_creation_to_target_lease() {
+    let repo = TempDir::new().expect("create temp repo");
+    let capture = repo.path().join("lease.argv");
+    let lease = repo.path().join("cargo-target-lease");
+    install_executable(
+        &lease,
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >"${CSA_CAPTURE_ARGS:?}"
+"#,
+    );
+
+    let output = Command::new("bash")
+        .arg(workspace_root().join("scripts/cargo-env-normalize.sh"))
+        .args(["cargo", "metadata"])
+        .current_dir(repo.path())
+        .env("CSA_CAPTURE_ARGS", &capture)
+        .env("CSA_CARGO_TARGET_LEASE", &lease)
+        .env("CARGO_INSTALL_ROOT", "")
+        .output()
+        .expect("normalizer should execute lease helper");
+
+    assert!(
+        output.status.success(),
+        "normalizer failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(capture).unwrap(),
+        "--\n/bin/sh\n-c\nmkdir -p \"$CARGO_INSTALL_ROOT\"; exec \"$@\"\ncargo-env-normalize\ncargo\nmetadata\n"
     );
 }
 

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
@@ -121,7 +121,8 @@ enforcement_mode = "best-effort"
     );
 
     // Bwrap construction must not panic on the resolved paths (#3074).
-    let cmd = csa_resource::from_isolation_plan(plan, "/usr/bin/tool", &[]);
+    let cmd =
+        csa_resource::from_isolation_plan(plan, "/usr/bin/tool", &[]).expect("valid bind paths");
     assert!(cmd.is_some(), "Bwrap plan should produce a command");
 }
 

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests.rs
@@ -566,7 +566,9 @@ enforcement_mode = "best-effort"
 
 #[test]
 fn clean_room_sandbox_plan_is_strict_readonly_and_has_exact_exposures() {
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let temp = tempfile::tempdir().expect("tempdir");
+    let _home = ScopedEnvVarRestore::set("HOME", temp.path());
     let project = temp.path().join("project");
     let session = temp.path().join("state/session");
     let evidence = temp.path().join("evidence.md");
@@ -602,7 +604,7 @@ enforcement_mode = "off"
 
     assert!(!sandbox.best_effort);
     assert!(plan.readonly_project_root);
-    assert_eq!(plan.project_root.as_deref(), Some(project.as_path()));
+    assert_eq!(plan.project_root, Some(project.canonicalize().unwrap()));
     assert!(!plan.user_daemon_ipc);
     assert!(plan.degraded_reasons.is_empty());
     assert!(plan.env_overrides.is_empty());
@@ -611,8 +613,15 @@ enforcement_mode = "off"
             .iter()
             .map(|path| path.requested().to_path_buf())
             .collect::<Vec<_>>(),
-        vec![evidence.canonicalize().unwrap()]
+        vec![
+            evidence.canonicalize().unwrap(),
+            project.canonicalize().unwrap()
+        ]
     );
+    assert_eq!(csa_resource::bwrap::sandbox_bind_fd_count(&plan), 2);
+    csa_resource::from_isolation_plan(&plan, "/bin/true", &[])
+        .expect("clean-room read-only binds are pinned before command construction")
+        .expect("required bwrap command");
     assert_eq!(
         plan.writable_paths,
         vec![

--- a/crates/cli-sub-agent/src/pipeline_sandbox_tests_tail.rs
+++ b/crates/cli-sub-agent/src/pipeline_sandbox_tests_tail.rs
@@ -387,7 +387,10 @@ writable_paths = ["/tmp/restricted-only"]
 
 #[test]
 fn test_extra_readable_appended_to_isolation_plan() {
+    let _env_lock = TEST_ENV_LOCK.blocking_lock();
     let project_root = tempfile::tempdir().expect("project root tempdir");
+    let project_path = project_root.path().canonicalize().expect("resolve fixture root");
+    let _claude_home = ScopedEnvVarRestore::set("CLAUDE_CONFIG_DIR", project_root.path().join("claude"));
     let cfg = parse_project_config(
         r#"
 [resources]
@@ -403,12 +406,12 @@ enforcement_mode = "best-effort"
     std::fs::write(&second, "bar").expect("write second readable file");
     let readable = vec![first.clone(), second.clone()];
 
-    let result = resolve_sandbox_options_with_capabilities(
+    let resolve = |exposed: &[PathBuf]| resolve_sandbox_options_with_capabilities(
         SandboxResolveInput {
             config: Some(&cfg),
             tool_name: "claude-code",
             session_id: "test-session",
-            project_root: project_root.path(),
+            project_root: &project_path,
             stream_mode: StreamMode::BufferOnly,
             idle_timeout_seconds: 120,
             liveness_dead_seconds: 600,
@@ -417,7 +420,7 @@ enforcement_mode = "best-effort"
             allow_user_daemon_ipc: false,
             readonly_project_root: false,
             extra_writable: &[],
-            extra_readable: &readable,
+            extra_readable: exposed,
             execution_env: None,
         },
         RunResourceOverrides::absent(),
@@ -425,16 +428,21 @@ enforcement_mode = "best-effort"
         csa_resource::FilesystemCapability::Bwrap,
     );
 
-    let SandboxResolution::Ok(opts) = result else {
-        panic!("Expected SandboxResolution::Ok");
+    let baseline_count = match resolve(&[]) {
+        SandboxResolution::Ok(opts) => opts.sandbox.expect("baseline sandbox").isolation_plan.readable_paths.len(),
+        SandboxResolution::RequiredButUnavailable(message) => panic!("baseline rejected: {message}"),
+    };
+    let opts = match resolve(&readable) {
+        SandboxResolution::Ok(opts) => opts,
+        SandboxResolution::RequiredButUnavailable(message) => panic!("sandbox rejected: {message}"),
     };
 
     let sandbox = opts.sandbox.expect("expected deterministic sandbox context");
 
     assert_eq!(
         sandbox.isolation_plan.readable_paths.len(),
-        2,
-        "expected two readable paths in the isolation plan"
+        baseline_count + 2,
+        "expected exactly two additional readable paths in the isolation plan"
     );
     assert!(sandbox
         .isolation_plan

--- a/crates/cli-sub-agent/src/pipeline_session_exec_clean_room.rs
+++ b/crates/cli-sub-agent/src/pipeline_session_exec_clean_room.rs
@@ -114,7 +114,7 @@ pub(crate) fn resolve_clean_room_sandbox_options_with_capabilities(
                 pids_max,
             )
         };
-    let mut plan = IsolationPlanBuilder::new(resource_enforcement)
+    let plan = IsolationPlanBuilder::new(resource_enforcement)
         .with_filesystem_enforcement(ResourceEnforcementMode::Required)
         .with_resource_capability(resource_capability)
         .with_filesystem_capability(filesystem_capability)
@@ -123,11 +123,11 @@ pub(crate) fn resolve_clean_room_sandbox_options_with_capabilities(
         .with_writable_path(session_dir.clone())
         .with_readable_path(evidence_bundle.clone())
         .with_readonly_project_root(true)
+        .with_project_root(&project_root)
         .with_soft_limit_percent(resources.soft_limit_percent)
         .with_memory_monitor_interval(resources.memory_monitor_interval_seconds)
         .build()
         .context("build strict clean-room isolation plan")?;
-    plan.project_root = Some(project_root);
     if !plan.degraded_reasons.is_empty() {
         bail!(
             "clean-room isolation may not degrade: {}",

--- a/crates/cli-sub-agent/src/review_convergence/clean_room_provider_tests.rs
+++ b/crates/cli-sub-agent/src/review_convergence/clean_room_provider_tests.rs
@@ -18,7 +18,7 @@ use super::clean_room::{
 use super::clean_room_provider::{
     AdmittedProviderSessionFactory, ExactProviderPrompt, ProviderSessionDriver,
 };
-use super::clean_room_tests::{epoch, factory, lease_context};
+use super::clean_room_tests::{epoch, factory, lease_context, physical_temp_path};
 use super::provider_command_authority::{
     ProviderCommandAuthority, ProviderEnvironmentInputs, SystemProviderProgramResolver,
 };
@@ -88,15 +88,16 @@ fn write_executable(path: &std::path::Path, body: &str) {
 #[test]
 fn provider_request_preserves_exact_prompt_and_evidence_bundle() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let lease_context = lease_context(temp.path());
+    let temp_root = physical_temp_path(temp.path());
+    let lease_context = lease_context(&temp_root);
     let frozen = epoch();
     let (mut factory, _plans, _cleanup_calls, _ledger) =
         factory(frozen.head_oid().as_str().to_string(), false);
     let guard = factory
         .create(
-            &temp.path().join("source"),
-            &temp.path().join("room"),
-            &temp.path().join("bundle"),
+            &temp_root.join("source"),
+            &temp_root.join("room"),
+            &temp_root.join("bundle"),
             frozen,
             &lease_context,
         )
@@ -139,15 +140,16 @@ fn provider_request_preserves_exact_prompt_and_evidence_bundle() {
 #[test]
 fn provider_request_rejects_non_xhigh_strongest_identity() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let lease_context = lease_context(temp.path());
+    let temp_root = physical_temp_path(temp.path());
+    let lease_context = lease_context(&temp_root);
     let frozen = epoch();
     let (mut factory, _plans, _cleanup_calls, _ledger) =
         factory(frozen.head_oid().as_str().to_string(), false);
     let guard = factory
         .create(
-            &temp.path().join("source"),
-            &temp.path().join("room"),
-            &temp.path().join("bundle"),
+            &temp_root.join("source"),
+            &temp_root.join("room"),
+            &temp_root.join("bundle"),
             frozen,
             &lease_context,
         )
@@ -210,15 +212,16 @@ impl ProviderSessionFactory for RecordingProviderFactory {
 #[tokio::test]
 async fn async_provider_port_propagates_success_and_error_with_a_fake_only() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let lease_context = lease_context(temp.path());
+    let temp_root = physical_temp_path(temp.path());
+    let lease_context = lease_context(&temp_root);
     let frozen = epoch();
     let (mut workspace_factory, _plans, _cleanup_calls, _ledger) =
         factory(frozen.head_oid().as_str().to_string(), false);
     let guard = workspace_factory
         .create(
-            &temp.path().join("source"),
-            &temp.path().join("room"),
-            &temp.path().join("bundle"),
+            &temp_root.join("source"),
+            &temp_root.join("room"),
+            &temp_root.join("bundle"),
             frozen,
             &lease_context,
         )
@@ -257,7 +260,8 @@ async fn async_provider_port_propagates_success_and_error_with_a_fake_only() {
 #[tokio::test]
 async fn production_adapter_executes_only_fingerprinted_fake_with_exact_contract() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let lease_context = lease_context(temp.path());
+    let temp_root = physical_temp_path(temp.path());
+    let lease_context = lease_context(&temp_root);
     let mut sandbox = crate::test_session_sandbox::ScopedSessionSandbox::new(&temp).await;
     sandbox.track_env("CSA_CLEAN_ROOM_PARENT_SENTINEL");
     unsafe {
@@ -267,11 +271,11 @@ async fn production_adapter_executes_only_fingerprinted_fake_with_exact_contract
     let frozen = epoch();
     let (mut workspace_factory, _plans, _cleanup_calls, _ledger) =
         factory(frozen.head_oid().as_str().to_string(), false);
-    let root = temp.path().join("clean-room");
-    let bundle = temp.path().join("evidence.md");
+    let root = temp_root.join("clean-room");
+    let bundle = temp_root.join("evidence.md");
     let guard = workspace_factory
         .create(
-            &temp.path().join("source"),
+            &temp_root.join("source"),
             &root,
             &bundle,
             frozen,
@@ -365,15 +369,16 @@ printf '%s' "$last"
 #[tokio::test]
 async fn production_adapter_rejects_stale_executor_request_and_program_before_execution() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let lease_context = lease_context(temp.path());
+    let temp_root = physical_temp_path(temp.path());
+    let lease_context = lease_context(&temp_root);
     let frozen = epoch();
     let (mut workspace_factory, _plans, _cleanup_calls, _ledger) =
         factory(frozen.head_oid().as_str().to_string(), false);
-    let root = temp.path().join("clean-room");
-    let bundle = temp.path().join("evidence.md");
+    let root = temp_root.join("clean-room");
+    let bundle = temp_root.join("evidence.md");
     let guard = workspace_factory
         .create(
-            &temp.path().join("source"),
+            &temp_root.join("source"),
             &root,
             &bundle,
             frozen,
@@ -475,15 +480,16 @@ async fn production_adapter_rejects_stale_executor_request_and_program_before_ex
 async fn production_adapter_propagates_fingerprinted_fake_nonzero_exit() {
     let temp = tempfile::tempdir().expect("tempdir");
     let _sandbox = crate::test_session_sandbox::ScopedSessionSandbox::new(&temp).await;
-    let lease_context = lease_context(temp.path());
+    let temp_root = physical_temp_path(temp.path());
+    let lease_context = lease_context(&temp_root);
     let frozen = epoch();
     let (mut workspace_factory, _plans, _cleanup_calls, _ledger) =
         factory(frozen.head_oid().as_str().to_string(), false);
-    let root = temp.path().join("clean-room");
-    let bundle = temp.path().join("evidence.md");
+    let root = temp_root.join("clean-room");
+    let bundle = temp_root.join("evidence.md");
     let guard = workspace_factory
         .create(
-            &temp.path().join("source"),
+            &temp_root.join("source"),
             &root,
             &bundle,
             frozen,

--- a/crates/cli-sub-agent/src/review_convergence/clean_room_tests.rs
+++ b/crates/cli-sub-agent/src/review_convergence/clean_room_tests.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -69,8 +69,12 @@ impl DetachedWorkspaceDriver for RecordingWorkspaceDriver {
     }
 }
 
+pub(super) fn physical_temp_path(root: &Path) -> PathBuf {
+    fs::canonicalize(root).expect("physical tempfile identity")
+}
+
 pub(super) fn lease_context(root: &Path) -> DetachedWorkspaceLeaseContext {
-    let store = DetachedWorkspaceLeaseStore::open(root).expect("lease store");
+    let store = DetachedWorkspaceLeaseStore::open(&physical_temp_path(root)).expect("lease store");
     DetachedWorkspaceLeaseContext::new(CampaignId::generate(), 1, store).expect("lease context")
 }
 
@@ -105,11 +109,12 @@ pub(super) fn factory(observed_head: String, cleanup_fails: bool) -> WorkspaceFa
 #[test]
 fn exact_oid_factory_builds_detached_non_interactive_git_plan_without_executing_git() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let source = temp.path().join("source");
-    let root = temp.path().join("clean-room");
-    let bundle = temp.path().join("provider-evidence.tar");
+    let temp_root = physical_temp_path(temp.path());
+    let source = temp_root.join("source");
+    let root = temp_root.join("clean-room");
+    let bundle = temp_root.join("provider-evidence.tar");
     let frozen = epoch();
-    let lease_context = lease_context(temp.path());
+    let lease_context = lease_context(&temp_root);
     let (mut factory, plans, cleanup_calls, _ledger) =
         factory(frozen.head_oid().as_str().to_string(), false);
 
@@ -177,15 +182,16 @@ fn exact_oid_factory_builds_detached_non_interactive_git_plan_without_executing_
 fn workspace_guard_requests_bounded_cleanup_on_drop() {
     let temp = tempfile::tempdir().expect("tempdir");
     let frozen = epoch();
-    let lease_context = lease_context(temp.path());
+    let temp_root = physical_temp_path(temp.path());
+    let lease_context = lease_context(&temp_root);
     let (mut factory, _plans, cleanup_calls, ledger) =
         factory(frozen.head_oid().as_str().to_string(), false);
     {
         let _guard = factory
             .create(
-                &temp.path().join("source"),
-                &temp.path().join("room"),
-                &temp.path().join("bundle"),
+                &temp_root.join("source"),
+                &temp_root.join("room"),
+                &temp_root.join("bundle"),
                 frozen,
                 &lease_context,
             )
@@ -199,14 +205,15 @@ fn workspace_guard_requests_bounded_cleanup_on_drop() {
 fn explicit_close_surfaces_cleanup_failure_and_drop_records_it() {
     let temp = tempfile::tempdir().expect("tempdir");
     let frozen = epoch();
-    let lease_context = lease_context(temp.path());
+    let temp_root = physical_temp_path(temp.path());
+    let lease_context = lease_context(&temp_root);
     let (mut factory, _plans, cleanup_calls, ledger) =
         factory(frozen.head_oid().as_str().to_string(), true);
     let guard = factory
         .create(
-            &temp.path().join("source"),
-            &temp.path().join("room"),
-            &temp.path().join("bundle"),
+            &temp_root.join("source"),
+            &temp_root.join("room"),
+            &temp_root.join("bundle"),
             frozen.clone(),
             &lease_context,
         )
@@ -221,9 +228,9 @@ fn explicit_close_surfaces_cleanup_failure_and_drop_records_it() {
 
     let _dropped = factory
         .create(
-            &temp.path().join("source-2"),
-            &temp.path().join("room-2"),
-            &temp.path().join("bundle-2"),
+            &temp_root.join("source-2"),
+            &temp_root.join("room-2"),
+            &temp_root.join("bundle-2"),
             frozen,
             &lease_context,
         )
@@ -237,14 +244,15 @@ fn explicit_close_surfaces_cleanup_failure_and_drop_records_it() {
 fn close_and_confirm_returns_a_receipt_only_after_successful_cleanup() {
     let temp = tempfile::tempdir().expect("tempdir");
     let frozen = epoch();
-    let lease_context = lease_context(temp.path());
+    let temp_root = physical_temp_path(temp.path());
+    let lease_context = lease_context(&temp_root);
     let (mut factory, _plans, cleanup_calls, _ledger) =
         factory(frozen.head_oid().as_str().to_string(), false);
     let guard = factory
         .create(
-            &temp.path().join("source"),
-            &temp.path().join("room"),
-            &temp.path().join("bundle"),
+            &temp_root.join("source"),
+            &temp_root.join("room"),
+            &temp_root.join("bundle"),
             frozen,
             &lease_context,
         )
@@ -263,13 +271,14 @@ fn close_and_confirm_returns_a_receipt_only_after_successful_cleanup() {
 fn observed_head_mismatch_fails_closed_and_cleans_partial_workspace() {
     let temp = tempfile::tempdir().expect("tempdir");
     let frozen = epoch();
-    let lease_context = lease_context(temp.path());
+    let temp_root = physical_temp_path(temp.path());
+    let lease_context = lease_context(&temp_root);
     let (mut factory, _plans, cleanup_calls, _ledger) = factory("c".repeat(40), false);
     let error = factory
         .create(
-            &temp.path().join("source"),
-            &temp.path().join("room"),
-            &temp.path().join("bundle"),
+            &temp_root.join("source"),
+            &temp_root.join("room"),
+            &temp_root.join("bundle"),
             frozen,
             &lease_context,
         )
@@ -282,7 +291,8 @@ fn observed_head_mismatch_fails_closed_and_cleans_partial_workspace() {
 fn workspace_factory_rejects_relative_boundaries_before_driver_invocation() {
     let temp = tempfile::tempdir().expect("tempdir");
     let frozen = epoch();
-    let lease_context = lease_context(temp.path());
+    let temp_root = physical_temp_path(temp.path());
+    let lease_context = lease_context(&temp_root);
     let (mut factory, plans, _cleanup_calls, _ledger) =
         factory(frozen.head_oid().as_str().to_string(), false);
     let error = factory

--- a/crates/cli-sub-agent/src/review_convergence/workspace_lease_tests.rs
+++ b/crates/cli-sub-agent/src/review_convergence/workspace_lease_tests.rs
@@ -13,6 +13,7 @@ use super::clean_room::{
     CleanRoomWorkspace, CleanupFailureLedger, DetachedWorkspaceLease,
     DetachedWorkspaceLeaseContext, LeaseAcquireFault, WorkspaceCleanup,
 };
+use super::clean_room_tests::physical_temp_path;
 use super::workspace_lease_fs::DetachedWorkspaceLeaseStore;
 
 #[derive(Default)]
@@ -44,7 +45,7 @@ fn context(root: &std::path::Path) -> DetachedWorkspaceLeaseContext {
     DetachedWorkspaceLeaseContext::new(
         CampaignId::generate(),
         1,
-        DetachedWorkspaceLeaseStore::open(root).unwrap(),
+        DetachedWorkspaceLeaseStore::open(&physical_temp_path(root)).unwrap(),
     )
     .unwrap()
 }
@@ -88,23 +89,24 @@ fn lease_recovery_state(fault: LeaseAcquireFault) -> LeaseRecoveryState {
 #[test]
 fn rejects_symlink_and_cross_filesystem_roots() {
     let temp = tempfile::tempdir().unwrap();
-    let target = temp.path().join("target");
-    let link = temp.path().join("link");
+    let temp_root = physical_temp_path(temp.path());
+    let target = temp_root.join("target");
+    let link = temp_root.join("link");
     fs::create_dir(&target).unwrap();
     symlink(&target, &link).unwrap();
     assert!(
-        context(temp.path())
+        context(&temp_root)
             .acquire(&workspace(link))
             .unwrap_err()
             .to_string()
             .contains("symlink")
     );
     assert_ne!(
-        fs::metadata(temp.path()).unwrap().dev(),
+        fs::metadata(&temp_root).unwrap().dev(),
         fs::metadata("/proc").unwrap().dev()
     );
     assert!(
-        context(temp.path())
+        context(&temp_root)
             .acquire(&workspace(PathBuf::from("/proc")))
             .unwrap_err()
             .to_string()
@@ -115,9 +117,10 @@ fn rejects_symlink_and_cross_filesystem_roots() {
 #[test]
 fn rejects_concurrent_and_replaced_workspace_roots() {
     let temp = tempfile::tempdir().unwrap();
-    let root = temp.path().join("workspace");
+    let temp_root = physical_temp_path(temp.path());
+    let root = temp_root.join("workspace");
     fs::create_dir(&root).unwrap();
-    let lease_context = context(temp.path());
+    let lease_context = context(&temp_root);
     let lease = acquire(&lease_context, workspace(root.clone()));
     assert!(
         lease_context
@@ -126,7 +129,7 @@ fn rejects_concurrent_and_replaced_workspace_roots() {
             .to_string()
             .contains("already leased")
     );
-    fs::rename(&root, temp.path().join("moved")).unwrap();
+    fs::rename(&root, temp_root.join("moved")).unwrap();
     fs::create_dir(&root).unwrap();
     assert!(
         lease
@@ -140,9 +143,10 @@ fn rejects_concurrent_and_replaced_workspace_roots() {
 #[test]
 fn rejects_changed_nonce_before_cleanup() {
     let temp = tempfile::tempdir().unwrap();
-    let root = temp.path().join("workspace");
+    let temp_root = physical_temp_path(temp.path());
+    let root = temp_root.join("workspace");
     fs::create_dir(&root).unwrap();
-    let lease = acquire(&context(temp.path()), workspace(root));
+    let lease = acquire(&context(&temp_root), workspace(root));
     let id = lease.identity();
     let changed = WorkspaceLeaseIdentity::new(
         id.campaign_id().clone(),
@@ -177,9 +181,10 @@ fn lease_create_fault_matrix_never_grants_an_unconfirmed_workspace() {
         LeaseAcquireFault::AfterFileSync,
     ] {
         let temp = tempfile::tempdir().unwrap();
-        let root = temp.path().join("workspace");
+        let temp_root = physical_temp_path(temp.path());
+        let root = temp_root.join("workspace");
         fs::create_dir(&root).unwrap();
-        let context = context(temp.path());
+        let context = context(&temp_root);
         let room = workspace(root.clone());
 
         assert!(context.acquire_with_fault(&room, fault).is_err());
@@ -200,9 +205,10 @@ fn lease_create_fault_matrix_never_grants_an_unconfirmed_workspace() {
 #[tokio::test]
 async fn owned_lease_survives_await_and_explicit_release_allows_reacquisition() {
     let temp = tempfile::tempdir().unwrap();
-    let root = temp.path().join("workspace");
+    let temp_root = physical_temp_path(temp.path());
+    let root = temp_root.join("workspace");
     fs::create_dir(&root).unwrap();
-    let context = context(temp.path());
+    let context = context(&temp_root);
     let lease = acquire(&context, workspace(root.clone()));
     tokio::task::yield_now().await;
     assert!(lease.validate_current().is_ok());
@@ -214,9 +220,10 @@ async fn owned_lease_survives_await_and_explicit_release_allows_reacquisition() 
 #[test]
 fn failed_close_and_future_drop_leave_a_fenced_nonreusable_lease() {
     let temp = tempfile::tempdir().unwrap();
-    let root = temp.path().join("workspace");
+    let temp_root = physical_temp_path(temp.path());
+    let root = temp_root.join("workspace");
     fs::create_dir(&root).unwrap();
-    let lease_context = context(temp.path());
+    let lease_context = context(&temp_root);
     let failure_ledger = CleanupFailureLedger::default();
     let lease = acquire_with(
         &lease_context,
@@ -230,9 +237,9 @@ fn failed_close_and_future_drop_leave_a_fenced_nonreusable_lease() {
     assert!(!failure_ledger.failures().is_empty());
     assert!(lease_context.acquire(&workspace(root)).is_err());
 
-    let drop_root = temp.path().join("dropped-workspace");
+    let drop_root = temp_root.join("dropped-workspace");
     fs::create_dir(&drop_root).unwrap();
-    let drop_context = context(temp.path());
+    let drop_context = context(&temp_root);
     let drop_failures = CleanupFailureLedger::default();
     let dropped = acquire_with(
         &drop_context,

--- a/crates/csa-acp/src/connection_spawn.rs
+++ b/crates/csa-acp/src/connection_spawn.rs
@@ -121,7 +121,7 @@ impl AcpConnection {
     fn prepare_sandbox_command(
         request: AcpSpawnRequest<'_>,
         sandbox: &AcpSandboxRequest<'_>,
-    ) -> PreparedSandboxCommand {
+    ) -> AcpResult<PreparedSandboxCommand> {
         let plan = sandbox.isolation_plan;
         let effective_env = Self::merge_sandbox_env(request.env, sandbox.env_overrides);
 
@@ -138,7 +138,9 @@ impl AcpConnection {
                     &bwrap_plan,
                     request.command,
                     &tool_args,
-                ) {
+                )
+                .map_err(|error| AcpError::ConfigError(error.to_string()))?
+                {
                     let program = bwrap_cmd.get_program().to_string_lossy().to_string();
                     let args: Vec<String> = bwrap_cmd
                         .get_args()
@@ -174,13 +176,13 @@ impl AcpConnection {
             }
         };
 
-        PreparedSandboxCommand {
+        Ok(PreparedSandboxCommand {
             effective_command,
             effective_args,
             effective_env,
             landlock_paths,
             has_bwrap,
-        }
+        })
     }
 
     /// Spawn an ACP process without resource sandboxing.
@@ -257,7 +259,7 @@ impl AcpConnection {
             effective_env,
             mut landlock_paths,
             has_bwrap,
-        } = Self::prepare_sandbox_command(request, &sandbox);
+        } = Self::prepare_sandbox_command(request, &sandbox)?;
 
         // --- Resource axis: apply resource isolation ---
         match plan.resource {

--- a/crates/csa-acp/src/connection_spawn_selection_tests.rs
+++ b/crates/csa-acp/src/connection_spawn_selection_tests.rs
@@ -1,0 +1,118 @@
+//! Frozen ordinary-bind selection must survive ACP command reconstruction.
+
+use super::*;
+use std::os::unix::fs::{MetadataExt, symlink};
+
+fn ordinary_bind_reconstruction(covered: bool, retarget: bool) {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    // Outside /tmp and /dev: these mounts intentionally keep logical destinations.
+    assert!(!root.starts_with("/tmp") && !root.starts_with("/dev"));
+    let a = root.join("a");
+    let b = root.join("b");
+    std::fs::create_dir(&a).unwrap();
+    std::fs::create_dir(&b).unwrap();
+    let input = a.join("input");
+    std::fs::write(&input, "accepted").unwrap();
+    let accepted = std::fs::metadata(&input).unwrap();
+    let alias = root.join("writable");
+    symlink(if covered { &a } else { &b }, &alias).unwrap();
+    let plan = csa_resource::isolation_plan::IsolationPlanBuilder::new(
+        csa_resource::isolation_plan::EnforcementMode::BestEffort,
+    )
+    .with_resource_capability(ResourceCapability::Setrlimit)
+    .with_filesystem_capability(FilesystemCapability::Bwrap)
+    .with_writable_path(alias.clone())
+    .with_readable_path(&input)
+    .build()
+    .unwrap();
+    // Find the retained snapshot descriptor without opening another descriptor.
+    let pin_fd = std::fs::read_dir("/proc/self/fd")
+        .unwrap()
+        .filter_map(Result::ok)
+        .find(|entry| {
+            std::fs::metadata(entry.path())
+                .is_ok_and(|meta| meta.dev() == accepted.dev() && meta.ino() == accepted.ino())
+        })
+        .unwrap()
+        .file_name()
+        .to_string_lossy()
+        .into_owned();
+    let env = HashMap::new();
+    let prepared = AcpConnection::prepare_sandbox_command(
+        AcpSpawnRequest {
+            command: "/bin/true",
+            args: &[],
+            working_dir: &root,
+            env: &env,
+            options: AcpConnectionOptions::default(),
+        },
+        &AcpSandboxRequest {
+            isolation_plan: &plan,
+            tool_name: "codex",
+            session_id: "01TEST",
+            env_overrides: None,
+        },
+    )
+    .unwrap();
+    let emitted = prepared
+        .effective_args
+        .windows(3)
+        .find(|args| args[0] == "--ro-bind-fd" && args[2] == input.to_string_lossy());
+    assert_eq!(emitted.is_some(), !covered);
+    if let Some(args) = emitted {
+        assert_eq!(args[1], pin_fd);
+    }
+    if retarget {
+        std::fs::remove_file(&alias).unwrap();
+        symlink(if covered { &b } else { &a }, &alias).unwrap();
+    }
+    let mut probe = Command::new("/bin/sh");
+    probe
+        .args([
+            "-c",
+            if covered {
+                "test ! -e /proc/self/fd/\"$1\""
+            } else {
+                "test /proc/self/fd/\"$1\" -ef \"$2\" && cat /proc/self/fd/\"$1\""
+            },
+            "probe",
+            &pin_fd,
+        ])
+        .arg(&input);
+    inherit_plan_bind_fds(&mut probe, &plan).unwrap();
+    drop(plan);
+    let output = csa_resource::bounded_command::output_with_timeout(
+        probe.into_std(),
+        Duration::from_secs(5),
+        csa_resource::bounded_command::MAX_OUTPUT_BYTES,
+    )
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "covered={covered}, retarget={retarget}: {output:?}"
+    );
+    if !covered {
+        assert_eq!(output.stdout, b"accepted");
+    }
+}
+
+#[test]
+fn temporal_selection_acp_emitted_fd_survives_alias_retarget() {
+    ordinary_bind_reconstruction(false, true);
+}
+
+#[test]
+fn temporal_selection_acp_unchanged_emitted_fd_is_inherited() {
+    ordinary_bind_reconstruction(false, false);
+}
+
+#[test]
+fn temporal_selection_acp_covered_snapshot_is_not_inherited() {
+    ordinary_bind_reconstruction(true, false);
+}
+
+#[test]
+fn temporal_selection_acp_inverse_retarget_does_not_inherit_unemitted_pin() {
+    ordinary_bind_reconstruction(true, true);
+}

--- a/crates/csa-acp/src/connection_spawn_selection_tests.rs
+++ b/crates/csa-acp/src/connection_spawn_selection_tests.rs
@@ -4,7 +4,7 @@ use super::*;
 use std::os::unix::fs::{MetadataExt, symlink};
 
 fn ordinary_bind_reconstruction(covered: bool, retarget: bool) {
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempfile::tempdir_in("/var/tmp").unwrap();
     let root = temp.path().canonicalize().unwrap();
     // Outside /tmp and /dev: these mounts intentionally keep logical destinations.
     assert!(!root.starts_with("/tmp") && !root.starts_with("/dev"));

--- a/crates/csa-acp/src/connection_spawn_tests.rs
+++ b/crates/csa-acp/src/connection_spawn_tests.rs
@@ -522,3 +522,47 @@ fn acp_extra_bind_survives_actual_preparation_and_reconstruction() {
     );
     assert_eq!(output.stdout, b"accepted");
 }
+
+#[tokio::test]
+async fn non_bwrap_ordinary_readable_allows_acp_cgroup_spawn() {
+    use std::os::unix::fs::PermissionsExt;
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("readable");
+    std::fs::write(&source, "accepted").unwrap();
+    let systemd = temp.path().join("systemd-run");
+    std::fs::write(&systemd, "#!/bin/sh\nexit 0\n").unwrap();
+    std::fs::set_permissions(&systemd, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let plan = csa_resource::IsolationPlanBuilder::new(csa_resource::EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::None)
+        .with_resource_capability(ResourceCapability::CgroupV2)
+        .with_readable_path(source)
+        .build()
+        .unwrap();
+    assert_eq!(plan.resource, ResourceCapability::CgroupV2);
+    let env = HashMap::from([("PATH".into(), temp.path().display().to_string())]);
+    let (connection, _handle) = AcpConnection::spawn_sandboxed(
+        AcpSpawnRequest {
+            command: "/bin/true",
+            args: &[],
+            working_dir: temp.path(),
+            env: &env,
+            options: AcpConnectionOptions::default(),
+        },
+        Some(AcpSandboxRequest {
+            isolation_plan: &plan,
+            tool_name: "codex",
+            session_id: "01NONBWRAP",
+            env_overrides: None,
+        }),
+    )
+    .await
+    .expect("ordinary readable must not reject a non-bwrap ACP cgroup spawn");
+    let mut child = connection.child.borrow_mut().take().unwrap();
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_secs(5), child.wait())
+            .await
+            .unwrap()
+            .unwrap()
+            .success()
+    );
+}

--- a/crates/csa-acp/src/connection_spawn_tests.rs
+++ b/crates/csa-acp/src/connection_spawn_tests.rs
@@ -292,7 +292,8 @@ fn prepare_sandbox_command_merges_runtime_env_overrides_into_bwrap_invocation() 
         env_overrides: Some(&sandbox_env_overrides),
     };
 
-    let prepared = AcpConnection::prepare_sandbox_command(request, &sandbox);
+    let prepared =
+        AcpConnection::prepare_sandbox_command(request, &sandbox).expect("valid sandbox");
 
     assert_eq!(prepared.effective_command, "bwrap");
     assert_eq!(
@@ -404,7 +405,8 @@ fn prepare_sandbox_command_scrubs_subtree_contract_from_bwrap_env_overrides() {
         env_overrides: Some(&sandbox_env_overrides),
     };
 
-    let prepared = AcpConnection::prepare_sandbox_command(request, &sandbox);
+    let prepared =
+        AcpConnection::prepare_sandbox_command(request, &sandbox).expect("valid sandbox");
 
     for key in csa_core::env::STARTUP_SUBTREE_ENV_KEYS {
         assert!(

--- a/crates/csa-acp/src/connection_spawn_tests.rs
+++ b/crates/csa-acp/src/connection_spawn_tests.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "connection_spawn_selection_tests.rs"]
+mod temporal_selection;
+
 #[test]
 fn append_stderr_tail_bounds_retained_memory_to_tail_window() {
     let mut stderr = "a".repeat(1024 * 1024);

--- a/crates/csa-acp/src/connection_spawn_tests.rs
+++ b/crates/csa-acp/src/connection_spawn_tests.rs
@@ -465,3 +465,60 @@ fn scrub_inherited_child_env_removes_git_push_authorization_for_wrapper_commands
         );
     }
 }
+
+#[test]
+fn acp_extra_bind_survives_actual_preparation_and_reconstruction() {
+    let temp = tempfile::tempdir().unwrap();
+    let project = temp.path().canonicalize().unwrap().join("project");
+    std::fs::create_dir(&project).unwrap();
+    std::fs::write(project.join("payload"), "accepted").unwrap();
+    let plan = csa_resource::isolation_plan::IsolationPlanBuilder::new(
+        csa_resource::isolation_plan::EnforcementMode::BestEffort,
+    )
+    .with_filesystem_capability(FilesystemCapability::Bwrap)
+    .with_writable_path(project.clone())
+    .with_project_root(&project)
+    .with_readonly_project_root(true)
+    .build()
+    .unwrap();
+    let env = HashMap::new();
+    let sandbox = AcpSandboxRequest {
+        isolation_plan: &plan,
+        tool_name: "codex",
+        session_id: "01TEST",
+        env_overrides: None,
+    };
+    let prepared = AcpConnection::prepare_sandbox_command(
+        AcpSpawnRequest {
+            command: "/bin/true",
+            args: &[],
+            working_dir: &project,
+            env: &env,
+            options: AcpConnectionOptions::default(),
+        },
+        &sandbox,
+    )
+    .unwrap();
+    let fd = prepared
+        .effective_args
+        .windows(3)
+        .find(|args| args[0] == "--ro-bind-fd" && args[2] == project.to_string_lossy())
+        .unwrap()[1]
+        .clone();
+    std::fs::rename(&project, project.with_extension("old")).unwrap();
+    let mut probe = Command::new("/bin/cat");
+    probe.arg(format!("/proc/self/fd/{fd}/payload"));
+    inherit_plan_bind_fds(&mut probe, &plan).unwrap();
+    let output = csa_resource::bounded_command::output_with_timeout(
+        probe.into_std(),
+        Duration::from_secs(5),
+        csa_resource::bounded_command::MAX_OUTPUT_BYTES,
+    )
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.stdout, b"accepted");
+}

--- a/crates/csa-process/src/lib_spawn.rs
+++ b/crates/csa-process/src/lib_spawn.rs
@@ -179,7 +179,7 @@ pub async fn spawn_tool_sandboxed(
     let mut landlock_paths: Option<Vec<std::path::PathBuf>> = None;
 
     let cmd = match plan.filesystem {
-        FilesystemCapability::Bwrap => wrap_command_with_bwrap(cmd, plan),
+        FilesystemCapability::Bwrap => wrap_command_with_bwrap(cmd, plan)?,
         FilesystemCapability::Landlock => {
             debug!("Landlock filesystem isolation will be applied in pre_exec");
             // Filter out project_root when readonly_project_root is set,
@@ -408,7 +408,7 @@ fn apply_plan_env_overrides(target: &mut Command, plan: &IsolationPlan) {
     }
 }
 
-fn wrap_command_with_bwrap(cmd: Command, plan: &IsolationPlan) -> Command {
+fn wrap_command_with_bwrap(cmd: Command, plan: &IsolationPlan) -> Result<Command> {
     let tool_binary = cmd.as_std().get_program().to_string_lossy().to_string();
     let tool_args: Vec<String> = cmd
         .as_std()
@@ -417,7 +417,7 @@ fn wrap_command_with_bwrap(cmd: Command, plan: &IsolationPlan) -> Command {
         .collect();
 
     if let Some(bwrap_cmd) =
-        csa_resource::bwrap::from_isolation_plan(plan, &tool_binary, &tool_args)
+        csa_resource::bwrap::from_isolation_plan(plan, &tool_binary, &tool_args)?
     {
         let mut wrapped = Command::from(bwrap_cmd);
         csa_core::env::scrub_subtree_contract_env_tokio(&mut wrapped);
@@ -427,10 +427,10 @@ fn wrap_command_with_bwrap(cmd: Command, plan: &IsolationPlan) -> Command {
             wrapped.current_dir(dir);
         }
         debug!("wrapped tool command with bwrap filesystem sandbox");
-        wrapped
+        Ok(wrapped)
     } else {
         warn!("bwrap requested but from_isolation_plan returned None; proceeding without");
-        cmd
+        Ok(cmd)
     }
 }
 
@@ -450,8 +450,9 @@ pub(crate) fn wrap_command_with_bwrap_required(
         .get("HOME")
         .map(|home| std::iter::once(("HOME".to_string(), home.clone())).collect())
         .unwrap_or_default();
-    let wrapped = csa_resource::bwrap::from_isolation_plan(&wrapper_plan, &tool_binary, &tool_args)
-        .ok_or_else(|| anyhow::anyhow!("required bwrap wrapper could not be constructed"))?;
+    let wrapped =
+        csa_resource::bwrap::from_isolation_plan(&wrapper_plan, &tool_binary, &tool_args)?
+            .ok_or_else(|| anyhow::anyhow!("required bwrap wrapper could not be constructed"))?;
     let mut wrapped = Command::from(wrapped);
     if let Some(directory) = cmd.as_std().get_current_dir() {
         wrapped.current_dir(directory);

--- a/crates/csa-process/src/lib_spawn_tests.rs
+++ b/crates/csa-process/src/lib_spawn_tests.rs
@@ -94,7 +94,7 @@ async fn non_bwrap_spawn_applies_plan_env_overrides_over_explicit_env() {
 #[test]
 fn bwrap_wrapper_scrubs_ambient_subtree_contract_env() {
     let original = Command::new("/usr/bin/tool");
-    let wrapped = wrap_command_with_bwrap(original, &bwrap_plan());
+    let wrapped = wrap_command_with_bwrap(original, &bwrap_plan()).expect("valid sandbox");
     let env = recorded_env(&wrapped);
 
     for key in csa_core::env::STARTUP_SUBTREE_ENV_KEYS {
@@ -109,7 +109,7 @@ fn bwrap_wrapper_scrubs_ambient_subtree_contract_env() {
 #[test]
 fn bwrap_wrapper_scrubs_ambient_git_push_authorization_env() {
     let original = Command::new("/usr/bin/tool");
-    let wrapped = wrap_command_with_bwrap(original, &bwrap_plan());
+    let wrapped = wrap_command_with_bwrap(original, &bwrap_plan()).expect("valid sandbox");
     let env = recorded_env(&wrapped);
 
     for key in csa_core::env::GIT_PUSH_AUTHORIZATION_ENV_KEYS {
@@ -126,7 +126,7 @@ fn bwrap_wrapper_preserves_explicit_typed_git_push_authorization() {
     let mut original = Command::new("/usr/bin/tool");
     original.env(csa_core::env::CSA_GIT_PUSH_ALLOWED_ENV_KEY, "true");
 
-    let wrapped = wrap_command_with_bwrap(original, &bwrap_plan());
+    let wrapped = wrap_command_with_bwrap(original, &bwrap_plan()).expect("valid sandbox");
     let env = recorded_env(&wrapped);
 
     assert_eq!(
@@ -211,4 +211,28 @@ fn cgroup_wrapper_preserves_explicit_typed_git_push_authorization() {
         Some(&None),
         "internal git-push marker must remain stripped"
     );
+}
+
+#[tokio::test]
+async fn bad_readonly_bind_returns_error_without_spawning_tool() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let marker = temp.path().join("child-started");
+    let mut original = Command::new("/usr/bin/touch");
+    original.arg(&marker);
+    let mut plan = bwrap_plan();
+    plan.readable_paths.push(temp.path().join("missing").into());
+    let result = spawn_tool_sandboxed(
+        original,
+        None,
+        SpawnOptions::default(),
+        Some(&plan),
+        "codex",
+        "01TEST",
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "invalid read-only bind must fail before spawning"
+    );
+    assert!(!marker.exists());
 }

--- a/crates/csa-process/src/lib_spawn_tests.rs
+++ b/crates/csa-process/src/lib_spawn_tests.rs
@@ -278,3 +278,38 @@ async fn extra_only_binds_reject_systemd_before_spawning_tool() {
     );
     assert!(!marker.exists());
 }
+
+#[tokio::test]
+async fn non_bwrap_ordinary_readable_allows_cgroup_spawn() {
+    use std::os::unix::fs::PermissionsExt;
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("readable");
+    std::fs::write(&source, "accepted").unwrap();
+    let systemd = temp.path().join("systemd-run");
+    std::fs::write(&systemd, "#!/bin/sh\nprintf cgroup-started\n").unwrap();
+    std::fs::set_permissions(&systemd, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let plan = csa_resource::IsolationPlanBuilder::new(csa_resource::EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::None)
+        .with_resource_capability(ResourceCapability::CgroupV2)
+        .with_readable_path(source)
+        .build()
+        .unwrap();
+    assert_eq!(plan.resource, ResourceCapability::CgroupV2);
+    let mut original = Command::new("/bin/true");
+    original.env("PATH", temp.path());
+    let (child, _handle) = spawn_tool_sandboxed(
+        original,
+        None,
+        SpawnOptions::default(),
+        Some(&plan),
+        "codex",
+        "01NONBWRAP",
+    )
+    .await
+    .expect("ordinary readable must not reject a non-bwrap cgroup spawn");
+    let result = crate::wait_and_capture(child, crate::StreamMode::BufferOnly)
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.output, "cgroup-started");
+}

--- a/crates/csa-process/src/lib_spawn_tests.rs
+++ b/crates/csa-process/src/lib_spawn_tests.rs
@@ -236,3 +236,45 @@ async fn bad_readonly_bind_returns_error_without_spawning_tool() {
     );
     assert!(!marker.exists());
 }
+
+#[tokio::test]
+async fn extra_only_binds_reject_systemd_before_spawning_tool() {
+    let temp = tempfile::tempdir().unwrap();
+    let project = temp.path().canonicalize().unwrap().join("project");
+    std::fs::create_dir(&project).unwrap();
+    let marker = project.join("child-started");
+    let mut plan = csa_resource::isolation_plan::IsolationPlanBuilder::new(
+        csa_resource::isolation_plan::EnforcementMode::BestEffort,
+    )
+    .with_filesystem_capability(FilesystemCapability::Bwrap)
+    .with_resource_capability(ResourceCapability::CgroupV2)
+    .with_writable_path(project.clone())
+    .with_project_root(&project)
+    .with_readonly_project_root(true)
+    .build()
+    .unwrap();
+    assert_eq!(plan.resource, ResourceCapability::Setrlimit);
+    // Even a caller that forces cgroup after planning must fail closed.
+    plan.resource = ResourceCapability::CgroupV2;
+    let mut original = Command::new("/usr/bin/touch");
+    original.arg(&marker);
+    let result = spawn_tool_sandboxed(
+        original,
+        None,
+        SpawnOptions::default(),
+        Some(&plan),
+        "codex",
+        "01TEST",
+    )
+    .await;
+    let error = result
+        .err()
+        .expect("systemd cannot carry extra bind descriptors");
+    assert!(
+        error
+            .to_string()
+            .contains("bind-fd cannot pass through systemd-run"),
+        "{error:#}"
+    );
+    assert!(!marker.exists());
+}

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -110,31 +110,16 @@ impl BwrapCommandBuilder {
         // adding an overlapping read-only bind afterward would downgrade the
         // writable mount.
         #[cfg(unix)]
-        let overlay_files: Vec<std::sync::Arc<std::fs::File>> = {
-            // Retain only pins consumed by emitted mounts. An ordinary readable
-            // covered by a writable grant does not require bind-FD support.
-            let mut files: Vec<_> = self
-                .readable_paths
+        let mut overlay_files =
+            sandbox_bind_files_from_paths(&self.readable_paths, &self.writable_paths, None);
+        #[cfg(unix)]
+        overlay_files.extend(
+            extra_ro_binds
                 .iter()
-                .filter(|path| {
-                    if path.writable_bind() {
-                        self.writable_paths.iter().any(|p| p == path.requested())
-                    } else {
-                        !self.is_covered_by_writable_path(path)
-                    }
-                })
-                .filter_map(crate::isolation_plan::ReadablePath::pinned_source_file)
-                .collect();
-            files.extend(
-                extra_ro_binds
-                    .iter()
-                    .filter_map(crate::isolation_plan::ReadablePath::pinned_source_file),
-            );
-            files
-        };
+                .filter_map(crate::isolation_plan::ReadablePath::pinned_source_file),
+        );
         for path in &self.readable_paths {
-            if path.writable_bind()
-                || self.is_covered_by_writable_path(path)
+            if !emits_readonly_bind(path, self.writable_paths.iter())
                 || self.is_late_readonly_overlay(path)
             {
                 continue;
@@ -205,24 +190,6 @@ impl BwrapCommandBuilder {
         }
 
         Ok(cmd)
-    }
-
-    fn is_covered_by_writable_path(
-        &self,
-        readable_path: &crate::isolation_plan::ReadablePath,
-    ) -> bool {
-        if readable_path.overrides_writable_mount() {
-            return false;
-        }
-        let readable_dest = if fresh_writable_mount_root(readable_path.requested()).is_some() {
-            readable_path.requested().to_path_buf()
-        } else {
-            readable_path.bind_source().to_path_buf()
-        };
-        self.writable_paths.iter().any(|writable_path| {
-            let writable_dest = effective_mount_destination(writable_path);
-            readable_dest == writable_dest || readable_dest.starts_with(&writable_dest)
-        })
     }
 
     fn is_late_readonly_overlay(&self, path: &crate::isolation_plan::ReadablePath) -> bool {
@@ -300,11 +267,7 @@ impl BwrapCommandBuilder {
     fn pinned_writable_file(&self, path: &Path) -> Option<std::sync::Arc<std::fs::File>> {
         #[cfg(unix)]
         {
-            self.readable_paths.iter().find_map(|readable| {
-                (readable.writable_bind() && readable.requested() == path)
-                    .then(|| readable.pinned_source_file())
-                    .flatten()
-            })
+            pinned_writable_file(&self.readable_paths, path)
         }
         #[cfg(not(unix))]
         {
@@ -513,24 +476,69 @@ pub fn from_isolation_plan(
     builder.build_with_home(None).map(Some)
 }
 
-/// Number of descriptors for all planned bind mounts, including extra mounts.
+/// Number of descriptors consumed by emitted bind mounts, not snapshot owners.
 pub fn sandbox_bind_fd_count(plan: &IsolationPlan) -> usize {
     sandbox_bind_files(plan).len()
 }
 
 pub(crate) fn readable_bind_fd_count(
     readable_paths: &[crate::isolation_plan::ReadablePath],
+    writable_paths: &[PathBuf],
+    readonly_project: Option<&Path>,
 ) -> usize {
-    sandbox_bind_files_from_paths(readable_paths).len()
+    sandbox_bind_files_from_paths(readable_paths, writable_paths, readonly_project).len()
+}
+
+// Writable grants imply readability, except for explicit overlays/extra binds.
+// Use this same selection for command emission and descriptor admission.
+fn emits_readonly_bind<'a>(
+    path: &crate::isolation_plan::ReadablePath,
+    mut writable_paths: impl Iterator<Item = &'a PathBuf>,
+) -> bool {
+    if path.writable_bind() {
+        return false;
+    }
+    if path.is_extra_bind() || path.overrides_writable_mount() {
+        return true;
+    }
+    let dest = if fresh_writable_mount_root(path.requested()).is_some() {
+        path.requested()
+    } else {
+        path.bind_source()
+    };
+    !writable_paths.any(|writable| dest.starts_with(effective_mount_destination(writable)))
+}
+
+#[cfg(unix)]
+fn pinned_writable_file(
+    readable_paths: &[crate::isolation_plan::ReadablePath],
+    path: &Path,
+) -> Option<std::sync::Arc<std::fs::File>> {
+    readable_paths.iter().find_map(|readable| {
+        (readable.writable_bind() && readable.requested() == path)
+            .then(|| readable.pinned_source_file())
+            .flatten()
+    })
 }
 
 #[cfg(unix)]
 fn sandbox_bind_files_from_paths(
     readable_paths: &[crate::isolation_plan::ReadablePath],
+    writable_paths: &[PathBuf],
+    readonly_project: Option<&Path>,
 ) -> Vec<std::sync::Arc<std::fs::File>> {
+    let writable = writable_paths
+        .iter()
+        .filter(|path| readonly_project != Some(path.as_path()));
     readable_paths
         .iter()
+        .filter(|path| emits_readonly_bind(path, writable.clone()))
         .filter_map(crate::isolation_plan::ReadablePath::pinned_source_file)
+        .chain(
+            writable
+                .clone()
+                .filter_map(|path| pinned_writable_file(readable_paths, path)),
+        )
         .collect()
 }
 
@@ -540,7 +548,13 @@ fn sandbox_bind_files(plan: &IsolationPlan) -> Vec<std::sync::Arc<std::fs::File>
     if plan.filesystem != FilesystemCapability::Bwrap {
         return Vec::new();
     }
-    sandbox_bind_files_from_paths(&plan.readable_paths)
+    sandbox_bind_files_from_paths(
+        &plan.readable_paths,
+        &plan.writable_paths,
+        plan.project_root
+            .as_deref()
+            .filter(|_| plan.readonly_project_root),
+    )
 }
 
 #[cfg(not(unix))]
@@ -551,6 +565,8 @@ fn sandbox_bind_files(_plan: &IsolationPlan) -> Vec<()> {
 #[cfg(not(unix))]
 fn sandbox_bind_files_from_paths(
     _readable_paths: &[crate::isolation_plan::ReadablePath],
+    _writable_paths: &[PathBuf],
+    _readonly_project: Option<&Path>,
 ) -> Vec<()> {
     Vec::new()
 }

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -67,6 +67,8 @@ impl BwrapCommandBuilder {
     }
 
     /// Produce a ready-to-spawn command, or return a path validation/pinning error.
+    /// Returns [`std::io::ErrorKind::Unsupported`] if pinned mounts need bind-FD
+    /// options unavailable in the installed bwrap.
     pub fn build(&self) -> std::io::Result<Command> {
         self.build_with_home(std::env::var_os("HOME").as_deref().map(Path::new))
     }
@@ -109,7 +111,20 @@ impl BwrapCommandBuilder {
         // writable mount.
         #[cfg(unix)]
         let overlay_files: Vec<std::sync::Arc<std::fs::File>> = {
-            let mut files = sandbox_bind_files_from_paths(&self.readable_paths);
+            // Retain only pins consumed by emitted mounts. An ordinary readable
+            // covered by a writable grant does not require bind-FD support.
+            let mut files: Vec<_> = self
+                .readable_paths
+                .iter()
+                .filter(|path| {
+                    if path.writable_bind() {
+                        self.writable_paths.iter().any(|p| p == path.requested())
+                    } else {
+                        !self.is_covered_by_writable_path(path)
+                    }
+                })
+                .filter_map(crate::isolation_plan::ReadablePath::pinned_source_file)
+                .collect();
             files.extend(
                 extra_ro_binds
                     .iter()
@@ -167,6 +182,12 @@ impl BwrapCommandBuilder {
 
         #[cfg(unix)]
         if !overlay_files.is_empty() {
+            if !crate::filesystem_sandbox::has_bwrap_bind_fd_options() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    "bwrap bind-fd required but --ro-bind-fd/--bind-fd are unavailable",
+                ));
+            }
             use std::os::fd::AsRawFd;
             use std::os::unix::process::CommandExt;
             // SAFETY: the closure only clears FD_CLOEXEC on descriptors this

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -6,10 +6,15 @@ use std::process::Command;
 use crate::filesystem_sandbox::FilesystemCapability;
 use crate::isolation_plan::IsolationPlan;
 
+#[path = "bwrap_inherit.rs"]
+mod inherit;
+pub use inherit::{inherit_sandbox_bind_fds, try_inherit_sandbox_bind_fds};
+
 /// Environment variable set inside the sandbox to signal filesystem isolation.
 const CSA_FS_SANDBOXED_ENV: &str = "CSA_FS_SANDBOXED";
 
 /// Builder for constructing a `bwrap` command with explicit read/write binds.
+#[derive(Clone)]
 pub struct BwrapCommandBuilder {
     tool_binary: String,
     tool_args: Vec<String>,
@@ -74,15 +79,22 @@ impl BwrapCommandBuilder {
     }
 
     fn build_with_home(&self, home: Option<&Path>) -> std::io::Result<Command> {
-        let mut cmd = Command::new("bwrap");
-        let extra_ro_binds: Vec<_> = self
-            .ro_binds
-            .iter()
-            .cloned()
-            .chain(self.implicit_ro_binds(home))
-            .collect();
+        let mut builder = self.clone();
+        builder.ro_binds.extend(self.implicit_ro_binds(home));
+        resolve_writable_mount_destinations(
+            &mut builder.writable_paths,
+            &builder.readable_paths,
+            None,
+        );
+        builder.build_resolved()
+    }
 
-        for path in self.readable_paths.iter().chain(&extra_ro_binds) {
+    // All selection predicates below consume resolved destinations, never live aliases.
+    fn build_resolved(&self) -> std::io::Result<Command> {
+        let mut cmd = Command::new("bwrap");
+        let extra_ro_binds = &self.ro_binds;
+
+        for path in self.readable_paths.iter().chain(extra_ro_binds) {
             validate_readonly_path(path)?;
         }
 
@@ -118,6 +130,12 @@ impl BwrapCommandBuilder {
                 .iter()
                 .filter_map(crate::isolation_plan::ReadablePath::pinned_source_file),
         );
+        #[cfg(test)]
+        AFTER_BIND_FILE_COLLECTION.with(|hook| {
+            if let Some(inject) = hook.take() {
+                inject();
+            }
+        });
         for path in &self.readable_paths {
             if !emits_readonly_bind(path, self.writable_paths.iter())
                 || self.is_late_readonly_overlay(path)
@@ -143,7 +161,7 @@ impl BwrapCommandBuilder {
         // (remapped HOME), the mount target may not exist inside the sandbox
         // (e.g. Gemini runtime home only seeds gemini-cli config, not gh-aider).
         // Emit --dir for the dest parent so bubblewrap can create the mount point.
-        for path in &extra_ro_binds {
+        for path in extra_ro_binds {
             Self::bind_extra_readonly_path(&mut cmd, path);
         }
 
@@ -298,14 +316,9 @@ impl BwrapCommandBuilder {
         let resolved = resolve_for_bind(path);
         let s = resolved.to_string_lossy();
         let fresh_mount_root = fresh_writable_mount_root(path);
-        // Elsewhere, bind at the resolved destination: bwrap cannot
-        // create a mount target by walking a state-path symlink into an
-        // autofs-backed CSA session-state root.
-        let dest_path = if fresh_mount_root.is_some() {
-            path
-        } else {
-            resolved.as_path()
-        };
+        // The destination was frozen before admission/FD collection. Resolving
+        // a pathname-backed source must not change that destination or coverage.
+        let dest_path = path;
         let dest = dest_path.to_string_lossy();
         if let Some(mount_root) = fresh_mount_root {
             let mount_root = Path::new(mount_root);
@@ -473,7 +486,7 @@ pub fn from_isolation_plan(
 
     // Implicit sources were captured in the plan. Reopening them here would
     // detach their FDs from capability checks and reconstructed spawn commands.
-    builder.build_with_home(None).map(Some)
+    builder.build_resolved().map(Some)
 }
 
 /// Number of descriptors consumed by emitted bind mounts, not snapshot owners.
@@ -506,7 +519,7 @@ fn emits_readonly_bind<'a>(
     } else {
         path.bind_source()
     };
-    !writable_paths.any(|writable| dest.starts_with(effective_mount_destination(writable)))
+    !writable_paths.any(|writable| dest.starts_with(writable))
 }
 
 #[cfg(unix)]
@@ -571,66 +584,25 @@ fn sandbox_bind_files_from_paths(
     Vec::new()
 }
 
-/// Keep `--ro-bind-fd` / `--bind-fd` descriptors open across `exec`.
-///
-/// ACP and cgroup paths reconstruct a command from program+args and must call
-/// this on the final spawn command.
-pub fn inherit_sandbox_bind_fds(cmd: &mut Command, plan: &IsolationPlan) {
-    #[cfg(unix)]
-    {
-        let files = sandbox_bind_files(plan);
-        if files.is_empty() {
-            return;
-        }
-        use std::os::fd::AsRawFd;
-        use std::os::unix::process::CommandExt;
-        // SAFETY: the closure only clears FD_CLOEXEC on descriptors the plan
-        // still holds so bwrap can inherit `--ro-bind-fd` / `--bind-fd` sources.
-        unsafe {
-            cmd.pre_exec(move || {
-                for file in &files {
-                    if libc::fcntl(file.as_raw_fd(), libc::F_SETFD, 0) != 0 {
-                        return Err(std::io::Error::last_os_error());
-                    }
-                }
-                Ok(())
-            });
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = (cmd, plan);
-    }
-}
-
-/// Inherit bind FDs, or fail closed when the reconstructed command cannot.
-pub fn try_inherit_sandbox_bind_fds(
-    cmd: &mut Command,
-    plan: &IsolationPlan,
-) -> std::io::Result<()> {
-    if sandbox_bind_fd_count(plan) == 0 {
-        return Ok(());
-    }
-    let program = Path::new(cmd.get_program());
-    if program == Path::new("systemd-run")
-        || program.file_name() == Some(std::ffi::OsStr::new("systemd-run"))
-    {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "bwrap bind-fd cannot pass through systemd-run; overlay --ro-bind-fd would be dropped",
-        ));
-    }
-    inherit_sandbox_bind_fds(cmd, plan);
-    Ok(())
-}
-
 /// Resolve the destination used for a bind mount. Fresh virtual filesystems
 /// keep their logical paths because their resolved host paths are hidden.
-fn effective_mount_destination(path: &Path) -> PathBuf {
-    if fresh_writable_mount_root(path).is_some() {
-        path.to_path_buf()
-    } else {
-        resolve_for_bind(path)
+/// Pinned writable overlays also mount at their retained logical destination.
+/// Mutate the existing path list once: counts, argv and reconstructed commands
+/// must not observe a writable alias again after this admission boundary.
+pub(crate) fn resolve_writable_mount_destinations(
+    writable_paths: &mut [PathBuf],
+    readable_paths: &[crate::isolation_plan::ReadablePath],
+    readonly_project: Option<&Path>,
+) {
+    for path in writable_paths {
+        if readonly_project != Some(path.as_path())
+            && fresh_writable_mount_root(path).is_none()
+            && !readable_paths
+                .iter()
+                .any(|readable| readable.writable_bind() && readable.requested() == path)
+        {
+            *path = resolve_for_bind(path);
+        }
     }
 }
 
@@ -649,6 +621,12 @@ fn fresh_writable_mount_root(path: &Path) -> Option<&'static str> {
     ["/tmp", "/dev"]
         .into_iter()
         .find(|mount_root| path.starts_with(Path::new(mount_root)))
+}
+
+#[cfg(test)]
+thread_local! {
+    pub(crate) static AFTER_BIND_FILE_COLLECTION: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 #[cfg(all(test, target_os = "linux"))]

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -387,16 +387,41 @@ impl BwrapCommandBuilder {
                 || self.ro_binds.iter().any(|existing| {
                     existing.bind_source() == gh_aider || existing.requested() == sandbox_gh_aider
                 });
-            if gh_aider.exists() && !already_visible {
-                ro_binds.push(crate::isolation_plan::ReadablePath::pinned_extra(
-                    sandbox_gh_aider,
-                    gh_aider,
-                ));
+            let absent = std::fs::symlink_metadata(&gh_aider)
+                .is_err_and(|error| error.kind() == std::io::ErrorKind::NotFound);
+            if !absent && !already_visible {
+                ro_binds.push(
+                    crate::isolation_plan::ReadablePath::pinned_home_config(gh_aider)
+                        .for_sandbox_home(self.sandbox_home(Some(home)).as_deref()),
+                );
             }
         }
 
         ro_binds.into_iter()
     }
+}
+
+/// Capture every extra source before capability checks and executor projection.
+/// The returned ReadablePaths use the same descriptor owners as ordinary binds.
+pub(crate) fn plan_extra_readonly_paths(
+    writable_paths: &[PathBuf],
+    readonly_project: Option<&Path>,
+    home: Option<&Path>,
+) -> std::io::Result<Vec<crate::isolation_plan::ReadablePath>> {
+    let mut builder = BwrapCommandBuilder::new("", &[]);
+    for path in writable_paths {
+        if readonly_project == Some(path.as_path()) {
+            builder.with_ro_bind(path, path);
+        } else {
+            builder.with_writable_path(path);
+        }
+    }
+    let implicit: Vec<_> = builder.implicit_ro_binds(home).collect();
+    builder.ro_binds.extend(implicit);
+    for path in &builder.ro_binds {
+        validate_readonly_path(path)?;
+    }
+    Ok(builder.ro_binds)
 }
 
 fn validate_readonly_path(path: &crate::isolation_plan::ReadablePath) -> std::io::Result<()> {
@@ -430,14 +455,29 @@ pub fn from_isolation_plan(
         // read-only instead of read-write.
         let is_project_root = plan.project_root.as_ref().is_some_and(|root| path == root);
         if plan.readonly_project_root && is_project_root {
-            builder.with_ro_bind(path, path);
+            if !plan
+                .readable_paths
+                .iter()
+                .any(|readable| readable.is_extra_bind() && readable.requested() == path)
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "read-only project bind must be pinned by IsolationPlanBuilder",
+                ));
+            }
         } else {
             builder.with_writable_path(path);
         }
     }
 
     for path in &plan.readable_paths {
-        builder.with_readable_path(path.clone());
+        if path.is_extra_bind() {
+            builder
+                .ro_binds
+                .push(path.for_sandbox_home(plan.env_overrides.get("HOME").map(Path::new)));
+        } else {
+            builder.with_readable_path(path.clone());
+        }
     }
 
     let mut env_overrides = plan.env_overrides.clone();
@@ -447,10 +487,12 @@ pub fn from_isolation_plan(
         builder.with_env(key, value);
     }
 
-    builder.build().map(Some)
+    // Implicit sources were captured in the plan. Reopening them here would
+    // detach their FDs from capability checks and reconstructed spawn commands.
+    builder.build_with_home(None).map(Some)
 }
 
-/// Number of overlay/writable bind descriptors the sandbox command must inherit.
+/// Number of descriptors for all planned bind mounts, including extra mounts.
 pub fn sandbox_bind_fd_count(plan: &IsolationPlan) -> usize {
     sandbox_bind_files(plan).len()
 }

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -15,7 +15,7 @@ pub struct BwrapCommandBuilder {
     tool_args: Vec<String>,
     writable_paths: Vec<PathBuf>,
     readable_paths: Vec<crate::isolation_plan::ReadablePath>,
-    ro_binds: Vec<(PathBuf, PathBuf)>,
+    ro_binds: Vec<crate::isolation_plan::ReadablePath>,
     env_vars: Vec<(String, String)>,
 }
 
@@ -57,6 +57,10 @@ impl BwrapCommandBuilder {
             "readable sandbox path must not be /tmp itself; expose a specific sub-path instead"
         );
         #[cfg(unix)]
+        if let Some(error) = path.pin_error() {
+            panic!("readable sandbox path could not be pinned: {}", error);
+        }
+        #[cfg(unix)]
         let has_pinned_source = path.pinned_source_file().is_some();
         #[cfg(not(unix))]
         let has_pinned_source = false;
@@ -71,7 +75,11 @@ impl BwrapCommandBuilder {
 
     /// Add an extra read-only bind mount beyond the default `/ → /`.
     pub fn with_ro_bind(&mut self, src: &Path, dest: &Path) -> &mut Self {
-        self.ro_binds.push((src.to_path_buf(), dest.to_path_buf()));
+        self.ro_binds
+            .push(crate::isolation_plan::ReadablePath::pinned_extra(
+                dest.to_path_buf(),
+                src.to_path_buf(),
+            ));
         self
     }
 
@@ -88,6 +96,12 @@ impl BwrapCommandBuilder {
 
     fn build_with_home(&self, home: Option<&Path>) -> Command {
         let mut cmd = Command::new("bwrap");
+        let extra_ro_binds: Vec<_> = self
+            .ro_binds
+            .iter()
+            .cloned()
+            .chain(self.implicit_ro_binds(home))
+            .collect();
 
         // Read-only root filesystem
         cmd.args(["--ro-bind", "/", "/"]);
@@ -113,8 +127,15 @@ impl BwrapCommandBuilder {
         // adding an overlapping read-only bind afterward would downgrade the
         // writable mount.
         #[cfg(unix)]
-        let overlay_files: Vec<std::sync::Arc<std::fs::File>> =
-            sandbox_bind_files_from_paths(&self.readable_paths);
+        let overlay_files: Vec<std::sync::Arc<std::fs::File>> = {
+            let mut files = sandbox_bind_files_from_paths(&self.readable_paths);
+            files.extend(
+                extra_ro_binds
+                    .iter()
+                    .filter_map(crate::isolation_plan::ReadablePath::pinned_source_file),
+            );
+            files
+        };
         for path in &self.readable_paths {
             if path.writable_bind()
                 || self.is_covered_by_writable_path(path)
@@ -141,19 +162,8 @@ impl BwrapCommandBuilder {
         // (remapped HOME), the mount target may not exist inside the sandbox
         // (e.g. Gemini runtime home only seeds gemini-cli config, not gh-aider).
         // Emit --dir for the dest parent so bubblewrap can create the mount point.
-        for (src, dest) in self
-            .ro_binds
-            .iter()
-            .cloned()
-            .chain(self.implicit_ro_binds(home))
-        {
-            let src = resolve_for_bind(&src);
-            if src != dest
-                && let Some(parent) = dest.parent()
-            {
-                cmd.args(["--dir", &parent.to_string_lossy()]);
-            }
-            cmd.args(["--ro-bind", &src.to_string_lossy(), &dest.to_string_lossy()]);
+        for path in &extra_ro_binds {
+            Self::bind_extra_readonly_path(&mut cmd, path);
         }
 
         // Namespace configuration
@@ -245,9 +255,11 @@ impl BwrapCommandBuilder {
             cmd.args(["--dir", &parent.to_string_lossy()]);
         }
         #[cfg(unix)]
-        if path.overrides_writable_mount()
-            && let Some(file) = path.pinned_source_file()
-        {
+        if let Some(error) = path.pin_error() {
+            panic!("readable sandbox path could not be pinned: {}", error);
+        }
+        #[cfg(unix)]
+        if let Some(file) = path.pinned_source_file() {
             use std::os::fd::AsRawFd;
             cmd.args([
                 "--ro-bind-fd",
@@ -261,6 +273,32 @@ impl BwrapCommandBuilder {
             &resolved.to_string_lossy(),
             &dest_path.to_string_lossy(),
         ]);
+    }
+
+    fn bind_extra_readonly_path(cmd: &mut Command, path: &crate::isolation_plan::ReadablePath) {
+        let dest = path.requested();
+        if path.bind_source() != dest
+            && let Some(parent) = dest.parent()
+            && parent != Path::new("/")
+        {
+            cmd.args(["--dir", &parent.to_string_lossy()]);
+        }
+        #[cfg(unix)]
+        if let Some(error) = path.pin_error() {
+            panic!("read-only bind source could not be pinned: {}", error);
+        }
+        #[cfg(unix)]
+        if let Some(file) = path.pinned_source_file() {
+            use std::os::fd::AsRawFd;
+            cmd.args([
+                "--ro-bind-fd",
+                &file.as_raw_fd().to_string(),
+                &dest.to_string_lossy(),
+            ]);
+            return;
+        }
+        let src = resolve_for_bind(path.bind_source());
+        cmd.args(["--ro-bind", &src.to_string_lossy(), &dest.to_string_lossy()]);
     }
 
     fn writable_nested_under_readonly_overlay(&self, path: &Path) -> bool {
@@ -357,7 +395,10 @@ impl BwrapCommandBuilder {
             .or_else(|| host_home.map(Path::to_path_buf))
     }
 
-    fn implicit_ro_binds(&self, home: Option<&Path>) -> impl Iterator<Item = (PathBuf, PathBuf)> {
+    fn implicit_ro_binds(
+        &self,
+        home: Option<&Path>,
+    ) -> impl Iterator<Item = crate::isolation_plan::ReadablePath> {
         let mut ro_binds = Vec::new();
 
         if let Some(home) = home {
@@ -374,12 +415,14 @@ impl BwrapCommandBuilder {
                 .writable_paths
                 .iter()
                 .any(|existing| existing == &gh_aider || gh_aider.starts_with(existing))
-                || self
-                    .ro_binds
-                    .iter()
-                    .any(|(src, dest)| src == &gh_aider || dest == &sandbox_gh_aider);
+                || self.ro_binds.iter().any(|existing| {
+                    existing.bind_source() == gh_aider || existing.requested() == sandbox_gh_aider
+                });
             if gh_aider.exists() && !already_visible {
-                ro_binds.push((gh_aider, sandbox_gh_aider));
+                ro_binds.push(crate::isolation_plan::ReadablePath::pinned_extra(
+                    sandbox_gh_aider,
+                    gh_aider,
+                ));
             }
         }
 
@@ -445,7 +488,6 @@ fn sandbox_bind_files_from_paths(
 ) -> Vec<std::sync::Arc<std::fs::File>> {
     readable_paths
         .iter()
-        .filter(|path| path.overrides_writable_mount() || path.writable_bind())
         .filter_map(crate::isolation_plan::ReadablePath::pinned_source_file)
         .collect()
 }

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -46,30 +46,7 @@ impl BwrapCommandBuilder {
         &mut self,
         path: impl Into<crate::isolation_plan::ReadablePath>,
     ) -> &mut Self {
-        let path = path.into();
-        assert!(
-            path.requested().is_absolute(),
-            "readable sandbox path must be absolute: {}",
-            path.requested().display()
-        );
-        assert!(
-            path.requested() != Path::new("/tmp"),
-            "readable sandbox path must not be /tmp itself; expose a specific sub-path instead"
-        );
-        #[cfg(unix)]
-        if let Some(error) = path.pin_error() {
-            panic!("readable sandbox path could not be pinned: {}", error);
-        }
-        #[cfg(unix)]
-        let has_pinned_source = path.pinned_source_file().is_some();
-        #[cfg(not(unix))]
-        let has_pinned_source = false;
-        assert!(
-            path.requested().exists() || path.bind_source().exists() || has_pinned_source,
-            "readable sandbox path must exist: {}",
-            path.requested().display()
-        );
-        self.readable_paths.push(path);
+        self.readable_paths.push(path.into());
         self
     }
 
@@ -89,12 +66,12 @@ impl BwrapCommandBuilder {
         self
     }
 
-    /// Consume the builder and produce a ready-to-spawn [`Command`].
-    pub fn build(&self) -> Command {
+    /// Produce a ready-to-spawn command, or return a path validation/pinning error.
+    pub fn build(&self) -> std::io::Result<Command> {
         self.build_with_home(std::env::var_os("HOME").as_deref().map(Path::new))
     }
 
-    fn build_with_home(&self, home: Option<&Path>) -> Command {
+    fn build_with_home(&self, home: Option<&Path>) -> std::io::Result<Command> {
         let mut cmd = Command::new("bwrap");
         let extra_ro_binds: Vec<_> = self
             .ro_binds
@@ -102,6 +79,10 @@ impl BwrapCommandBuilder {
             .cloned()
             .chain(self.implicit_ro_binds(home))
             .collect();
+
+        for path in self.readable_paths.iter().chain(&extra_ro_binds) {
+            validate_readonly_path(path)?;
+        }
 
         // Read-only root filesystem
         cmd.args(["--ro-bind", "/", "/"]);
@@ -202,7 +183,7 @@ impl BwrapCommandBuilder {
             }
         }
 
-        cmd
+        Ok(cmd)
     }
 
     fn is_covered_by_writable_path(
@@ -237,10 +218,6 @@ impl BwrapCommandBuilder {
         // would reopen the #3102 TOCTOU after a symlink replacement.
         let resolved = path.bind_source();
         let tmp_prefix = Path::new("/tmp");
-        assert!(
-            path.requested() != tmp_prefix,
-            "readable sandbox path must not be /tmp itself; expose a specific sub-path instead"
-        );
         let dest_path = if path.overrides_writable_mount()
             || fresh_writable_mount_root(path.requested()).is_some()
         {
@@ -253,10 +230,6 @@ impl BwrapCommandBuilder {
             && parent != Path::new("/")
         {
             cmd.args(["--dir", &parent.to_string_lossy()]);
-        }
-        #[cfg(unix)]
-        if let Some(error) = path.pin_error() {
-            panic!("readable sandbox path could not be pinned: {}", error);
         }
         #[cfg(unix)]
         if let Some(file) = path.pinned_source_file() {
@@ -282,10 +255,6 @@ impl BwrapCommandBuilder {
             && parent != Path::new("/")
         {
             cmd.args(["--dir", &parent.to_string_lossy()]);
-        }
-        #[cfg(unix)]
-        if let Some(error) = path.pin_error() {
-            panic!("read-only bind source could not be pinned: {}", error);
         }
         #[cfg(unix)]
         if let Some(file) = path.pinned_source_file() {
@@ -430,18 +399,28 @@ impl BwrapCommandBuilder {
     }
 }
 
+fn validate_readonly_path(path: &crate::isolation_plan::ReadablePath) -> std::io::Result<()> {
+    if !path.requested().is_absolute() || path.requested() == Path::new("/tmp") {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "readable sandbox path must be absolute and must not be /tmp itself",
+        ));
+    }
+    path.validate_pin()
+}
+
 /// Build a bwrap [`Command`] from an [`IsolationPlan`] if the plan calls
 /// for bubblewrap filesystem isolation.
 ///
 /// Returns `Some(Command)` when `plan.filesystem == FilesystemCapability::Bwrap`,
-/// `None` otherwise.
+/// `None` otherwise. Invalid or unpinnable read-only sources return an error.
 pub fn from_isolation_plan(
     plan: &IsolationPlan,
     tool_binary: &str,
     tool_args: &[String],
-) -> Option<Command> {
+) -> std::io::Result<Option<Command>> {
     if plan.filesystem != FilesystemCapability::Bwrap {
-        return None;
+        return Ok(None);
     }
 
     let mut builder = BwrapCommandBuilder::new(tool_binary, tool_args);
@@ -468,7 +447,7 @@ pub fn from_isolation_plan(
         builder.with_env(key, value);
     }
 
-    Some(builder.build())
+    builder.build().map(Some)
 }
 
 /// Number of overlay/writable bind descriptors the sandbox command must inherit.

--- a/crates/csa-resource/src/bwrap.rs
+++ b/crates/csa-resource/src/bwrap.rs
@@ -515,6 +515,10 @@ fn sandbox_bind_files_from_paths(
 
 #[cfg(unix)]
 fn sandbox_bind_files(plan: &IsolationPlan) -> Vec<std::sync::Arc<std::fs::File>> {
+    // Only bwrap consumes bind descriptors; other backends keep pins CLOEXEC.
+    if plan.filesystem != FilesystemCapability::Bwrap {
+        return Vec::new();
+    }
     sandbox_bind_files_from_paths(&plan.readable_paths)
 }
 

--- a/crates/csa-resource/src/bwrap_inherit.rs
+++ b/crates/csa-resource/src/bwrap_inherit.rs
@@ -1,0 +1,62 @@
+//! Bind-descriptor inheritance for reconstructed sandbox commands.
+
+use std::path::Path;
+use std::process::Command;
+
+use super::sandbox_bind_fd_count;
+#[cfg(unix)]
+use super::sandbox_bind_files;
+use crate::isolation_plan::IsolationPlan;
+
+/// Keep `--ro-bind-fd` / `--bind-fd` descriptors open across `exec`.
+///
+/// ACP and cgroup paths reconstruct a command from program+args and must call
+/// this on the final spawn command.
+pub fn inherit_sandbox_bind_fds(cmd: &mut Command, plan: &IsolationPlan) {
+    #[cfg(unix)]
+    {
+        let files = sandbox_bind_files(plan);
+        if files.is_empty() {
+            return;
+        }
+        use std::os::fd::AsRawFd;
+        use std::os::unix::process::CommandExt;
+        // SAFETY: the closure only clears FD_CLOEXEC on descriptors the plan
+        // still holds so bwrap can inherit `--ro-bind-fd` / `--bind-fd` sources.
+        unsafe {
+            cmd.pre_exec(move || {
+                for file in &files {
+                    if libc::fcntl(file.as_raw_fd(), libc::F_SETFD, 0) != 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                }
+                Ok(())
+            });
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (cmd, plan);
+    }
+}
+
+/// Inherit bind FDs, or fail closed when the reconstructed command cannot.
+pub fn try_inherit_sandbox_bind_fds(
+    cmd: &mut Command,
+    plan: &IsolationPlan,
+) -> std::io::Result<()> {
+    if sandbox_bind_fd_count(plan) == 0 {
+        return Ok(());
+    }
+    let program = Path::new(cmd.get_program());
+    if program == Path::new("systemd-run")
+        || program.file_name() == Some(std::ffi::OsStr::new("systemd-run"))
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "bwrap bind-fd cannot pass through systemd-run; overlay --ro-bind-fd would be dropped",
+        ));
+    }
+    inherit_sandbox_bind_fds(cmd, plan);
+    Ok(())
+}

--- a/crates/csa-resource/src/bwrap_tests.rs
+++ b/crates/csa-resource/src/bwrap_tests.rs
@@ -357,22 +357,16 @@ fn test_bwrap_readonly_project_root() {
         .join("project");
     std::fs::create_dir(&project).expect("create project root");
     let project_str = project.to_string_lossy().into_owned();
-    let plan = IsolationPlan {
-        resource: ResourceCapability::None,
-        filesystem: FilesystemCapability::Bwrap,
-        writable_paths: vec![project.clone(), PathBuf::from("/tmp/session")],
-        readable_paths: Vec::new(),
-        env_overrides: HashMap::new(),
-        degraded_reasons: Vec::new(),
-        memory_max_mb: None,
-        memory_swap_max_mb: None,
-        pids_max: None,
-        readonly_project_root: true,
-        project_root: Some(project.clone()),
-        soft_limit_percent: None,
-        memory_monitor_interval_seconds: None,
-        user_daemon_ipc: false,
-    };
+    let plan = crate::isolation_plan::IsolationPlanBuilder::new(
+        crate::isolation_plan::EnforcementMode::BestEffort,
+    )
+    .with_filesystem_capability(FilesystemCapability::Bwrap)
+    .with_writable_path(project.clone())
+    .with_writable_path(PathBuf::from("/tmp/session"))
+    .with_project_root(&project)
+    .with_readonly_project_root(true)
+    .build()
+    .expect("pinned readonly project plan");
 
     let cmd = from_isolation_plan(&plan, "/usr/bin/tool", &[])
         .expect("valid bind paths")

--- a/crates/csa-resource/src/bwrap_tests.rs
+++ b/crates/csa-resource/src/bwrap_tests.rs
@@ -24,7 +24,7 @@ mod pinning;
 #[test]
 fn test_bwrap_command_basic() {
     let builder = BwrapCommandBuilder::new("/usr/bin/tool", &["--flag".into(), "arg".into()]);
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
 
     // Program is bwrap
@@ -51,7 +51,7 @@ fn test_bwrap_command_with_writable_paths() {
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_writable_path(Path::new("/home/user/project"));
     builder.with_writable_path(Path::new("/tmp/session"));
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
 
     // Count --bind occurrences (writable bind mounts)
@@ -79,7 +79,7 @@ fn test_bwrap_non_tmp_writable_path_creates_parent_dir_before_bind() {
 
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_writable_path(Path::new(path));
-    let args = command_args(&builder.build());
+    let args = command_args(&builder.build().expect("valid bind paths"));
 
     let dir_pos = args
         .windows(2)
@@ -115,7 +115,8 @@ fn test_bwrap_from_isolation_plan_bwrap() {
         user_daemon_ipc: false,
     };
 
-    let result = from_isolation_plan(&plan, "/usr/bin/tool", &["run".into()]);
+    let result =
+        from_isolation_plan(&plan, "/usr/bin/tool", &["run".into()]).expect("valid bind paths");
     assert!(result.is_some(), "Bwrap plan should produce Some(Command)");
 
     let cmd = result.unwrap();
@@ -143,14 +144,14 @@ fn test_bwrap_from_isolation_plan_none() {
         user_daemon_ipc: false,
     };
 
-    let result = from_isolation_plan(&plan, "/usr/bin/tool", &[]);
+    let result = from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("valid bind paths");
     assert!(result.is_none(), "Non-Bwrap plan should produce None");
 }
 
 #[test]
 fn test_bwrap_env_passthrough() {
     let builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
 
     // Find --setenv CSA_FS_SANDBOXED 1 sequence
@@ -181,7 +182,9 @@ fn test_bwrap_gh_aider_bind_targets_overridden_sandbox_home() {
 
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_env("HOME", "/sandbox/runtime-home");
-    let cmd = builder.build_with_home(Some(&host_home));
+    let cmd = builder
+        .build_with_home(Some(&host_home))
+        .expect("valid bind paths");
     let args = command_args(&cmd);
 
     let found_bind = args.windows(3).any(|window| {
@@ -228,7 +231,9 @@ fn test_bwrap_gh_aider_bind_not_skipped_when_session_dir_writable() {
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_env("HOME", &sandbox_home.to_string_lossy());
     builder.writable_paths.push(session_dir);
-    let cmd = builder.build_with_home(Some(&host_home));
+    let cmd = builder
+        .build_with_home(Some(&host_home))
+        .expect("valid bind paths");
     let args = command_args(&cmd);
 
     let found_bind = args.windows(3).any(|window| {
@@ -263,7 +268,9 @@ fn test_bwrap_from_isolation_plan_sets_tmpdir_override() {
         user_daemon_ipc: false,
     };
 
-    let cmd = from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("should produce command");
+    let cmd = from_isolation_plan(&plan, "/usr/bin/tool", &[])
+        .expect("valid bind paths")
+        .expect("should produce command");
     let args = command_args(&cmd);
     let found_tmpdir_env = args
         .windows(3)
@@ -312,7 +319,9 @@ fn test_bwrap_from_isolation_plan_scrubs_subtree_contract_env_overrides() {
         user_daemon_ipc: false,
     };
 
-    let cmd = from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("should produce command");
+    let cmd = from_isolation_plan(&plan, "/usr/bin/tool", &[])
+        .expect("valid bind paths")
+        .expect("should produce command");
     let args = command_args(&cmd);
 
     assert!(
@@ -341,7 +350,11 @@ fn test_bwrap_from_isolation_plan_scrubs_subtree_contract_env_overrides() {
 #[test]
 fn test_bwrap_readonly_project_root() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let project = temp.path().join("project");
+    let project = temp
+        .path()
+        .canonicalize()
+        .expect("resolve fixture root")
+        .join("project");
     std::fs::create_dir(&project).expect("create project root");
     let project_str = project.to_string_lossy().into_owned();
     let plan = IsolationPlan {
@@ -361,7 +374,9 @@ fn test_bwrap_readonly_project_root() {
         user_daemon_ipc: false,
     };
 
-    let cmd = from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("should produce command");
+    let cmd = from_isolation_plan(&plan, "/usr/bin/tool", &[])
+        .expect("valid bind paths")
+        .expect("should produce command");
     let args = command_args(&cmd);
 
     // The project root should be mounted read-only through its retained FD.
@@ -394,7 +409,7 @@ fn test_bwrap_extra_writable_under_tmp_ordering() {
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_writable_path(Path::new("/home/user/project"));
     builder.with_writable_path(Path::new("/tmp/foo"));
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
 
     // Locate key positions

--- a/crates/csa-resource/src/bwrap_tests.rs
+++ b/crates/csa-resource/src/bwrap_tests.rs
@@ -176,7 +176,7 @@ fn test_bwrap_env_passthrough() {
 #[test]
 fn test_bwrap_gh_aider_bind_targets_overridden_sandbox_home() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let host_home = temp.path().join("host-home");
+    let host_home = temp.path().canonicalize().unwrap().join("host-home");
     let gh_aider = host_home.join(".config/gh-aider");
     std::fs::create_dir_all(&gh_aider).expect("create gh-aider config");
 
@@ -219,7 +219,7 @@ fn test_bwrap_gh_aider_bind_targets_overridden_sandbox_home() {
 #[test]
 fn test_bwrap_gh_aider_bind_not_skipped_when_session_dir_writable() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let host_home = temp.path().join("host-home");
+    let host_home = temp.path().canonicalize().unwrap().join("host-home");
     let gh_aider = host_home.join(".config/gh-aider");
     std::fs::create_dir_all(&gh_aider).expect("create gh-aider config");
 

--- a/crates/csa-resource/src/bwrap_tests.rs
+++ b/crates/csa-resource/src/bwrap_tests.rs
@@ -18,6 +18,9 @@ fn command_args(cmd: &Command) -> Vec<String> {
 #[path = "bwrap_tests_virtual.rs"]
 mod virtual_filesystem;
 
+#[path = "bwrap_tests_pinning.rs"]
+mod pinning;
+
 #[test]
 fn test_bwrap_command_basic() {
     let builder = BwrapCommandBuilder::new("/usr/bin/tool", &["--flag".into(), "arg".into()]);
@@ -182,8 +185,7 @@ fn test_bwrap_gh_aider_bind_targets_overridden_sandbox_home() {
     let args = command_args(&cmd);
 
     let found_bind = args.windows(3).any(|window| {
-        window[0] == "--ro-bind"
-            && window[1] == gh_aider.to_string_lossy()
+        (window[0] == "--ro-bind" || window[0] == "--ro-bind-fd")
             && window[2] == "/sandbox/runtime-home/.config/gh-aider"
     });
 
@@ -230,8 +232,7 @@ fn test_bwrap_gh_aider_bind_not_skipped_when_session_dir_writable() {
     let args = command_args(&cmd);
 
     let found_bind = args.windows(3).any(|window| {
-        window[0] == "--ro-bind"
-            && window[1] == gh_aider.to_string_lossy()
+        (window[0] == "--ro-bind" || window[0] == "--ro-bind-fd")
             && window[2] == sandbox_home.join(".config/gh-aider").to_string_lossy()
     });
 
@@ -339,10 +340,14 @@ fn test_bwrap_from_isolation_plan_scrubs_subtree_contract_env_overrides() {
 
 #[test]
 fn test_bwrap_readonly_project_root() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let project = temp.path().join("project");
+    std::fs::create_dir(&project).expect("create project root");
+    let project_str = project.to_string_lossy().into_owned();
     let plan = IsolationPlan {
         resource: ResourceCapability::None,
         filesystem: FilesystemCapability::Bwrap,
-        writable_paths: vec![PathBuf::from("/project"), PathBuf::from("/tmp/session")],
+        writable_paths: vec![project.clone(), PathBuf::from("/tmp/session")],
         readable_paths: Vec::new(),
         env_overrides: HashMap::new(),
         degraded_reasons: Vec::new(),
@@ -350,7 +355,7 @@ fn test_bwrap_readonly_project_root() {
         memory_swap_max_mb: None,
         pids_max: None,
         readonly_project_root: true,
-        project_root: Some(PathBuf::from("/project")),
+        project_root: Some(project.clone()),
         soft_limit_percent: None,
         memory_monitor_interval_seconds: None,
         user_daemon_ipc: false,
@@ -359,19 +364,13 @@ fn test_bwrap_readonly_project_root() {
     let cmd = from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("should produce command");
     let args = command_args(&cmd);
 
-    // /project should appear after --ro-bind (not --bind)
-    let ro_bind_positions: Vec<_> = args
-        .iter()
-        .enumerate()
-        .filter(|(_, a)| *a == "--ro-bind")
-        .map(|(i, _)| i)
-        .collect();
-    let project_after_ro = ro_bind_positions
-        .iter()
-        .any(|&pos| args.get(pos + 1).map(|s| s.as_str()) == Some("/project"));
+    // The project root should be mounted read-only through its retained FD.
+    let project_after_ro_fd = args
+        .windows(3)
+        .any(|window| window[0] == "--ro-bind-fd" && window[2] == project_str);
     assert!(
-        project_after_ro,
-        "/project should be --ro-bind when readonly_project_root is true; args: {args:?}"
+        project_after_ro_fd,
+        "project root should be --ro-bind-fd when readonly_project_root is true; args: {args:?}"
     );
 
     // /tmp/session should still be --bind (writable)

--- a/crates/csa-resource/src/bwrap_tests_paths.rs
+++ b/crates/csa-resource/src/bwrap_tests_paths.rs
@@ -15,7 +15,7 @@ fn test_bwrap_command_with_readable_tmp_file() {
 
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_readable_path(&readable);
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
     let readable_str = readable.to_string_lossy().into_owned();
 
@@ -34,10 +34,16 @@ fn test_bwrap_command_with_readable_tmp_file() {
 }
 
 #[test]
-#[should_panic(expected = "must not be /tmp itself")]
 fn test_bwrap_readable_tmp_root_rejected() {
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_readable_path(Path::new("/tmp"));
+    assert!(
+        builder
+            .build_with_home(None)
+            .unwrap_err()
+            .to_string()
+            .contains("must not be /tmp itself")
+    );
 }
 
 #[test]
@@ -49,7 +55,7 @@ fn test_bwrap_readable_and_writable_paths_after_tmpfs() {
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_writable_path(Path::new("/tmp/work"));
     builder.with_readable_path(&readable);
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
     let readable_str = readable.to_string_lossy().into_owned();
 
@@ -83,7 +89,7 @@ fn test_bwrap_duplicate_readable_writable_path_keeps_writable_bind() {
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_writable_path(path);
     builder.with_readable_path(path);
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
 
     assert!(
@@ -103,7 +109,7 @@ fn test_bwrap_duplicate_readable_writable_path_keeps_writable_bind() {
 fn test_bwrap_nested_tmp_path_creates_intermediate_dirs() {
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_writable_path(Path::new("/tmp/deep/nested/dir"));
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
 
     // Must have --dir for intermediate parent
@@ -145,7 +151,7 @@ fn test_bwrap_bare_tmp_is_bind_mounted_when_explicitly_writable() {
     // /tmp is an explicit config grant, not a request for empty tmpfs.
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_writable_path(Path::new("/tmp"));
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
 
     // --tmpfs /tmp must exist
@@ -175,7 +181,9 @@ fn test_bwrap_auto_ro_binds_gh_aider_config_when_present() {
     std::fs::create_dir_all(&gh_aider).expect("create gh-aider dir");
 
     let builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
-    let cmd = builder.build_with_home(Some(home.path()));
+    let cmd = builder
+        .build_with_home(Some(home.path()))
+        .expect("valid bind paths");
     let args = command_args(&cmd);
 
     assert!(
@@ -225,7 +233,9 @@ fn from_isolation_plan_keeps_tmp_symlink_logical_readable_destination() {
         user_daemon_ipc: false,
     };
     let args = command_args(
-        &from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("bwrap isolation plan"),
+        &from_isolation_plan(&plan, "/usr/bin/tool", &[])
+            .expect("valid bind paths")
+            .expect("bwrap isolation plan"),
     );
 
     assert!(
@@ -269,7 +279,9 @@ fn from_isolation_plan_does_not_remount_writable_canonical_child_readonly_throug
         user_daemon_ipc: false,
     };
     let args = command_args(
-        &from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("bwrap isolation plan"),
+        &from_isolation_plan(&plan, "/usr/bin/tool", &[])
+            .expect("valid bind paths")
+            .expect("bwrap isolation plan"),
     );
     let canonical = canonical_file.to_string_lossy();
 
@@ -326,7 +338,7 @@ fn test_bwrap_readable_path_binds_resolved_dest_when_logical_parents_missing() {
 
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_readable_path(&logical_file);
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
 
     let resolved_str = resolved.to_string_lossy();
@@ -394,7 +406,9 @@ fn from_isolation_plan_pins_validated_readable_symlink_bind_source() {
         user_daemon_ipc: false,
     };
     let args = command_args(
-        &from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("bwrap isolation plan"),
+        &from_isolation_plan(&plan, "/usr/bin/tool", &[])
+            .expect("valid bind paths")
+            .expect("bwrap isolation plan"),
     );
     let replaced = replaced_target.to_string_lossy();
     let dest = readable_symlink.to_string_lossy();

--- a/crates/csa-resource/src/bwrap_tests_paths.rs
+++ b/crates/csa-resource/src/bwrap_tests_paths.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+fn ro_bind_destination(args: &[String], destination: &str) -> Option<usize> {
+    args.windows(3).position(|window| {
+        (window[0] == "--ro-bind" && window[2] == destination)
+            || (window[0] == "--ro-bind-fd" && window[2] == destination)
+    })
+}
+
 #[test]
 fn test_bwrap_command_with_readable_tmp_file() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -16,12 +23,8 @@ fn test_bwrap_command_with_readable_tmp_file() {
         .iter()
         .position(|arg| arg == "--tmpfs")
         .expect("--tmpfs must be present");
-    let ro_bind_pos = args
-        .windows(3)
-        .position(|window| {
-            window[0] == "--ro-bind" && window[1] == readable_str && window[2] == readable_str
-        })
-        .expect("--ro-bind readable path must be present");
+    let ro_bind_pos = ro_bind_destination(&args, &readable_str)
+        .expect("read-only FD bind readable path must be present");
 
     assert_eq!(args[tmpfs_pos + 1], "/tmp");
     assert!(
@@ -58,12 +61,8 @@ fn test_bwrap_readable_and_writable_paths_after_tmpfs() {
         .windows(3)
         .position(|window| window[0] == "--bind" && window[1] == "/tmp/work")
         .expect("writable bind should be present");
-    let readable_bind_pos = args
-        .windows(3)
-        .position(|window| {
-            window[0] == "--ro-bind" && window[1] == readable_str && window[2] == readable_str
-        })
-        .expect("readable ro-bind should be present");
+    let readable_bind_pos = ro_bind_destination(&args, &readable_str)
+        .expect("read-only FD bind readable path must be present");
 
     assert!(
         tmpfs_pos < writable_bind_pos,
@@ -180,11 +179,7 @@ fn test_bwrap_auto_ro_binds_gh_aider_config_when_present() {
     let args = command_args(&cmd);
 
     assert!(
-        args.windows(3).any(|window| {
-            window[0] == "--ro-bind"
-                && window[1] == gh_aider.to_string_lossy()
-                && window[2] == gh_aider.to_string_lossy()
-        }),
+        ro_bind_destination(&args, &gh_aider.to_string_lossy()).is_some(),
         "~/.config/gh-aider should be explicitly re-bound read-only so sandboxed gh commands can still read the aider auth config; args: {args:?}"
     );
 }
@@ -234,11 +229,7 @@ fn from_isolation_plan_keeps_tmp_symlink_logical_readable_destination() {
     );
 
     assert!(
-        args.windows(3).any(|window| {
-            window[0] == "--ro-bind"
-                && window[1] == canonical_source.to_string_lossy()
-                && window[2] == logical_destination.to_string_lossy()
-        }),
+        ro_bind_destination(&args, &logical_destination.to_string_lossy()).is_some(),
         "readable bind must use the canonical source at the /tmp logical destination; args: {args:?}"
     );
 }
@@ -341,15 +332,11 @@ fn test_bwrap_readable_path_binds_resolved_dest_when_logical_parents_missing() {
     let resolved_str = resolved.to_string_lossy();
     let logical_str = logical_file.to_string_lossy();
     assert!(
-        args.windows(3).any(|window| {
-            window[0] == "--ro-bind" && window[1] == resolved_str && window[2] == resolved_str
-        }),
-        "readable bind must use the resolved dest so bwrap never sees the missing logical parents; args: {args:?}"
+        ro_bind_destination(&args, &resolved_str).is_some(),
+        "readable bind must use the resolved destination so bwrap never sees the missing logical parents; args: {args:?}"
     );
     assert!(
-        !args.windows(3).any(|window| window[0] == "--ro-bind"
-            && window[1] == logical_str
-            && window[2] == logical_str),
+        ro_bind_destination(&args, &logical_str).is_none(),
         "readable bind must not target the logical dest; args: {args:?}"
     );
 }
@@ -409,20 +396,17 @@ fn from_isolation_plan_pins_validated_readable_symlink_bind_source() {
     let args = command_args(
         &from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("bwrap isolation plan"),
     );
-    let validated = validated_target.to_string_lossy();
     let replaced = replaced_target.to_string_lossy();
     let dest = readable_symlink.to_string_lossy();
 
     assert!(
-        args.windows(3).any(|window| {
-            window[0] == "--ro-bind" && window[1] == validated && window[2] == dest
-        }),
-        "bind source must stay the validated target after symlink replacement; args: {args:?}"
+        ro_bind_destination(&args, &dest).is_some(),
+        "bind must retain the validated descriptor at the requested destination; args: {args:?}"
     );
     assert!(
         !args
             .windows(3)
-            .any(|window| window[0] == "--ro-bind" && window[1] == replaced),
+            .any(|window| { window[0] == "--ro-bind" && window[1] == replaced }),
         "replaced symlink target must not become the bind source; args: {args:?}"
     );
 }

--- a/crates/csa-resource/src/bwrap_tests_paths.rs
+++ b/crates/csa-resource/src/bwrap_tests_paths.rs
@@ -9,7 +9,7 @@ fn ro_bind_destination(args: &[String], destination: &str) -> Option<usize> {
 
 #[test]
 fn test_bwrap_command_with_readable_tmp_file() {
-    let temp = tempfile::tempdir().expect("tempdir");
+    let temp = tempfile::tempdir_in("/tmp").expect("/tmp fixture");
     let readable = temp.path().join("foo.json");
     std::fs::write(&readable, "{}").expect("write readable file");
 
@@ -48,7 +48,7 @@ fn test_bwrap_readable_tmp_root_rejected() {
 
 #[test]
 fn test_bwrap_readable_and_writable_paths_after_tmpfs() {
-    let temp = tempfile::tempdir().expect("tempdir");
+    let temp = tempfile::tempdir_in("/tmp").expect("/tmp fixture");
     let readable = temp.path().join("bar.txt");
     std::fs::write(&readable, "hello").expect("write readable file");
 
@@ -82,7 +82,7 @@ fn test_bwrap_readable_and_writable_paths_after_tmpfs() {
 
 #[test]
 fn test_bwrap_duplicate_readable_writable_path_keeps_writable_bind() {
-    let temp = tempfile::tempdir().expect("tempdir");
+    let temp = tempfile::tempdir_in("/tmp").expect("/tmp fixture");
     let path = temp.path();
     let path_str = path.to_string_lossy().into_owned();
 
@@ -176,7 +176,7 @@ fn test_bwrap_bare_tmp_is_bind_mounted_when_explicitly_writable() {
 
 #[test]
 fn test_bwrap_auto_ro_binds_gh_aider_config_when_present() {
-    let home = tempfile::tempdir().expect("tempdir");
+    let home = tempfile::tempdir_in("/tmp").expect("/tmp fixture");
     let gh_aider = home.path().join(".config/gh-aider");
     std::fs::create_dir_all(&gh_aider).expect("create gh-aider dir");
 
@@ -197,7 +197,7 @@ fn test_bwrap_auto_ro_binds_gh_aider_config_when_present() {
 fn from_isolation_plan_keeps_tmp_symlink_logical_readable_destination() {
     use std::os::unix::fs::symlink;
 
-    let temp = tempfile::tempdir().expect("tempdir");
+    let temp = tempfile::tempdir_in("/tmp").expect("/tmp fixture");
     let canonical_source = temp.path().join("canonical-source.json");
     let logical_destination = temp.path().join("logical-readable.json");
     std::fs::write(&canonical_source, "{}").expect("write canonical source");
@@ -358,7 +358,7 @@ fn test_bwrap_readable_path_binds_resolved_dest_when_logical_parents_missing() {
 fn from_isolation_plan_pins_validated_readable_symlink_bind_source() {
     use std::os::unix::fs::symlink;
 
-    let temp = tempfile::tempdir().expect("tempdir");
+    let temp = tempfile::tempdir_in("/tmp").expect("/tmp fixture");
     let validated_target = temp.path().join("validated-target.json");
     let replaced_target = temp.path().join("replaced-target.json");
     let readable_symlink = temp.path().join("readable-link.json");

--- a/crates/csa-resource/src/bwrap_tests_pinning.rs
+++ b/crates/csa-resource/src/bwrap_tests_pinning.rs
@@ -1,0 +1,105 @@
+//! Read-only bind identity and fail-closed regressions for #3174.
+
+use super::*;
+use std::os::unix::fs::symlink;
+
+fn bind_fd(command: &Command, dest: &Path) -> String {
+    let args = command_args(command);
+    args.windows(3)
+        .find(|args| args[0] == "--ro-bind-fd" && args[2] == dest.to_string_lossy())
+        .unwrap_or_else(|| panic!("missing pinned mount for {}: {args:?}", dest.display()))[1]
+        .clone()
+}
+
+#[test]
+fn pinned_readonly_regular_and_extra_sources_survive_replacement_and_builder_drop() {
+    let temp = tempfile::tempdir().unwrap();
+    for extra in [false, true] {
+        let source = temp.path().join(if extra { "extra" } else { "readable" });
+        std::fs::write(&source, "accepted").unwrap();
+        let mut builder = BwrapCommandBuilder::new("/bin/true", &[]);
+        if extra {
+            builder.with_ro_bind(&source, &source);
+        } else {
+            builder.with_readable_path(&source);
+        }
+        std::fs::rename(&source, source.with_extension("old")).unwrap();
+        std::fs::write(&source, "replacement").unwrap();
+        let command = builder.build_with_home(None);
+        let fd = bind_fd(&command, &source);
+        drop(builder);
+        assert_eq!(
+            std::fs::read_to_string(format!("/proc/self/fd/{fd}")).unwrap(),
+            "accepted"
+        );
+    }
+}
+
+#[test]
+fn pinned_readonly_rejects_symlink_and_missing_sources() {
+    let temp = tempfile::tempdir().unwrap();
+    let real = temp.path().join("real");
+    std::fs::write(&real, "data").unwrap();
+    let link = temp.path().join("link");
+    symlink(&real, &link).unwrap();
+    for source in [link, temp.path().join("missing")] {
+        for extra in [false, true] {
+            assert!(
+                std::panic::catch_unwind(|| {
+                    let mut builder = BwrapCommandBuilder::new("/bin/true", &[]);
+                    if extra {
+                        builder.with_ro_bind(&source, &source);
+                    } else {
+                        builder.with_readable_path(&source);
+                    }
+                    builder.build_with_home(None)
+                })
+                .is_err(),
+                "source must fail closed: {}",
+                source.display()
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn pinned_readonly_preserves_explicit_nonregular_path_binds() {
+    let temp = tempfile::tempdir().unwrap();
+    let socket = temp.path().join("control.sock");
+    let _listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+    let mut builder = BwrapCommandBuilder::new("/bin/true", &[]);
+    builder.with_ro_bind(&socket, &socket);
+    let command = builder.build_with_home(None);
+    let args = command_args(&command);
+    let source = socket.to_string_lossy();
+    assert!(
+        args.windows(3)
+            .any(|window| window[0] == "--ro-bind" && window[1] == source && window[2] == source),
+        "intentional nonregular bind must remain pathname-backed; args: {args:?}"
+    );
+    assert!(
+        !args
+            .windows(3)
+            .any(|window| window[0] == "--ro-bind-fd" && window[2] == source),
+        "nonregular bind must not be read-opened for FD mounting; args: {args:?}"
+    );
+}
+
+#[test]
+fn pinned_readonly_implicit_remap_retains_directory_descriptor() {
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join(".config/gh-aider");
+    std::fs::create_dir_all(&source).unwrap();
+    std::fs::write(source.join("hosts.yml"), "accepted").unwrap();
+    let mut builder = BwrapCommandBuilder::new("/bin/true", &[]);
+    builder.with_env("HOME", "/sandbox-home");
+    let command = builder.build_with_home(Some(temp.path()));
+    let fd = bind_fd(&command, Path::new("/sandbox-home/.config/gh-aider"));
+    std::fs::rename(&source, source.with_extension("old")).unwrap();
+    drop(builder);
+    assert_eq!(
+        std::fs::read_to_string(format!("/proc/self/fd/{fd}/hosts.yml")).unwrap(),
+        "accepted"
+    );
+}

--- a/crates/csa-resource/src/bwrap_tests_pinning.rs
+++ b/crates/csa-resource/src/bwrap_tests_pinning.rs
@@ -3,6 +3,24 @@
 use super::*;
 use std::os::unix::fs::symlink;
 
+#[test]
+fn bad_readonly_bind_returns_error_before_child_spawn() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    let missing = root.as_path().join("missing");
+    let marker = root.as_path().join("child-started");
+    let result: std::io::Result<()> = (|| {
+        let mut builder =
+            BwrapCommandBuilder::new("/usr/bin/touch", &[marker.display().to_string()]);
+        builder.with_ro_bind(&missing, &missing);
+        let mut command = builder.build_with_home(None)?;
+        command.spawn()?.wait()?;
+        Ok(())
+    })();
+    assert!(!marker.exists());
+    assert!(result.is_err(), "bad bind must return a recoverable error");
+}
+
 fn bind_fd(command: &Command, dest: &Path) -> String {
     let args = command_args(command);
     args.windows(3)
@@ -14,8 +32,11 @@ fn bind_fd(command: &Command, dest: &Path) -> String {
 #[test]
 fn pinned_readonly_regular_and_extra_sources_survive_replacement_and_builder_drop() {
     let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
     for extra in [false, true] {
-        let source = temp.path().join(if extra { "extra" } else { "readable" });
+        let source = root
+            .as_path()
+            .join(if extra { "extra" } else { "readable" });
         std::fs::write(&source, "accepted").unwrap();
         let mut builder = BwrapCommandBuilder::new("/bin/true", &[]);
         if extra {
@@ -25,7 +46,7 @@ fn pinned_readonly_regular_and_extra_sources_survive_replacement_and_builder_dro
         }
         std::fs::rename(&source, source.with_extension("old")).unwrap();
         std::fs::write(&source, "replacement").unwrap();
-        let command = builder.build_with_home(None);
+        let command = builder.build_with_home(None).expect("valid bind paths");
         let fd = bind_fd(&command, &source);
         drop(builder);
         assert_eq!(
@@ -38,24 +59,22 @@ fn pinned_readonly_regular_and_extra_sources_survive_replacement_and_builder_dro
 #[test]
 fn pinned_readonly_rejects_symlink_and_missing_sources() {
     let temp = tempfile::tempdir().unwrap();
-    let real = temp.path().join("real");
+    let root = temp.path().canonicalize().unwrap();
+    let real = root.as_path().join("real");
     std::fs::write(&real, "data").unwrap();
-    let link = temp.path().join("link");
+    let link = root.as_path().join("link");
     symlink(&real, &link).unwrap();
-    for source in [link, temp.path().join("missing")] {
+    for source in [link, root.as_path().join("missing")] {
         for extra in [false, true] {
+            let mut builder = BwrapCommandBuilder::new("/bin/true", &[]);
+            if extra {
+                builder.with_ro_bind(&source, &source);
+            } else {
+                builder.with_readable_path(&source);
+            }
             assert!(
-                std::panic::catch_unwind(|| {
-                    let mut builder = BwrapCommandBuilder::new("/bin/true", &[]);
-                    if extra {
-                        builder.with_ro_bind(&source, &source);
-                    } else {
-                        builder.with_readable_path(&source);
-                    }
-                    builder.build_with_home(None)
-                })
-                .is_err(),
-                "source must fail closed: {}",
+                builder.build_with_home(None).is_err(),
+                "{}",
                 source.display()
             );
         }
@@ -66,11 +85,12 @@ fn pinned_readonly_rejects_symlink_and_missing_sources() {
 #[test]
 fn pinned_readonly_preserves_explicit_nonregular_path_binds() {
     let temp = tempfile::tempdir().unwrap();
-    let socket = temp.path().join("control.sock");
+    let root = temp.path().canonicalize().unwrap();
+    let socket = root.as_path().join("control.sock");
     let _listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
     let mut builder = BwrapCommandBuilder::new("/bin/true", &[]);
     builder.with_ro_bind(&socket, &socket);
-    let command = builder.build_with_home(None);
+    let command = builder.build_with_home(None).expect("valid bind paths");
     let args = command_args(&command);
     let source = socket.to_string_lossy();
     assert!(
@@ -89,12 +109,15 @@ fn pinned_readonly_preserves_explicit_nonregular_path_binds() {
 #[test]
 fn pinned_readonly_implicit_remap_retains_directory_descriptor() {
     let temp = tempfile::tempdir().unwrap();
-    let source = temp.path().join(".config/gh-aider");
+    let root = temp.path().canonicalize().unwrap();
+    let source = root.as_path().join(".config/gh-aider");
     std::fs::create_dir_all(&source).unwrap();
     std::fs::write(source.join("hosts.yml"), "accepted").unwrap();
     let mut builder = BwrapCommandBuilder::new("/bin/true", &[]);
     builder.with_env("HOME", "/sandbox-home");
-    let command = builder.build_with_home(Some(temp.path()));
+    let command = builder
+        .build_with_home(Some(root.as_path()))
+        .expect("valid bind paths");
     let fd = bind_fd(&command, Path::new("/sandbox-home/.config/gh-aider"));
     std::fs::rename(&source, source.with_extension("old")).unwrap();
     drop(builder);

--- a/crates/csa-resource/src/bwrap_tests_virtual.rs
+++ b/crates/csa-resource/src/bwrap_tests_virtual.rs
@@ -22,7 +22,7 @@ fn test_bwrap_binds_non_tmp_symlink_writable_path_at_canonical_destination() {
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_writable_path(&logical_writable);
 
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
 
     let bind_idx = args
@@ -67,7 +67,7 @@ fn test_bwrap_keeps_dev_shm_symlink_writable_path_at_logical_destination() {
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_writable_path(&link);
 
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
     let bind_idx = args
         .windows(3)

--- a/crates/csa-resource/src/bwrap_tests_virtual.rs
+++ b/crates/csa-resource/src/bwrap_tests_virtual.rs
@@ -74,7 +74,12 @@ fn test_bwrap_keeps_dev_shm_symlink_writable_path_at_logical_destination() {
         .position(|window| window[0] == "--bind")
         .expect("--bind not found");
     let logical_parent = dev_shm.path().to_string_lossy().to_string();
-    let canonical_source = source.path().to_string_lossy().to_string();
+    let canonical_source = source
+        .path()
+        .canonicalize()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
     let logical_destination = link.to_string_lossy().to_string();
     let logical_parent_dir_idx = args
         .windows(2)

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -8,6 +8,8 @@ use crate::sandbox::ResourceCapability;
 
 pub const DEFAULT_SANDBOX_TMPDIR: &str = "/tmp";
 
+#[path = "isolation_plan_build.rs"]
+mod build;
 #[path = "isolation_plan_claude.rs"]
 mod claude_paths;
 #[path = "isolation_plan_codex.rs"]
@@ -60,7 +62,7 @@ pub struct IsolationPlan {
     pub filesystem: FilesystemCapability,
     /// Paths the sandboxed process is allowed to write to.
     pub writable_paths: Vec<PathBuf>,
-    /// Paths the sandboxed process may read via read-only bind mounts.
+    /// Validated bind sources, including extra read-only mounts and their FD owners.
     pub readable_paths: Vec<ReadablePath>,
     /// Extra environment variables injected into the child process.
     pub env_overrides: HashMap<String, String>,
@@ -469,104 +471,6 @@ impl IsolationPlanBuilder {
                 Err(error) => self.preflight_error = Some(error),
             }
         }
-    }
-
-    /// Consume the builder and produce an [`IsolationPlan`].
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when filesystem enforcement is `Required` but the
-    /// filesystem capability is `None`.
-    pub fn build(mut self) -> anyhow::Result<IsolationPlan> {
-        if let Some(error) = self.preflight_error.take() {
-            return Err(error);
-        }
-        // Filesystem enforcement: use dedicated override if set, otherwise
-        // inherit from the resource enforcement mode.
-        let fs_mode = self.fs_enforcement_mode.unwrap_or(self.enforcement_mode);
-
-        match fs_mode {
-            EnforcementMode::Off => {
-                self.filesystem = FilesystemCapability::None;
-            }
-            EnforcementMode::Required => {
-                if self.filesystem == FilesystemCapability::None {
-                    anyhow::bail!("filesystem isolation required but no capability detected");
-                }
-            }
-            EnforcementMode::BestEffort => {
-                if self.filesystem == FilesystemCapability::None {
-                    self.degraded_reasons
-                        .push("no filesystem isolation available; proceeding without".into());
-                }
-            }
-        }
-
-        // Resource enforcement: handled separately.
-        match self.enforcement_mode {
-            EnforcementMode::BestEffort => {
-                if self.resource == ResourceCapability::None {
-                    self.degraded_reasons
-                        .push("no resource isolation available; proceeding without".into());
-                }
-            }
-            EnforcementMode::Off | EnforcementMode::Required => {
-                // Required for resources is checked upstream in pipeline_sandbox.
-                // Off is a no-op for the resource axis (capabilities are kept as-is
-                // because cgroup limits don't need explicit disabling here).
-            }
-        }
-
-        readable::downgrade_incompatible_cgroup_filesystem(
-            &mut self.resource,
-            self.filesystem,
-            &self.readable_paths,
-            &mut self.degraded_reasons,
-        );
-
-        if self.filesystem != FilesystemCapability::None
-            && !self.readonly_project_root
-            && let Some(project_root) = self.project_root.as_deref()
-            && let Some([git_dir, common_dir]) =
-                runtime_path::linked_worktree_git_admin_dirs(project_root)?
-        {
-            self.writable_paths.extend([common_dir, git_dir]);
-        }
-
-        readable::push_runtime_daemon_socket_readable_paths(
-            self.filesystem,
-            self.user_daemon_ipc,
-            &self.writable_paths,
-            &mut self.readable_paths,
-        );
-
-        codex_paths::validate_required_writable_dirs(
-            self.filesystem,
-            &self.required_writable_dirs,
-            &self.writable_paths,
-        )?;
-        hermes_paths::finish_plan(
-            self.filesystem,
-            &self.readable_paths,
-            self.pending_hermes_runtime.take(),
-        )?;
-
-        Ok(IsolationPlan {
-            resource: self.resource,
-            filesystem: self.filesystem,
-            writable_paths: self.writable_paths,
-            readable_paths: self.readable_paths,
-            env_overrides: self.env_overrides,
-            degraded_reasons: self.degraded_reasons,
-            memory_max_mb: self.memory_max_mb,
-            memory_swap_max_mb: self.memory_swap_max_mb,
-            pids_max: self.pids_max,
-            readonly_project_root: self.readonly_project_root,
-            project_root: self.project_root,
-            soft_limit_percent: self.soft_limit_percent,
-            memory_monitor_interval_seconds: self.memory_monitor_interval_seconds,
-            user_daemon_ipc: self.user_daemon_ipc,
-        })
     }
 
     #[allow(dead_code)]

--- a/crates/csa-resource/src/isolation_plan.rs
+++ b/crates/csa-resource/src/isolation_plan.rs
@@ -61,6 +61,8 @@ pub struct IsolationPlan {
     /// Filesystem-level capability (bwrap / landlock / none).
     pub filesystem: FilesystemCapability,
     /// Paths the sandboxed process is allowed to write to.
+    /// Bwrap plans retain effective mount destinations resolved at admission;
+    /// use the builder rather than inserting unresolved writable aliases.
     pub writable_paths: Vec<PathBuf>,
     /// Validated bind sources, including extra read-only mounts and their FD owners.
     pub readable_paths: Vec<ReadablePath>,
@@ -98,7 +100,18 @@ impl IsolationPlan {
     /// Add a writable directory, pre-creating it when its parent exists so
     /// bwrap bind sources are present on cold start.
     pub fn add_writable_dir_or_creatable_parent(&mut self, dir: &Path) -> bool {
-        add_dir_or_creatable_parent(&mut self.writable_paths, dir)
+        let previous_len = self.writable_paths.len();
+        let added = add_dir_or_creatable_parent(&mut self.writable_paths, dir);
+        if self.filesystem == FilesystemCapability::Bwrap {
+            crate::bwrap::resolve_writable_mount_destinations(
+                &mut self.writable_paths[previous_len..],
+                &self.readable_paths,
+                self.project_root
+                    .as_deref()
+                    .filter(|_| self.readonly_project_root),
+            );
+        }
+        added
     }
 }
 

--- a/crates/csa-resource/src/isolation_plan_bind_fd_capability_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_bind_fd_capability_tests.rs
@@ -367,3 +367,88 @@ fn non_bwrap_ordinary_readable_does_not_inherit_unused_descriptors() {
         assert_eq!(crate::bwrap::sandbox_bind_fd_count(&plan), 0);
     }
 }
+
+#[test]
+fn public_bwrap_builder_checks_pinned_bind_capability() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    let (_home, _env) = isolated_home(&temp);
+    let _path = install_legacy_bwrap(&temp);
+    let file = root.join("file");
+    let directory = root.join("directory");
+    std::fs::write(&file, "accepted").unwrap();
+    std::fs::create_dir(&directory).unwrap();
+    for supported in [false, true] {
+        if supported {
+            std::fs::write(
+                temp.path().join("bwrap"),
+                "#!/bin/sh\necho '--ro-bind-fd FD DEST --bind-fd FD DEST'\n",
+            )
+            .unwrap();
+        }
+        for source in [&file, &directory] {
+            for extra in [false, true] {
+                let mut builder = crate::BwrapCommandBuilder::new("/bin/true", &[]);
+                if extra {
+                    builder.with_ro_bind(source, source);
+                } else {
+                    builder.with_readable_path(source);
+                }
+                let result = builder.build();
+                if supported {
+                    let command = result.expect("modern bwrap supports pinned binds");
+                    assert!(command.get_args().any(|arg| arg == "--ro-bind-fd"));
+                } else {
+                    let error = result.expect_err("legacy bwrap must fail before command return");
+                    assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
+                }
+            }
+        }
+        // Public plans can bypass plan-builder admission; command construction
+        // must still enforce the same capability contract.
+        let mut plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+            .with_filesystem_capability(FilesystemCapability::None)
+            .with_readable_path(&file)
+            .build()
+            .unwrap();
+        plan.filesystem = FilesystemCapability::Bwrap;
+        let result = crate::from_isolation_plan(&plan, "/bin/true", &[]);
+        if supported {
+            assert!(result.unwrap().is_some());
+        } else {
+            assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::Unsupported);
+        }
+    }
+}
+
+#[test]
+fn public_bwrap_builder_preserves_no_bind_compatibility_and_path_errors() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    let (_home, _env) = isolated_home(&temp);
+    let _path = install_legacy_bwrap(&temp);
+    let file = root.join("readable");
+    std::fs::write(&file, "accepted").unwrap();
+    let socket = root.join("control.sock");
+    let _listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+    let mut builder = crate::BwrapCommandBuilder::new("/bin/true", &[]);
+    assert!(
+        builder.build().is_ok(),
+        "no binds need no new bwrap options"
+    );
+    builder.with_writable_path(&root).with_readable_path(&file);
+    let command = builder.build().expect("covered readable emits no FD mount");
+    assert!(!command.get_args().any(|arg| arg == "--ro-bind-fd"));
+    builder.with_ro_bind(&socket, &socket);
+    assert!(
+        builder.build().is_ok(),
+        "nonregular pathname binds remain supported"
+    );
+    builder.with_ro_bind(&root.join("missing"), &root.join("missing"));
+    assert_eq!(
+        builder.build().unwrap_err().kind(),
+        std::io::ErrorKind::NotFound
+    );
+}

--- a/crates/csa-resource/src/isolation_plan_bind_fd_capability_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_bind_fd_capability_tests.rs
@@ -108,3 +108,232 @@ fn legacy_bwrap_keeps_ordinary_plans_and_fails_closed_for_hermes_bind_fd() {
         "failed Hermes bind-FD plan must not activate runtime"
     );
 }
+
+#[test]
+fn extra_only_binds_require_modern_bwrap_before_activation() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    let home = root.join("home");
+    std::fs::create_dir(&home).unwrap();
+    let _home = ScopedEnvVar::set("HOME", &home);
+    let _path = install_legacy_bwrap(&temp);
+    let project = root.join("project");
+    std::fs::create_dir(&project).unwrap();
+    let ordinary = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_writable_path(project.clone())
+        .build()
+        .expect("ordinary pathname mounts work with standard bwrap");
+    assert_eq!(crate::bwrap::sandbox_bind_fd_count(&ordinary), 0);
+    for implicit in [false, true] {
+        if implicit {
+            std::fs::create_dir_all(home.join(".config/gh-aider")).unwrap();
+        }
+        let result = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+            .with_filesystem_capability(FilesystemCapability::Bwrap)
+            .with_writable_path(project.clone())
+            .with_project_root(&project)
+            .with_readonly_project_root(!implicit)
+            .build();
+        let error = result.expect_err("extra-only binds require descriptor support");
+        assert!(error.to_string().contains("bind-fd"), "{error:#}");
+    }
+}
+
+#[test]
+fn extra_only_binds_survive_command_reconstruction_and_reject_systemd() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    let home = root.join("home");
+    std::fs::create_dir(&home).unwrap();
+    let _home = ScopedEnvVar::set("HOME", &home);
+    let project = root.join("project");
+    std::fs::create_dir(&project).unwrap();
+    for implicit in [false, true] {
+        let source = if implicit {
+            home.join(".config/gh-aider")
+        } else {
+            project.clone()
+        };
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("payload"), "accepted").unwrap();
+        let mut plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+            .with_filesystem_capability(FilesystemCapability::Bwrap)
+            .with_resource_capability(ResourceCapability::CgroupV2)
+            .with_writable_path(project.clone())
+            .with_project_root(&project)
+            .with_readonly_project_root(!implicit)
+            .build()
+            .unwrap();
+        if implicit {
+            plan.env_overrides
+                .insert("HOME".into(), "/sandbox-home".into());
+        }
+        let built = crate::from_isolation_plan(&plan, "/bin/true", &[])
+            .unwrap()
+            .unwrap();
+        if implicit {
+            let args: Vec<_> = built.get_args().collect();
+            assert!(args.windows(3).any(
+                |args| args[0] == "--ro-bind-fd" && args[2] == "/sandbox-home/.config/gh-aider"
+            ));
+        }
+        // Execute the reconstructed argv with a bounded stand-in for bwrap;
+        // the original Command and its pre_exec owners are gone before spawn.
+        let mut probe = std::process::Command::new("/bin/sh");
+        probe.args(["-c", "while [ $# -gt 0 ]; do if [ \"$1\" = --ro-bind-fd ]; then exec /bin/cat /proc/self/fd/\"$2\"/payload; fi; shift; done; exit 64", "probe"]);
+        probe.args(built.get_args());
+        let mut systemd = std::process::Command::new("systemd-run");
+        systemd.args(built.get_args());
+        drop(built);
+        std::fs::rename(&source, source.with_extension("old")).unwrap();
+        crate::bwrap::inherit_sandbox_bind_fds(&mut probe, &plan);
+        let output = crate::bounded_command::output_with_timeout(
+            probe,
+            std::time::Duration::from_secs(5),
+            crate::bounded_command::MAX_OUTPUT_BYTES,
+        )
+        .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(output.stdout, b"accepted");
+        assert_eq!(plan.resource, ResourceCapability::Setrlimit);
+        assert!(crate::bwrap::sandbox_bind_fd_count(&plan) > 0);
+        assert!(crate::bwrap::try_inherit_sandbox_bind_fds(&mut systemd, &plan).is_err());
+        std::fs::rename(source.with_extension("old"), &source).unwrap();
+    }
+}
+
+#[test]
+fn extra_bind_preflight_preserves_3148_activation_and_overlay_fds() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let layouts = [
+        (None, "state.db"),
+        (Some("flat"), "state.flat.db"),
+        (Some("direct"), "direct/state.db"),
+        (Some("nested"), "profiles/nested/state.db"),
+    ];
+    for (profile, relative) in layouts {
+        for reject in [true, false] {
+            let temp = tempfile::tempdir().unwrap();
+            let root = temp.path().canonicalize().unwrap();
+            let home = root.join("home");
+            std::fs::create_dir(&home).unwrap();
+            let _home = ScopedEnvVar::set("HOME", &home);
+            let hermes = root.join("hermes");
+            std::fs::create_dir_all(hermes.join("logs")).unwrap();
+            std::fs::write(hermes.join("config.yaml"), "model: test\n").unwrap();
+            let legacy = hermes.join(relative);
+            std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+            if matches!(profile, Some("direct" | "nested")) {
+                std::fs::write(
+                    legacy.parent().unwrap().join("config.yaml"),
+                    "model: test\n",
+                )
+                .unwrap();
+            }
+            let database = rusqlite::Connection::open(&legacy).unwrap();
+            database
+                .execute_batch(
+                    "CREATE TABLE probe(value TEXT); INSERT INTO probe VALUES ('accepted');",
+                )
+                .unwrap();
+            let project = root.join("project");
+            let session = root.join("session");
+            std::fs::create_dir(&project).unwrap();
+            std::fs::create_dir(&session).unwrap();
+            let execution_env = std::collections::HashMap::from([(
+                "HERMES_HOME".into(),
+                hermes.to_string_lossy().into_owned(),
+            )]);
+            let builder = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+                .with_filesystem_capability(FilesystemCapability::Bwrap)
+                .with_execution_env(Some(&execution_env))
+                .with_tool_defaults("hermes", &project, &session)
+                .with_readonly_project_root(true);
+            if reject {
+                // The project disappears after runtime preparation. Extra bind
+                // pinning must fail before publishing the SQLite generation.
+                std::fs::remove_dir(&project).unwrap();
+                assert!(builder.build().is_err());
+                assert_eq!(resolve_hermes_state_db(&hermes, profile), legacy);
+                assert!(!hermes.join(".csa-runtime/.csa-runtime-ready").exists());
+            } else {
+                let plan = builder.build().unwrap();
+                let resolved = resolve_hermes_state_db(&hermes, profile);
+                assert_ne!(resolved, legacy);
+                let published = rusqlite::Connection::open(&resolved).unwrap();
+                let value: String = published
+                    .query_row("SELECT value FROM probe", [], |row| row.get(0))
+                    .unwrap();
+                assert_eq!(value, "accepted");
+                let built = crate::from_isolation_plan(&plan, "/bin/true", &[])
+                    .unwrap()
+                    .unwrap();
+                let args: Vec<_> = built
+                    .get_args()
+                    .map(|arg| arg.to_string_lossy().into_owned())
+                    .collect();
+                let config = hermes.join("config.yaml");
+                let fd = args
+                    .windows(3)
+                    .find(|args| args[0] == "--ro-bind-fd" && args[2] == config.to_string_lossy())
+                    .unwrap()[1]
+                    .clone();
+                assert!(
+                    args.windows(3)
+                        .any(|args| args[0] == "--bind-fd" && args[2] == hermes.to_string_lossy())
+                );
+                drop(built);
+                let mut probe = std::process::Command::new("/bin/cat");
+                probe.arg(format!("/proc/self/fd/{fd}"));
+                crate::bwrap::inherit_sandbox_bind_fds(&mut probe, &plan);
+                let output = crate::bounded_command::output_with_timeout(
+                    probe,
+                    std::time::Duration::from_secs(5),
+                    crate::bounded_command::MAX_OUTPUT_BYTES,
+                )
+                .unwrap();
+                assert!(output.status.success());
+                assert_eq!(output.stdout, b"model: test\n");
+            }
+        }
+    }
+}
+
+#[test]
+fn extra_only_binds_reject_dangling_implicit_source_without_unwinding() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().canonicalize().unwrap();
+    std::fs::create_dir(home.join(".config")).unwrap();
+    std::os::unix::fs::symlink(home.join("missing"), home.join(".config/gh-aider")).unwrap();
+    let _home = ScopedEnvVar::set("HOME", &home);
+    assert!(
+        IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+            .with_filesystem_capability(FilesystemCapability::Bwrap)
+            .build()
+            .is_err()
+    );
+}
+
+#[test]
+fn test_builder_best_effort_with_bwrap() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let (_home, _env) = isolated_home(&temp);
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_resource_capability(ResourceCapability::CgroupV2)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .build()
+        .expect("BestEffort with Bwrap should succeed");
+
+    assert_eq!(plan.resource, ResourceCapability::CgroupV2);
+    assert_eq!(plan.filesystem, FilesystemCapability::Bwrap);
+    assert!(plan.degraded_reasons.is_empty());
+}

--- a/crates/csa-resource/src/isolation_plan_bind_fd_capability_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_bind_fd_capability_tests.rs
@@ -3,6 +3,9 @@
 use super::*;
 use std::path::Path;
 
+#[path = "isolation_plan_emitted_bind_tests.rs"]
+mod emitted_bind_tests;
+
 #[cfg(unix)]
 struct PathGuard(Option<std::ffi::OsString>);
 

--- a/crates/csa-resource/src/isolation_plan_bind_fd_capability_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_bind_fd_capability_tests.rs
@@ -337,3 +337,33 @@ fn test_builder_best_effort_with_bwrap() {
     assert_eq!(plan.filesystem, FilesystemCapability::Bwrap);
     assert!(plan.degraded_reasons.is_empty());
 }
+
+#[test]
+fn non_bwrap_ordinary_readable_does_not_inherit_unused_descriptors() {
+    use std::os::fd::AsRawFd;
+    let temp = tempfile::tempdir().unwrap();
+    for filesystem in [FilesystemCapability::None, FilesystemCapability::Landlock] {
+        let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+            .with_filesystem_capability(filesystem)
+            .with_readable_path(temp.path().to_path_buf())
+            .build()
+            .unwrap();
+        let file = plan.readable_paths[0].pinned_source_file().unwrap();
+        let mut command = std::process::Command::new("/bin/sh");
+        command
+            .args(["-c", "test ! -e \"$1\"", "probe"])
+            .arg(format!("/proc/self/fd/{}", file.as_raw_fd()));
+        crate::bwrap::try_inherit_sandbox_bind_fds(&mut command, &plan).unwrap();
+        let output = crate::bounded_command::output_with_timeout(
+            command,
+            std::time::Duration::from_secs(5),
+            crate::bounded_command::MAX_OUTPUT_BYTES,
+        )
+        .unwrap();
+        assert!(
+            output.status.success(),
+            "{filesystem} must keep unused pins CLOEXEC"
+        );
+        assert_eq!(crate::bwrap::sandbox_bind_fd_count(&plan), 0);
+    }
+}

--- a/crates/csa-resource/src/isolation_plan_build.rs
+++ b/crates/csa-resource/src/isolation_plan_build.rs
@@ -78,10 +78,21 @@ impl IsolationPlanBuilder {
                 )?);
         }
 
+        let bind_fd_count = if self.filesystem == FilesystemCapability::Bwrap {
+            crate::bwrap::readable_bind_fd_count(
+                &self.readable_paths,
+                &self.writable_paths,
+                self.project_root
+                    .as_deref()
+                    .filter(|_| self.readonly_project_root),
+            )
+        } else {
+            0
+        };
         readable::downgrade_incompatible_cgroup_filesystem(
             &mut self.resource,
             self.filesystem,
-            &self.readable_paths,
+            bind_fd_count,
             &mut self.degraded_reasons,
         );
 
@@ -92,7 +103,7 @@ impl IsolationPlanBuilder {
         )?;
         hermes_paths::finish_plan(
             self.filesystem,
-            &self.readable_paths,
+            bind_fd_count,
             self.pending_hermes_runtime.take(),
         )?;
 

--- a/crates/csa-resource/src/isolation_plan_build.rs
+++ b/crates/csa-resource/src/isolation_plan_build.rs
@@ -1,0 +1,116 @@
+//! Final validation and activation of the fully owned isolation plan.
+
+use super::*;
+
+impl IsolationPlanBuilder {
+    /// Consume the builder and produce an [`IsolationPlan`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when filesystem enforcement is `Required` but the
+    /// filesystem capability is `None`, or bind pinning/capability validation fails.
+    pub fn build(mut self) -> anyhow::Result<IsolationPlan> {
+        if let Some(error) = self.preflight_error.take() {
+            return Err(error);
+        }
+        // Filesystem enforcement: use dedicated override if set, otherwise
+        // inherit from the resource enforcement mode.
+        let fs_mode = self.fs_enforcement_mode.unwrap_or(self.enforcement_mode);
+
+        match fs_mode {
+            EnforcementMode::Off => {
+                self.filesystem = FilesystemCapability::None;
+            }
+            EnforcementMode::Required => {
+                if self.filesystem == FilesystemCapability::None {
+                    anyhow::bail!("filesystem isolation required but no capability detected");
+                }
+            }
+            EnforcementMode::BestEffort => {
+                if self.filesystem == FilesystemCapability::None {
+                    self.degraded_reasons
+                        .push("no filesystem isolation available; proceeding without".into());
+                }
+            }
+        }
+
+        // Resource enforcement: handled separately.
+        match self.enforcement_mode {
+            EnforcementMode::BestEffort => {
+                if self.resource == ResourceCapability::None {
+                    self.degraded_reasons
+                        .push("no resource isolation available; proceeding without".into());
+                }
+            }
+            EnforcementMode::Off | EnforcementMode::Required => {
+                // Required for resources is checked upstream in pipeline_sandbox.
+                // Off is a no-op for the resource axis (capabilities are kept as-is
+                // because cgroup limits don't need explicit disabling here).
+            }
+        }
+
+        if self.filesystem != FilesystemCapability::None
+            && !self.readonly_project_root
+            && let Some(project_root) = self.project_root.as_deref()
+            && let Some([git_dir, common_dir]) =
+                runtime_path::linked_worktree_git_admin_dirs(project_root)?
+        {
+            self.writable_paths.extend([common_dir, git_dir]);
+        }
+
+        readable::push_runtime_daemon_socket_readable_paths(
+            self.filesystem,
+            self.user_daemon_ipc,
+            &self.writable_paths,
+            &mut self.readable_paths,
+        );
+
+        if self.filesystem == FilesystemCapability::Bwrap {
+            let readonly_project = self
+                .project_root
+                .as_deref()
+                .filter(|_| self.readonly_project_root);
+            self.readable_paths
+                .extend(crate::bwrap::plan_extra_readonly_paths(
+                    &self.writable_paths,
+                    readonly_project,
+                    std::env::var_os("HOME").as_deref().map(Path::new),
+                )?);
+        }
+
+        readable::downgrade_incompatible_cgroup_filesystem(
+            &mut self.resource,
+            self.filesystem,
+            &self.readable_paths,
+            &mut self.degraded_reasons,
+        );
+
+        codex_paths::validate_required_writable_dirs(
+            self.filesystem,
+            &self.required_writable_dirs,
+            &self.writable_paths,
+        )?;
+        hermes_paths::finish_plan(
+            self.filesystem,
+            &self.readable_paths,
+            self.pending_hermes_runtime.take(),
+        )?;
+
+        Ok(IsolationPlan {
+            resource: self.resource,
+            filesystem: self.filesystem,
+            writable_paths: self.writable_paths,
+            readable_paths: self.readable_paths,
+            env_overrides: self.env_overrides,
+            degraded_reasons: self.degraded_reasons,
+            memory_max_mb: self.memory_max_mb,
+            memory_swap_max_mb: self.memory_swap_max_mb,
+            pids_max: self.pids_max,
+            readonly_project_root: self.readonly_project_root,
+            project_root: self.project_root,
+            soft_limit_percent: self.soft_limit_percent,
+            memory_monitor_interval_seconds: self.memory_monitor_interval_seconds,
+            user_daemon_ipc: self.user_daemon_ipc,
+        })
+    }
+}

--- a/crates/csa-resource/src/isolation_plan_build.rs
+++ b/crates/csa-resource/src/isolation_plan_build.rs
@@ -78,6 +78,20 @@ impl IsolationPlanBuilder {
                 )?);
         }
 
+        codex_paths::validate_required_writable_dirs(
+            self.filesystem,
+            &self.required_writable_dirs,
+            &self.writable_paths,
+        )?;
+        if self.filesystem == FilesystemCapability::Bwrap {
+            crate::bwrap::resolve_writable_mount_destinations(
+                &mut self.writable_paths,
+                &self.readable_paths,
+                self.project_root
+                    .as_deref()
+                    .filter(|_| self.readonly_project_root),
+            );
+        }
         let bind_fd_count = if self.filesystem == FilesystemCapability::Bwrap {
             crate::bwrap::readable_bind_fd_count(
                 &self.readable_paths,
@@ -96,11 +110,6 @@ impl IsolationPlanBuilder {
             &mut self.degraded_reasons,
         );
 
-        codex_paths::validate_required_writable_dirs(
-            self.filesystem,
-            &self.required_writable_dirs,
-            &self.writable_paths,
-        )?;
         hermes_paths::finish_plan(
             self.filesystem,
             bind_fd_count,

--- a/crates/csa-resource/src/isolation_plan_claude_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_claude_tests.rs
@@ -58,7 +58,7 @@ impl Drop for ScopedEnvVar {
 fn test_tool_defaults_claude_code_rejects_unwritable_claude_home() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();
-    let home = temp.path().join("home");
+    let home = temp.path().canonicalize().unwrap().join("home");
     std::fs::create_dir_all(&home).unwrap();
     let _home_env = ScopedEnvVar::set("HOME", &home);
 
@@ -126,7 +126,7 @@ fn test_tool_defaults_claude_code_rejects_unwritable_claude_home() {
 fn test_tool_defaults_claude_code_honors_tool_state_dirs_config() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();
-    let home = temp.path().join("home");
+    let home = temp.path().canonicalize().unwrap().join("home");
     std::fs::create_dir_all(&home).unwrap();
     let _home_env = ScopedEnvVar::set("HOME", &home);
     let _claude_home_env = ScopedEnvVar::unset("CLAUDE_CONFIG_DIR");
@@ -175,7 +175,7 @@ fn test_tool_defaults_claude_code_honors_tool_state_dirs_config() {
 fn test_peer_tool_exposes_claude_home_without_probe() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();
-    let home = temp.path().join("home");
+    let home = temp.path().canonicalize().unwrap().join("home");
     std::fs::create_dir_all(&home).unwrap();
     let _home_env = ScopedEnvVar::set("HOME", &home);
     // Use the default ~/.claude layout (no override) for the peer path.
@@ -241,7 +241,7 @@ fn test_peer_tool_exposes_claude_home_without_probe() {
 fn test_codex_parent_exposes_writable_claude_home_nested_erofs_regression() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();
-    let home = temp.path().join("home");
+    let home = temp.path().canonicalize().unwrap().join("home");
     std::fs::create_dir_all(&home).unwrap();
     let _home_env = ScopedEnvVar::set("HOME", &home);
     let _claude_home_env = ScopedEnvVar::unset("CLAUDE_CONFIG_DIR");

--- a/crates/csa-resource/src/isolation_plan_emitted_bind_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_emitted_bind_tests.rs
@@ -1,0 +1,224 @@
+//! Emitted binds, not retained snapshot pins, determine FD admission (#3174).
+
+use super::*;
+use std::os::fd::AsRawFd;
+use std::process::Command;
+
+fn install_modern_bwrap(temp: &tempfile::TempDir) {
+    std::fs::write(
+        temp.path().join("bwrap"),
+        "#!/bin/sh\necho '--ro-bind-fd FD DEST --bind-fd FD DEST'\n",
+    )
+    .unwrap();
+}
+
+fn emitted_fds(command: &Command) -> Vec<String> {
+    let args: Vec<_> = command.get_args().collect();
+    args.windows(3)
+        .filter(|args| args[0] == "--ro-bind-fd" || args[0] == "--bind-fd")
+        .map(|args| args[1].to_string_lossy().into_owned())
+        .collect()
+}
+
+fn covered_readable_plan(supported: bool) {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    let (_home, _env) = isolated_home(&temp);
+    let _path = install_legacy_bwrap(&temp);
+    if supported {
+        install_modern_bwrap(&temp);
+    }
+    let file = root.join("input");
+    std::fs::write(&file, "accepted").unwrap();
+    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .with_resource_capability(ResourceCapability::CgroupV2)
+        .with_writable_path(root.clone())
+        .with_readable_path(&file)
+        .build()
+        .expect("covered readable needs no descriptor-bind capability");
+    assert_eq!(plan.resource, ResourceCapability::CgroupV2);
+    assert!(plan.degraded_reasons.is_empty());
+    assert_eq!(crate::bwrap::sandbox_bind_fd_count(&plan), 0);
+    let built = crate::from_isolation_plan(&plan, "/bin/true", &[])
+        .unwrap()
+        .unwrap();
+    assert!(emitted_fds(&built).is_empty());
+    let mut public = crate::BwrapCommandBuilder::new("/bin/true", &[]);
+    public.with_writable_path(&root).with_readable_path(&file);
+    assert!(emitted_fds(&public.build().unwrap()).is_empty());
+    let mut systemd = Command::new("systemd-run");
+    crate::bwrap::try_inherit_sandbox_bind_fds(&mut systemd, &plan).unwrap();
+
+    // The snapshot remains owned, but reconstructed commands must not inherit it.
+    let pin = plan.readable_paths[0].pinned_source_file().unwrap();
+    let mut probe = Command::new("/bin/sh");
+    probe
+        .args(["-c", "test ! -e \"$1\"", "probe"])
+        .arg(format!("/proc/self/fd/{}", pin.as_raw_fd()));
+    crate::bwrap::try_inherit_sandbox_bind_fds(&mut probe, &plan).unwrap();
+    drop(built);
+    drop(plan);
+    assert!(pin.metadata().unwrap().is_file());
+    let output = crate::bounded_command::output_with_timeout(
+        probe,
+        std::time::Duration::from_secs(5),
+        crate::bounded_command::MAX_OUTPUT_BYTES,
+    )
+    .unwrap();
+    assert!(output.status.success());
+}
+
+#[test]
+fn covered_readable_legacy_plan_preserves_cgroup_without_bind_fds() {
+    covered_readable_plan(false);
+}
+
+#[test]
+fn covered_readable_modern_plan_preserves_cgroup_without_bind_fds() {
+    covered_readable_plan(true);
+}
+
+#[test]
+fn emitted_bind_projection_matches_plan_and_public_builder_combinations() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    let (_home, _env) = isolated_home(&temp);
+    let _path = install_legacy_bwrap(&temp);
+    let project = root.join("project");
+    let nested = project.join("nested");
+    std::fs::create_dir_all(&nested).unwrap();
+    let child = nested.join("input");
+    let outside = root.join("outside");
+    std::fs::write(&child, "child").unwrap();
+    std::fs::write(&outside, "outside").unwrap();
+
+    for supported in [false, true] {
+        if supported {
+            install_modern_bwrap(&temp);
+        }
+        for filesystem in [
+            FilesystemCapability::Bwrap,
+            FilesystemCapability::None,
+            FilesystemCapability::Landlock,
+        ] {
+            for case in [
+                "covered",
+                "uncovered",
+                "extra",
+                "overlay",
+                "nested",
+                "readonly-project",
+            ] {
+                let readable = match case {
+                    "uncovered" => ReadablePath::from(&outside),
+                    "extra" => ReadablePath::pinned_extra(child.clone(), child.clone()),
+                    "overlay" | "nested" => {
+                        ReadablePath::try_pinned_readonly_overlay(nested.clone()).unwrap()
+                    }
+                    _ => ReadablePath::from(&child),
+                };
+                let mut builder = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+                    .with_filesystem_capability(filesystem)
+                    .with_resource_capability(ResourceCapability::CgroupV2)
+                    .with_writable_path(project.clone())
+                    .with_project_root(&project)
+                    .with_readonly_project_root(case == "readonly-project")
+                    .with_readable_path(readable.clone());
+                let mut public = crate::BwrapCommandBuilder::new("/bin/true", &[]);
+                if case == "readonly-project" {
+                    public.with_ro_bind(&project, &project);
+                } else {
+                    public.with_writable_path(&project);
+                }
+                if case == "extra" {
+                    public.with_ro_bind(&child, &child);
+                } else {
+                    public.with_readable_path(readable);
+                }
+                if case == "nested" {
+                    let writable = ReadablePath::pinned_writable(
+                        child.clone(),
+                        std::fs::File::open(&child).unwrap(),
+                    );
+                    builder = builder
+                        .with_writable_path(child.clone())
+                        .with_readable_path(writable.clone());
+                    public
+                        .with_writable_path(&child)
+                        .with_readable_path(writable);
+                }
+                let expected = match case {
+                    "covered" => 0,
+                    "nested" | "readonly-project" => 2,
+                    _ => 1,
+                };
+                let result = builder.build();
+                let public_result = public.build();
+                if !supported && expected > 0 {
+                    assert_eq!(
+                        public_result.unwrap_err().kind(),
+                        std::io::ErrorKind::Unsupported
+                    );
+                    if filesystem == FilesystemCapability::Bwrap {
+                        let error = result.unwrap_err();
+                        assert!(error.to_string().contains("bind-fd"), "{case}: {error:#}");
+                        continue;
+                    }
+                } else {
+                    assert_eq!(
+                        emitted_fds(&public_result.unwrap()).len(),
+                        expected,
+                        "{case}"
+                    );
+                }
+                let plan = result.unwrap();
+                let built = crate::from_isolation_plan(&plan, "/bin/true", &[]).unwrap();
+                let fds = if filesystem == FilesystemCapability::Bwrap {
+                    let built = built.unwrap();
+                    let fds = emitted_fds(&built);
+                    assert_eq!(fds.len(), expected, "{case}");
+                    fds
+                } else {
+                    assert!(built.is_none());
+                    Vec::new()
+                };
+                let count = fds.len();
+                assert_eq!(crate::bwrap::sandbox_bind_fd_count(&plan), count, "{case}");
+                let resource = if filesystem == FilesystemCapability::Landlock || count > 0 {
+                    ResourceCapability::Setrlimit
+                } else {
+                    ResourceCapability::CgroupV2
+                };
+                assert_eq!(plan.resource, resource, "{filesystem}: {case}");
+                let mut systemd = Command::new("systemd-run");
+                assert_eq!(
+                    crate::bwrap::try_inherit_sandbox_bind_fds(&mut systemd, &plan).is_ok(),
+                    count == 0
+                );
+                let pins: Vec<_> = plan
+                    .readable_paths
+                    .iter()
+                    .filter_map(ReadablePath::pinned_source_file)
+                    .collect();
+                let mut probe = Command::new("/bin/sh");
+                probe.args(["-c", "while [ $# -gt 0 ]; do if [ \"$2\" = yes ]; then test -e /proc/self/fd/\"$1\" || exit 1; else test ! -e /proc/self/fd/\"$1\" || exit 2; fi; shift 2; done", "probe"]);
+                for pin in &pins {
+                    let fd = pin.as_raw_fd().to_string();
+                    probe.args([fd.as_str(), if fds.contains(&fd) { "yes" } else { "no" }]);
+                }
+                crate::bwrap::try_inherit_sandbox_bind_fds(&mut probe, &plan).unwrap();
+                drop(plan);
+                let output = crate::bounded_command::output_with_timeout(
+                    probe,
+                    std::time::Duration::from_secs(5),
+                    crate::bounded_command::MAX_OUTPUT_BYTES,
+                )
+                .unwrap();
+                assert!(output.status.success(), "{filesystem}: {case}");
+            }
+        }
+    }
+}

--- a/crates/csa-resource/src/isolation_plan_emitted_bind_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_emitted_bind_tests.rs
@@ -1,6 +1,9 @@
 //! Emitted binds, not retained snapshot pins, determine FD admission (#3174).
 
 use super::*;
+
+#[path = "isolation_plan_temporal_selection_tests.rs"]
+mod temporal_selection;
 use std::os::fd::AsRawFd;
 use std::process::Command;
 

--- a/crates/csa-resource/src/isolation_plan_hermes.rs
+++ b/crates/csa-resource/src/isolation_plan_hermes.rs
@@ -343,11 +343,11 @@ fn runtime_ready(marker: &Path) -> bool {
 
 pub(super) fn finish_plan(
     filesystem: FilesystemCapability,
-    readable_paths: &[ReadablePath],
+    bind_fd_count: usize,
     pending: Option<PendingRuntimeActivation>,
 ) -> anyhow::Result<()> {
     if filesystem == FilesystemCapability::Bwrap
-        && crate::bwrap::readable_bind_fd_count(readable_paths) > 0
+        && bind_fd_count > 0
         && !crate::filesystem_sandbox::has_bwrap_bind_fd_options()
     {
         anyhow::bail!(

--- a/crates/csa-resource/src/isolation_plan_hermes_runtime_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_hermes_runtime_tests.rs
@@ -58,6 +58,7 @@ fn test_tool_defaults_hermes_writes_runtime_but_protects_configuration() {
     );
 
     let command = crate::from_isolation_plan(&plan, "/usr/bin/tool", &[])
+        .expect("valid bind paths")
         .expect("Bubblewrap plan should produce a command");
     let args = command
         .get_args()
@@ -347,7 +348,9 @@ fn test_tool_defaults_hermes_rejects_runtime_logs_symlink_outside_home() {
         .build();
 
     if let Ok(plan) = &result {
-        if let Some(command) = crate::from_isolation_plan(plan, "/usr/bin/tool", &[]) {
+        if let Some(command) =
+            crate::from_isolation_plan(plan, "/usr/bin/tool", &[]).expect("valid bind paths")
+        {
             let args = command
                 .get_args()
                 .map(|arg| arg.to_string_lossy().into_owned())
@@ -472,7 +475,7 @@ fn test_tool_defaults_hermes_rejects_relative_environment_paths() {
         let message = match built {
             Err(error) => error.to_string(),
             Ok(plan) => match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                crate::from_isolation_plan(&plan, "/usr/bin/tool", &[])
+                crate::from_isolation_plan(&plan, "/usr/bin/tool", &[]).expect("valid bind paths")
             })) {
                 Ok(_) => "produced a sandbox command".to_string(),
                 Err(_) => "panicked at bwrap absolute-path assertion".to_string(),

--- a/crates/csa-resource/src/isolation_plan_hermes_runtime_toctou_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_hermes_runtime_toctou_tests.rs
@@ -99,6 +99,7 @@ fn hermes_runtime_leaf_replaced_with_symlink_after_plan_does_not_bind_outside() 
         replace_path_with_outside_symlink(&hermes_home.join(leaf), &outside);
         let args = command_args(
             &crate::from_isolation_plan(&plan, "/usr/bin/tool", &[])
+                .expect("valid bind paths")
                 .expect("planned Hermes sandbox must still produce a bwrap command"),
         );
         assert_no_outside_writable_bind(&args, &outside, leaf);
@@ -128,6 +129,7 @@ fn hermes_home_replaced_with_symlink_after_plan_does_not_bind_outside() {
         .expect("replace Hermes home with outside symlink");
     let args = command_args(
         &crate::from_isolation_plan(&plan, "/usr/bin/tool", &[])
+            .expect("valid bind paths")
             .expect("planned Hermes sandbox must still produce a bwrap command"),
     );
     assert_no_outside_writable_bind(&args, &outside, "HERMES_HOME");

--- a/crates/csa-resource/src/isolation_plan_hermes_sqlite_3148_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_hermes_sqlite_3148_tests.rs
@@ -24,6 +24,7 @@ fn live_sqlite_database(path: &Path, value: &str) -> rusqlite::Connection {
 
 fn command_args(plan: &IsolationPlan) -> Vec<String> {
     crate::from_isolation_plan(plan, "/usr/bin/tool", &[])
+        .expect("valid bind paths")
         .expect("planned Hermes sandbox must produce a bwrap command")
         .get_args()
         .map(|arg| arg.to_string_lossy().into_owned())

--- a/crates/csa-resource/src/isolation_plan_overlay_fd_inherit_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_overlay_fd_inherit_tests.rs
@@ -111,6 +111,7 @@ fn acp_style_reconstruction_keeps_overlay_ro_bind_fd_usable() {
         .expect("regular overlay leaf must pin");
     let plan = overlay_bind_plan(overlay);
     let built = crate::from_isolation_plan(&plan, "/bin/cat", &[dest.to_string_lossy().into()])
+        .expect("valid bind paths")
         .expect("pinned overlay must produce a bwrap command");
     let args: Vec<String> = built
         .get_args()
@@ -140,6 +141,7 @@ fn cgroup_style_reconstruction_fail_closed_or_keeps_overlay_ro_bind_fd() {
     plan.resource = ResourceCapability::CgroupV2;
 
     let built = crate::from_isolation_plan(&plan, "/bin/cat", &[dest.to_string_lossy().into()])
+        .expect("valid bind paths")
         .expect("pinned overlay must produce a bwrap command");
     let args: Vec<String> = built
         .get_args()

--- a/crates/csa-resource/src/isolation_plan_overlay_toctou_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_overlay_toctou_tests.rs
@@ -93,6 +93,7 @@ fn try_pinned_readonly_overlay_fails_closed_when_leaf_replaced_with_symlink() {
     let raced_target = config.with_file_name("overlay-toctou-target");
     let args = command_args(
         &crate::from_isolation_plan(&overlay_bind_plan(overlay), "/usr/bin/tool", &[])
+            .expect("valid bind paths")
             .expect("pinned overlay must still produce a bwrap command"),
     );
     assert_overlay_bind_uses_pinned_identity(&args, &config, &raced_target);
@@ -129,6 +130,7 @@ fn hermes_preflight_fails_closed_when_overlay_leaf_replaced_with_symlink() {
     let raced_target = config.with_file_name("overlay-toctou-target");
     let args = command_args(
         &crate::from_isolation_plan(&plan, "/usr/bin/tool", &[])
+            .expect("valid bind paths")
             .expect("pinned Hermes overlay must still produce a bwrap command"),
     );
     assert_overlay_bind_uses_pinned_identity(&args, &config, &raced_target);
@@ -151,6 +153,7 @@ fn try_pinned_readonly_overlay_fails_closed_when_directory_replaced_with_symlink
     let raced_target = profiles.with_file_name("overlay-toctou-dir-target");
     let args = command_args(
         &crate::from_isolation_plan(&overlay_bind_plan(overlay), "/usr/bin/tool", &[])
+            .expect("valid bind paths")
             .expect("pinned overlay directory must still produce a bwrap command"),
     );
     assert_overlay_bind_uses_pinned_identity(&args, &profiles, &raced_target);

--- a/crates/csa-resource/src/isolation_plan_path_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_path_tests.rs
@@ -2,6 +2,24 @@ use super::*;
 use std::ffi::OsString;
 use std::path::Path;
 
+#[test]
+fn pinned_readonly_rejects_regular_file_identity_race() {
+    fn replace(path: &Path) {
+        std::fs::rename(path, path.with_extension("old")).unwrap();
+        std::fs::write(path, "replacement").unwrap();
+    }
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("source");
+    std::fs::write(&source, "accepted").unwrap();
+    readable::AFTER_READONLY_OVERLAY_METADATA.with(|hook| hook.set(Some(replace)));
+    let result = ReadablePath::try_pinned_readonly_overlay(source);
+    readable::AFTER_READONLY_OVERLAY_METADATA.with(|hook| hook.set(None));
+    assert!(
+        result.is_err(),
+        "replacement between stat and open must fail closed"
+    );
+}
+
 struct ScopedEnvVar {
     key: &'static str,
     previous: Option<OsString>,

--- a/crates/csa-resource/src/isolation_plan_path_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_path_tests.rs
@@ -50,7 +50,7 @@ impl Drop for ScopedEnvVar {
 #[test]
 fn test_resolve_writable_relative_path_against_project_root() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let project = tmp.path().join("project");
+    let project = tmp.path().canonicalize().unwrap().join("project");
     let drafts = project.join("drafts");
     std::fs::create_dir_all(&drafts).expect("create drafts dir");
 
@@ -66,7 +66,7 @@ fn test_resolve_writable_symlink_inside_project_to_external_target() {
     use std::os::unix::fs::symlink;
 
     let tmp = tempfile::tempdir().expect("tempdir");
-    let project = tmp.path().join("project");
+    let project = tmp.path().canonicalize().unwrap().join("project");
     let external = tmp.path().join("external-drafts");
     std::fs::create_dir_all(&project).expect("create project dir");
     std::fs::create_dir_all(&external).expect("create external dir");
@@ -84,7 +84,7 @@ fn test_resolve_writable_symlink_inside_project_to_external_target() {
 #[test]
 fn test_resolve_writable_allows_nonexistent_path_with_existing_parent() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let project = tmp.path().join("project");
+    let project = tmp.path().canonicalize().unwrap().join("project");
     std::fs::create_dir_all(&project).expect("create project dir");
 
     let resolved = resolve_writable_paths(&[PathBuf::from("drafts/new")], &project)
@@ -98,8 +98,8 @@ fn test_resolve_writable_allows_nonexistent_path_with_existing_parent() {
 
 #[test]
 fn test_validate_readable_paths_accepts_project_local_relative_path() {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let project = tmp.path().join("project");
+    let tmp = tempfile::tempdir_in("/tmp").expect("/tmp fixture");
+    let project = tmp.path().canonicalize().unwrap().join("project");
     let context_file = project.join(".csa").join("review-context.md");
     std::fs::create_dir_all(context_file.parent().expect("context parent dir"))
         .expect("create .csa dir");
@@ -126,7 +126,7 @@ fn test_validate_readable_paths_accepts_project_local_relative_path() {
 #[test]
 fn test_resolve_writable_accepts_config_path_outside_default_roots() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let project = tmp.path().join("project");
+    let project = tmp.path().canonicalize().unwrap().join("project");
     let external = tmp.path().join("external-data");
     std::fs::create_dir_all(&project).expect("create project dir");
     std::fs::create_dir_all(&external).expect("create external dir");
@@ -176,8 +176,11 @@ fn validate_readable_paths_accepts_unix_socket_without_read_opening() {
     let socket = fixture.path().join("review.sock");
     let _listener = UnixListener::bind(&socket).expect("bind Unix socket");
 
-    let readable = validate_readable_paths(std::slice::from_ref(&socket), fixture.path())
-        .expect("Unix socket should remain a path-bound readable source");
+    let readable = validate_readable_paths(
+        std::slice::from_ref(&socket),
+        &fixture.path().canonicalize().unwrap(),
+    )
+    .expect("Unix socket should remain a path-bound readable source");
     assert_eq!(readable.len(), 1);
     assert_eq!(readable[0].bind_source(), socket.canonicalize().unwrap());
     assert!(
@@ -198,8 +201,11 @@ fn validate_readable_paths_accepts_fifo_without_read_opening() {
     // SAFETY: `fifo_name` is NUL-free and remains alive for the call.
     assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
 
-    let readable = validate_readable_paths(std::slice::from_ref(&fifo), fixture.path())
-        .expect("FIFO should remain a path-bound readable source");
+    let readable = validate_readable_paths(
+        std::slice::from_ref(&fifo),
+        &fixture.path().canonicalize().unwrap(),
+    )
+    .expect("FIFO should remain a path-bound readable source");
     assert_eq!(readable.len(), 1);
     assert_eq!(readable[0].bind_source(), fifo.canonicalize().unwrap());
     assert!(
@@ -215,7 +221,7 @@ fn test_validate_readable_paths_allows_ssd_mirror_of_home_and_project() {
 
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().expect("tempdir");
-    let home = temp.path().join("home");
+    let home = temp.path().canonicalize().unwrap().join("home");
     let project = temp.path().join("project");
     let mirror_root = temp.path().join("mirror-rootfs");
     let mirror_home = mirror_root.join(home.strip_prefix("/").expect("absolute home"));
@@ -245,7 +251,7 @@ fn test_validate_readable_paths_allows_ssd_mirror_of_home_and_project() {
 fn test_validate_readable_paths_rejects_unrelated_and_sensitive_paths_with_ssd_mirror() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().expect("tempdir");
-    let home = temp.path().join("home");
+    let home = temp.path().canonicalize().unwrap().join("home");
     let project = home.join("project");
     let mirror_root = temp.path().join("mirror-rootfs");
     let unrelated = PathBuf::from("/var");
@@ -312,7 +318,7 @@ fn test_validate_readable_paths_rejects_mnt_ssd_mirror_alias() {
 fn test_validate_writable_paths_rejects_ssd_mirror_exception() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().expect("tempdir");
-    let home = temp.path().join("home");
+    let home = temp.path().canonicalize().unwrap().join("home");
     let project = home.join("project");
     let mirror_home =
         Path::new("/ssd/mirror-rootfs").join(home.strip_prefix("/").expect("absolute home"));
@@ -327,8 +333,8 @@ fn test_validate_writable_paths_rejects_ssd_mirror_exception() {
 fn test_validate_writable_allows_xdg_runtime_child_but_rejects_root() {
     let _guard = ENV_LOCK.lock().unwrap();
     let tmp = tempfile::tempdir().expect("tempdir");
-    let project = tmp.path().join("project");
-    let runtime_root = tmp.path().join("run/user/1001");
+    let project = tmp.path().canonicalize().unwrap().join("project");
+    let runtime_root = tmp.path().canonicalize().unwrap().join("run/user/1001");
     let runtime_child = runtime_root.join("just");
     std::fs::create_dir_all(&project).expect("create project dir");
     std::fs::create_dir_all(&runtime_child).expect("create runtime child dir");
@@ -360,7 +366,7 @@ fn test_xdg_runtime_child_helper_keeps_run_user_scope_narrow() {
 fn test_user_daemon_ipc_exposes_daemon_sockets_readonly() {
     let _guard = ENV_LOCK.lock().unwrap();
     let tmp = tempfile::tempdir().expect("tempdir");
-    let runtime_root = tmp.path().join("run/user/1001");
+    let runtime_root = tmp.path().canonicalize().unwrap().join("run/user/1001");
     let runtime_child = runtime_root.join("cli-sub-agent");
     let bus_socket = runtime_root.join("bus");
     let systemd_socket = runtime_root.join("systemd/private");
@@ -389,7 +395,7 @@ fn test_user_daemon_ipc_exposes_daemon_sockets_readonly() {
 fn test_daemon_sockets_not_exposed_without_user_daemon_ipc() {
     let _guard = ENV_LOCK.lock().unwrap();
     let tmp = tempfile::tempdir().expect("tempdir");
-    let runtime_root = tmp.path().join("run/user/1001");
+    let runtime_root = tmp.path().canonicalize().unwrap().join("run/user/1001");
     let bus_socket = runtime_root.join("bus");
     std::fs::create_dir_all(&runtime_root).expect("create runtime root");
     std::fs::write(&bus_socket, "").expect("create bus socket placeholder");
@@ -409,7 +415,7 @@ fn test_writable_validation_error_includes_original_and_resolved_path() {
     use std::os::unix::fs::symlink;
 
     let tmp = tempfile::tempdir().expect("tempdir");
-    let project = tmp.path().join("project");
+    let project = tmp.path().canonicalize().unwrap().join("project");
     std::fs::create_dir_all(&project).expect("create project dir");
     symlink("/etc", project.join("etc-link")).expect("create symlink");
 
@@ -428,7 +434,7 @@ fn test_writable_validation_error_includes_original_and_resolved_path() {
 fn test_claude_tool_defaults_precreate_claude_dir_for_session_env() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().expect("tempdir");
-    let home = temp.path().join("home");
+    let home = temp.path().canonicalize().unwrap().join("home");
     std::fs::create_dir_all(&home).expect("create home");
     let _home_env = ScopedEnvVar::set("HOME", &home);
 

--- a/crates/csa-resource/src/isolation_plan_readable.rs
+++ b/crates/csa-resource/src/isolation_plan_readable.rs
@@ -648,7 +648,7 @@ fn path_already_exposed(
 pub(super) fn downgrade_incompatible_cgroup_filesystem(
     resource: &mut ResourceCapability,
     filesystem: FilesystemCapability,
-    readable_paths: &[ReadablePath],
+    bind_fd_count: usize,
     degraded_reasons: &mut Vec<String>,
 ) {
     if *resource != ResourceCapability::CgroupV2 {
@@ -661,17 +661,10 @@ pub(super) fn downgrade_incompatible_cgroup_filesystem(
         );
         return;
     }
-    #[cfg(unix)]
-    if filesystem == FilesystemCapability::Bwrap
-        && readable_paths
-            .iter()
-            .any(|path| path.pinned_source_file().is_some())
-    {
+    if filesystem == FilesystemCapability::Bwrap && bind_fd_count > 0 {
         *resource = ResourceCapability::Setrlimit;
         degraded_reasons.push(
             "bwrap bind-fd cannot be combined with cgroup wrapper; falling back to setrlimit resource isolation".into(),
         );
     }
-    #[cfg(not(unix))]
-    let _ = readable_paths;
 }

--- a/crates/csa-resource/src/isolation_plan_readable.rs
+++ b/crates/csa-resource/src/isolation_plan_readable.rs
@@ -39,9 +39,10 @@ mod recovery;
 #[cfg(all(test, unix))]
 pub(crate) use recovery::AFTER_RESERVED_LEAF_CREATED;
 #[cfg(unix)]
-pub(super) use recovery::recover_reserved_names_at;
-#[cfg(all(test, unix))]
-use recovery::run_after_reserved_leaf_created;
+pub(super) use recovery::{
+    create_unlinked_overlay_leaf_at, open_or_create_writable_dir_at, open_overlay_leaf_at,
+    recover_reserved_names_at, reject_symlink_leaf_at,
+};
 
 /// Validated readable bind: requested destination plus the source pinned at
 /// validation time so later replacement cannot change the bind (#3102).
@@ -52,7 +53,7 @@ pub struct ReadablePath {
     overrides_writable_mount: bool,
     writable_bind: bool,
     #[cfg(unix)]
-    source_file: Option<Arc<File>>,
+    source_file: Result<Option<Arc<File>>, Arc<std::io::Error>>,
 }
 
 impl PartialEq for ReadablePath {
@@ -88,7 +89,12 @@ impl ReadablePath {
     /// Clone the file or directory descriptor pinned during overlay validation.
     #[cfg(unix)]
     pub(crate) fn pinned_source_file(&self) -> Option<Arc<File>> {
-        self.source_file.clone()
+        self.source_file.as_ref().ok().cloned().flatten()
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn pin_error(&self) -> Option<&std::io::Error> {
+        self.source_file.as_ref().err().map(Arc::as_ref)
     }
 
     /// Clone the descriptor held since validation for a regular-file snapshot.
@@ -100,6 +106,9 @@ impl ReadablePath {
     pub fn open_pinned_regular_file(&self) -> std::io::Result<File> {
         self.source_file
             .as_ref()
+            .ok()
+            .and_then(Option::as_ref)
+            .cloned()
             .ok_or_else(|| {
                 std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
@@ -111,7 +120,7 @@ impl ReadablePath {
 
     pub(crate) fn pinned(requested: PathBuf, bind_source: PathBuf) -> Self {
         #[cfg(unix)]
-        let source_file = open_pinned_source(&bind_source).ok().flatten();
+        let source_file = open_pinned_source(&bind_source).map_err(Arc::new);
 
         Self {
             requested,
@@ -121,6 +130,10 @@ impl ReadablePath {
             #[cfg(unix)]
             source_file,
         }
+    }
+
+    pub(crate) fn pinned_extra(requested: PathBuf, bind_source: PathBuf) -> Self {
+        Self::pinned(requested, bind_source)
     }
 
     pub(crate) fn try_pinned(requested: PathBuf, bind_source: PathBuf) -> std::io::Result<Self> {
@@ -133,7 +146,7 @@ impl ReadablePath {
             overrides_writable_mount: false,
             writable_bind: false,
             #[cfg(unix)]
-            source_file,
+            source_file: Ok(source_file),
         })
     }
 
@@ -148,7 +161,7 @@ impl ReadablePath {
             bind_source,
             overrides_writable_mount: true,
             writable_bind: false,
-            source_file: Some(Arc::new(file)),
+            source_file: Ok(Some(Arc::new(file))),
         }
     }
 
@@ -168,7 +181,7 @@ impl ReadablePath {
             bind_source,
             overrides_writable_mount: false,
             writable_bind: true,
-            source_file: Some(Arc::new(file)),
+            source_file: Ok(Some(Arc::new(file))),
         }
     }
 
@@ -182,7 +195,7 @@ impl ReadablePath {
         bind_source: PathBuf,
     ) -> std::io::Result<Self> {
         #[cfg(unix)]
-        let source_file = open_pinned_overlay_source(&bind_source)?;
+        let source_file = open_pinned_source(&bind_source)?;
         #[cfg(not(unix))]
         if fs::symlink_metadata(&bind_source)?.file_type().is_symlink() {
             return Err(std::io::Error::new(
@@ -197,7 +210,7 @@ impl ReadablePath {
             overrides_writable_mount: true,
             writable_bind: false,
             #[cfg(unix)]
-            source_file,
+            source_file: Ok(source_file),
         })
     }
 }
@@ -220,19 +233,11 @@ fn run_after_readonly_overlay_metadata(path: &Path) {
 
 #[cfg(unix)]
 fn open_pinned_source(bind_source: &Path) -> std::io::Result<Option<Arc<File>>> {
-    pin_readable_source(bind_source, false)
+    pin_readable_source(bind_source)
 }
 
 #[cfg(unix)]
-fn open_pinned_overlay_source(bind_source: &Path) -> std::io::Result<Option<Arc<File>>> {
-    pin_readable_source(bind_source, true)
-}
-
-#[cfg(unix)]
-fn pin_readable_source(
-    bind_source: &Path,
-    reject_symlink: bool,
-) -> std::io::Result<Option<Arc<File>>> {
+fn pin_readable_source(bind_source: &Path) -> std::io::Result<Option<Arc<File>>> {
     let mut components = bind_source.components();
     if !matches!(components.next(), Some(Component::RootDir)) {
         return Err(std::io::Error::new(
@@ -266,23 +271,18 @@ fn pin_readable_source(
             "pinned readable source contains a non-normal final component",
         ));
     };
-    let mut expected = stat_at(&parent, name)?;
+    let expected = stat_at(&parent, name)?;
     #[cfg(test)]
-    if reject_symlink {
-        run_after_readonly_overlay_metadata(bind_source);
-    }
-    if reject_symlink {
-        expected = stat_at(&parent, name)?;
-    }
+    run_after_readonly_overlay_metadata(bind_source);
 
-    if reject_symlink && expected.st_mode & libc::S_IFMT == libc::S_IFLNK {
+    if expected.st_mode & libc::S_IFMT == libc::S_IFLNK {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
             "read-only overlay cannot protect a symlink directory entry",
         ));
     }
 
-    if expected.st_mode & libc::S_IFMT == libc::S_IFDIR && reject_symlink {
+    if expected.st_mode & libc::S_IFMT == libc::S_IFDIR {
         let file = open_directory_at(&parent, name)?;
         confirm_opened_identity(&file, &expected)?;
         return Ok(Some(Arc::new(file)));
@@ -499,129 +499,21 @@ pub(super) fn directory_entry_names(dir: &File) -> std::io::Result<Vec<std::ffi:
     result
 }
 
-#[cfg(unix)]
-pub(super) fn create_unlinked_overlay_leaf_at(
-    parent: &File,
-    name: &std::ffi::OsStr,
-    directory: bool,
-) -> std::io::Result<File> {
-    let _lock = recovery::acquire_reserved_name_lock(parent)?;
-    let name = path_component(name)?;
-    if directory {
-        // SAFETY: parent is live and name is a unique, validated component.
-        if unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o700) } != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        #[cfg(test)]
-        run_after_reserved_leaf_created(parent, std::ffi::OsStr::from_bytes(name.to_bytes()));
-        let file = match open_directory_at(parent, std::ffi::OsStr::from_bytes(name.to_bytes())) {
-            Ok(file) => file,
-            Err(error) => {
-                // SAFETY: parent is live and name identifies the placeholder created above.
-                unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR) };
-                return Err(error);
-            }
-        };
-        // SAFETY: remove the private placeholder name while retaining its open fd.
-        if unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR) } != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-        return Ok(file);
-    }
-    // SAFETY: parent is live; O_EXCL prevents aliasing an attacker-controlled leaf.
-    let fd = unsafe {
-        libc::openat(
-            parent.as_raw_fd(),
-            name.as_ptr(),
-            libc::O_RDONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-            0o600,
-        )
-    };
-    if fd < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    // SAFETY: fd is uniquely owned; unlink removes the alternate writable pathname.
-    let file = unsafe { File::from_raw_fd(fd) };
-    #[cfg(test)]
-    run_after_reserved_leaf_created(parent, std::ffi::OsStr::from_bytes(name.to_bytes()));
-    if unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), 0) } != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(file)
-}
-
-#[cfg(unix)]
-pub(super) fn open_overlay_leaf_at(parent: &File, name: &std::ffi::OsStr) -> std::io::Result<File> {
-    let stat = stat_at(parent, name)?;
-    match stat.st_mode & libc::S_IFMT {
-        libc::S_IFLNK => Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "read-only overlay cannot protect a symlink directory entry",
-        )),
-        libc::S_IFDIR => open_directory_at(parent, name),
-        libc::S_IFREG => open_regular_at(parent, name),
-        _ => Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "read-only overlay cannot protect a non-file overlay leaf",
-        )),
-    }
-}
-
-#[cfg(unix)]
-pub(super) fn reject_symlink_leaf_at(parent: &File, name: &std::ffi::OsStr) -> std::io::Result<()> {
-    match stat_at(parent, name) {
-        Ok(stat) if stat.st_mode & libc::S_IFMT == libc::S_IFLNK => Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "runtime path is a symlink",
-        )),
-        Ok(_) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error),
-    }
-}
-
-#[cfg(unix)]
-pub(super) fn open_or_create_writable_dir_at(
-    parent: &File,
-    name: &std::ffi::OsStr,
-) -> std::io::Result<File> {
-    let c_name = path_component(name)?;
-    // SAFETY: `parent` is a live directory descriptor and `c_name` is a valid
-    // NUL-terminated path component.
-    let mkdir = unsafe { libc::mkdirat(parent.as_raw_fd(), c_name.as_ptr(), 0o700) };
-    if mkdir != 0 {
-        let error = std::io::Error::last_os_error();
-        if error.raw_os_error() != Some(libc::EEXIST) {
-            return Err(error);
-        }
-    }
-    let directory = open_directory_at(parent, name)?;
-    use std::os::unix::fs::PermissionsExt;
-    if directory.metadata()?.permissions().mode() & 0o222 == 0 {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "directory has no write permission bits",
-        ));
-    }
-    recover_reserved_names_at(&directory)?;
-    for attempt in 0..16 {
-        let probe = format!(".csa-write-probe-{}-{attempt}", std::process::id());
-        match create_unlinked_overlay_leaf_at(&directory, probe.as_ref(), false) {
-            Ok(_) => return Ok(directory),
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(error),
-        }
-    }
-    Err(std::io::Error::new(
-        std::io::ErrorKind::AlreadyExists,
-        "could not allocate a unique write probe",
-    ))
-}
-
 impl From<PathBuf> for ReadablePath {
     fn from(requested: PathBuf) -> Self {
         let bind_source = runtime_path::canonicalize_or_fallback(&requested);
-        Self::pinned(requested, bind_source)
+        let mut path = Self::pinned(requested.clone(), bind_source);
+        #[cfg(unix)]
+        if std::fs::symlink_metadata(&requested)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            path.source_file = Err(Arc::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "readable sandbox path must not be a symlink",
+            )));
+        }
+        path
     }
 }
 
@@ -729,10 +621,9 @@ pub(super) fn downgrade_incompatible_cgroup_filesystem(
     }
     #[cfg(unix)]
     if filesystem == FilesystemCapability::Bwrap
-        && readable_paths.iter().any(|path| {
-            (path.overrides_writable_mount() || path.writable_bind())
-                && path.pinned_source_file().is_some()
-        })
+        && readable_paths
+            .iter()
+            .any(|path| path.pinned_source_file().is_some())
     {
         *resource = ResourceCapability::Setrlimit;
         degraded_reasons.push(

--- a/crates/csa-resource/src/isolation_plan_readable.rs
+++ b/crates/csa-resource/src/isolation_plan_readable.rs
@@ -44,6 +44,14 @@ pub(super) use recovery::{
     recover_reserved_names_at, reject_symlink_leaf_at,
 };
 
+/// Extra mounts retain their position after ordinary mounts; host GitHub
+/// credentials additionally follow the final sandbox HOME without reopening.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExtraBind {
+    Exact,
+    HomeConfig,
+}
+
 /// Validated readable bind: requested destination plus the source pinned at
 /// validation time so later replacement cannot change the bind (#3102).
 #[derive(Debug, Clone)]
@@ -52,6 +60,7 @@ pub struct ReadablePath {
     bind_source: PathBuf,
     overrides_writable_mount: bool,
     writable_bind: bool,
+    extra_bind: Option<ExtraBind>,
     #[cfg(unix)]
     source_file: Result<Option<Arc<File>>, Arc<std::io::Error>>,
 }
@@ -62,6 +71,7 @@ impl PartialEq for ReadablePath {
             && self.bind_source == other.bind_source
             && self.overrides_writable_mount == other.overrides_writable_mount
             && self.writable_bind == other.writable_bind
+            && self.extra_bind == other.extra_bind
     }
 }
 
@@ -131,13 +141,37 @@ impl ReadablePath {
             bind_source,
             overrides_writable_mount: false,
             writable_bind: false,
+            extra_bind: None,
             #[cfg(unix)]
             source_file,
         }
     }
 
     pub(crate) fn pinned_extra(requested: PathBuf, bind_source: PathBuf) -> Self {
-        Self::pinned(requested, bind_source)
+        let mut path = Self::pinned(requested, bind_source);
+        path.extra_bind = Some(ExtraBind::Exact);
+        path
+    }
+
+    pub(crate) fn pinned_home_config(source: PathBuf) -> Self {
+        let mut path = Self::pinned_extra(source.clone(), source);
+        path.extra_bind = Some(ExtraBind::HomeConfig);
+        path
+    }
+
+    pub(crate) fn is_extra_bind(&self) -> bool {
+        self.extra_bind.is_some()
+    }
+
+    /// Remap only the destination; clones share the already pinned source FD.
+    pub(crate) fn for_sandbox_home(&self, home: Option<&Path>) -> Self {
+        let mut path = self.clone();
+        if self.extra_bind == Some(ExtraBind::HomeConfig)
+            && let Some(home) = home.filter(|home| home.is_absolute())
+        {
+            path.requested = home.join(".config/gh-aider");
+        }
+        path
     }
 
     pub(crate) fn try_pinned(requested: PathBuf, bind_source: PathBuf) -> std::io::Result<Self> {
@@ -149,6 +183,7 @@ impl ReadablePath {
             bind_source,
             overrides_writable_mount: false,
             writable_bind: false,
+            extra_bind: None,
             #[cfg(unix)]
             source_file: Ok(source_file),
         })
@@ -165,6 +200,7 @@ impl ReadablePath {
             bind_source,
             overrides_writable_mount: true,
             writable_bind: false,
+            extra_bind: None,
             source_file: Ok(Some(Arc::new(file))),
         }
     }
@@ -185,6 +221,7 @@ impl ReadablePath {
             bind_source,
             overrides_writable_mount: false,
             writable_bind: true,
+            extra_bind: None,
             source_file: Ok(Some(Arc::new(file))),
         }
     }
@@ -213,6 +250,7 @@ impl ReadablePath {
             bind_source,
             overrides_writable_mount: true,
             writable_bind: false,
+            extra_bind: None,
             #[cfg(unix)]
             source_file: Ok(source_file),
         })

--- a/crates/csa-resource/src/isolation_plan_readable.rs
+++ b/crates/csa-resource/src/isolation_plan_readable.rs
@@ -92,9 +92,13 @@ impl ReadablePath {
         self.source_file.as_ref().ok().cloned().flatten()
     }
 
-    #[cfg(unix)]
-    pub(crate) fn pin_error(&self) -> Option<&std::io::Error> {
-        self.source_file.as_ref().err().map(Arc::as_ref)
+    /// Report a retained pin failure without discarding its I/O error provenance.
+    pub(crate) fn validate_pin(&self) -> std::io::Result<()> {
+        #[cfg(unix)]
+        if let Err(error) = &self.source_file {
+            return Err(std::io::Error::new(error.kind(), error.clone()));
+        }
+        Ok(())
     }
 
     /// Clone the descriptor held since validation for a regular-file snapshot.

--- a/crates/csa-resource/src/isolation_plan_readable_recovery.rs
+++ b/crates/csa-resource/src/isolation_plan_readable_recovery.rs
@@ -3,7 +3,7 @@ use std::cell::Cell;
 #[cfg(unix)]
 use std::fs::File;
 #[cfg(unix)]
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, FromRawFd};
 #[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(all(test, unix))]
@@ -94,4 +94,126 @@ pub(crate) fn recover_reserved_names_at(parent: &File) -> std::io::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(unix)]
+pub(crate) fn create_unlinked_overlay_leaf_at(
+    parent: &File,
+    name: &std::ffi::OsStr,
+    directory: bool,
+) -> std::io::Result<File> {
+    let _lock = acquire_reserved_name_lock(parent)?;
+    let name = super::path_component(name)?;
+    if directory {
+        // SAFETY: parent is live and name is a unique, validated component.
+        if unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o700) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        #[cfg(test)]
+        run_after_reserved_leaf_created(parent, std::ffi::OsStr::from_bytes(name.to_bytes()));
+        let file =
+            match super::open_directory_at(parent, std::ffi::OsStr::from_bytes(name.to_bytes())) {
+                Ok(file) => file,
+                Err(error) => {
+                    // SAFETY: parent is live and name identifies the placeholder created above.
+                    unsafe {
+                        libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR)
+                    };
+                    return Err(error);
+                }
+            };
+        // SAFETY: remove the private placeholder name while retaining its open fd.
+        if unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR) } != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        return Ok(file);
+    }
+    // SAFETY: parent is live; O_EXCL prevents aliasing an attacker-controlled leaf.
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            0o600,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: fd is uniquely owned; unlink removes the alternate writable pathname.
+    let file = unsafe { File::from_raw_fd(fd) };
+    #[cfg(test)]
+    run_after_reserved_leaf_created(parent, std::ffi::OsStr::from_bytes(name.to_bytes()));
+    if unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), 0) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(file)
+}
+
+#[cfg(unix)]
+pub(crate) fn open_overlay_leaf_at(parent: &File, name: &std::ffi::OsStr) -> std::io::Result<File> {
+    let stat = super::stat_at(parent, name)?;
+    match stat.st_mode & libc::S_IFMT {
+        libc::S_IFLNK => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "read-only overlay cannot protect a symlink directory entry",
+        )),
+        libc::S_IFDIR => super::open_directory_at(parent, name),
+        libc::S_IFREG => super::open_regular_at(parent, name),
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "read-only overlay cannot protect a non-file overlay leaf",
+        )),
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn reject_symlink_leaf_at(parent: &File, name: &std::ffi::OsStr) -> std::io::Result<()> {
+    match super::stat_at(parent, name) {
+        Ok(stat) if stat.st_mode & libc::S_IFMT == libc::S_IFLNK => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "runtime path is a symlink",
+        )),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn open_or_create_writable_dir_at(
+    parent: &File,
+    name: &std::ffi::OsStr,
+) -> std::io::Result<File> {
+    let c_name = super::path_component(name)?;
+    // SAFETY: `parent` is a live directory descriptor and `c_name` is a valid
+    // NUL-terminated path component.
+    let mkdir = unsafe { libc::mkdirat(parent.as_raw_fd(), c_name.as_ptr(), 0o700) };
+    if mkdir != 0 {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() != Some(libc::EEXIST) {
+            return Err(error);
+        }
+    }
+    let directory = super::open_directory_at(parent, name)?;
+    use std::os::unix::fs::PermissionsExt;
+    if directory.metadata()?.permissions().mode() & 0o222 == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "directory has no write permission bits",
+        ));
+    }
+    recover_reserved_names_at(&directory)?;
+    for attempt in 0..16 {
+        let probe = format!(".csa-write-probe-{}-{attempt}", std::process::id());
+        match create_unlinked_overlay_leaf_at(&directory, probe.as_ref(), false) {
+            Ok(_) => return Ok(directory),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        "could not allocate a unique write probe",
+    ))
 }

--- a/crates/csa-resource/src/isolation_plan_rust_env_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_rust_env_tests.rs
@@ -43,7 +43,7 @@ impl Drop for ScopedEnvVar {
 fn tool_defaults_do_not_expose_usr_local_as_rust_state_home() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();
-    let home = temp.path().join("home");
+    let home = temp.path().canonicalize().unwrap().join("home");
     std::fs::create_dir_all(home.join(".cargo")).unwrap();
     std::fs::create_dir_all(home.join(".rustup")).unwrap();
     let _home = ScopedEnvVar::set("HOME", &home);
@@ -70,7 +70,7 @@ fn tool_defaults_do_not_expose_usr_local_as_rust_state_home() {
 fn tool_defaults_override_cargo_home_env_when_usr_local_is_readonly() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();
-    let home = temp.path().join("home");
+    let home = temp.path().canonicalize().unwrap().join("home");
     std::fs::create_dir_all(home.join(".cargo")).unwrap();
     std::fs::create_dir_all(home.join(".rustup")).unwrap();
     let _home = ScopedEnvVar::set("HOME", &home);
@@ -105,7 +105,7 @@ fn tool_defaults_override_cargo_home_env_when_usr_local_is_readonly() {
 fn tool_defaults_redirect_mise_cargo_home_to_sandbox_owned_cache() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();
-    let home = temp.path().join("home");
+    let home = temp.path().canonicalize().unwrap().join("home");
     std::fs::create_dir_all(home.join(".cargo")).unwrap();
     let _home = ScopedEnvVar::set("HOME", &home);
     let _xdg = ScopedEnvVar::unset("XDG_STATE_HOME");

--- a/crates/csa-resource/src/isolation_plan_temporal_selection_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_temporal_selection_tests.rs
@@ -1,0 +1,184 @@
+//! Writable destinations are selected once, before descriptor admission.
+
+use super::*;
+use std::os::unix::fs::symlink;
+
+fn admission_retarget(covered: bool, modern: bool, filesystem: FilesystemCapability) {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let (home, _env) = isolated_home(&temp);
+    let root = home.canonicalize().unwrap();
+    assert!(!root.starts_with("/tmp") && !root.starts_with("/dev"));
+    let _path = install_legacy_bwrap(&temp);
+    if modern {
+        install_modern_bwrap(&temp);
+    }
+    let a = root.join("a");
+    let b = root.join("b");
+    let project = root.join("project");
+    let session = root.join("session");
+    for dir in [&a, &b, &project, &session] {
+        std::fs::create_dir(dir).unwrap();
+    }
+    let input = a.join("input");
+    std::fs::write(&input, "accepted").unwrap();
+    let alias = root.join("state");
+    symlink(if covered { &a } else { &b }, &alias).unwrap();
+    let _xdg = ScopedEnvVar::set("XDG_STATE_HOME", &alias);
+    let builder = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(filesystem)
+        .with_resource_capability(ResourceCapability::CgroupV2)
+        .with_tool_defaults("test-tool", &project, &session)
+        .with_readable_path(&input);
+    assert!(
+        builder.writable_paths.contains(&alias),
+        "real XDG default retains alias until admission"
+    );
+    let plan = builder.build().unwrap();
+    let expected = usize::from(!covered && filesystem == FilesystemCapability::Bwrap);
+    assert_eq!(crate::bwrap::sandbox_bind_fd_count(&plan), expected);
+    let expected_resource = if expected > 0 || filesystem == FilesystemCapability::Landlock {
+        ResourceCapability::Setrlimit
+    } else {
+        ResourceCapability::CgroupV2
+    };
+    assert_eq!(plan.resource, expected_resource);
+    std::fs::remove_file(&alias).unwrap();
+    symlink(if covered { &b } else { &a }, &alias).unwrap();
+    let built = crate::from_isolation_plan(&plan, "/bin/true", &[])
+        .expect("admitted mount selection must not change after alias retarget");
+    if let Some(built) = built {
+        assert_eq!(emitted_fds(&built).len(), expected);
+        let args: Vec<_> = built.get_args().collect();
+        let destination = if covered { &a } else { &b };
+        assert!(
+            args.windows(3)
+                .any(|args| args[0] == "--bind" && args[2] == destination)
+        );
+    } else {
+        assert_ne!(filesystem, FilesystemCapability::Bwrap);
+    }
+    assert_eq!(crate::bwrap::sandbox_bind_fd_count(&plan), expected);
+    assert_eq!(plan.resource, expected_resource);
+    let mut systemd = Command::new("systemd-run");
+    let result = crate::bwrap::try_inherit_sandbox_bind_fds(&mut systemd, &plan);
+    if expected == 0 {
+        result.unwrap();
+    } else {
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidInput);
+    }
+}
+
+#[test]
+fn temporal_selection_added_writable_alias_keeps_its_destination() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    let (_home, _env) = isolated_home(&temp);
+    let _path = install_legacy_bwrap(&temp);
+    let a = root.join("a");
+    let b = root.join("b");
+    std::fs::create_dir(&a).unwrap();
+    std::fs::create_dir(&b).unwrap();
+    let alias = root.join("runtime-home");
+    symlink(&a, &alias).unwrap();
+    let mut plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
+        .with_filesystem_capability(FilesystemCapability::Bwrap)
+        .build()
+        .unwrap();
+    assert!(plan.add_writable_dir_or_creatable_parent(&alias));
+    std::fs::remove_file(&alias).unwrap();
+    symlink(&b, &alias).unwrap();
+    let command = crate::from_isolation_plan(&plan, "/bin/true", &[])
+        .unwrap()
+        .unwrap();
+    let args: Vec<_> = command.get_args().collect();
+    assert!(
+        args.windows(3)
+            .any(|args| args[0] == "--bind" && args[1] == a && args[2] == a)
+    );
+}
+
+#[test]
+fn temporal_selection_admission_covered_legacy_alias_retarget() {
+    admission_retarget(true, false, FilesystemCapability::Bwrap);
+}
+
+#[test]
+fn temporal_selection_admission_uncovered_modern_alias_retarget() {
+    admission_retarget(false, true, FilesystemCapability::Bwrap);
+}
+
+#[test]
+fn temporal_selection_admission_non_bwrap_alias_retarget() {
+    for filesystem in [FilesystemCapability::None, FilesystemCapability::Landlock] {
+        admission_retarget(false, false, filesystem);
+    }
+}
+
+fn public_collection_retarget(covered: bool) {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    let (_home, _env) = isolated_home(&temp);
+    let _path = install_legacy_bwrap(&temp);
+    let a = root.join("a");
+    let b = root.join("b");
+    std::fs::create_dir(&a).unwrap();
+    std::fs::create_dir(&b).unwrap();
+    let input = a.join("input");
+    std::fs::write(&input, "accepted").unwrap();
+    let alias = root.join("state");
+    symlink(if covered { &a } else { &b }, &alias).unwrap();
+    let readable = ReadablePath::from(&input);
+    let pin = readable.pinned_source_file().unwrap();
+    let fd = pin.as_raw_fd().to_string();
+    // Execute the returned Command, including its real ownership/pre_exec closure.
+    std::fs::write(temp.path().join("bwrap"), format!(
+        "#!/bin/sh\n[ \"$1\" = --help ] && {{ echo '--ro-bind-fd FD DEST --bind-fd FD DEST'; exit 0; }}\n{}\n",
+        if covered {
+            format!("test ! -e /proc/self/fd/{fd}")
+        } else {
+            format!("test /proc/self/fd/{fd} -ef '{}' && cat /proc/self/fd/{fd}", input.display())
+        }
+    )).unwrap();
+    let mut builder = crate::BwrapCommandBuilder::new("/bin/true", &[]);
+    builder
+        .with_writable_path(&alias)
+        .with_readable_path(readable);
+    crate::bwrap::AFTER_BIND_FILE_COLLECTION.set(Some(Box::new(move || {
+        std::fs::remove_file(&alias).unwrap();
+        symlink(if covered { &b } else { &a }, &alias).unwrap();
+    })));
+    let command = builder.build().unwrap();
+    assert_eq!(
+        emitted_fds(&command),
+        if covered { vec![] } else { vec![fd] }
+    );
+    drop(builder);
+    let output = crate::bounded_command::output_with_timeout(
+        command,
+        std::time::Duration::from_secs(5),
+        crate::bounded_command::MAX_OUTPUT_BYTES,
+    )
+    .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        output.stdout,
+        if covered {
+            b"".as_slice()
+        } else {
+            b"accepted".as_slice()
+        }
+    );
+}
+
+#[test]
+fn temporal_selection_public_collection_emission_uncovered_retarget() {
+    public_collection_retarget(false);
+}
+
+#[test]
+fn temporal_selection_public_collection_emission_covered_retarget() {
+    public_collection_retarget(true);
+}

--- a/crates/csa-resource/src/isolation_plan_temporal_selection_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_temporal_selection_tests.rs
@@ -5,7 +5,7 @@ use std::os::unix::fs::symlink;
 
 fn admission_retarget(covered: bool, modern: bool, filesystem: FilesystemCapability) {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempfile::tempdir_in("/var/tmp").unwrap();
     let (home, _env) = isolated_home(&temp);
     let root = home.canonicalize().unwrap();
     assert!(!root.starts_with("/tmp") && !root.starts_with("/dev"));
@@ -72,7 +72,7 @@ fn admission_retarget(covered: bool, modern: bool, filesystem: FilesystemCapabil
 #[test]
 fn temporal_selection_added_writable_alias_keeps_its_destination() {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempfile::tempdir_in("/var/tmp").unwrap();
     let root = temp.path().canonicalize().unwrap();
     let (_home, _env) = isolated_home(&temp);
     let _path = install_legacy_bwrap(&temp);
@@ -118,7 +118,7 @@ fn temporal_selection_admission_non_bwrap_alias_retarget() {
 
 fn public_collection_retarget(covered: bool) {
     let _lock = ENV_LOCK.lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempfile::tempdir_in("/var/tmp").unwrap();
     let root = temp.path().canonicalize().unwrap();
     let (_home, _env) = isolated_home(&temp);
     let _path = install_legacy_bwrap(&temp);

--- a/crates/csa-resource/src/isolation_plan_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_tests.rs
@@ -72,19 +72,6 @@ fn isolated_home(temp: &tempfile::TempDir) -> (PathBuf, [ScopedEnvVar; 6]) {
 }
 
 #[test]
-fn test_builder_best_effort_with_bwrap() {
-    let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
-        .with_resource_capability(ResourceCapability::CgroupV2)
-        .with_filesystem_capability(FilesystemCapability::Bwrap)
-        .build()
-        .expect("BestEffort with Bwrap should succeed");
-
-    assert_eq!(plan.resource, ResourceCapability::CgroupV2);
-    assert_eq!(plan.filesystem, FilesystemCapability::Bwrap);
-    assert!(plan.degraded_reasons.is_empty());
-}
-
-#[test]
 fn test_builder_degrades_cgroup_landlock_to_setrlimit() {
     let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
         .with_resource_capability(ResourceCapability::CgroupV2)

--- a/crates/csa-resource/src/isolation_plan_tests.rs
+++ b/crates/csa-resource/src/isolation_plan_tests.rs
@@ -56,7 +56,7 @@ impl Drop for ScopedEnvVar {
 }
 
 fn isolated_home(temp: &tempfile::TempDir) -> (PathBuf, [ScopedEnvVar; 6]) {
-    let home = temp.path().join("home");
+    let home = temp.path().canonicalize().unwrap().join("home");
     std::fs::create_dir_all(&home).expect("create isolated HOME");
     (
         home.clone(),
@@ -246,7 +246,7 @@ fn test_submodule_detection_adds_superproject_root() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let _guard = ENV_LOCK.lock().unwrap();
     let (_home, _env) = isolated_home(&tmp);
-    let superproject = tmp.path().join("monorepo");
+    let superproject = tmp.path().canonicalize().unwrap().join("monorepo");
     let submodule = superproject.join("crates").join("sub-crate");
 
     // Superproject has a .git directory
@@ -259,7 +259,7 @@ fn test_submodule_detection_adds_superproject_root() {
     )
     .expect("write .git file");
 
-    let session = tmp.path().join("session");
+    let session = tmp.path().canonicalize().unwrap().join("session");
     std::fs::create_dir_all(&session).expect("create session dir");
 
     let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
@@ -284,12 +284,12 @@ fn test_non_submodule_does_not_add_superproject() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let _guard = ENV_LOCK.lock().unwrap();
     let (_home, _env) = isolated_home(&tmp);
-    let project = tmp.path().join("project");
+    let project = tmp.path().canonicalize().unwrap().join("project");
 
     // Normal repo: .git is a directory
     std::fs::create_dir_all(project.join(".git")).expect("create .git dir");
 
-    let session = tmp.path().join("session");
+    let session = tmp.path().canonicalize().unwrap().join("session");
     std::fs::create_dir_all(&session).expect("create session dir");
 
     let plan = IsolationPlanBuilder::new(EnforcementMode::BestEffort)
@@ -329,7 +329,7 @@ fn test_tool_defaults_codex() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();
     let (_home, _env) = isolated_home(&temp);
-    let codex_home = temp.path().join("codex-home");
+    let codex_home = temp.path().canonicalize().unwrap().join("codex-home");
     let _codex_home_env = ScopedEnvVar::set("CODEX_HOME", &codex_home);
     let project = PathBuf::from("/tmp/project");
     let session = PathBuf::from("/tmp/session");
@@ -363,7 +363,11 @@ fn test_tool_defaults_codex_honors_codex_home_env() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();
     let (_home, _env) = isolated_home(&temp);
-    let codex_home = temp.path().join("custom-codex-home");
+    let codex_home = temp
+        .path()
+        .canonicalize()
+        .unwrap()
+        .join("custom-codex-home");
     let _codex_home_env = ScopedEnvVar::set("CODEX_HOME", &codex_home);
 
     let project = PathBuf::from("/tmp/project");

--- a/crates/csa-resource/src/isolation_plan_tests_tail.rs
+++ b/crates/csa-resource/src/isolation_plan_tests_tail.rs
@@ -92,7 +92,7 @@ fn test_parent_tool_defaults_expose_existing_codex_home_for_nested_csa() {
     let _guard = ENV_LOCK.lock().unwrap();
     let temp = tempfile::tempdir().unwrap();
     let (_home, _env) = isolated_home(&temp);
-    let codex_home = temp.path().join("codex-home");
+    let codex_home = temp.path().canonicalize().unwrap().join("codex-home");
     std::fs::create_dir(&codex_home).unwrap();
     let _codex_home_env = ScopedEnvVar::set("CODEX_HOME", &codex_home);
 

--- a/crates/csa-resource/tests/bwrap_extra_writable_file.rs
+++ b/crates/csa-resource/tests/bwrap_extra_writable_file.rs
@@ -15,7 +15,7 @@ fn command_args(cmd: &Command) -> Vec<String> {
 fn bwrap_extra_writable_tmp_file_does_not_create_directory_target() {
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_writable_path(Path::new("/tmp/e2e-test-state.json"));
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
 
     assert!(
@@ -38,7 +38,7 @@ fn bwrap_extra_writable_tmp_file_does_not_create_directory_target() {
 fn bwrap_extra_writable_nested_tmp_file_creates_parent_only() {
     let mut builder = BwrapCommandBuilder::new("/usr/bin/tool", &[]);
     builder.with_writable_path(Path::new("/tmp/csa/state.json"));
-    let cmd = builder.build();
+    let cmd = builder.build().expect("valid bind paths");
     let args = command_args(&cmd);
 
     assert!(

--- a/scripts/tests/build-exact-head-binaries-tests.sh
+++ b/scripts/tests/build-exact-head-binaries-tests.sh
@@ -33,6 +33,10 @@ mkdir -p \
   "${fixture}/crates/cli-sub-agent/src" \
   "${fixture}/crates/weave/src"
 git -C "${tmp}" init -q fixture
+# Git show-toplevel canonicalizes through a host TMPDIR symlink. Rebind so
+# --repo/--output-dir match production's repo identity without weakening the
+# exact-build symlink rejection or canonicalizing untrusted production input.
+fixture="$(git -C "${fixture}" rev-parse --show-toplevel)"
 git -C "${fixture}" config user.name "Exact Build Test"
 git -C "${fixture}" config user.email "exact-build@example.invalid"
 

--- a/scripts/tests/cargo-env-normalize-target-lease-tests.sh
+++ b/scripts/tests/cargo-env-normalize-target-lease-tests.sh
@@ -43,7 +43,7 @@ run_normalizer() {
 }
 
 run_normalizer_with_default_install_root() {
-    env \
+    env -u CARGO_INSTALL_ROOT \
         PATH="$bin:/usr/bin:/bin" \
         HOME="$home" \
         CSA_TEST_REPO_ROOT="$repo" \
@@ -114,6 +114,9 @@ set -e
     echo "FAIL pre-lease install-root mutation status=$install_root_rc log=$(cat "$log")"; exit 1;
 }
 [ ! -e "$repo/target" ] || { echo "FAIL target mutated before lease helper"; exit 1; }
+[ "$(cat "$log")" = "lease <--> </bin/sh> <-c> <mkdir -p \"\$CARGO_INSTALL_ROOT\"; exec \"\$@\"> <cargo-env-normalize> <cargo> <metadata> target=<$mirror$repo/target>" ] || {
+    echo "FAIL default install-root lease argv=$(cat \"$log\")"; exit 1;
+}
 
 # PATH discovery is enabled once the lexical canonical parent exists.
 mkdir -p "$mirror$repo"

--- a/scripts/tests/post-merge-rebuild-tests.sh
+++ b/scripts/tests/post-merge-rebuild-tests.sh
@@ -180,7 +180,7 @@ order_lease="$tmp_lease/order"
 : >"$order_lease"
 setup_fake_tools "$tmp_lease/tools" 0 0
 set +e
-env -u CSA_SESSION_ID -u CSA_SESSION_DIR \
+env -u CSA_SESSION_ID -u CSA_SESSION_DIR -u CARGO_INSTALL_ROOT \
     CSA_TEST_ORDER_FILE="$order_lease" \
     CSA_POST_MERGE_INSTALL_DIR="$install_dir_lease" \
     CSA_POST_MERGE_JUST="$tmp_lease/tools/just" \

--- a/weave.lock
+++ b/weave.lock
@@ -1,6 +1,6 @@
 [versions]
-csa = "0.1.1230"
-weave = "0.1.1230"
+csa = "0.1.1231"
+weave = "0.1.1231"
 last_migrated_at = "2026-03-08T12:08:01.820964091Z"
 
 [migrations]


### PR DESCRIPTION
## Summary
- Fail closed on read-only source pinning errors; retain ordinary, extra and implicit bind descriptors through command construction and ACP reconstruction.
- Match capability/cgroup admission and inherited descriptors to emitted mounts; freeze writable destinations before selection to prevent alias-retarget inconsistencies.
- Preserve Hermes SQLite/profile activation and overlay ordering. Fix related test fixture environment assumptions without weakening production validation.

## Verification
Exact head: `5096e1bc13ebf53ce346dded5f0149db008db4dd`
Tree: `74d49a1dd74f8099d7731ad7c26f19ad76889e25`

- Full local `just quality-gates`: default 7782/7782; all-features 7812/7812; 8 skipped each; Live 5/5 each.
- Fresh independent native critical review: PASS, 43/43 changed paths reviewed, zero findings. Native equivalent authorized because CSA/Codex quota unavailable (#3059); this is not a CSA verdict.
- Review JSON SHA256: `a9343acd5612e72e6bf131d4fd9aa402a85fc6d57fd70227ce7a1a9945912ab1` (`/home/obj/tmp/3174-5096e1bc-native-review.json`).
- Full-gate log SHA256: `63abd9f280c9b9e4234ec08a0f44889475949b08429cfb6c70ffe179fbe9de27`.
- Pre-push Live passed; static gate reused exact receipt `7df019e63713324dc3d8d8d02b1bbe68c3e0865f028cd13d68022669d373c0ec`. Documented `CSA_SKIP_REVIEW_CHECK=1` used only for native-review substitution with exact-head reason logged; other hooks remained enabled.
- GitHub Actions are not this repository's acceptance gate.

Closes #3174
Refs #3177
Refs #3180
Refs #3184
Refs #3059
